### PR TITLE
test(web): add comprehensive frontend and ws-bridge test coverage

### DIFF
--- a/web/package.json
+++ b/web/package.json
@@ -40,6 +40,9 @@
   },
   "devDependencies": {
     "@tailwindcss/vite": "^4.0.0",
+    "@testing-library/jest-dom": "^6.9.1",
+    "@testing-library/react": "^16.3.2",
+    "@testing-library/user-event": "^14.6.1",
     "@types/bun": "^1.2.5",
     "@types/react": "^19.0.0",
     "@types/react-dom": "^19.0.0",

--- a/web/src/components/Composer.test.tsx
+++ b/web/src/components/Composer.test.tsx
@@ -1,0 +1,346 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import type { SessionState } from "../../server/session-types.js";
+
+// Polyfill scrollIntoView for jsdom
+Element.prototype.scrollIntoView = vi.fn();
+
+const mockSendToSession = vi.fn();
+
+// Build a controllable mock store state
+let mockStoreState: Record<string, unknown> = {};
+
+vi.mock("../ws.js", () => ({
+  sendToSession: (...args: unknown[]) => mockSendToSession(...args),
+}));
+
+vi.mock("../api.js", () => ({
+  api: {
+    gitPull: vi.fn().mockResolvedValue({ success: true, output: "", git_ahead: 0, git_behind: 0 }),
+  },
+}));
+
+// Mock useStore as a function that takes a selector
+const mockAppendMessage = vi.fn();
+const mockUpdateSession = vi.fn();
+const mockSetPreviousPermissionMode = vi.fn();
+
+vi.mock("../store.js", () => {
+  // Create a mock store function that acts like zustand's useStore
+  const useStore = (selector: (state: Record<string, unknown>) => unknown) => {
+    return selector(mockStoreState);
+  };
+  // Add getState for imperative access (used by Composer for appendMessage)
+  useStore.getState = () => mockStoreState;
+  return { useStore };
+});
+
+import { Composer } from "./Composer.js";
+
+function makeSession(overrides: Partial<SessionState> = {}): SessionState {
+  return {
+    session_id: "s1",
+    model: "claude-sonnet-4-5-20250929",
+    cwd: "/test",
+    tools: [],
+    permissionMode: "acceptEdits",
+    claude_code_version: "1.0",
+    mcp_servers: [],
+    agents: [],
+    slash_commands: [],
+    skills: [],
+    total_cost_usd: 0,
+    num_turns: 0,
+    context_used_percent: 0,
+    is_compacting: false,
+    git_branch: "",
+    is_worktree: false,
+    repo_root: "",
+    git_ahead: 0,
+    git_behind: 0,
+    total_lines_added: 0,
+    total_lines_removed: 0,
+    ...overrides,
+  };
+}
+
+function setupMockStore(overrides: {
+  isConnected?: boolean;
+  sessionStatus?: "idle" | "running" | "compacting" | null;
+  session?: Partial<SessionState>;
+} = {}) {
+  const {
+    isConnected = true,
+    sessionStatus = "idle",
+    session = {},
+  } = overrides;
+
+  const sessionsMap = new Map<string, SessionState>();
+  sessionsMap.set("s1", makeSession(session));
+
+  const cliConnectedMap = new Map<string, boolean>();
+  cliConnectedMap.set("s1", isConnected);
+
+  const sessionStatusMap = new Map<string, "idle" | "running" | "compacting" | null>();
+  sessionStatusMap.set("s1", sessionStatus);
+
+  const previousPermissionModeMap = new Map<string, string>();
+  previousPermissionModeMap.set("s1", "acceptEdits");
+
+  mockStoreState = {
+    sessions: sessionsMap,
+    cliConnected: cliConnectedMap,
+    sessionStatus: sessionStatusMap,
+    previousPermissionMode: previousPermissionModeMap,
+    appendMessage: mockAppendMessage,
+    updateSession: mockUpdateSession,
+    setPreviousPermissionMode: mockSetPreviousPermissionMode,
+  };
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  setupMockStore();
+});
+
+// ─── Basic rendering ────────────────────────────────────────────────────────
+
+describe("Composer basic rendering", () => {
+  it("renders textarea and send button", () => {
+    const { container } = render(<Composer sessionId="s1" />);
+    const textarea = container.querySelector("textarea");
+    expect(textarea).toBeTruthy();
+    // Send button (the round one with the arrow SVG) - identified by title
+    const sendBtn = screen.getByTitle("Send message");
+    expect(sendBtn).toBeTruthy();
+  });
+});
+
+// ─── Send button disabled state ──────────────────────────────────────────────
+
+describe("Composer send button state", () => {
+  it("send button is disabled when text is empty", () => {
+    render(<Composer sessionId="s1" />);
+    const sendBtn = screen.getByTitle("Send message");
+    expect(sendBtn.hasAttribute("disabled")).toBe(true);
+  });
+
+  it("send button is disabled when CLI is not connected", () => {
+    setupMockStore({ isConnected: false });
+    render(<Composer sessionId="s1" />);
+    const sendBtn = screen.getByTitle("Send message");
+    expect(sendBtn.hasAttribute("disabled")).toBe(true);
+  });
+
+  it("typing text enables the send button", async () => {
+    const { container } = render(<Composer sessionId="s1" />);
+    const textarea = container.querySelector("textarea")!;
+
+    fireEvent.change(textarea, { target: { value: "Hello world" } });
+
+    const sendBtn = screen.getByTitle("Send message");
+    expect(sendBtn.hasAttribute("disabled")).toBe(false);
+  });
+});
+
+// ─── Sending messages ────────────────────────────────────────────────────────
+
+describe("Composer sending messages", () => {
+  it("pressing Enter sends the message via sendToSession", () => {
+    const { container } = render(<Composer sessionId="s1" />);
+    const textarea = container.querySelector("textarea")!;
+
+    fireEvent.change(textarea, { target: { value: "test message" } });
+    fireEvent.keyDown(textarea, { key: "Enter", shiftKey: false });
+
+    expect(mockSendToSession).toHaveBeenCalledWith("s1", expect.objectContaining({
+      type: "user_message",
+      content: "test message",
+      session_id: "s1",
+    }));
+  });
+
+  it("pressing Shift+Enter does NOT send the message", () => {
+    const { container } = render(<Composer sessionId="s1" />);
+    const textarea = container.querySelector("textarea")!;
+
+    fireEvent.change(textarea, { target: { value: "line 1" } });
+    fireEvent.keyDown(textarea, { key: "Enter", shiftKey: true });
+
+    expect(mockSendToSession).not.toHaveBeenCalled();
+  });
+
+  it("clicking the send button sends the message", () => {
+    const { container } = render(<Composer sessionId="s1" />);
+    const textarea = container.querySelector("textarea")!;
+
+    fireEvent.change(textarea, { target: { value: "click send" } });
+    fireEvent.click(screen.getByTitle("Send message"));
+
+    expect(mockSendToSession).toHaveBeenCalledWith("s1", expect.objectContaining({
+      type: "user_message",
+      content: "click send",
+    }));
+  });
+
+  it("textarea is cleared after sending", () => {
+    const { container } = render(<Composer sessionId="s1" />);
+    const textarea = container.querySelector("textarea")! as HTMLTextAreaElement;
+
+    fireEvent.change(textarea, { target: { value: "to be cleared" } });
+    fireEvent.keyDown(textarea, { key: "Enter", shiftKey: false });
+
+    expect(textarea.value).toBe("");
+  });
+});
+
+// ─── Plan mode toggle ────────────────────────────────────────────────────────
+
+describe("Composer plan mode toggle", () => {
+  it("pressing Shift+Tab toggles plan mode", () => {
+    const { container } = render(<Composer sessionId="s1" />);
+    const textarea = container.querySelector("textarea")!;
+
+    fireEvent.keyDown(textarea, { key: "Tab", shiftKey: true });
+
+    // Should call sendToSession to set plan mode
+    expect(mockSendToSession).toHaveBeenCalledWith("s1", {
+      type: "set_permission_mode",
+      mode: "plan",
+    });
+  });
+});
+
+// ─── Interrupt button ────────────────────────────────────────────────────────
+
+describe("Composer interrupt button", () => {
+  it("interrupt button appears when session is running", () => {
+    setupMockStore({ sessionStatus: "running" });
+    render(<Composer sessionId="s1" />);
+
+    const stopBtn = screen.getByTitle("Stop generation");
+    expect(stopBtn).toBeTruthy();
+    // Send button should not be present
+    expect(screen.queryByTitle("Send message")).toBeNull();
+  });
+
+  it("interrupt button sends interrupt message", () => {
+    setupMockStore({ sessionStatus: "running" });
+    render(<Composer sessionId="s1" />);
+
+    fireEvent.click(screen.getByTitle("Stop generation"));
+
+    expect(mockSendToSession).toHaveBeenCalledWith("s1", { type: "interrupt" });
+  });
+
+  it("send button appears when session is idle", () => {
+    setupMockStore({ sessionStatus: "idle" });
+    render(<Composer sessionId="s1" />);
+
+    expect(screen.getByTitle("Send message")).toBeTruthy();
+    expect(screen.queryByTitle("Stop generation")).toBeNull();
+  });
+});
+
+// ─── Slash menu ──────────────────────────────────────────────────────────────
+
+describe("Composer slash menu", () => {
+  it("slash menu opens when typing /", () => {
+    setupMockStore({
+      session: {
+        slash_commands: ["help", "clear"],
+        skills: ["commit"],
+      },
+    });
+    const { container } = render(<Composer sessionId="s1" />);
+    const textarea = container.querySelector("textarea")!;
+
+    fireEvent.change(textarea, { target: { value: "/" } });
+
+    // Commands should appear in the menu
+    expect(screen.getByText("/help")).toBeTruthy();
+    expect(screen.getByText("/clear")).toBeTruthy();
+    expect(screen.getByText("/commit")).toBeTruthy();
+  });
+
+  it("slash commands are filtered as user types", () => {
+    setupMockStore({
+      session: {
+        slash_commands: ["help", "clear"],
+        skills: ["commit"],
+      },
+    });
+    const { container } = render(<Composer sessionId="s1" />);
+    const textarea = container.querySelector("textarea")!;
+
+    fireEvent.change(textarea, { target: { value: "/cl" } });
+
+    expect(screen.getByText("/clear")).toBeTruthy();
+    expect(screen.queryByText("/help")).toBeNull();
+    // "commit" does not match "cl" so it should not appear either
+    expect(screen.queryByText("/commit")).toBeNull();
+  });
+
+  it("slash menu does not open when there are no commands", () => {
+    setupMockStore({
+      session: {
+        slash_commands: [],
+        skills: [],
+      },
+    });
+    const { container } = render(<Composer sessionId="s1" />);
+    const textarea = container.querySelector("textarea")!;
+
+    fireEvent.change(textarea, { target: { value: "/" } });
+
+    // No command items should appear
+    expect(screen.queryByText("/help")).toBeNull();
+  });
+
+  it("slash menu shows command types", () => {
+    setupMockStore({
+      session: {
+        slash_commands: ["help"],
+        skills: ["commit"],
+      },
+    });
+    const { container } = render(<Composer sessionId="s1" />);
+    const textarea = container.querySelector("textarea")!;
+
+    fireEvent.change(textarea, { target: { value: "/" } });
+
+    // Each command should display its type
+    expect(screen.getByText("command")).toBeTruthy();
+    expect(screen.getByText("skill")).toBeTruthy();
+  });
+});
+
+// ─── Disabled state ──────────────────────────────────────────────────────────
+
+describe("Composer disabled state", () => {
+  it("textarea is disabled when CLI is not connected", () => {
+    setupMockStore({ isConnected: false });
+    const { container } = render(<Composer sessionId="s1" />);
+    const textarea = container.querySelector("textarea")! as HTMLTextAreaElement;
+
+    expect(textarea.disabled).toBe(true);
+  });
+
+  it("textarea shows correct placeholder when connected", () => {
+    setupMockStore({ isConnected: true });
+    const { container } = render(<Composer sessionId="s1" />);
+    const textarea = container.querySelector("textarea")! as HTMLTextAreaElement;
+
+    expect(textarea.placeholder).toContain("Type a message");
+  });
+
+  it("textarea shows waiting placeholder when not connected", () => {
+    setupMockStore({ isConnected: false });
+    const { container } = render(<Composer sessionId="s1" />);
+    const textarea = container.querySelector("textarea")! as HTMLTextAreaElement;
+
+    expect(textarea.placeholder).toContain("Waiting for CLI connection");
+  });
+});

