### PR TITLE
feat(web): archive sessions instead of deleting them

### DIFF
--- a/web/server/cli-launcher.ts
+++ b/web/server/cli-launcher.ts
@@ -14,6 +14,7 @@ export interface SdkSessionInfo {
   createdAt: number;
   /** The CLI's internal session ID (from system.init), used for --resume */
   cliSessionId?: string;
+  archived?: boolean;
 }
 
 export interface LaunchOptions {
@@ -310,6 +311,17 @@ export class CliLauncher {
   isAlive(sessionId: string): boolean {
     const session = this.sessions.get(sessionId);
     return !!session && session.state !== "exited";
+  }
+
+  /**
+   * Set the archived flag on a session.
+   */
+  setArchived(sessionId: string, archived: boolean): void {
+    const info = this.sessions.get(sessionId);
+    if (info) {
+      info.archived = archived;
+      this.persistState();
+    }
   }
 
   /**

--- a/web/server/session-store.ts
+++ b/web/server/session-store.ts
@@ -11,6 +11,7 @@ export interface PersistedSession {
   messageHistory: BrowserIncomingMessage[];
   pendingMessages: string[];
   pendingPermissions: [string, PermissionRequest][];
+  archived?: boolean;
 }
 
 // ─── Store ──────────────────────────────────────────────────────────────────
@@ -78,6 +79,15 @@ export class SessionStore {
       // Dir doesn't exist yet
     }
     return sessions;
+  }
+
+  /** Set the archived flag on a persisted session. */
+  setArchived(sessionId: string, archived: boolean): boolean {
+    const session = this.load(sessionId);
+    if (!session) return false;
+    session.archived = archived;
+    this.saveSync(session);
+    return true;
   }
 
   /** Remove a session file from disk. */

--- a/web/src/api.ts
+++ b/web/src/api.ts
@@ -88,6 +88,12 @@ export const api = {
   relaunchSession: (sessionId: string) =>
     post(`/sessions/${encodeURIComponent(sessionId)}/relaunch`),
 
+  archiveSession: (sessionId: string) =>
+    post(`/sessions/${encodeURIComponent(sessionId)}/archive`),
+
+  unarchiveSession: (sessionId: string) =>
+    post(`/sessions/${encodeURIComponent(sessionId)}/unarchive`),
+
   listDirs: (path?: string) =>
     get<DirListResult>(`/fs/list${path ? `?path=${encodeURIComponent(path)}` : ""}`),
 

--- a/web/src/types.ts
+++ b/web/src/types.ts
@@ -40,4 +40,5 @@ export interface SdkSessionInfo {
   permissionMode?: string;
   cwd: string;
   createdAt: number;
+  archived?: boolean;
 }


### PR DESCRIPTION
## Summary
- Sessions can now be **archived** instead of permanently deleted — the hover button on active sessions is now an archive icon instead of X
- Archived sessions appear in a collapsible **"Archived (N)"** section at the bottom of the sidebar, with dimmed styling
- Each archived session has a **restore** button (moves back to active) and a **delete permanently** button
- Archived sessions preserve all data (messages, metadata) on disk but their CLI process is killed and won't auto-relaunch

## Changes
- **Backend**: `archived` flag on `PersistedSession` + `SdkSessionInfo`, `setArchived()` methods, `POST /sessions/:id/archive` and `/unarchive` routes, auto-relaunch guards
- **Frontend**: `archiveSession()` / `unarchiveSession()` API methods, sidebar split into active/archived sections with new action buttons

## Test plan
- [ ] Create a session, send a few messages, click archive → moves to "Archived" section
- [ ] Expand archived, click restore → session moves back to active list
- [ ] Archive a session, restart the server → archived session still in archived section
- [ ] Click on an archived session → shows message history without relaunching CLI
- [ ] From archived section, click delete permanently → session fully removed

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/the-vibe-company/companion/pull/56" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
