### PR TITLE
fix: add web/dist to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ bun.lockb
 bun.lock
 package-lock.json
 test-live.ts
+web/dist/


### PR DESCRIPTION
Adds `web/dist/` to `.gitignore` to prevent built frontend assets from being committed.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/the-vibe-company/claude-code-controller/pull/2" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
