### PR TITLE
feat(web): named environment profiles (~/.companion/envs/)

### DIFF
--- a/web/server/env-manager.ts
+++ b/web/server/env-manager.ts
@@ -1,0 +1,146 @@
+import {
+  mkdirSync,
+  readdirSync,
+  readFileSync,
+  writeFileSync,
+  unlinkSync,
+  existsSync,
+} from "node:fs";
+import { join } from "node:path";
+import { homedir } from "node:os";
+
+// ─── Types ──────────────────────────────────────────────────────────────────
+
+export interface CompanionEnv {
+  name: string;
+  slug: string;
+  variables: Record<string, string>;
+  createdAt: number;
+  updatedAt: number;
+}
+
+// ─── Paths ──────────────────────────────────────────────────────────────────
+
+const COMPANION_DIR = join(homedir(), ".companion");
+const ENVS_DIR = join(COMPANION_DIR, "envs");
+
+function ensureDir(): void {
+  mkdirSync(ENVS_DIR, { recursive: true });
+}
+
+function filePath(slug: string): string {
+  return join(ENVS_DIR, `${slug}.json`);
+}
+
+// ─── Helpers ────────────────────────────────────────────────────────────────
+
+function slugify(name: string): string {
+  return name
+    .toLowerCase()
+    .replace(/\s+/g, "-")
+    .replace(/[^a-z0-9-]/g, "")
+    .replace(/-+/g, "-")
+    .replace(/^-|-$/g, "");
+}
+
+// ─── CRUD ───────────────────────────────────────────────────────────────────
+
+export function listEnvs(): CompanionEnv[] {
+  ensureDir();
+  try {
+    const files = readdirSync(ENVS_DIR).filter((f) => f.endsWith(".json"));
+    const envs: CompanionEnv[] = [];
+    for (const file of files) {
+      try {
+        const raw = readFileSync(join(ENVS_DIR, file), "utf-8");
+        envs.push(JSON.parse(raw));
+      } catch {
+        // Skip corrupt files
+      }
+    }
+    envs.sort((a, b) => a.name.localeCompare(b.name));
+    return envs;
+  } catch {
+    return [];
+  }
+}
+
+export function getEnv(slug: string): CompanionEnv | null {
+  ensureDir();
+  try {
+    const raw = readFileSync(filePath(slug), "utf-8");
+    return JSON.parse(raw) as CompanionEnv;
+  } catch {
+    return null;
+  }
+}
+
+export function createEnv(
+  name: string,
+  variables: Record<string, string> = {},
+): CompanionEnv {
+  if (!name || !name.trim()) throw new Error("Environment name is required");
+  const slug = slugify(name.trim());
+  if (!slug) throw new Error("Environment name must contain alphanumeric characters");
+
+  ensureDir();
+  if (existsSync(filePath(slug))) {
+    throw new Error(`An environment with a similar name already exists ("${slug}")`);
+  }
+
+  const now = Date.now();
+  const env: CompanionEnv = {
+    name: name.trim(),
+    slug,
+    variables,
+    createdAt: now,
+    updatedAt: now,
+  };
+  writeFileSync(filePath(slug), JSON.stringify(env, null, 2), "utf-8");
+  return env;
+}
+
+export function updateEnv(
+  slug: string,
+  updates: { name?: string; variables?: Record<string, string> },
+): CompanionEnv | null {
+  ensureDir();
+  const existing = getEnv(slug);
+  if (!existing) return null;
+
+  const newName = updates.name?.trim() || existing.name;
+  const newSlug = slugify(newName);
+  if (!newSlug) throw new Error("Environment name must contain alphanumeric characters");
+
+  // If name changed, check for slug collision with a different env
+  if (newSlug !== slug && existsSync(filePath(newSlug))) {
+    throw new Error(`An environment with a similar name already exists ("${newSlug}")`);
+  }
+
+  const env: CompanionEnv = {
+    name: newName,
+    slug: newSlug,
+    variables: updates.variables ?? existing.variables,
+    createdAt: existing.createdAt,
+    updatedAt: Date.now(),
+  };
+
+  // If slug changed, delete old file
+  if (newSlug !== slug) {
+    try { unlinkSync(filePath(slug)); } catch { /* ok */ }
+  }
+
+  writeFileSync(filePath(newSlug), JSON.stringify(env, null, 2), "utf-8");
+  return env;
+}
+
+export function deleteEnv(slug: string): boolean {
+  ensureDir();
+  if (!existsSync(filePath(slug))) return false;
+  try {
+    unlinkSync(filePath(slug));
+    return true;
+  } catch {
+    return false;
+  }
+}

