### PR TITLE
feat(web): persist sessions to disk for dev mode resilience

### DIFF
--- a/web/server/index.ts
+++ b/web/server/index.ts
@@ -8,6 +8,7 @@ import { serveStatic } from "hono/bun";
 import { createRoutes } from "./routes.js";
 import { CliLauncher } from "./cli-launcher.js";
 import { WsBridge } from "./ws-bridge.js";
+import { SessionStore } from "./session-store.js";
 import type { SocketData } from "./ws-bridge.js";
 import type { ServerWebSocket } from "bun";
 
@@ -15,8 +16,16 @@ const __dirname = dirname(fileURLToPath(import.meta.url));
 const packageRoot = process.env.__VIBE_PACKAGE_ROOT || resolve(__dirname, "..");
 
 const port = Number(process.env.PORT) || 3456;
+const sessionStore = new SessionStore();
 const wsBridge = new WsBridge();
 const launcher = new CliLauncher(port);
+
+// ── Restore persisted sessions from disk ────────────────────────────────────
+wsBridge.setStore(sessionStore);
+launcher.setStore(sessionStore);
+launcher.restoreFromDisk();
+wsBridge.restoreFromDisk();
+console.log(`[server] Session persistence: ${sessionStore.directory}`);
 
 const app = new Hono();
 

--- a/web/server/session-store.ts
+++ b/web/server/session-store.ts
@@ -1,0 +1,119 @@
+import { mkdirSync, readdirSync, readFileSync, writeFileSync, unlinkSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import type { SessionState, BrowserIncomingMessage, PermissionRequest } from "./session-types.js";
+
+// ─── Serializable session shape ─────────────────────────────────────────────
+
+export interface PersistedSession {
+  id: string;
+  state: SessionState;
+  messageHistory: BrowserIncomingMessage[];
+  pendingMessages: string[];
+  pendingPermissions: [string, PermissionRequest][];
+}
+
+// ─── Store ──────────────────────────────────────────────────────────────────
+
+const DEFAULT_DIR = join(tmpdir(), "vibe-sessions");
+
+export class SessionStore {
+  private dir: string;
+  private debounceTimers = new Map<string, ReturnType<typeof setTimeout>>();
+
+  constructor(dir?: string) {
+    this.dir = dir || DEFAULT_DIR;
+    mkdirSync(this.dir, { recursive: true });
+  }
+
+  private filePath(sessionId: string): string {
+    return join(this.dir, `${sessionId}.json`);
+  }
+
+  /** Debounced write — batches rapid changes (e.g. multiple stream events). */
+  save(session: PersistedSession): void {
+    const existing = this.debounceTimers.get(session.id);
+    if (existing) clearTimeout(existing);
+
+    const timer = setTimeout(() => {
+      this.debounceTimers.delete(session.id);
+      this.saveSync(session);
+    }, 150);
+    this.debounceTimers.set(session.id, timer);
+  }
+
+  /** Immediate write — use for critical state changes. */
+  saveSync(session: PersistedSession): void {
+    try {
+      writeFileSync(this.filePath(session.id), JSON.stringify(session), "utf-8");
+    } catch (err) {
+      console.error(`[session-store] Failed to save session ${session.id}:`, err);
+    }
+  }
+
+  /** Load a single session from disk. */
+  load(sessionId: string): PersistedSession | null {
+    try {
+      const raw = readFileSync(this.filePath(sessionId), "utf-8");
+      return JSON.parse(raw) as PersistedSession;
+    } catch {
+      return null;
+    }
+  }
+
+  /** Load all sessions from disk. */
+  loadAll(): PersistedSession[] {
+    const sessions: PersistedSession[] = [];
+    try {
+      const files = readdirSync(this.dir).filter((f) => f.endsWith(".json") && f !== "launcher.json");
+      for (const file of files) {
+        try {
+          const raw = readFileSync(join(this.dir, file), "utf-8");
+          sessions.push(JSON.parse(raw));
+        } catch {
+          // Skip corrupt files
+        }
+      }
+    } catch {
+      // Dir doesn't exist yet
+    }
+    return sessions;
+  }
+
+  /** Remove a session file from disk. */
+  remove(sessionId: string): void {
+    const timer = this.debounceTimers.get(sessionId);
+    if (timer) {
+      clearTimeout(timer);
+      this.debounceTimers.delete(sessionId);
+    }
+    try {
+      unlinkSync(this.filePath(sessionId));
+    } catch {
+      // File may not exist
+    }
+  }
+
+  /** Persist launcher state (separate file). */
+  saveLauncher(data: unknown): void {
+    try {
+      writeFileSync(join(this.dir, "launcher.json"), JSON.stringify(data), "utf-8");
+    } catch (err) {
+      console.error("[session-store] Failed to save launcher state:", err);
+    }
+  }
+
+  /** Load launcher state. */
+  loadLauncher<T>(): T | null {
+    try {
+      const raw = readFileSync(join(this.dir, "launcher.json"), "utf-8");
+      return JSON.parse(raw) as T;
+    } catch {
+      return null;
+    }
+  }
+
+  get directory(): string {
+    return this.dir;
+  }
+}


### PR DESCRIPTION
## Summary
- Adds `SessionStore` class that persists session state (message history, metadata, permissions) as JSON files in `/tmp/vibe-sessions/`
- `WsBridge` saves state after meaningful changes (assistant/result/user messages, permissions) with debounced writes (150ms)
- `CliLauncher` persists its session map and recovers live PIDs on restart via `process.kill(pid, 0)`
- Server restores all sessions from disk on startup, so CLI reconnections find their state intact

## Problem
When `bun --watch` restarts the backend during development, the in-memory `WsBridge` and `CliLauncher` are recreated empty. CLI processes survive (they're separate processes) but reconnect to a blank server — all conversation history is lost.

## How it works
```
Backend restart (bun --watch):
1. Server stops → CLI processes still alive
2. Server restarts → loads sessions from /tmp/vibe-sessions/
3. CLI reconnects on same ws://localhost:3456/ws/cli/{id}
4. WsBridge finds its session with full history
5. Browser reconnects → receives complete message_history
```

## Test plan
- [ ] Start a session, send a few messages
- [ ] Edit a server file to trigger `bun --watch` restart
- [ ] Verify conversation history is preserved after reload
- [ ] Verify CLI reconnects and session remains functional
- [ ] Kill a session, verify the JSON file is cleaned up

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/the-vibe-company/companion/pull/45" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
