### PR TITLE
fix: remove vibe alias, update repo URLs to companion

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@
   <a href="https://www.npmjs.com/package/the-vibe-companion"><img src="https://img.shields.io/npm/v/the-vibe-companion.svg" alt="npm version" /></a>
   <a href="https://www.npmjs.com/package/the-vibe-companion"><img src="https://img.shields.io/npm/dm/the-vibe-companion.svg" alt="npm downloads" /></a>
   <a href="LICENSE"><img src="https://img.shields.io/badge/License-MIT-blue.svg" alt="MIT License" /></a>
-  <a href="https://github.com/The-Vibe-Company/claude-code-controller/stargazers"><img src="https://img.shields.io/github/stars/The-Vibe-Company/claude-code-controller.svg?style=social" alt="GitHub Stars" /></a>
+  <a href="https://github.com/The-Vibe-Company/companion/stargazers"><img src="https://img.shields.io/github/stars/The-Vibe-Company/companion.svg?style=social" alt="GitHub Stars" /></a>
 </p>
 
 <br />
@@ -30,12 +30,6 @@ bunx the-vibe-companion
 ```
 
 That's it. Open [http://localhost:3456](http://localhost:3456) and start coding.
-
-You can also use the shorter alias:
-
-```bash
-bunx vibe
-```
 
 <br />
 
@@ -120,8 +114,8 @@ The complete protocol specification is documented in [`WEBSOCKET_PROTOCOL_REVERS
 ## Development
 
 ```bash
-git clone https://github.com/The-Vibe-Company/claude-code-controller.git
-cd claude-code-controller/web
+git clone https://github.com/The-Vibe-Company/companion.git
+cd companion/web
 bun install
 bun run dev          # server on :3456 + Vite on :5174
 ```

--- a/web/package.json
+++ b/web/package.json
@@ -6,8 +6,7 @@
   "license": "MIT",
   "author": "The Vibe Company",
   "bin": {
-    "the-vibe-companion": "./bin/cli.ts",
-    "vibe": "./bin/cli.ts"
+    "the-vibe-companion": "./bin/cli.ts"
   },
   "files": [
     "bin/",


### PR DESCRIPTION
## Summary

- Removes the `vibe` bin alias from `package.json` (only `bunx the-vibe-companion` remains)
- Updates all GitHub URLs in README from `claude-code-controller` to `companion` to match the renamed repo

## Test plan

- [ ] Verify `bunx the-vibe-companion` still works
- [ ] Confirm README badges and links point to the correct repo

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/the-vibe-company/companion/pull/30" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