--- a/web/src/components/EnvManager.tsx
+++ b/web/src/components/EnvManager.tsx
@@ -1,0 +1,292 @@
+import { useState, useEffect } from "react";
+import { createPortal } from "react-dom";
+import { api, type CompanionEnv } from "../api.js";
+
+interface Props {
+  onClose: () => void;
+}
+
+interface VarRow {
+  key: string;
+  value: string;
+}
+
+export function EnvManager({ onClose }: Props) {
+  const [envs, setEnvs] = useState<CompanionEnv[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [editingSlug, setEditingSlug] = useState<string | null>(null);
+  const [editName, setEditName] = useState("");
+  const [editVars, setEditVars] = useState<VarRow[]>([]);
+  const [error, setError] = useState("");
+
+  // New env form
+  const [newName, setNewName] = useState("");
+  const [newVars, setNewVars] = useState<VarRow[]>([{ key: "", value: "" }]);
+  const [creating, setCreating] = useState(false);
+
+  const refresh = () => {
+    api.listEnvs().then(setEnvs).catch(() => {}).finally(() => setLoading(false));
+  };
+
+  useEffect(() => { refresh(); }, []);
+
+  function startEdit(env: CompanionEnv) {
+    setEditingSlug(env.slug);
+    setEditName(env.name);
+    const rows = Object.entries(env.variables).map(([key, value]) => ({ key, value }));
+    if (rows.length === 0) rows.push({ key: "", value: "" });
+    setEditVars(rows);
+    setError("");
+  }
+
+  function cancelEdit() {
+    setEditingSlug(null);
+    setError("");
+  }
+
+  async function saveEdit() {
+    if (!editingSlug) return;
+    const variables: Record<string, string> = {};
+    for (const row of editVars) {
+      const k = row.key.trim();
+      if (k) variables[k] = row.value;
+    }
+    try {
+      await api.updateEnv(editingSlug, { name: editName.trim() || undefined, variables });
+      setEditingSlug(null);
+      setError("");
+      refresh();
+    } catch (e: unknown) {
+      setError(e instanceof Error ? e.message : String(e));
+    }
+  }
+
+  async function handleDelete(slug: string) {
+    try {
+      await api.deleteEnv(slug);
+      if (editingSlug === slug) setEditingSlug(null);
+      refresh();
+    } catch (e: unknown) {
+      setError(e instanceof Error ? e.message : String(e));
+    }
+  }
+
+  async function handleCreate() {
+    const name = newName.trim();
+    if (!name) return;
+    setCreating(true);
+    const variables: Record<string, string> = {};
+    for (const row of newVars) {
+      const k = row.key.trim();
+      if (k) variables[k] = row.value;
+    }
+    try {
+      await api.createEnv(name, variables);
+      setNewName("");
+      setNewVars([{ key: "", value: "" }]);
+      setError("");
+      refresh();
+    } catch (e: unknown) {
+      setError(e instanceof Error ? e.message : String(e));
+    } finally {
+      setCreating(false);
+    }
+  }
+
+  return createPortal(
+    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/50" onClick={onClose}>
+      <div
+        className="w-full max-w-lg max-h-[80vh] flex flex-col bg-cc-bg border border-cc-border rounded-[14px] shadow-2xl overflow-hidden"
+        onClick={(e) => e.stopPropagation()}
+      >
+        {/* Header */}
+        <div className="flex items-center justify-between px-5 py-4 border-b border-cc-border">
+          <h2 className="text-sm font-semibold text-cc-fg">Manage Environments</h2>
+          <button
+            onClick={onClose}
+            className="w-6 h-6 flex items-center justify-center rounded-md text-cc-muted hover:text-cc-fg hover:bg-cc-hover transition-colors cursor-pointer"
+          >
+            <svg viewBox="0 0 16 16" fill="none" stroke="currentColor" strokeWidth="2" className="w-3.5 h-3.5">
+              <path d="M4 4l8 8M12 4l-8 8" strokeLinecap="round" />
+            </svg>
+          </button>
+        </div>
+
+        {/* Content */}
+        <div className="flex-1 overflow-y-auto px-5 py-4 space-y-4">
+          {/* Error */}
+          {error && (
+            <div className="px-3 py-2 rounded-lg bg-cc-error/10 border border-cc-error/20 text-xs text-cc-error">
+              {error}
+            </div>
+          )}
+
+          {/* Existing environments */}
+          {loading ? (
+            <div className="text-xs text-cc-muted text-center py-4">Loading...</div>
+          ) : envs.length === 0 ? (
+            <div className="text-xs text-cc-muted text-center py-4">No environments yet. Create one below.</div>
+          ) : (
+            envs.map((env) => (
+              <div key={env.slug} className="border border-cc-border rounded-[10px] overflow-hidden">
+                {/* Env header row */}
+                <div className="flex items-center gap-2 px-3 py-2.5 bg-cc-card">
+                  <span className="text-xs font-medium text-cc-fg flex-1">{env.name}</span>
+                  <span className="text-[10px] text-cc-muted">
+                    {Object.keys(env.variables).length} var{Object.keys(env.variables).length !== 1 ? "s" : ""}
+                  </span>
+                  {editingSlug === env.slug ? (
+                    <button
+                      onClick={cancelEdit}
+                      className="text-[10px] text-cc-muted hover:text-cc-fg cursor-pointer"
+                    >
+                      Cancel
+                    </button>
+                  ) : (
+                    <>
+                      <button
+                        onClick={() => startEdit(env)}
+                        className="text-[10px] text-cc-muted hover:text-cc-fg cursor-pointer"
+                      >
+                        Edit
+                      </button>
+                      <button
+                        onClick={() => handleDelete(env.slug)}
+                        className="text-[10px] text-cc-muted hover:text-cc-error cursor-pointer"
+                      >
+                        Delete
+                      </button>
+                    </>
+                  )}
+                </div>
+
+                {/* Edit form */}
+                {editingSlug === env.slug && (
+                  <div className="px-3 py-3 space-y-2 border-t border-cc-border">
+                    <input
+                      type="text"
+                      value={editName}
+                      onChange={(e) => setEditName(e.target.value)}
+                      placeholder="Environment name"
+                      className="w-full px-2 py-1.5 text-xs bg-cc-input-bg border border-cc-border rounded-lg text-cc-fg placeholder:text-cc-muted focus:outline-none focus:border-cc-primary/50"
+                    />
+                    <VarEditor rows={editVars} onChange={setEditVars} />
+                    <button
+                      onClick={saveEdit}
+                      className="px-3 py-1.5 text-xs font-medium bg-cc-primary hover:bg-cc-primary-hover text-white rounded-lg transition-colors cursor-pointer"
+                    >
+                      Save
+                    </button>
+                  </div>
+                )}
+
+                {/* Variable preview (collapsed) */}
+                {editingSlug !== env.slug && Object.keys(env.variables).length > 0 && (
+                  <div className="px-3 py-2 border-t border-cc-border space-y-0.5">
+                    {Object.entries(env.variables).map(([k, v]) => (
+                      <div key={k} className="flex items-center gap-1 text-[11px]">
+                        <span className="font-mono-code text-cc-fg">{k}</span>
+                        <span className="text-cc-muted">=</span>
+                        <span className="font-mono-code text-cc-muted truncate">{v}</span>
+                      </div>
+                    ))}
+                  </div>
+                )}
+              </div>
+            ))
+          )}
+
+          {/* Create new environment */}
+          <div className="border border-cc-border rounded-[10px] overflow-hidden">
+            <div className="px-3 py-2.5 bg-cc-card">
+              <span className="text-xs font-medium text-cc-muted">New Environment</span>
+            </div>
+            <div className="px-3 py-3 space-y-2 border-t border-cc-border">
+              <input
+                type="text"
+                value={newName}
+                onChange={(e) => setNewName(e.target.value)}
+                placeholder="Environment name (e.g. production)"
+                className="w-full px-2 py-1.5 text-xs bg-cc-input-bg border border-cc-border rounded-lg text-cc-fg placeholder:text-cc-muted focus:outline-none focus:border-cc-primary/50"
+                onKeyDown={(e) => {
+                  if (e.key === "Enter" && newName.trim()) handleCreate();
+                }}
+              />
+              <VarEditor rows={newVars} onChange={setNewVars} />
+              <button
+                onClick={handleCreate}
+                disabled={!newName.trim() || creating}
+                className={`px-3 py-1.5 text-xs font-medium rounded-lg transition-colors ${
+                  newName.trim() && !creating
+                    ? "bg-cc-primary hover:bg-cc-primary-hover text-white cursor-pointer"
+                    : "bg-cc-hover text-cc-muted cursor-not-allowed"
+                }`}
+              >
+                {creating ? "Creating..." : "Create"}
+              </button>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>,
+    document.body,
+  );
+}
+
+// ─── Key-Value Editor ───────────────────────────────────────────────────
+
+function VarEditor({ rows, onChange }: { rows: VarRow[]; onChange: (rows: VarRow[]) => void }) {
+  function updateRow(i: number, field: "key" | "value", val: string) {
+    const next = [...rows];
+    next[i] = { ...next[i], [field]: val };
+    onChange(next);
+  }
+
+  function removeRow(i: number) {
+    const next = rows.filter((_, idx) => idx !== i);
+    if (next.length === 0) next.push({ key: "", value: "" });
+    onChange(next);
+  }
+
+  function addRow() {
+    onChange([...rows, { key: "", value: "" }]);
+  }
+
+  return (
+    <div className="space-y-1.5">
+      {rows.map((row, i) => (
+        <div key={i} className="flex items-center gap-1.5">
+          <input
+            type="text"
+            value={row.key}
+            onChange={(e) => updateRow(i, "key", e.target.value)}
+            placeholder="KEY"
+            className="flex-1 min-w-0 px-2 py-1 text-[11px] font-mono-code bg-cc-input-bg border border-cc-border rounded-md text-cc-fg placeholder:text-cc-muted focus:outline-none focus:border-cc-primary/50"
+          />
+          <span className="text-[10px] text-cc-muted">=</span>
+          <input
+            type="text"
+            value={row.value}
+            onChange={(e) => updateRow(i, "value", e.target.value)}
+            placeholder="value"
+            className="flex-1 min-w-0 px-2 py-1 text-[11px] font-mono-code bg-cc-input-bg border border-cc-border rounded-md text-cc-fg placeholder:text-cc-muted focus:outline-none focus:border-cc-primary/50"
+          />
+          <button
+            onClick={() => removeRow(i)}
+            className="w-5 h-5 flex items-center justify-center rounded text-cc-muted hover:text-cc-error transition-colors cursor-pointer shrink-0"
+          >
+            <svg viewBox="0 0 16 16" fill="none" stroke="currentColor" strokeWidth="2" className="w-2.5 h-2.5">
+              <path d="M4 4l8 8M12 4l-8 8" strokeLinecap="round" />
+            </svg>
+          </button>
+        </div>
+      ))}
+      <button
+        onClick={addRow}
+        className="text-[10px] text-cc-muted hover:text-cc-fg transition-colors cursor-pointer"
+      >
+        + Add variable
+      </button>
+    </div>
+  );
+}

--- a/web/src/components/Sidebar.tsx
+++ b/web/src/components/Sidebar.tsx
@@ -2,10 +2,12 @@ import { useState, useEffect, useCallback, useRef } from "react";
 import { useStore } from "../store.js";
 import { api } from "../api.js";
 import { connectSession, disconnectSession } from "../ws.js";
+import { EnvManager } from "./EnvManager.js";
 
 export function Sidebar() {
   const [editingSessionId, setEditingSessionId] = useState<string | null>(null);
   const [editingName, setEditingName] = useState("");
+  const [showEnvManager, setShowEnvManager] = useState(false);
   const editInputRef = useRef<HTMLInputElement>(null);
   const sessions = useStore((s) => s.sessions);
   const sdkSessions = useStore((s) => s.sdkSessions);
@@ -267,8 +269,17 @@ export function Sidebar() {
         )}
       </div>
 
-      {/* Footer: dark mode toggle */}
-      <div className="p-3 border-t border-cc-border">
+      {/* Footer */}
+      <div className="p-3 border-t border-cc-border space-y-0.5">
+        <button
+          onClick={() => setShowEnvManager(true)}
+          className="w-full flex items-center gap-2.5 px-3 py-2 rounded-[10px] text-sm text-cc-muted hover:text-cc-fg hover:bg-cc-hover transition-colors cursor-pointer"
+        >
+          <svg viewBox="0 0 16 16" fill="currentColor" className="w-4 h-4">
+            <path d="M8 1a2 2 0 012 2v1h2a2 2 0 012 2v6a2 2 0 01-2 2H4a2 2 0 01-2-2V6a2 2 0 012-2h2V3a2 2 0 012-2zm0 1.5a.5.5 0 00-.5.5v1h1V3a.5.5 0 00-.5-.5zM4 5.5a.5.5 0 00-.5.5v6a.5.5 0 00.5.5h8a.5.5 0 00.5-.5V6a.5.5 0 00-.5-.5H4z" />
+          </svg>
+          <span>Environments</span>
+        </button>
         <button
           onClick={toggleDarkMode}
           className="w-full flex items-center gap-2.5 px-3 py-2 rounded-[10px] text-sm text-cc-muted hover:text-cc-fg hover:bg-cc-hover transition-colors cursor-pointer"
@@ -286,6 +297,10 @@ export function Sidebar() {
         </button>
       </div>
 
+      {/* Environment manager modal */}
+      {showEnvManager && (
+        <EnvManager onClose={() => setShowEnvManager(false)} />
+      )}
     </aside>
   );
 }


