### PR TITLE
feat(web): git fetch on branch picker open

### DIFF
--- a/web/server/git-utils.ts
+++ b/web/server/git-utils.ts
@@ -283,6 +283,15 @@ export function isWorktreeDirty(worktreePath: string): boolean {
   return status !== null && status.length > 0;
 }
 
+export function gitFetch(cwd: string): { success: boolean; output: string } {
+  try {
+    const output = git("fetch --prune", cwd);
+    return { success: true, output };
+  } catch (e: unknown) {
+    return { success: false, output: e instanceof Error ? e.message : String(e) };
+  }
+}
+
 export function gitPull(
   cwd: string,
 ): { success: boolean; output: string } {

--- a/web/server/routes.ts
+++ b/web/server/routes.ts
@@ -261,6 +261,13 @@ export function createRoutes(launcher: CliLauncher, wsBridge: WsBridge, sessionS
     return c.json(result);
   });
 
+  api.post("/git/fetch", async (c) => {
+    const body = await c.req.json().catch(() => ({}));
+    const { repoRoot } = body;
+    if (!repoRoot) return c.json({ error: "repoRoot required" }, 400);
+    return c.json(gitUtils.gitFetch(repoRoot));
+  });
+
   api.post("/git/pull", async (c) => {
     const body = await c.req.json().catch(() => ({}));
     const { cwd } = body;

--- a/web/src/api.ts
+++ b/web/src/api.ts
@@ -158,6 +158,8 @@ export const api = {
     post<WorktreeCreateResult>("/git/worktree", { repoRoot, branch, ...opts }),
   removeWorktree: (repoRoot: string, worktreePath: string, force?: boolean) =>
     del<{ removed: boolean; reason?: string }>("/git/worktree", { repoRoot, worktreePath, force }),
+  gitFetch: (repoRoot: string) =>
+    post<{ success: boolean; output: string }>("/git/fetch", { repoRoot }),
   gitPull: (cwd: string) =>
     post<{ success: boolean; output: string; git_ahead: number; git_behind: number }>("/git/pull", { cwd }),
 };

--- a/web/src/components/HomePage.tsx
+++ b/web/src/components/HomePage.tsx
@@ -566,7 +566,11 @@ export function HomePage() {
               <button
                 onClick={() => {
                   if (!showBranchDropdown && gitRepoInfo) {
-                    api.listBranches(gitRepoInfo.repoRoot).then(setBranches).catch(() => setBranches([]));
+                    api.gitFetch(gitRepoInfo.repoRoot)
+                      .catch(() => {})
+                      .finally(() => {
+                        api.listBranches(gitRepoInfo.repoRoot).then(setBranches).catch(() => setBranches([]));
+                      });
                   }
                   setShowBranchDropdown(!showBranchDropdown);
                   setBranchFilter("");


### PR DESCRIPTION
## Summary
- Runs `git fetch --prune` automatically when the branch picker dropdown is opened
- Ensures the branch list reflects the latest remote state (new branches, deleted branches, accurate ahead/behind counts)
- Fetch is non-blocking — dropdown opens instantly, branch list updates when fetch completes
- Network failures are silently ignored (falls back to local branch data)

## Changes
- `web/server/git-utils.ts` — new `gitFetch()` function
- `web/server/routes.ts` — new `POST /api/git/fetch` endpoint
- `web/src/api.ts` — new `gitFetch` client method
- `web/src/components/HomePage.tsx` — triggers fetch before refreshing branches on dropdown open

## Test plan
- [x] Typecheck passes (`bun run typecheck`)
- [x] All 272 tests pass (`bun run test`)
- [ ] Manual: open app, select a git repo, open branch dropdown — verify new remote branches appear after a moment

Code was generated directly by AI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/the-vibe-company/companion/pull/72" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
