### PR TITLE
fix(web): chat scroll and composer visibility in plan mode

### DIFF
--- a/web/src/components/ChatView.tsx
+++ b/web/src/components/ChatView.tsx
@@ -18,7 +18,7 @@ export function ChatView({ sessionId }: { sessionId: string }) {
   );
 
   return (
-    <div className="flex flex-col h-full">
+    <div className="flex flex-col h-full min-h-0">
       {/* CLI disconnected banner */}
       {connStatus === "connected" && !cliConnected && (
         <div className="px-4 py-2 bg-cc-warning/10 border-b border-cc-warning/20 text-center flex items-center justify-center gap-3">
@@ -48,7 +48,7 @@ export function ChatView({ sessionId }: { sessionId: string }) {
 
       {/* Permission banners */}
       {perms.length > 0 && (
-        <div className="border-t border-cc-border bg-cc-card">
+        <div className="shrink-0 max-h-[60vh] overflow-y-auto border-t border-cc-border bg-cc-card">
           {perms.map((p) => (
             <PermissionBanner key={p.request_id} permission={p} sessionId={sessionId} />
           ))}

--- a/web/src/components/MessageFeed.tsx
+++ b/web/src/components/MessageFeed.tsx
@@ -419,7 +419,7 @@ export function MessageFeed({ sessionId }: { sessionId: string }) {
   }
 
   return (
-    <div className="flex-1 relative overflow-hidden">
+    <div className="flex-1 min-h-0 relative overflow-hidden">
       <div
         ref={containerRef}
         onScroll={handleScroll}


### PR DESCRIPTION
## Summary
- Fix chat view not being scrollable when content overflows
- Fix composer input being pushed off screen when permission banners (especially AskUserQuestion with multiple questions) are displayed

## Root Cause
- Flexbox `min-height: auto` default prevents nested flex containers from shrinking below content size, breaking `overflow-y-auto`
- Permission banners container had no height constraints, allowing it to grow unbounded

## Changes
- Add `min-h-0` to ChatView and MessageFeed containers to allow proper flexbox shrinking
- Add `max-h-[60vh] overflow-y-auto` to permission banners container so it scrolls internally

## Test plan
- [x] Open a session in plan mode
- [x] Trigger AskUserQuestion with multiple questions/options
- [x] Verify chat is scrollable and composer remains visible

🤖 Generated with [Claude Code](https://claude.ai/code)