### PR DESCRIPTION
## Summary

- Adds a `~/.companion/envs/` directory for storing named environment profiles as JSON files
- Users can create/edit/delete environments with key-value pairs via a modal UI
- When creating a session, select an environment to inject its variables into the Claude Code CLI process
- Accessible from both the HomePage env dropdown and the sidebar "Environments" button

## What's new

**Backend:**
- `web/server/env-manager.ts` — CRUD operations for `~/.companion/envs/*.json` (list, get, create, update, delete with slug-based naming)
- 5 new API routes: `GET/POST /api/envs`, `GET/PUT/DELETE /api/envs/:slug`
- `POST /api/sessions/create` now accepts `envSlug` and merges the environment's variables into the CLI process env

**Frontend:**
- `EnvManager` modal (React portal) with inline key-value editor for managing environments
- Environment selector dropdown on HomePage (between folder and model selectors)
- "Environments" button in sidebar footer opening the manager modal
- Selected env persisted in localStorage

## Test plan

- [ ] Create an environment via sidebar > Environments > "New Environment" form
- [ ] Verify JSON file appears at `~/.companion/envs/{slug}.json`
- [ ] Select the env in HomePage dropdown, create a session
- [ ] Verify server log: `[routes] Injecting env "name" (N vars): KEY1, KEY2`
- [ ] Ask the agent to `echo $KEY1` — confirm the value is set
- [ ] Edit and delete environments via the modal
- [ ] Verify "No env" option clears the selection

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/the-vibe-company/companion/pull/50" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