--- a/web/src/components/MessageBubble.test.tsx
+++ b/web/src/components/MessageBubble.test.tsx
@@ -1,0 +1,303 @@
+// @vitest-environment jsdom
+import { render, screen, fireEvent } from "@testing-library/react";
+import type { ChatMessage, ContentBlock } from "../types.js";
+
+// Mock react-markdown to avoid ESM/parsing issues in tests
+vi.mock("react-markdown", () => ({
+  default: ({ children }: { children: string }) => <div data-testid="markdown">{children}</div>,
+}));
+
+vi.mock("remark-gfm", () => ({
+  default: {},
+}));
+
+import { MessageBubble } from "./MessageBubble.js";
+
+function makeMessage(overrides: Partial<ChatMessage> & { role: ChatMessage["role"] }): ChatMessage {
+  return {
+    id: `msg-${Math.random().toString(36).slice(2, 8)}`,
+    content: "",
+    timestamp: Date.now(),
+    ...overrides,
+  };
+}
+
+// ─── System messages ─────────────────────────────────────────────────────────
+
+describe("MessageBubble - system messages", () => {
+  it("renders system message with italic text", () => {
+    const msg = makeMessage({ role: "system", content: "Session started" });
+    const { container } = render(<MessageBubble message={msg} />);
+
+    const italicSpan = container.querySelector(".italic");
+    expect(italicSpan).toBeTruthy();
+    expect(italicSpan?.textContent).toBe("Session started");
+  });
+
+  it("renders system message with divider lines", () => {
+    const msg = makeMessage({ role: "system", content: "Divider test" });
+    const { container } = render(<MessageBubble message={msg} />);
+
+    // There should be 2 divider elements (h-px)
+    const dividers = container.querySelectorAll(".h-px");
+    expect(dividers.length).toBe(2);
+  });
+});
+
+// ─── User messages ───────────────────────────────────────────────────────────
+
+describe("MessageBubble - user messages", () => {
+  it("renders user message right-aligned with content", () => {
+    const msg = makeMessage({ role: "user", content: "Hello Claude" });
+    const { container } = render(<MessageBubble message={msg} />);
+
+    // Check for right-alignment (justify-end)
+    const wrapper = container.querySelector(".justify-end");
+    expect(wrapper).toBeTruthy();
+
+    // Check content
+    expect(screen.getByText("Hello Claude")).toBeTruthy();
+  });
+
+  it("renders user messages with image thumbnails", () => {
+    const msg = makeMessage({
+      role: "user",
+      content: "See this image",
+      images: [
+        { media_type: "image/png", data: "abc123base64" },
+        { media_type: "image/jpeg", data: "def456base64" },
+      ],
+    });
+    const { container } = render(<MessageBubble message={msg} />);
+
+    const images = container.querySelectorAll("img");
+    expect(images.length).toBe(2);
+    expect(images[0].getAttribute("src")).toBe("data:image/png;base64,abc123base64");
+    expect(images[1].getAttribute("src")).toBe("data:image/jpeg;base64,def456base64");
+    expect(images[0].getAttribute("alt")).toBe("attachment");
+  });
+
+  it("does not render images section when images array is empty", () => {
+    const msg = makeMessage({ role: "user", content: "No images", images: [] });
+    const { container } = render(<MessageBubble message={msg} />);
+
+    const images = container.querySelectorAll("img");
+    expect(images.length).toBe(0);
+  });
+});
+
+// ─── Assistant messages ──────────────────────────────────────────────────────
+
+describe("MessageBubble - assistant messages", () => {
+  it("renders plain text assistant message with markdown", () => {
+    const msg = makeMessage({ role: "assistant", content: "Hello world" });
+    render(<MessageBubble message={msg} />);
+
+    // Our mock renders content inside data-testid="markdown"
+    const markdown = screen.getByTestId("markdown");
+    expect(markdown.textContent).toBe("Hello world");
+  });
+
+  it("renders assistant message with text content blocks", () => {
+    const msg = makeMessage({
+      role: "assistant",
+      content: "",
+      contentBlocks: [
+        { type: "text", text: "Here is the answer" },
+      ],
+    });
+    render(<MessageBubble message={msg} />);
+
+    const markdown = screen.getByTestId("markdown");
+    expect(markdown.textContent).toBe("Here is the answer");
+  });
+
+  it("renders tool_use content blocks as ToolBlock components", () => {
+    const msg = makeMessage({
+      role: "assistant",
+      content: "",
+      contentBlocks: [
+        { type: "tool_use", id: "tu-1", name: "Bash", input: { command: "pwd" } },
+      ],
+    });
+    render(<MessageBubble message={msg} />);
+
+    // ToolBlock renders with the label "Terminal" for Bash
+    expect(screen.getByText("Terminal")).toBeTruthy();
+    // And the preview should show the command
+    expect(screen.getByText("pwd")).toBeTruthy();
+  });
+
+  it("renders thinking blocks with 'Thinking' label and char count", () => {
+    const thinkingText = "Let me analyze this problem step by step...";
+    const msg = makeMessage({
+      role: "assistant",
+      content: "",
+      contentBlocks: [
+        { type: "thinking", thinking: thinkingText },
+      ],
+    });
+    render(<MessageBubble message={msg} />);
+
+    expect(screen.getByText("Thinking")).toBeTruthy();
+    expect(screen.getByText(`${thinkingText.length} chars`)).toBeTruthy();
+  });
+
+  it("thinking blocks expand and collapse on click", () => {
+    const thinkingText = "Deep analysis of the problem at hand.";
+    const msg = makeMessage({
+      role: "assistant",
+      content: "",
+      contentBlocks: [
+        { type: "thinking", thinking: thinkingText },
+      ],
+    });
+    render(<MessageBubble message={msg} />);
+
+    // Initially collapsed - thinking text should not be visible in a pre
+    expect(screen.queryByText(thinkingText)).toBeNull();
+
+    // Find and click the thinking button
+    const thinkingButton = screen.getByText("Thinking").closest("button")!;
+    fireEvent.click(thinkingButton);
+
+    // Now the thinking text should be visible
+    expect(screen.getByText(thinkingText)).toBeTruthy();
+
+    // Click again to collapse
+    fireEvent.click(thinkingButton);
+    expect(screen.queryByText(thinkingText)).toBeNull();
+  });
+
+  it("renders tool_result blocks with string content", () => {
+    const msg = makeMessage({
+      role: "assistant",
+      content: "",
+      contentBlocks: [
+        { type: "tool_result", tool_use_id: "tu-1", content: "Command output: success" },
+      ],
+    });
+    render(<MessageBubble message={msg} />);
+
+    expect(screen.getByText("Command output: success")).toBeTruthy();
+  });
+
+  it("renders tool_result blocks with JSON content", () => {
+    const jsonContent = [{ type: "text" as const, text: "nested result" }];
+    const msg = makeMessage({
+      role: "assistant",
+      content: "",
+      contentBlocks: [
+        { type: "tool_result", tool_use_id: "tu-2", content: jsonContent as unknown as string },
+      ],
+    });
+    render(<MessageBubble message={msg} />);
+
+    // The JSON.stringify of the content should be rendered
+    const rendered = screen.getByText(JSON.stringify(jsonContent));
+    expect(rendered).toBeTruthy();
+  });
+
+  it("renders tool_result error blocks with error styling", () => {
+    const msg = makeMessage({
+      role: "assistant",
+      content: "",
+      contentBlocks: [
+        { type: "tool_result", tool_use_id: "tu-3", content: "Error: file not found", is_error: true },
+      ],
+    });
+    const { container } = render(<MessageBubble message={msg} />);
+
+    expect(screen.getByText("Error: file not found")).toBeTruthy();
+    // Check for error styling class
+    const errorDiv = container.querySelector(".text-cc-error");
+    expect(errorDiv).toBeTruthy();
+  });
+
+  it("renders non-error tool_result without error styling", () => {
+    const msg = makeMessage({
+      role: "assistant",
+      content: "",
+      contentBlocks: [
+        { type: "tool_result", tool_use_id: "tu-4", content: "Success output" },
+      ],
+    });
+    const { container } = render(<MessageBubble message={msg} />);
+
+    expect(screen.getByText("Success output")).toBeTruthy();
+    const resultDiv = screen.getByText("Success output");
+    expect(resultDiv.className).toContain("text-cc-muted");
+    expect(resultDiv.className).not.toContain("text-cc-error");
+  });
+});
+
+// ─── groupContentBlocks behavior (tested indirectly through MessageBubble) ──
+
+describe("MessageBubble - content block grouping", () => {
+  it("groups consecutive same-tool tool_use blocks together", () => {
+    const msg = makeMessage({
+      role: "assistant",
+      content: "",
+      contentBlocks: [
+        { type: "tool_use", id: "tu-1", name: "Read", input: { file_path: "/a.ts" } },
+        { type: "tool_use", id: "tu-2", name: "Read", input: { file_path: "/b.ts" } },
+        { type: "tool_use", id: "tu-3", name: "Read", input: { file_path: "/c.ts" } },
+      ],
+    });
+    const { container } = render(<MessageBubble message={msg} />);
+
+    // When grouped, there should be a count badge showing "3"
+    expect(screen.getByText("3")).toBeTruthy();
+    // The label should appear once (grouped)
+    const labels = screen.getAllByText("Read File");
+    expect(labels.length).toBe(1);
+  });
+
+  it("does not group different tool types together", () => {
+    const msg = makeMessage({
+      role: "assistant",
+      content: "",
+      contentBlocks: [
+        { type: "tool_use", id: "tu-1", name: "Read", input: { file_path: "/a.ts" } },
+        { type: "tool_use", id: "tu-2", name: "Bash", input: { command: "ls" } },
+      ],
+    });
+    render(<MessageBubble message={msg} />);
+
+    // Both labels should appear separately
+    expect(screen.getByText("Read File")).toBeTruthy();
+    expect(screen.getByText("Terminal")).toBeTruthy();
+  });
+
+  it("renders a single tool_use without group count badge", () => {
+    const msg = makeMessage({
+      role: "assistant",
+      content: "",
+      contentBlocks: [
+        { type: "tool_use", id: "tu-1", name: "Bash", input: { command: "echo hi" } },
+      ],
+    });
+    render(<MessageBubble message={msg} />);
+
+    // Should render Terminal label but no count badge
+    expect(screen.getByText("Terminal")).toBeTruthy();
+    expect(screen.queryByText("1")).toBeNull();
+  });
+
+  it("groups same tools separated by non-tool blocks into separate groups", () => {
+    const msg = makeMessage({
+      role: "assistant",
+      content: "",
+      contentBlocks: [
+        { type: "tool_use", id: "tu-1", name: "Read", input: { file_path: "/a.ts" } },
+        { type: "text", text: "Let me check something else" },
+        { type: "tool_use", id: "tu-2", name: "Read", input: { file_path: "/b.ts" } },
+      ],
+    });
+    render(<MessageBubble message={msg} />);
+
+    // The two Read tools should not be grouped since there is a text block between them
+    const labels = screen.getAllByText("Read File");
+    expect(labels.length).toBe(2);
+  });
+});

