### PR TITLE
fix(web): use --resume on CLI relaunch to restore conversation context

### DIFF
--- a/web/server/routes.ts
+++ b/web/server/routes.ts
@@ -47,6 +47,13 @@ export function createRoutes(launcher: CliLauncher, wsBridge: WsBridge) {
     return c.json({ ok: true });
   });
 
+  api.post("/sessions/:id/relaunch", async (c) => {
+    const id = c.req.param("id");
+    const ok = await launcher.relaunch(id);
+    if (!ok) return c.json({ error: "Session not found" }, 404);
+    return c.json({ ok: true });
+  });
+
   api.delete("/sessions/:id", async (c) => {
     const id = c.req.param("id");
     await launcher.kill(id);


### PR DESCRIPTION
## Summary

- Capture the CLI's internal `session_id` from `system.init` and persist it in `SdkSessionInfo`
- On relaunch, use `--resume <cliSessionId>` instead of `-p ""` so the CLI restores its full conversation history
- Add reconnection watchdog: after server restart, gives CLI processes 10s to reconnect, then kills + relaunches stale ones
- Add `POST /api/sessions/:id/relaunch` endpoint for manual reconnection from the UI

## Test plan

- [ ] Start a session, send a few messages, restart the dev server — verify the session reconnects and conversation context is preserved
- [ ] Verify fresh sessions still work with `-p ""`
- [ ] Test manual relaunch via `POST /api/sessions/:id/relaunch`
- [ ] Verify `cliSessionId` appears in the persisted launcher.json after first `system.init`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/the-vibe-company/companion/pull/46" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
