### PR TITLE
feat(web): enlarge homepage logo as hero element

### DIFF
--- a/web/src/components/HomePage.tsx
+++ b/web/src/components/HomePage.tsx
@@ -306,8 +306,8 @@ export function HomePage() {
     <div className="flex-1 h-full flex items-center justify-center px-3 sm:px-4">
       <div className="w-full max-w-2xl">
         {/* Logo + Title */}
-        <div className="flex items-center justify-center gap-3 mb-4 sm:mb-6">
-          <img src="/logo.svg" alt="The Vibe Companion" className="w-9 h-9 sm:w-10 sm:h-10" />
+        <div className="flex flex-col items-center justify-center mb-4 sm:mb-6">
+          <img src="/logo.svg" alt="The Vibe Companion" className="w-24 h-24 sm:w-32 sm:h-32 mb-3" />
           <h1 className="text-xl sm:text-2xl font-semibold text-cc-fg">
             The Vibe Companion
           </h1>


### PR DESCRIPTION
## Summary
- Display the Clawd logo prominently on the homepage as a hero element
- Increased logo size from ~40px to ~128px (responsive: 96px mobile, 128px desktop)
- Changed layout from inline (logo beside title) to stacked (logo above title)

## Test plan
- [ ] Verify logo displays large and centered above the title on the homepage
- [ ] Check responsive sizing (smaller on mobile, larger on desktop)
- [ ] All 272 existing tests pass

> This code was generated directly by AI and has not been reviewed by a human.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/the-vibe-company/companion/pull/71" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