--- a/web/src/components/MessageFeed.test.tsx
+++ b/web/src/components/MessageFeed.test.tsx
@@ -1,0 +1,394 @@
+// @vitest-environment jsdom
+
+// jsdom does not implement scrollIntoView; polyfill it before any React rendering
+beforeAll(() => {
+  Element.prototype.scrollIntoView = vi.fn();
+});
+
+import { render, screen } from "@testing-library/react";
+import type { ChatMessage } from "../types.js";
+
+// Mock react-markdown to avoid ESM issues in tests
+vi.mock("react-markdown", () => ({
+  default: ({ children }: { children: string }) => <div data-testid="markdown">{children}</div>,
+}));
+
+vi.mock("remark-gfm", () => ({
+  default: {},
+}));
+
+// Build a mock for the store that returns configurable values per session
+const mockStoreValues: Record<string, unknown> = {};
+
+vi.mock("../store.js", () => ({
+  useStore: (selector: (state: Record<string, unknown>) => unknown) => {
+    const state = {
+      messages: mockStoreValues.messages ?? new Map(),
+      streaming: mockStoreValues.streaming ?? new Map(),
+      streamingStartedAt: mockStoreValues.streamingStartedAt ?? new Map(),
+      streamingOutputTokens: mockStoreValues.streamingOutputTokens ?? new Map(),
+      sessionStatus: mockStoreValues.sessionStatus ?? new Map(),
+    };
+    return selector(state);
+  },
+}));
+
+import { MessageFeed } from "./MessageFeed.js";
+
+function makeMessage(overrides: Partial<ChatMessage> & { role: ChatMessage["role"] }): ChatMessage {
+  return {
+    id: `msg-${Math.random().toString(36).slice(2, 8)}`,
+    content: "",
+    timestamp: Date.now(),
+    ...overrides,
+  };
+}
+
+function setStoreMessages(sessionId: string, msgs: ChatMessage[]) {
+  const map = new Map();
+  map.set(sessionId, msgs);
+  mockStoreValues.messages = map;
+}
+
+function setStoreStreaming(sessionId: string, text: string | undefined) {
+  const map = new Map();
+  if (text !== undefined) map.set(sessionId, text);
+  mockStoreValues.streaming = map;
+}
+
+function setStoreStatus(sessionId: string, status: string | null) {
+  const statusMap = new Map();
+  if (status) statusMap.set(sessionId, status);
+  mockStoreValues.sessionStatus = statusMap;
+}
+
+function setStoreStreamingStartedAt(sessionId: string, startedAt: number | undefined) {
+  const map = new Map();
+  if (startedAt !== undefined) map.set(sessionId, startedAt);
+  mockStoreValues.streamingStartedAt = map;
+}
+
+function setStoreStreamingOutputTokens(sessionId: string, tokens: number | undefined) {
+  const map = new Map();
+  if (tokens !== undefined) map.set(sessionId, tokens);
+  mockStoreValues.streamingOutputTokens = map;
+}
+
+function resetStore() {
+  mockStoreValues.messages = new Map();
+  mockStoreValues.streaming = new Map();
+  mockStoreValues.streamingStartedAt = new Map();
+  mockStoreValues.streamingOutputTokens = new Map();
+  mockStoreValues.sessionStatus = new Map();
+}
+
+beforeEach(() => {
+  resetStore();
+});
+
+// ─── Pure functions tested through component output ──────────────────────────
+// Since formatElapsed, formatTokens, getToolOnlyName, extractToolItems,
+// groupToolMessages, groupMessages are not exported, we test them through the
+// component's rendered output.
+
+// ─── formatElapsed (tested via generation stats bar) ─────────────────────────
+
+describe("MessageFeed - formatElapsed via stats bar", () => {
+  it("formats seconds only (e.g. '5s') for short durations", () => {
+    const sid = "test-elapsed-secs";
+    setStoreMessages(sid, [makeMessage({ role: "user", content: "hi" })]);
+    setStoreStatus(sid, "running");
+    // Set startedAt to 5 seconds ago
+    setStoreStreamingStartedAt(sid, Date.now() - 5000);
+
+    render(<MessageFeed sessionId={sid} />);
+
+    // Should show "5s" (or close) in the stats bar
+    expect(screen.getByText(/^\d+s$/)).toBeTruthy();
+  });
+
+  it("formats minutes and seconds (e.g. '2m 30s') for longer durations", () => {
+    const sid = "test-elapsed-mins";
+    setStoreMessages(sid, [makeMessage({ role: "user", content: "hi" })]);
+    setStoreStatus(sid, "running");
+    setStoreStreamingStartedAt(sid, Date.now() - 150_000); // 2m 30s ago
+
+    render(<MessageFeed sessionId={sid} />);
+
+    expect(screen.getByText(/^\d+m \d+s$/)).toBeTruthy();
+  });
+});
+
+// ─── formatTokens (tested via generation stats bar) ──────────────────────────
+
+describe("MessageFeed - formatTokens via stats bar", () => {
+  it("formats token count with 'k' suffix for values >= 1000", () => {
+    const sid = "test-tokens-k";
+    setStoreMessages(sid, [makeMessage({ role: "user", content: "hi" })]);
+    setStoreStatus(sid, "running");
+    setStoreStreamingStartedAt(sid, Date.now() - 3000);
+    setStoreStreamingOutputTokens(sid, 1500);
+
+    render(<MessageFeed sessionId={sid} />);
+
+    // Should display token count formatted as "1.5k"
+    expect(screen.getByText(/1\.5k/)).toBeTruthy();
+  });
+
+  it("formats token count as plain number for values < 1000", () => {
+    const sid = "test-tokens-plain";
+    setStoreMessages(sid, [makeMessage({ role: "user", content: "hi" })]);
+    setStoreStatus(sid, "running");
+    setStoreStreamingStartedAt(sid, Date.now() - 3000);
+    setStoreStreamingOutputTokens(sid, 500);
+
+    render(<MessageFeed sessionId={sid} />);
+
+    expect(screen.getByText(/500/)).toBeTruthy();
+  });
+});
+
+// ─── Empty state ─────────────────────────────────────────────────────────────
+
+describe("MessageFeed - empty state", () => {
+  it("shows empty state when no messages and no streaming", () => {
+    const sid = "test-empty";
+    setStoreMessages(sid, []);
+
+    render(<MessageFeed sessionId={sid} />);
+
+    expect(screen.getByText("Start a conversation")).toBeTruthy();
+    expect(screen.getByText(/Send a message to begin/)).toBeTruthy();
+  });
+
+  it("does not show empty state when there are messages", () => {
+    const sid = "test-not-empty";
+    setStoreMessages(sid, [
+      makeMessage({ role: "user", content: "Hello" }),
+    ]);
+
+    render(<MessageFeed sessionId={sid} />);
+
+    expect(screen.queryByText("Start a conversation")).toBeNull();
+  });
+});
+
+// ─── Message rendering ───────────────────────────────────────────────────────
+
+describe("MessageFeed - message rendering", () => {
+  it("renders user and assistant messages", () => {
+    const sid = "test-render-msgs";
+    setStoreMessages(sid, [
+      makeMessage({ id: "u1", role: "user", content: "What is 2+2?" }),
+      makeMessage({ id: "a1", role: "assistant", content: "The answer is 4." }),
+    ]);
+
+    render(<MessageFeed sessionId={sid} />);
+
+    expect(screen.getByText("What is 2+2?")).toBeTruthy();
+    // The assistant message goes through the mocked Markdown component
+    expect(screen.getByText("The answer is 4.")).toBeTruthy();
+  });
+
+  it("renders system messages in the feed", () => {
+    const sid = "test-system-msg";
+    setStoreMessages(sid, [
+      makeMessage({ id: "s1", role: "system", content: "Session restored" }),
+      makeMessage({ id: "u1", role: "user", content: "Continue" }),
+    ]);
+
+    render(<MessageFeed sessionId={sid} />);
+
+    expect(screen.getByText("Session restored")).toBeTruthy();
+    expect(screen.getByText("Continue")).toBeTruthy();
+  });
+});
+
+// ─── Streaming indicator ─────────────────────────────────────────────────────
+
+describe("MessageFeed - streaming text", () => {
+  it("renders streaming text with cursor animation", () => {
+    const sid = "test-streaming";
+    setStoreMessages(sid, [
+      makeMessage({ id: "u1", role: "user", content: "Hello" }),
+    ]);
+    setStoreStreaming(sid, "I am currently thinking about");
+
+    const { container } = render(<MessageFeed sessionId={sid} />);
+
+    expect(screen.getByText("I am currently thinking about")).toBeTruthy();
+    // Check for the blinking cursor element (animate class with pulse-dot)
+    const cursor = container.querySelector('[class*="animate-"]');
+    expect(cursor).toBeTruthy();
+  });
+
+  it("does not render streaming indicator when no streaming text", () => {
+    const sid = "test-no-stream";
+    setStoreMessages(sid, [
+      makeMessage({ id: "u1", role: "user", content: "Hello" }),
+    ]);
+
+    const { container } = render(<MessageFeed sessionId={sid} />);
+
+    // No pre element with streaming content
+    const preElements = container.querySelectorAll("pre.font-serif-assistant");
+    expect(preElements.length).toBe(0);
+  });
+});
+
+// ─── Generation stats bar ────────────────────────────────────────────────────
+
+describe("MessageFeed - generation stats bar", () => {
+  it("renders stats bar when session is running", () => {
+    const sid = "test-stats";
+    setStoreMessages(sid, [makeMessage({ role: "user", content: "hi" })]);
+    setStoreStatus(sid, "running");
+    setStoreStreamingStartedAt(sid, Date.now() - 10_000);
+
+    render(<MessageFeed sessionId={sid} />);
+
+    expect(screen.getByText("Generating...")).toBeTruthy();
+  });
+
+  it("does not render stats bar when session is idle", () => {
+    const sid = "test-idle";
+    setStoreMessages(sid, [makeMessage({ role: "user", content: "hi" })]);
+    setStoreStatus(sid, "idle");
+
+    render(<MessageFeed sessionId={sid} />);
+
+    expect(screen.queryByText("Generating...")).toBeNull();
+  });
+
+  it("shows output tokens in stats bar when available", () => {
+    const sid = "test-tokens-stats";
+    setStoreMessages(sid, [makeMessage({ role: "user", content: "hi" })]);
+    setStoreStatus(sid, "running");
+    setStoreStreamingStartedAt(sid, Date.now() - 5000);
+    setStoreStreamingOutputTokens(sid, 2500);
+
+    render(<MessageFeed sessionId={sid} />);
+
+    expect(screen.getByText("Generating...")).toBeTruthy();
+    // Should show "2.5k" token count
+    expect(screen.getByText(/2\.5k/)).toBeTruthy();
+  });
+});
+
+// ─── getToolOnlyName behavior (tested via grouping) ──────────────────────────
+
+describe("MessageFeed - tool-only message detection", () => {
+  it("groups consecutive same-tool assistant messages", () => {
+    const sid = "test-tool-group";
+    setStoreMessages(sid, [
+      makeMessage({
+        id: "a1",
+        role: "assistant",
+        content: "",
+        contentBlocks: [
+          { type: "tool_use", id: "tu-1", name: "Read", input: { file_path: "/a.ts" } },
+        ],
+      }),
+      makeMessage({
+        id: "a2",
+        role: "assistant",
+        content: "",
+        contentBlocks: [
+          { type: "tool_use", id: "tu-2", name: "Read", input: { file_path: "/b.ts" } },
+        ],
+      }),
+    ]);
+
+    render(<MessageFeed sessionId={sid} />);
+
+    // When grouped at message level, both should appear under a single "Read File" group
+    // with a count badge showing "2"
+    expect(screen.getByText("2")).toBeTruthy();
+    const labels = screen.getAllByText("Read File");
+    expect(labels.length).toBe(1);
+  });
+
+  it("does not group different tool types across messages", () => {
+    const sid = "test-no-tool-group";
+    setStoreMessages(sid, [
+      makeMessage({
+        id: "a1",
+        role: "assistant",
+        content: "",
+        contentBlocks: [
+          { type: "tool_use", id: "tu-1", name: "Read", input: { file_path: "/a.ts" } },
+        ],
+      }),
+      makeMessage({
+        id: "a2",
+        role: "assistant",
+        content: "",
+        contentBlocks: [
+          { type: "tool_use", id: "tu-2", name: "Bash", input: { command: "ls" } },
+        ],
+      }),
+    ]);
+
+    render(<MessageFeed sessionId={sid} />);
+
+    expect(screen.getByText("Read File")).toBeTruthy();
+    expect(screen.getByText("Terminal")).toBeTruthy();
+  });
+
+  it("does not treat assistant messages with text as tool-only", () => {
+    const sid = "test-mixed-msg";
+    setStoreMessages(sid, [
+      makeMessage({
+        id: "a1",
+        role: "assistant",
+        content: "",
+        contentBlocks: [
+          { type: "text", text: "Let me check something" },
+          { type: "tool_use", id: "tu-1", name: "Read", input: { file_path: "/a.ts" } },
+        ],
+      }),
+    ]);
+
+    render(<MessageFeed sessionId={sid} />);
+
+    // Should render as a regular message, not grouped
+    expect(screen.getByText("Let me check something")).toBeTruthy();
+    expect(screen.getByText("Read File")).toBeTruthy();
+  });
+});
+
+// ─── groupMessages with subagent nesting ─────────────────────────────────────
+
+describe("MessageFeed - subagent grouping", () => {
+  it("nests child messages under Task tool_use entries", () => {
+    const sid = "test-subagent";
+    setStoreMessages(sid, [
+      makeMessage({
+        id: "a1",
+        role: "assistant",
+        content: "",
+        contentBlocks: [
+          {
+            type: "tool_use",
+            id: "task-1",
+            name: "Task",
+            input: { description: "Research the problem", subagent_type: "researcher" },
+          },
+        ],
+      }),
+      makeMessage({
+        id: "child-1",
+        role: "assistant",
+        content: "Found the answer",
+        parentToolUseId: "task-1",
+      }),
+    ]);
+
+    render(<MessageFeed sessionId={sid} />);
+
+    // The subagent container should show the description
+    expect(screen.getByText("Research the problem")).toBeTruthy();
+    // The agent type badge should be shown
+    expect(screen.getByText("researcher")).toBeTruthy();
+  });
+});

