### PR TITLE
fix(web): session reconnection with auto-relaunch and persist

### DIFF
--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -1,5 +1,6 @@
-import { useEffect, useState, useSyncExternalStore } from "react";
+import { useEffect, useSyncExternalStore } from "react";
 import { useStore } from "./store.js";
+import { connectSession } from "./ws.js";
 import { Sidebar } from "./components/Sidebar.js";
 import { ChatView } from "./components/ChatView.js";
 import { TopBar } from "./components/TopBar.js";
@@ -25,6 +26,14 @@ export default function App() {
   useEffect(() => {
     document.documentElement.classList.toggle("dark", darkMode);
   }, [darkMode]);
+
+  // Auto-connect to restored session on mount
+  useEffect(() => {
+    const restoredId = useStore.getState().currentSessionId;
+    if (restoredId) {
+      connectSession(restoredId);
+    }
+  }, []);
 
   if (hash === "#/playground") {
     return <Playground />;

--- a/web/src/api.ts
+++ b/web/src/api.ts
@@ -63,6 +63,9 @@ export const api = {
   deleteSession: (sessionId: string) =>
     del(`/sessions/${encodeURIComponent(sessionId)}`),
 
+  relaunchSession: (sessionId: string) =>
+    post(`/sessions/${encodeURIComponent(sessionId)}/relaunch`),
+
   listDirs: (path?: string) =>
     get<DirListResult>(`/fs/list${path ? `?path=${encodeURIComponent(path)}` : ""}`),
 

--- a/web/src/components/ChatView.tsx
+++ b/web/src/components/ChatView.tsx
@@ -1,5 +1,6 @@
 import { useMemo } from "react";
 import { useStore } from "../store.js";
+import { api } from "../api.js";
 import { MessageFeed } from "./MessageFeed.js";
 import { Composer } from "./Composer.js";
 import { PermissionBanner } from "./PermissionBanner.js";
@@ -9,6 +10,7 @@ export function ChatView({ sessionId }: { sessionId: string }) {
   const connStatus = useStore(
     (s) => s.connectionStatus.get(sessionId) ?? "disconnected"
   );
+  const cliConnected = useStore((s) => s.cliConnected.get(sessionId) ?? false);
 
   const perms = useMemo(
     () => (sessionPerms ? Array.from(sessionPerms.values()) : []),
@@ -17,7 +19,22 @@ export function ChatView({ sessionId }: { sessionId: string }) {
 
   return (
     <div className="flex flex-col h-full">
-      {/* Connection warning */}
+      {/* CLI disconnected banner */}
+      {connStatus === "connected" && !cliConnected && (
+        <div className="px-4 py-2 bg-cc-warning/10 border-b border-cc-warning/20 text-center flex items-center justify-center gap-3">
+          <span className="text-xs text-cc-warning font-medium">
+            CLI disconnected
+          </span>
+          <button
+            onClick={() => api.relaunchSession(sessionId).catch(console.error)}
+            className="text-xs font-medium px-3 py-1 rounded-md bg-cc-warning/20 hover:bg-cc-warning/30 text-cc-warning transition-colors cursor-pointer"
+          >
+            Reconnect
+          </button>
+        </div>
+      )}
+
+      {/* WebSocket disconnected banner */}
       {connStatus === "disconnected" && (
         <div className="px-4 py-2 bg-cc-warning/10 border-b border-cc-warning/20 text-center">
           <span className="text-xs text-cc-warning font-medium">

--- a/web/src/components/TopBar.tsx
+++ b/web/src/components/TopBar.tsx
@@ -1,4 +1,5 @@
 import { useStore } from "../store.js";
+import { api } from "../api.js";
 
 export function TopBar() {
   const currentSessionId = useStore((s) => s.currentSessionId);
@@ -33,9 +34,16 @@ export function TopBar() {
                 isConnected ? "bg-cc-success" : "bg-cc-muted opacity-40"
               }`}
             />
-            <span className="text-[11px] text-cc-muted hidden sm:inline">
-              {isConnected ? "Connected" : "Disconnected"}
-            </span>
+            {isConnected ? (
+              <span className="text-[11px] text-cc-muted hidden sm:inline">Connected</span>
+            ) : (
+              <button
+                onClick={() => currentSessionId && api.relaunchSession(currentSessionId).catch(console.error)}
+                className="text-[11px] text-cc-warning hover:text-cc-warning/80 font-medium cursor-pointer hidden sm:inline"
+              >
+                Reconnect
+              </button>
+            )}
           </div>
         )}
       </div>


### PR DESCRIPTION
## Summary

- **Auto-relaunch**: when a browser connects to a session whose CLI is dead, the server automatically relaunches the CLI with `--resume` (debounced 5s per session to avoid duplicate launches)
- **Reconnect button**: shown in the ChatView banner and TopBar when CLI is disconnected — calls `POST /api/sessions/:id/relaunch`
- **Session persistence**: `currentSessionId` saved to `localStorage` so browser refresh restores the active session
- **Resume fix**: always pass `-p ""` alongside `--resume` for headless mode; detect fast exits (<5s) and clear `cliSessionId` so the next relaunch starts fresh

## Test plan

- [ ] Start a session, send a message, verify response
- [ ] Restart the backend → browser auto-reconnects and triggers CLI relaunch
- [ ] Verify conversation history is preserved after reconnect
- [ ] Refresh browser tab → verify it restores to the same session
- [ ] Kill CLI manually → verify "Reconnect" button appears and works
- [ ] Test rapid reconnections don't spawn duplicate CLI processes (5s debounce)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/the-vibe-company/companion/pull/49" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
