### PR TITLE
fix: scope permission requests to their session tab

### DIFF
--- a/web/src/components/ChatView.tsx
+++ b/web/src/components/ChatView.tsx
@@ -5,14 +5,14 @@ import { Composer } from "./Composer.js";
 import { PermissionBanner } from "./PermissionBanner.js";
 
 export function ChatView({ sessionId }: { sessionId: string }) {
-  const pendingPermissions = useStore((s) => s.pendingPermissions);
+  const sessionPerms = useStore((s) => s.pendingPermissions.get(sessionId));
   const connStatus = useStore(
     (s) => s.connectionStatus.get(sessionId) ?? "disconnected"
   );
 
   const perms = useMemo(
-    () => Array.from(pendingPermissions.values()),
-    [pendingPermissions]
+    () => (sessionPerms ? Array.from(sessionPerms.values()) : []),
+    [sessionPerms]
   );
 
   return (

--- a/web/src/components/PermissionBanner.tsx
+++ b/web/src/components/PermissionBanner.tsx
@@ -21,7 +21,7 @@ export function PermissionBanner({
       behavior: "allow",
       updated_input: updatedInput,
     });
-    removePermission(permission.request_id);
+    removePermission(sessionId, permission.request_id);
   }
 
   function handleDeny() {
@@ -32,7 +32,7 @@ export function PermissionBanner({
       behavior: "deny",
       message: "Denied by user",
     });
-    removePermission(permission.request_id);
+    removePermission(sessionId, permission.request_id);
   }
 
   const isAskUser = permission.tool_name === "AskUserQuestion";

--- a/web/src/ws.ts
+++ b/web/src/ws.ts
@@ -221,7 +221,7 @@ function handleMessage(sessionId: string, event: MessageEvent) {
     }
 
     case "permission_request": {
-      store.addPermission(data.request);
+      store.addPermission(sessionId, data.request);
       // Also extract tasks from permission requests (tool_name + input available)
       const req = data.request;
       if (req.tool_name && req.input) {
@@ -236,7 +236,7 @@ function handleMessage(sessionId: string, event: MessageEvent) {
     }
 
     case "permission_cancelled": {
-      store.removePermission(data.request_id);
+      store.removePermission(sessionId, data.request_id);
       break;
     }
 


### PR DESCRIPTION
## Summary
- Permission requests were stored in a flat global `Map<string, PermissionRequest>`, causing them to appear in **all** tabs regardless of which session triggered them
- Changed `pendingPermissions` to a per-session `Map<string, Map<string, PermissionRequest>>` so each tab only shows its own permissions
- Updated `addPermission`/`removePermission` signatures to take `sessionId`
- Added cleanup of session permissions in `removeSession`

## Test plan
- [ ] Open two sessions in separate tabs
- [ ] Trigger a permission request on one session (e.g., Bash tool)
- [ ] Confirm it only appears in that session's tab, not the other
- [ ] Allow/Deny permission and confirm it's removed only from that tab

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/the-vibe-company/companion/pull/35" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