--- a/web/src/components/PermissionBanner.test.tsx
+++ b/web/src/components/PermissionBanner.test.tsx
@@ -1,0 +1,462 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/react";
+import type { PermissionRequest } from "../../server/session-types.js";
+import type { PermissionUpdate } from "../../server/session-types.js";
+
+// Polyfill scrollIntoView for jsdom
+Element.prototype.scrollIntoView = vi.fn();
+
+// Mock react-markdown to avoid ESM/jsdom issues
+vi.mock("react-markdown", () => ({
+  default: ({ children }: { children: string }) => <div data-testid="markdown">{children}</div>,
+}));
+vi.mock("remark-gfm", () => ({
+  default: {},
+}));
+
+const mockRemovePermission = vi.fn();
+const mockSendToSession = vi.fn();
+
+vi.mock("../store.js", () => ({
+  useStore: (selector: (state: Record<string, unknown>) => unknown) =>
+    selector({ removePermission: mockRemovePermission }),
+}));
+
+vi.mock("../ws.js", () => ({
+  sendToSession: (...args: unknown[]) => mockSendToSession(...args),
+}));
+
+import { PermissionBanner } from "./PermissionBanner.js";
+
+function makePermission(overrides: Partial<PermissionRequest> = {}): PermissionRequest {
+  return {
+    request_id: "req-1",
+    tool_name: "Bash",
+    input: { command: "ls -la" },
+    tool_use_id: "tu-1",
+    timestamp: Date.now(),
+    ...overrides,
+  };
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+// ─── Label rendering ────────────────────────────────────────────────────────
+
+describe("PermissionBanner label rendering", () => {
+  it("renders 'Permission Request' label for standard tools", () => {
+    render(
+      <PermissionBanner permission={makePermission()} sessionId="s1" />,
+    );
+    expect(screen.getByText("Permission Request")).toBeTruthy();
+  });
+
+  it("renders 'Question' label for AskUserQuestion tool", () => {
+    render(
+      <PermissionBanner
+        permission={makePermission({
+          tool_name: "AskUserQuestion",
+          input: { question: "What do you want?" },
+        })}
+        sessionId="s1"
+      />,
+    );
+    expect(screen.getByText("Question")).toBeTruthy();
+    // Should NOT show "Permission Request"
+    expect(screen.queryByText("Permission Request")).toBeNull();
+  });
+});
+
+// ─── BashDisplay ─────────────────────────────────────────────────────────────
+
+describe("BashDisplay", () => {
+  it("renders the command with $ prefix", () => {
+    const { container } = render(
+      <PermissionBanner
+        permission={makePermission({
+          tool_name: "Bash",
+          input: { command: "echo hello", description: "Print hello" },
+        })}
+        sessionId="s1"
+      />,
+    );
+    // The $ prefix is in a span inside a pre, so check the pre's text content
+    const pre = container.querySelector("pre");
+    expect(pre).toBeTruthy();
+    expect(pre!.textContent).toContain("$ echo hello");
+    expect(screen.getByText("Print hello")).toBeTruthy();
+  });
+});
+
+// ─── EditDisplay ─────────────────────────────────────────────────────────────
+
+describe("EditDisplay", () => {
+  it("renders old/new strings with added/removed labels", () => {
+    render(
+      <PermissionBanner
+        permission={makePermission({
+          tool_name: "Edit",
+          input: {
+            file_path: "/src/main.ts",
+            old_string: "const a = 1;",
+            new_string: "const a = 2;",
+          },
+        })}
+        sessionId="s1"
+      />,
+    );
+    expect(screen.getByText("/src/main.ts")).toBeTruthy();
+    expect(screen.getByText("removed")).toBeTruthy();
+    expect(screen.getByText("added")).toBeTruthy();
+    expect(screen.getByText("const a = 1;")).toBeTruthy();
+    expect(screen.getByText("const a = 2;")).toBeTruthy();
+  });
+});
+
+// ─── WriteDisplay ────────────────────────────────────────────────────────────
+
+describe("WriteDisplay", () => {
+  it("renders file path and content preview", () => {
+    render(
+      <PermissionBanner
+        permission={makePermission({
+          tool_name: "Write",
+          input: {
+            file_path: "/src/output.ts",
+            content: "export default 42;",
+          },
+        })}
+        sessionId="s1"
+      />,
+    );
+    expect(screen.getByText("/src/output.ts")).toBeTruthy();
+    expect(screen.getByText("export default 42;")).toBeTruthy();
+  });
+
+  it("truncates content longer than 500 characters", () => {
+    const longContent = "x".repeat(600);
+    render(
+      <PermissionBanner
+        permission={makePermission({
+          tool_name: "Write",
+          input: {
+            file_path: "/src/big.ts",
+            content: longContent,
+          },
+        })}
+        sessionId="s1"
+      />,
+    );
+    // The displayed content should be truncated (500 chars + "...")
+    const pre = screen.getByText(/^x+\.\.\.$/);
+    expect(pre.textContent).toBe("x".repeat(500) + "...");
+  });
+});
+
+// ─── ReadDisplay ─────────────────────────────────────────────────────────────
+
+describe("ReadDisplay", () => {
+  it("renders file path", () => {
+    render(
+      <PermissionBanner
+        permission={makePermission({
+          tool_name: "Read",
+          input: { file_path: "/etc/config.json" },
+        })}
+        sessionId="s1"
+      />,
+    );
+    expect(screen.getByText("/etc/config.json")).toBeTruthy();
+  });
+});
+
+// ─── GlobDisplay ─────────────────────────────────────────────────────────────
+
+describe("GlobDisplay", () => {
+  it("renders pattern and optional path", () => {
+    render(
+      <PermissionBanner
+        permission={makePermission({
+          tool_name: "Glob",
+          input: { pattern: "**/*.ts", path: "/src" },
+        })}
+        sessionId="s1"
+      />,
+    );
+    expect(screen.getByText("**/*.ts")).toBeTruthy();
+    expect(screen.getByText("/src")).toBeTruthy();
+  });
+
+  it("renders pattern without path", () => {
+    render(
+      <PermissionBanner
+        permission={makePermission({
+          tool_name: "Glob",
+          input: { pattern: "*.json" },
+        })}
+        sessionId="s1"
+      />,
+    );
+    expect(screen.getByText("*.json")).toBeTruthy();
+  });
+});
+
+// ─── GrepDisplay ─────────────────────────────────────────────────────────────
+
+describe("GrepDisplay", () => {
+  it("renders pattern, path, and glob", () => {
+    render(
+      <PermissionBanner
+        permission={makePermission({
+          tool_name: "Grep",
+          input: { pattern: "TODO", path: "/src", glob: "*.ts" },
+        })}
+        sessionId="s1"
+      />,
+    );
+    expect(screen.getByText("TODO")).toBeTruthy();
+    expect(screen.getByText("/src")).toBeTruthy();
+    expect(screen.getByText("*.ts")).toBeTruthy();
+  });
+});
+
+// ─── GenericDisplay ──────────────────────────────────────────────────────────
+
+describe("GenericDisplay", () => {
+  it("renders key-value pairs for unknown tools", () => {
+    render(
+      <PermissionBanner
+        permission={makePermission({
+          tool_name: "SomeUnknownTool",
+          input: { foo: "bar", count: 42 },
+        })}
+        sessionId="s1"
+      />,
+    );
+    expect(screen.getByText("foo:")).toBeTruthy();
+    expect(screen.getByText("bar")).toBeTruthy();
+    expect(screen.getByText("count:")).toBeTruthy();
+    expect(screen.getByText("42")).toBeTruthy();
+  });
+
+  it("renders description when no entries", () => {
+    render(
+      <PermissionBanner
+        permission={makePermission({
+          tool_name: "SomeUnknownTool",
+          input: {},
+          description: "A custom tool description",
+        })}
+        sessionId="s1"
+      />,
+    );
+    expect(screen.getByText("A custom tool description")).toBeTruthy();
+  });
+});
+
+// ─── Allow / Deny buttons ────────────────────────────────────────────────────
+
+describe("Allow and Deny buttons", () => {
+  it("Allow button calls sendToSession with correct permission_response", () => {
+    const perm = makePermission({ request_id: "req-42" });
+    render(<PermissionBanner permission={perm} sessionId="s1" />);
+
+    fireEvent.click(screen.getByText("Allow"));
+
+    expect(mockSendToSession).toHaveBeenCalledWith("s1", {
+      type: "permission_response",
+      request_id: "req-42",
+      behavior: "allow",
+      updated_input: undefined,
+    });
+    expect(mockRemovePermission).toHaveBeenCalledWith("s1", "req-42");
+  });
+
+  it("Deny button calls sendToSession with deny behavior", () => {
+    const perm = makePermission({ request_id: "req-43" });
+    render(<PermissionBanner permission={perm} sessionId="s1" />);
+
+    fireEvent.click(screen.getByText("Deny"));
+
+    expect(mockSendToSession).toHaveBeenCalledWith("s1", {
+      type: "permission_response",
+      request_id: "req-43",
+      behavior: "deny",
+      message: "Denied by user",
+    });
+    expect(mockRemovePermission).toHaveBeenCalledWith("s1", "req-43");
+  });
+});
+
+// ─── Permission suggestion buttons ──────────────────────────────────────────
+
+describe("Permission suggestion buttons", () => {
+  it("renders addRules suggestion with correct label", () => {
+    const suggestion: PermissionUpdate = {
+      type: "addRules",
+      rules: [{ toolName: "Bash", ruleContent: "allow ls" }],
+      behavior: "allow",
+      destination: "session",
+    };
+    const perm = makePermission({ permission_suggestions: [suggestion] });
+    render(<PermissionBanner permission={perm} sessionId="s1" />);
+
+    expect(screen.getByText('Allow "allow ls" for session')).toBeTruthy();
+  });
+
+  it("renders setMode suggestion with correct label", () => {
+    const suggestion: PermissionUpdate = {
+      type: "setMode",
+      mode: "bypassPermissions",
+      destination: "session",
+    };
+    const perm = makePermission({ permission_suggestions: [suggestion] });
+    render(<PermissionBanner permission={perm} sessionId="s1" />);
+
+    expect(screen.getByText('Set mode to "bypassPermissions"')).toBeTruthy();
+  });
+
+  it("renders addDirectories suggestion with correct label", () => {
+    const suggestion: PermissionUpdate = {
+      type: "addDirectories",
+      directories: ["/home/user/project"],
+      destination: "userSettings",
+    };
+    const perm = makePermission({ permission_suggestions: [suggestion] });
+    render(<PermissionBanner permission={perm} sessionId="s1" />);
+
+    expect(screen.getByText("Trust /home/user/project always")).toBeTruthy();
+  });
+
+  it("clicking a suggestion calls sendToSession with updated_permissions", () => {
+    const suggestion: PermissionUpdate = {
+      type: "addRules",
+      rules: [{ toolName: "Bash" }],
+      behavior: "allow",
+      destination: "session",
+    };
+    const perm = makePermission({
+      request_id: "req-50",
+      permission_suggestions: [suggestion],
+    });
+    render(<PermissionBanner permission={perm} sessionId="s1" />);
+
+    fireEvent.click(screen.getByText("Allow Bash for session"));
+
+    expect(mockSendToSession).toHaveBeenCalledWith("s1", {
+      type: "permission_response",
+      request_id: "req-50",
+      behavior: "allow",
+      updated_input: undefined,
+      updated_permissions: [suggestion],
+    });
+  });
+});
+
+// ─── AskUserQuestionDisplay ──────────────────────────────────────────────────
+
+describe("AskUserQuestionDisplay", () => {
+  it("renders options and handles selection", () => {
+    const perm = makePermission({
+      request_id: "req-ask-1",
+      tool_name: "AskUserQuestion",
+      input: {
+        questions: [
+          {
+            header: "Pick one",
+            question: "Which color?",
+            options: [
+              { label: "Red", description: "A warm color" },
+              { label: "Blue", description: "A cool color" },
+            ],
+          },
+        ],
+      },
+    });
+    render(<PermissionBanner permission={perm} sessionId="s1" />);
+
+    expect(screen.getByText("Pick one")).toBeTruthy();
+    expect(screen.getByText("Which color?")).toBeTruthy();
+    expect(screen.getByText("Red")).toBeTruthy();
+    expect(screen.getByText("Blue")).toBeTruthy();
+    expect(screen.getByText("A warm color")).toBeTruthy();
+    expect(screen.getByText("A cool color")).toBeTruthy();
+
+    // Clicking an option with a single question auto-submits
+    fireEvent.click(screen.getByText("Red"));
+
+    expect(mockSendToSession).toHaveBeenCalledWith("s1", expect.objectContaining({
+      type: "permission_response",
+      request_id: "req-ask-1",
+      behavior: "allow",
+    }));
+    // The updated_input spreads permission.input and adds { answers: { "0": "Red" } }
+    const call = mockSendToSession.mock.calls[0][1];
+    expect(call.updated_input.answers).toEqual({ "0": "Red" });
+  });
+
+  it("renders fallback for simple question string", () => {
+    const perm = makePermission({
+      tool_name: "AskUserQuestion",
+      input: { question: "Are you sure?" },
+    });
+    render(<PermissionBanner permission={perm} sessionId="s1" />);
+
+    expect(screen.getByText("Are you sure?")).toBeTruthy();
+  });
+
+  it("does not show Allow/Deny buttons for AskUserQuestion", () => {
+    const perm = makePermission({
+      tool_name: "AskUserQuestion",
+      input: { question: "Yes or no?" },
+    });
+    render(<PermissionBanner permission={perm} sessionId="s1" />);
+
+    expect(screen.queryByText("Allow")).toBeNull();
+    expect(screen.queryByText("Deny")).toBeNull();
+  });
+});
+
+// ─── ExitPlanModeDisplay ─────────────────────────────────────────────────────
+
+describe("ExitPlanModeDisplay", () => {
+  it("renders plan markdown and allowed prompts", () => {
+    const perm = makePermission({
+      tool_name: "ExitPlanMode",
+      input: {
+        plan: "## Step 1\nDo something",
+        allowedPrompts: [
+          { tool: "Bash", prompt: "Run tests" },
+          { tool: "Edit", prompt: "Fix typo" },
+        ],
+      },
+    });
+    render(<PermissionBanner permission={perm} sessionId="s1" />);
+
+    // Plan header
+    expect(screen.getByText("Plan")).toBeTruthy();
+    // Markdown content rendered via mock
+    expect(screen.getByTestId("markdown")).toBeTruthy();
+    expect(screen.getByTestId("markdown").textContent).toBe("## Step 1\nDo something");
+
+    // Allowed prompts
+    expect(screen.getByText("Requested permissions")).toBeTruthy();
+    expect(screen.getByText("Bash")).toBeTruthy();
+    expect(screen.getByText("Run tests")).toBeTruthy();
+    expect(screen.getByText("Edit")).toBeTruthy();
+    expect(screen.getByText("Fix typo")).toBeTruthy();
+  });
+
+  it("renders fallback when no plan or prompts", () => {
+    const perm = makePermission({
+      tool_name: "ExitPlanMode",
+      input: {},
+    });
+    render(<PermissionBanner permission={perm} sessionId="s1" />);
+
+    expect(screen.getByText("Plan approval requested")).toBeTruthy();
+  });
+});

--- a/web/src/components/Sidebar.test.tsx
+++ b/web/src/components/Sidebar.test.tsx
@@ -1,0 +1,397 @@
+// @vitest-environment jsdom
+import { render, screen, fireEvent } from "@testing-library/react";
+import "@testing-library/jest-dom";
+import type { SessionState, SdkSessionInfo } from "../types.js";
+
+// ─── Mock setup ──────────────────────────────────────────────────────────────
+
+const mockConnectSession = vi.fn();
+const mockDisconnectSession = vi.fn();
+
+vi.mock("../ws.js", () => ({
+  connectSession: (...args: unknown[]) => mockConnectSession(...args),
+  disconnectSession: (...args: unknown[]) => mockDisconnectSession(...args),
+}));
+
+const mockApi = {
+  listSessions: vi.fn().mockResolvedValue([]),
+  deleteSession: vi.fn().mockResolvedValue({}),
+  archiveSession: vi.fn().mockResolvedValue({}),
+  unarchiveSession: vi.fn().mockResolvedValue({}),
+};
+
+vi.mock("../api.js", () => ({
+  api: {
+    listSessions: (...args: unknown[]) => mockApi.listSessions(...args),
+    deleteSession: (...args: unknown[]) => mockApi.deleteSession(...args),
+    archiveSession: (...args: unknown[]) => mockApi.archiveSession(...args),
+    unarchiveSession: (...args: unknown[]) => mockApi.unarchiveSession(...args),
+  },
+}));
+
+// Mock EnvManager to avoid rendering complexity
+vi.mock("./EnvManager.js", () => ({
+  EnvManager: () => <div data-testid="env-manager">EnvManager</div>,
+}));
+
+// ─── Store mock helpers ──────────────────────────────────────────────────────
+
+// We need to mock the store. The Sidebar uses `useStore((s) => s.xxx)` selector pattern.
+// We'll provide a real-ish mock that supports selector calls.
+
+interface MockStoreState {
+  sessions: Map<string, SessionState>;
+  sdkSessions: SdkSessionInfo[];
+  currentSessionId: string | null;
+  darkMode: boolean;
+  cliConnected: Map<string, boolean>;
+  sessionStatus: Map<string, "idle" | "running" | "compacting" | null>;
+  sessionNames: Map<string, string>;
+  pendingPermissions: Map<string, Map<string, unknown>>;
+  setCurrentSession: ReturnType<typeof vi.fn>;
+  toggleDarkMode: ReturnType<typeof vi.fn>;
+  removeSession: ReturnType<typeof vi.fn>;
+  newSession: ReturnType<typeof vi.fn>;
+  setSidebarOpen: ReturnType<typeof vi.fn>;
+  setSessionName: ReturnType<typeof vi.fn>;
+  setSdkSessions: ReturnType<typeof vi.fn>;
+}
+
+function makeSession(id: string, overrides: Partial<SessionState> = {}): SessionState {
+  return {
+    session_id: id,
+    model: "claude-sonnet-4-5-20250929",
+    cwd: "/home/user/projects/myapp",
+    tools: [],
+    permissionMode: "default",
+    claude_code_version: "1.0",
+    mcp_servers: [],
+    agents: [],
+    slash_commands: [],
+    skills: [],
+    total_cost_usd: 0,
+    num_turns: 0,
+    context_used_percent: 0,
+    is_compacting: false,
+    git_branch: "",
+    is_worktree: false,
+    repo_root: "",
+    git_ahead: 0,
+    git_behind: 0,
+    total_lines_added: 0,
+    total_lines_removed: 0,
+    ...overrides,
+  };
+}
+
+function makeSdkSession(id: string, overrides: Partial<SdkSessionInfo> = {}): SdkSessionInfo {
+  return {
+    sessionId: id,
+    state: "connected",
+    cwd: "/home/user/projects/myapp",
+    createdAt: Date.now(),
+    archived: false,
+    ...overrides,
+  };
+}
+
+let mockState: MockStoreState;
+
+function createMockState(overrides: Partial<MockStoreState> = {}): MockStoreState {
+  return {
+    sessions: new Map(),
+    sdkSessions: [],
+    currentSessionId: null,
+    darkMode: false,
+    cliConnected: new Map(),
+    sessionStatus: new Map(),
+    sessionNames: new Map(),
+    pendingPermissions: new Map(),
+    setCurrentSession: vi.fn(),
+    toggleDarkMode: vi.fn(),
+    removeSession: vi.fn(),
+    newSession: vi.fn(),
+    setSidebarOpen: vi.fn(),
+    setSessionName: vi.fn(),
+    setSdkSessions: vi.fn(),
+    ...overrides,
+  };
+}
+
+// Mock the store module
+vi.mock("../store.js", () => {
+  // We create a function that acts like the zustand hook with selectors
+  const useStoreFn = (selector: (state: MockStoreState) => unknown) => {
+    return selector(mockState);
+  };
+  // Also support useStore.getState() which Sidebar uses directly
+  useStoreFn.getState = () => mockState;
+
+  return { useStore: useStoreFn };
+});
+
+// ─── Import component after mocks ───────────────────────────────────────────
+
+import { Sidebar } from "./Sidebar.js";
+
+// ─── Tests ──────────────────────────────────────────────────────────────────
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockState = createMockState();
+});
+
+describe("Sidebar", () => {
+  it("renders 'New Session' button", () => {
+    render(<Sidebar />);
+    expect(screen.getByText("New Session")).toBeInTheDocument();
+  });
+
+  it("renders 'No sessions yet.' when no sessions exist", () => {
+    render(<Sidebar />);
+    expect(screen.getByText("No sessions yet.")).toBeInTheDocument();
+  });
+
+  it("renders session items for active sessions", () => {
+    const session = makeSession("s1");
+    const sdk = makeSdkSession("s1", { model: "claude-sonnet-4-5-20250929" });
+    mockState = createMockState({
+      sessions: new Map([["s1", session]]),
+      sdkSessions: [sdk],
+    });
+
+    render(<Sidebar />);
+    // The session label defaults to model name
+    expect(screen.getByText("claude-sonnet-4-5-20250929")).toBeInTheDocument();
+  });
+
+  it("session items show model name or session ID", () => {
+    // Session with model name
+    const session1 = makeSession("s1", { model: "claude-opus-4-6" });
+    const sdk1 = makeSdkSession("s1", { model: "claude-opus-4-6" });
+
+    // Session without model (falls back to short ID)
+    const session2 = makeSession("abcdef12-3456-7890-abcd-ef1234567890", { model: "" });
+    const sdk2 = makeSdkSession("abcdef12-3456-7890-abcd-ef1234567890", { model: "" });
+
+    mockState = createMockState({
+      sessions: new Map([
+        ["s1", session1],
+        ["abcdef12-3456-7890-abcd-ef1234567890", session2],
+      ]),
+      sdkSessions: [sdk1, sdk2],
+    });
+
+    render(<Sidebar />);
+    expect(screen.getByText("claude-opus-4-6")).toBeInTheDocument();
+    // Falls back to shortId (first 8 chars)
+    expect(screen.getByText("abcdef12")).toBeInTheDocument();
+  });
+
+  it("session items show directory name from cwd", () => {
+    const session = makeSession("s1", { cwd: "/home/user/projects/myapp" });
+    const sdk = makeSdkSession("s1");
+    mockState = createMockState({
+      sessions: new Map([["s1", session]]),
+      sdkSessions: [sdk],
+    });
+
+    render(<Sidebar />);
+    expect(screen.getByText("myapp")).toBeInTheDocument();
+  });
+
+  it("session items show git branch when available", () => {
+    const session = makeSession("s1", { git_branch: "feature/awesome" });
+    const sdk = makeSdkSession("s1");
+    mockState = createMockState({
+      sessions: new Map([["s1", session]]),
+      sdkSessions: [sdk],
+    });
+
+    render(<Sidebar />);
+    expect(screen.getByText("feature/awesome")).toBeInTheDocument();
+  });
+
+  it("session items show worktree badge when is_worktree is true", () => {
+    const session = makeSession("s1", { git_branch: "feature/wt", is_worktree: true });
+    const sdk = makeSdkSession("s1", { isWorktree: true });
+    mockState = createMockState({
+      sessions: new Map([["s1", session]]),
+      sdkSessions: [sdk],
+    });
+
+    render(<Sidebar />);
+    expect(screen.getByText("wt")).toBeInTheDocument();
+  });
+
+  it("session items show ahead/behind counts", () => {
+    const session = makeSession("s1", {
+      git_branch: "main",
+      git_ahead: 3,
+      git_behind: 2,
+    });
+    const sdk = makeSdkSession("s1");
+    mockState = createMockState({
+      sessions: new Map([["s1", session]]),
+      sdkSessions: [sdk],
+    });
+
+    render(<Sidebar />);
+    // The component renders "3↑" and "2↓" using HTML entities
+    const container = screen.getByText("main").closest("div")!;
+    expect(container.textContent).toContain("3");
+    expect(container.textContent).toContain("2");
+  });
+
+  it("session items show lines added/removed", () => {
+    const session = makeSession("s1", {
+      git_branch: "main",
+      total_lines_added: 42,
+      total_lines_removed: 7,
+    });
+    const sdk = makeSdkSession("s1");
+    mockState = createMockState({
+      sessions: new Map([["s1", session]]),
+      sdkSessions: [sdk],
+    });
+
+    render(<Sidebar />);
+    expect(screen.getByText("+42")).toBeInTheDocument();
+    expect(screen.getByText("-7")).toBeInTheDocument();
+  });
+
+  it("active session has highlighted styling (bg-cc-active class)", () => {
+    const session = makeSession("s1");
+    const sdk = makeSdkSession("s1");
+    mockState = createMockState({
+      sessions: new Map([["s1", session]]),
+      sdkSessions: [sdk],
+      currentSessionId: "s1",
+    });
+
+    render(<Sidebar />);
+    // Find the session button element
+    const sessionButton = screen.getByText("claude-sonnet-4-5-20250929").closest("button");
+    expect(sessionButton).toHaveClass("bg-cc-active");
+  });
+
+  it("clicking a session calls setCurrentSession and connectSession", () => {
+    const session = makeSession("s1");
+    const sdk = makeSdkSession("s1");
+    mockState = createMockState({
+      sessions: new Map([["s1", session]]),
+      sdkSessions: [sdk],
+      currentSessionId: null,
+    });
+
+    render(<Sidebar />);
+    const sessionButton = screen.getByText("claude-sonnet-4-5-20250929").closest("button")!;
+    fireEvent.click(sessionButton);
+
+    expect(mockState.setCurrentSession).toHaveBeenCalledWith("s1");
+    expect(mockConnectSession).toHaveBeenCalledWith("s1");
+  });
+
+  it("New Session button calls newSession", () => {
+    render(<Sidebar />);
+    fireEvent.click(screen.getByText("New Session"));
+
+    expect(mockState.newSession).toHaveBeenCalled();
+  });
+
+  it("double-clicking a session enters edit mode", () => {
+    const session = makeSession("s1");
+    const sdk = makeSdkSession("s1");
+    mockState = createMockState({
+      sessions: new Map([["s1", session]]),
+      sdkSessions: [sdk],
+    });
+
+    render(<Sidebar />);
+    const sessionButton = screen.getByText("claude-sonnet-4-5-20250929").closest("button")!;
+    fireEvent.doubleClick(sessionButton);
+
+    // After double-click, an input should appear for renaming
+    const input = screen.getByDisplayValue("claude-sonnet-4-5-20250929");
+    expect(input).toBeInTheDocument();
+    expect(input.tagName).toBe("INPUT");
+  });
+
+  it("archive button exists in the DOM for session items", () => {
+    const session = makeSession("s1");
+    const sdk = makeSdkSession("s1");
+    mockState = createMockState({
+      sessions: new Map([["s1", session]]),
+      sdkSessions: [sdk],
+    });
+
+    render(<Sidebar />);
+    // Archive button has title "Archive session"
+    const archiveButton = screen.getByTitle("Archive session");
+    expect(archiveButton).toBeInTheDocument();
+  });
+
+  it("archived sessions section shows count", () => {
+    const sdk1 = makeSdkSession("s1", { archived: false });
+    const sdk2 = makeSdkSession("s2", { archived: true });
+    const sdk3 = makeSdkSession("s3", { archived: true });
+
+    mockState = createMockState({
+      sdkSessions: [sdk1, sdk2, sdk3],
+    });
+
+    render(<Sidebar />);
+    // The component renders "Archived (2)"
+    expect(screen.getByText(/Archived \(2\)/)).toBeInTheDocument();
+  });
+
+  it("toggle archived shows/hides archived sessions", () => {
+    const sdk1 = makeSdkSession("s1", { archived: false, model: "active-model" });
+    const sdk2 = makeSdkSession("s2", { archived: true, model: "archived-model" });
+
+    mockState = createMockState({
+      sdkSessions: [sdk1, sdk2],
+    });
+
+    render(<Sidebar />);
+
+    // Archived sessions should not be visible initially
+    expect(screen.queryByText("archived-model")).not.toBeInTheDocument();
+
+    // Click the archived toggle button
+    const toggleButton = screen.getByText(/Archived \(1\)/);
+    fireEvent.click(toggleButton);
+
+    // Now the archived session should be visible
+    expect(screen.getByText("archived-model")).toBeInTheDocument();
+  });
+
+  it("dark mode button toggles theme", () => {
+    mockState = createMockState({ darkMode: false });
+
+    render(<Sidebar />);
+    const darkModeButton = screen.getByText("Dark mode").closest("button")!;
+    fireEvent.click(darkModeButton);
+
+    expect(mockState.toggleDarkMode).toHaveBeenCalled();
+  });
+
+  it("permission badge shows count for sessions with pending permissions", () => {
+    const session = makeSession("s1");
+    const sdk = makeSdkSession("s1");
+    const permMap = new Map<string, unknown>([
+      ["r1", { request_id: "r1", tool_name: "Bash" }],
+      ["r2", { request_id: "r2", tool_name: "Read" }],
+    ]);
+    mockState = createMockState({
+      sessions: new Map([["s1", session]]),
+      sdkSessions: [sdk],
+      pendingPermissions: new Map([["s1", permMap as Map<string, unknown>]]),
+      cliConnected: new Map([["s1", true]]),
+    });
+
+    render(<Sidebar />);
+    // The permission count badge shows "2"
+    expect(screen.getByText("2")).toBeInTheDocument();
+  });
+});

