### PR TITLE
feat: allow dev server access over Tailscale/LAN

### DIFF
--- a/web/vite.config.ts
+++ b/web/vite.config.ts
@@ -5,6 +5,7 @@ import tailwindcss from "@tailwindcss/vite";
 export default defineConfig({
   plugins: [react(), tailwindcss()],
   server: {
+    host: "0.0.0.0",
     port: 5174,
     proxy: {
       "/api": "http://localhost:3456",


### PR DESCRIPTION
## Summary
- Bind Vite dev server to `0.0.0.0` so it's reachable from Tailscale and LAN devices
- Production mode already worked (Bun.serve defaults to all interfaces, frontend uses relative URLs + `location.host`)
- This one-line change makes dev mode (`bun run dev:vite`) accessible remotely too

## Test plan
- [ ] Start dev servers: `bun run dev` + `bun run dev:vite`
- [ ] Access `http://<tailscale-ip>:5174` from another device
- [ ] Verify API calls and WebSocket connections work through the Vite proxy

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/the-vibe-company/companion/pull/33" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
