### PR TITLE
fix: always update statusLine settings on agent spawn

### DIFF
--- a/src/controller.ts
+++ b/src/controller.ts
@@ -570,8 +570,8 @@ export class ClaudeCodeController
       }
     }
 
-    // Inject statusLine capture if we have an agent name
-    if (agentName && !settings.statusLine) {
+    // Always inject/update statusLine capture for the current team+agent
+    if (agentName) {
       const logPath = statusLineLogPath(this.teamName, agentName);
       const statusLineSettings = buildStatusLineSettings(logPath);
       settings = { ...settings, ...statusLineSettings };


### PR DESCRIPTION
## Summary
- Fix stale statusLine paths in `settings.local.json` causing events to silently fail
- Always overwrite the `statusLine` command on each spawn instead of skipping when the key exists

## Root cause
The previous code checked `if (!settings.statusLine)` before injecting the capture command. After a first run, the key persisted with a path pointing to a now-destroyed team directory, so subsequent spawns never got a fresh capture path.

## Test plan
- [x] Unit tests pass (214/214)
- [x] Manual test: statusline events now fire on every run

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/the-vibe-company/claude-code-controller/pull/21" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