--- a/web/src/components/ToolBlock.test.tsx
+++ b/web/src/components/ToolBlock.test.tsx
@@ -1,0 +1,354 @@
+// @vitest-environment jsdom
+import { render, screen, fireEvent } from "@testing-library/react";
+import { ToolBlock, ToolIcon, getToolIcon, getToolLabel, getPreview } from "./ToolBlock.js";
+
+// ─── getToolIcon ─────────────────────────────────────────────────────────────
+
+describe("getToolIcon", () => {
+  it("returns 'terminal' for Bash", () => {
+    expect(getToolIcon("Bash")).toBe("terminal");
+  });
+
+  it("returns 'file' for Read", () => {
+    expect(getToolIcon("Read")).toBe("file");
+  });
+
+  it("returns 'file-plus' for Write", () => {
+    expect(getToolIcon("Write")).toBe("file-plus");
+  });
+
+  it("returns 'file-edit' for Edit", () => {
+    expect(getToolIcon("Edit")).toBe("file-edit");
+  });
+
+  it("returns 'search' for Glob", () => {
+    expect(getToolIcon("Glob")).toBe("search");
+  });
+
+  it("returns 'search' for Grep", () => {
+    expect(getToolIcon("Grep")).toBe("search");
+  });
+
+  it("returns 'globe' for WebFetch", () => {
+    expect(getToolIcon("WebFetch")).toBe("globe");
+  });
+
+  it("returns 'globe' for WebSearch", () => {
+    expect(getToolIcon("WebSearch")).toBe("globe");
+  });
+
+  it("returns 'list' for TaskCreate", () => {
+    expect(getToolIcon("TaskCreate")).toBe("list");
+  });
+
+  it("returns 'message' for SendMessage", () => {
+    expect(getToolIcon("SendMessage")).toBe("message");
+  });
+
+  it("returns 'tool' for unknown tool names", () => {
+    expect(getToolIcon("SomeUnknownTool")).toBe("tool");
+    expect(getToolIcon("")).toBe("tool");
+    expect(getToolIcon("FooBar")).toBe("tool");
+  });
+});
+
+// ─── getToolLabel ────────────────────────────────────────────────────────────
+
+describe("getToolLabel", () => {
+  it("returns 'Terminal' for Bash", () => {
+    expect(getToolLabel("Bash")).toBe("Terminal");
+  });
+
+  it("returns 'Read File' for Read", () => {
+    expect(getToolLabel("Read")).toBe("Read File");
+  });
+
+  it("returns 'Write File' for Write", () => {
+    expect(getToolLabel("Write")).toBe("Write File");
+  });
+
+  it("returns 'Edit File' for Edit", () => {
+    expect(getToolLabel("Edit")).toBe("Edit File");
+  });
+
+  it("returns 'Find Files' for Glob", () => {
+    expect(getToolLabel("Glob")).toBe("Find Files");
+  });
+
+  it("returns 'Search Content' for Grep", () => {
+    expect(getToolLabel("Grep")).toBe("Search Content");
+  });
+
+  it("returns the name itself for unknown tools", () => {
+    expect(getToolLabel("WebFetch")).toBe("WebFetch");
+    expect(getToolLabel("SomeUnknownTool")).toBe("SomeUnknownTool");
+    expect(getToolLabel("CustomTool")).toBe("CustomTool");
+  });
+});
+
+// ─── getPreview ──────────────────────────────────────────────────────────────
+
+describe("getPreview", () => {
+  it("extracts command for Bash tools", () => {
+    expect(getPreview("Bash", { command: "ls -la" })).toBe("ls -la");
+  });
+
+  it("truncates Bash commands longer than 60 chars", () => {
+    const longCommand = "a".repeat(80);
+    const result = getPreview("Bash", { command: longCommand });
+    expect(result).toBe("a".repeat(60) + "...");
+    expect(result.length).toBe(63);
+  });
+
+  it("does not truncate Bash commands at exactly 60 chars", () => {
+    const exactCommand = "b".repeat(60);
+    expect(getPreview("Bash", { command: exactCommand })).toBe(exactCommand);
+  });
+
+  it("extracts last 2 path segments for Read", () => {
+    expect(getPreview("Read", { file_path: "/home/user/project/src/index.ts" })).toBe("src/index.ts");
+  });
+
+  it("extracts last 2 path segments for Write", () => {
+    expect(getPreview("Write", { file_path: "/var/log/app.log" })).toBe("log/app.log");
+  });
+
+  it("extracts last 2 path segments for Edit", () => {
+    expect(getPreview("Edit", { file_path: "/a/b/c/d.txt" })).toBe("c/d.txt");
+  });
+
+  it("handles short paths for file tools", () => {
+    expect(getPreview("Read", { file_path: "file.txt" })).toBe("file.txt");
+  });
+
+  it("extracts pattern for Glob", () => {
+    expect(getPreview("Glob", { pattern: "**/*.ts" })).toBe("**/*.ts");
+  });
+
+  it("extracts pattern for Grep", () => {
+    expect(getPreview("Grep", { pattern: "TODO|FIXME" })).toBe("TODO|FIXME");
+  });
+
+  it("extracts query for WebSearch", () => {
+    expect(getPreview("WebSearch", { query: "react testing library" })).toBe("react testing library");
+  });
+
+  it("returns empty string for unknown tools", () => {
+    expect(getPreview("UnknownTool", { some: "data" })).toBe("");
+  });
+
+  it("returns empty string for Bash without command", () => {
+    expect(getPreview("Bash", { description: "something" })).toBe("");
+  });
+
+  it("returns empty string for Read without file_path", () => {
+    expect(getPreview("Read", { content: "data" })).toBe("");
+  });
+});
+
+// ─── ToolIcon ────────────────────────────────────────────────────────────────
+
+describe("ToolIcon", () => {
+  it("renders an SVG for terminal type", () => {
+    const { container } = render(<ToolIcon type="terminal" />);
+    const svg = container.querySelector("svg");
+    expect(svg).toBeTruthy();
+    expect(svg?.querySelector("polyline")).toBeTruthy();
+  });
+
+  it("renders an SVG for file type", () => {
+    const { container } = render(<ToolIcon type="file" />);
+    const svg = container.querySelector("svg");
+    expect(svg).toBeTruthy();
+    expect(svg?.querySelector("path")).toBeTruthy();
+  });
+
+  it("renders an SVG for search type", () => {
+    const { container } = render(<ToolIcon type="search" />);
+    const svg = container.querySelector("svg");
+    expect(svg).toBeTruthy();
+    expect(svg?.querySelector("circle")).toBeTruthy();
+  });
+
+  it("renders an SVG for globe type", () => {
+    const { container } = render(<ToolIcon type="globe" />);
+    const svg = container.querySelector("svg");
+    expect(svg).toBeTruthy();
+    expect(svg?.querySelector("circle")).toBeTruthy();
+  });
+
+  it("renders an SVG for message type", () => {
+    const { container } = render(<ToolIcon type="message" />);
+    const svg = container.querySelector("svg");
+    expect(svg).toBeTruthy();
+  });
+
+  it("renders an SVG for list type", () => {
+    const { container } = render(<ToolIcon type="list" />);
+    const svg = container.querySelector("svg");
+    expect(svg).toBeTruthy();
+  });
+
+  it("renders a default SVG for unknown type", () => {
+    const { container } = render(<ToolIcon type="tool" />);
+    const svg = container.querySelector("svg");
+    expect(svg).toBeTruthy();
+    expect(svg?.querySelector("path")).toBeTruthy();
+  });
+});
+
+// ─── ToolBlock component ─────────────────────────────────────────────────────
+
+describe("ToolBlock", () => {
+  it("renders with correct label and preview", () => {
+    render(
+      <ToolBlock
+        name="Bash"
+        input={{ command: "echo hello" }}
+        toolUseId="tool-1"
+      />
+    );
+    expect(screen.getByText("Terminal")).toBeTruthy();
+    // Preview text appears in the header button area
+    const previewSpan = screen.getByText("echo hello");
+    expect(previewSpan).toBeTruthy();
+    expect(previewSpan.className).toContain("truncate");
+  });
+
+  it("renders with label only when no preview is available", () => {
+    render(
+      <ToolBlock
+        name="WebFetch"
+        input={{ url: "https://example.com" }}
+        toolUseId="tool-2"
+      />
+    );
+    expect(screen.getByText("WebFetch")).toBeTruthy();
+  });
+
+  it("is collapsed by default (does not show details)", () => {
+    render(
+      <ToolBlock
+        name="Bash"
+        input={{ command: "ls -la" }}
+        toolUseId="tool-3"
+      />
+    );
+    // The expanded detail area should not be present
+    expect(screen.queryByText("$")).toBeNull();
+  });
+
+  it("expands on click to show input details", () => {
+    render(
+      <ToolBlock
+        name="Bash"
+        input={{ command: "ls -la" }}
+        toolUseId="tool-4"
+      />
+    );
+
+    // Click the button to expand
+    const button = screen.getByRole("button");
+    fireEvent.click(button);
+
+    // After expanding, the detail area should be visible with a pre element
+    const allLsLa = screen.getAllByText("ls -la");
+    // One is the preview in the header, the other is in the expanded pre block
+    expect(allLsLa.length).toBe(2);
+    const preElement = allLsLa.find((el) => el.closest("pre"))?.closest("pre");
+    expect(preElement).toBeTruthy();
+  });
+
+  it("collapses on second click", () => {
+    const { container } = render(
+      <ToolBlock
+        name="Bash"
+        input={{ command: "ls -la" }}
+        toolUseId="tool-5"
+      />
+    );
+
+    const button = screen.getByRole("button");
+
+    // Expand - the detail area with the border-t class should appear
+    fireEvent.click(button);
+    expect(container.querySelector(".border-t")).toBeTruthy();
+
+    // Collapse - the detail area should disappear
+    fireEvent.click(button);
+    expect(container.querySelector(".border-t")).toBeNull();
+  });
+
+  it("renders Bash command with $ prefix when expanded", () => {
+    render(
+      <ToolBlock
+        name="Bash"
+        input={{ command: "npm install" }}
+        toolUseId="tool-6"
+      />
+    );
+
+    fireEvent.click(screen.getByRole("button"));
+
+    // When expanded, the command appears in both the preview header and the code block.
+    // Find the pre element containing the $ prefix.
+    const allMatches = screen.getAllByText("npm install");
+    const preElement = allMatches.find((el) => el.closest("pre"))?.closest("pre");
+    expect(preElement).toBeTruthy();
+    // Check the $ prefix is rendered as a span inside the pre
+    const dollarSpan = preElement?.querySelector("span");
+    expect(dollarSpan?.textContent).toBe("$ ");
+  });
+
+  it("renders Edit diff view when expanded", () => {
+    render(
+      <ToolBlock
+        name="Edit"
+        input={{
+          file_path: "/home/user/src/app.ts",
+          old_string: "const x = 1;",
+          new_string: "const x = 2;",
+        }}
+        toolUseId="tool-7"
+      />
+    );
+
+    fireEvent.click(screen.getByRole("button"));
+
+    // The preview header shows "src/app.ts" (last 2 segments), expanded shows full path
+    expect(screen.getByText("/home/user/src/app.ts")).toBeTruthy();
+    // Check diff sections
+    expect(screen.getByText("removed")).toBeTruthy();
+    expect(screen.getByText("added")).toBeTruthy();
+    expect(screen.getByText("const x = 1;")).toBeTruthy();
+    expect(screen.getByText("const x = 2;")).toBeTruthy();
+  });
+
+  it("renders Read file path when expanded", () => {
+    render(
+      <ToolBlock
+        name="Read"
+        input={{ file_path: "/home/user/test.txt" }}
+        toolUseId="tool-8"
+      />
+    );
+
+    fireEvent.click(screen.getByRole("button"));
+    expect(screen.getByText("/home/user/test.txt")).toBeTruthy();
+  });
+
+  it("renders JSON for unknown tools when expanded", () => {
+    render(
+      <ToolBlock
+        name="CustomTool"
+        input={{ foo: "bar", count: 42 }}
+        toolUseId="tool-9"
+      />
+    );
+
+    fireEvent.click(screen.getByRole("button"));
+    const preElement = document.querySelector("pre");
+    expect(preElement?.textContent).toContain('"foo": "bar"');
+    expect(preElement?.textContent).toContain('"count": 42');
+  });
+});

--- a/web/src/utils/names.test.ts
+++ b/web/src/utils/names.test.ts
@@ -1,0 +1,123 @@
+import { generateSessionName, generateUniqueSessionName } from "./names.js";
+
+describe("generateSessionName", () => {
+  it("returns a string with two words separated by a space", () => {
+    const name = generateSessionName();
+    const parts = name.split(" ");
+    expect(parts).toHaveLength(2);
+    expect(parts[0].length).toBeGreaterThan(0);
+    expect(parts[1].length).toBeGreaterThan(0);
+  });
+
+  it("returns names where both words are capitalized", () => {
+    // Run multiple times to increase confidence
+    for (let i = 0; i < 20; i++) {
+      const name = generateSessionName();
+      const [adj, noun] = name.split(" ");
+      expect(adj[0]).toBe(adj[0].toUpperCase());
+      expect(noun[0]).toBe(noun[0].toUpperCase());
+    }
+  });
+
+  it("produces different results across multiple calls (statistical)", () => {
+    const names = new Set<string>();
+    for (let i = 0; i < 10; i++) {
+      names.add(generateSessionName());
+    }
+    // With 40 adjectives * 40 nouns = 1600 combinations, getting the same result
+    // 10 times in a row is astronomically unlikely (1/1600^9)
+    expect(names.size).toBeGreaterThan(1);
+  });
+});
+
+describe("generateUniqueSessionName", () => {
+  it("returns a name not in the existing set", () => {
+    const existing = new Set(["Swift Falcon", "Calm River", "Bold Cedar"]);
+    const name = generateUniqueSessionName(existing);
+    expect(existing.has(name)).toBe(false);
+    // Should still be a valid two-word name
+    expect(name.split(" ")).toHaveLength(2);
+  });
+
+  it("returns a valid name when given an empty set", () => {
+    const name = generateUniqueSessionName(new Set());
+    const parts = name.split(" ");
+    expect(parts).toHaveLength(2);
+    expect(parts[0][0]).toBe(parts[0][0].toUpperCase());
+    expect(parts[1][0]).toBe(parts[1][0].toUpperCase());
+  });
+
+  it("returns a name even when nearly all combinations are taken", () => {
+    // Build a large existing set missing just a few combinations
+    const adjectives = [
+      "Swift", "Calm", "Bold", "Bright", "Warm", "Keen", "Vast", "Crisp", "Agile", "Noble",
+      "Vivid", "Lucid", "Brisk", "Deft", "Fleet", "Grand", "Lush", "Prime", "Sage", "True",
+      "Clear", "Deep", "Fair", "Firm", "Glad", "Kind", "Pure", "Rich", "Safe", "Wise",
+      "Fresh", "Sharp", "Steady", "Quick", "Gentle", "Silent", "Golden", "Radiant", "Serene", "Verdant",
+    ];
+    const nouns = [
+      "Falcon", "River", "Cedar", "Stone", "Ember", "Frost", "Bloom", "Ridge", "Crane", "Birch",
+      "Coral", "Dawn", "Flint", "Grove", "Heron", "Lark", "Maple", "Opal", "Pearl", "Quartz",
+      "Reef", "Sage", "Tide", "Vale", "Wren", "Aspen", "Brook", "Cliff", "Delta", "Eagle",
+      "Fern", "Harbor", "Iris", "Jade", "Lotus", "Mesa", "Nova", "Orbit", "Pebble", "Summit",
+    ];
+
+    const existing = new Set<string>();
+    for (const adj of adjectives) {
+      for (const noun of nouns) {
+        existing.add(`${adj} ${noun}`);
+      }
+    }
+    // Remove a few so there's something to return
+    existing.delete("Swift Falcon");
+    existing.delete("Calm River");
+    existing.delete("Bold Cedar");
+
+    const name = generateUniqueSessionName(existing);
+    // It should return a string (the function always returns something)
+    expect(typeof name).toBe("string");
+    expect(name.split(" ")).toHaveLength(2);
+  });
+
+  it("retries when collisions occur (mocked Math.random)", () => {
+    const adjectives = [
+      "Swift", "Calm", "Bold", "Bright", "Warm", "Keen", "Vast", "Crisp", "Agile", "Noble",
+      "Vivid", "Lucid", "Brisk", "Deft", "Fleet", "Grand", "Lush", "Prime", "Sage", "True",
+      "Clear", "Deep", "Fair", "Firm", "Glad", "Kind", "Pure", "Rich", "Safe", "Wise",
+      "Fresh", "Sharp", "Steady", "Quick", "Gentle", "Silent", "Golden", "Radiant", "Serene", "Verdant",
+    ];
+    const nouns = [
+      "Falcon", "River", "Cedar", "Stone", "Ember", "Frost", "Bloom", "Ridge", "Crane", "Birch",
+      "Coral", "Dawn", "Flint", "Grove", "Heron", "Lark", "Maple", "Opal", "Pearl", "Quartz",
+      "Reef", "Sage", "Tide", "Vale", "Wren", "Aspen", "Brook", "Cliff", "Delta", "Eagle",
+      "Fern", "Harbor", "Iris", "Jade", "Lotus", "Mesa", "Nova", "Orbit", "Pebble", "Summit",
+    ];
+
+    // Math.random returning 0 will produce adjectives[0] + nouns[0] = "Swift Falcon"
+    // After 3 collisions (6 calls to Math.random), return different values for a unique name
+    const collisionName = `${adjectives[0]} ${nouns[0]}`; // "Swift Falcon"
+    const existing = new Set([collisionName]);
+
+    let callCount = 0;
+    const originalRandom = Math.random;
+    Math.random = () => {
+      callCount++;
+      // First 6 calls (3 iterations x 2 calls each) return 0 -> "Swift Falcon"
+      if (callCount <= 6) return 0;
+      // After that, return 0.5 to pick a different name
+      return 0.5;
+    };
+
+    try {
+      const name = generateUniqueSessionName(existing);
+      // It should have retried (more than 2 calls to Math.random)
+      expect(callCount).toBeGreaterThan(2);
+      // The returned name should not be in the existing set
+      expect(name).not.toBe(collisionName);
+      // Should still be a valid two-word name
+      expect(name.split(" ")).toHaveLength(2);
+    } finally {
+      Math.random = originalRandom;
+    }
+  });
+});

--- a/web/vitest.config.ts
+++ b/web/vitest.config.ts
@@ -4,9 +4,10 @@ export default defineConfig({
   test: {
     globals: true,
     environment: "node",
-    include: ["server/**/*.test.ts", "src/**/*.test.ts"],
+    include: ["server/**/*.test.ts", "src/**/*.test.ts", "src/**/*.test.tsx"],
     environmentMatchGlobs: [
       ["src/**/*.test.ts", "jsdom"],
+      ["src/**/*.test.tsx", "jsdom"],
     ],
     setupFiles: ["src/test-setup.ts"],
   },


### PR DESCRIPTION
## Summary

- Add **7 new test files** for React components and utils, expanding from ~230 to **458 tests** across 17 test files
- Expand `ws-bridge.test.ts` with **18 new edge-case tests** (auth_status routing, permission_response with updated_permissions, multi-browser broadcasting, Buffer handling, malformed JSON, empty NDJSON lines, restore with pending permissions)
- Add `@testing-library/react`, `@testing-library/jest-dom`, and `@testing-library/user-event` as devDependencies
- Update `vitest.config.ts` to discover `.test.tsx` files and run them in jsdom environment

### New test files

| File | Tests | Covers |
|------|-------|--------|
| `PermissionBanner.test.tsx` | 23 | Tool-specific displays, allow/deny flow, permission suggestions, AskUserQuestion, ExitPlanMode |
| `Composer.test.tsx` | 19 | Send/disabled states, Enter/Shift+Enter, plan mode, interrupt, slash commands, connection states |
| `ToolBlock.test.tsx` | 47 | `getToolIcon`, `getToolLabel`, `getPreview` functions, expand/collapse, tool detail views |
| `MessageBubble.test.tsx` | 18 | System/user/assistant rendering, images, content blocks, thinking blocks, tool_result |
| `MessageFeed.test.tsx` | 17 | Empty state, message rendering, streaming, generation stats, tool-only grouping, subagent nesting |
| `Sidebar.test.tsx` | 18 | Session list, git info, archive/unarchive, rename, dark mode, permission badges |
| `names.test.ts` | 7 | Name generation format, uniqueness, collision retry |

## Test plan

- [x] All 458 tests pass (`bun run test`)
- [x] Typecheck passes (`bun run typecheck`)
- [x] Pre-commit hooks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code) — not reviewed by a human
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/the-vibe-company/companion/pull/77" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
