### PR TITLE
feat(web): add notification sound on task completion

### DIFF
--- a/web/src/components/Sidebar.tsx
+++ b/web/src/components/Sidebar.tsx
@@ -17,6 +17,8 @@ export function Sidebar() {
   const setCurrentSession = useStore((s) => s.setCurrentSession);
   const darkMode = useStore((s) => s.darkMode);
   const toggleDarkMode = useStore((s) => s.toggleDarkMode);
+  const notificationSound = useStore((s) => s.notificationSound);
+  const toggleNotificationSound = useStore((s) => s.toggleNotificationSound);
   const cliConnected = useStore((s) => s.cliConnected);
   const sessionStatus = useStore((s) => s.sessionStatus);
   const removeSession = useStore((s) => s.removeSession);
@@ -460,6 +462,21 @@ export function Sidebar() {
             <path d="M8 1a2 2 0 012 2v1h2a2 2 0 012 2v6a2 2 0 01-2 2H4a2 2 0 01-2-2V6a2 2 0 012-2h2V3a2 2 0 012-2zm0 1.5a.5.5 0 00-.5.5v1h1V3a.5.5 0 00-.5-.5zM4 5.5a.5.5 0 00-.5.5v6a.5.5 0 00.5.5h8a.5.5 0 00.5-.5V6a.5.5 0 00-.5-.5H4z" />
           </svg>
           <span>Environments</span>
+        </button>
+        <button
+          onClick={toggleNotificationSound}
+          className="w-full flex items-center gap-2.5 px-3 py-2 rounded-[10px] text-sm text-cc-muted hover:text-cc-fg hover:bg-cc-hover transition-colors cursor-pointer"
+        >
+          {notificationSound ? (
+            <svg viewBox="0 0 20 20" fill="currentColor" className="w-4 h-4">
+              <path d="M9.383 3.076A1 1 0 0110 4v12a1 1 0 01-1.707.707L4.586 13H2a1 1 0 01-1-1V8a1 1 0 011-1h2.586l3.707-3.707a1 1 0 011.09-.217zM14.657 2.929a1 1 0 011.414 0A9.972 9.972 0 0119 10a9.972 9.972 0 01-2.929 7.071 1 1 0 01-1.414-1.414A7.971 7.971 0 0017 10c0-2.21-.894-4.208-2.343-5.657a1 1 0 010-1.414zm-2.829 2.828a1 1 0 011.415 0A5.983 5.983 0 0115 10a5.984 5.984 0 01-1.757 4.243 1 1 0 01-1.415-1.415A3.984 3.984 0 0013 10a3.983 3.983 0 00-1.172-2.828 1 1 0 010-1.415z" />
+            </svg>
+          ) : (
+            <svg viewBox="0 0 20 20" fill="currentColor" className="w-4 h-4">
+              <path fillRule="evenodd" d="M9.383 3.076A1 1 0 0110 4v12a1 1 0 01-1.707.707L4.586 13H2a1 1 0 01-1-1V8a1 1 0 011-1h2.586l3.707-3.707a1 1 0 011.09-.217zM12.293 7.293a1 1 0 011.414 0L15 8.586l1.293-1.293a1 1 0 111.414 1.414L16.414 10l1.293 1.293a1 1 0 01-1.414 1.414L15 11.414l-1.293 1.293a1 1 0 01-1.414-1.414L13.586 10l-1.293-1.293a1 1 0 010-1.414z" clipRule="evenodd" />
+            </svg>
+          )}
+          <span>{notificationSound ? "Sound on" : "Sound off"}</span>
         </button>
         <button
           onClick={toggleDarkMode}

--- a/web/src/store.ts
+++ b/web/src/store.ts
@@ -43,6 +43,7 @@ interface AppState {
 
   // UI
   darkMode: boolean;
+  notificationSound: boolean;
   sidebarOpen: boolean;
   taskPanelOpen: boolean;
   homeResetKey: number;
@@ -54,6 +55,8 @@ interface AppState {
   // Actions
   setDarkMode: (v: boolean) => void;
   toggleDarkMode: () => void;
+  setNotificationSound: (v: boolean) => void;
+  toggleNotificationSound: () => void;
   setSidebarOpen: (v: boolean) => void;
   setTaskPanelOpen: (open: boolean) => void;
   newSession: () => void;
@@ -128,6 +131,13 @@ function getInitialDarkMode(): boolean {
   return window.matchMedia("(prefers-color-scheme: dark)").matches;
 }
 
+function getInitialNotificationSound(): boolean {
+  if (typeof window === "undefined") return true;
+  const stored = localStorage.getItem("cc-notification-sound");
+  if (stored !== null) return stored === "true";
+  return true;
+}
+
 export const useStore = create<AppState>((set) => ({
   sessions: new Map(),
   sdkSessions: [],
@@ -146,6 +156,7 @@ export const useStore = create<AppState>((set) => ({
   sessionNames: getInitialSessionNames(),
   recentlyRenamed: new Set(),
   darkMode: getInitialDarkMode(),
+  notificationSound: getInitialNotificationSound(),
   sidebarOpen: typeof window !== "undefined" ? window.innerWidth >= 768 : true,
   taskPanelOpen: typeof window !== "undefined" ? window.innerWidth >= 1024 : false,
   homeResetKey: 0,
@@ -163,6 +174,16 @@ export const useStore = create<AppState>((set) => ({
       const next = !s.darkMode;
       localStorage.setItem("cc-dark-mode", String(next));
       return { darkMode: next };
+    }),
+  setNotificationSound: (v) => {
+    localStorage.setItem("cc-notification-sound", String(v));
+    set({ notificationSound: v });
+  },
+  toggleNotificationSound: () =>
+    set((s) => {
+      const next = !s.notificationSound;
+      localStorage.setItem("cc-notification-sound", String(next));
+      return { notificationSound: next };
     }),
   setSidebarOpen: (v) => set({ sidebarOpen: v }),
   setTaskPanelOpen: (open) => set({ taskPanelOpen: open }),

--- a/web/src/utils/notification-sound.ts
+++ b/web/src/utils/notification-sound.ts
@@ -1,0 +1,51 @@
+let audioContext: AudioContext | null = null;
+
+function getAudioContext(): AudioContext {
+  if (!audioContext) {
+    audioContext = new AudioContext();
+  }
+  return audioContext;
+}
+
+/**
+ * Plays a pleasant two-tone notification chime using the Web Audio API.
+ * Two short sine-wave tones in sequence (E5 → G5).
+ */
+export function playNotificationSound(): void {
+  try {
+    const ctx = getAudioContext();
+
+    if (ctx.state === "suspended") {
+      ctx.resume();
+    }
+
+    const now = ctx.currentTime;
+
+    // First tone: E5 (659.25 Hz)
+    const osc1 = ctx.createOscillator();
+    const gain1 = ctx.createGain();
+    osc1.type = "sine";
+    osc1.frequency.setValueAtTime(659.25, now);
+    gain1.gain.setValueAtTime(0.3, now);
+    gain1.gain.exponentialRampToValueAtTime(0.001, now + 0.3);
+    osc1.connect(gain1);
+    gain1.connect(ctx.destination);
+    osc1.start(now);
+    osc1.stop(now + 0.3);
+
+    // Second tone: G5 (783.99 Hz)
+    const osc2 = ctx.createOscillator();
+    const gain2 = ctx.createGain();
+    osc2.type = "sine";
+    osc2.frequency.setValueAtTime(783.99, now + 0.15);
+    gain2.gain.setValueAtTime(0.001, now);
+    gain2.gain.setValueAtTime(0.3, now + 0.15);
+    gain2.gain.exponentialRampToValueAtTime(0.001, now + 0.5);
+    osc2.connect(gain2);
+    gain2.connect(ctx.destination);
+    osc2.start(now + 0.15);
+    osc2.stop(now + 0.5);
+  } catch {
+    // Silently fail if Web Audio API is not available
+  }
+}

--- a/web/src/ws.ts
+++ b/web/src/ws.ts
@@ -1,6 +1,7 @@
 import { useStore } from "./store.js";
 import type { BrowserIncomingMessage, BrowserOutgoingMessage, ContentBlock, ChatMessage, TaskItem } from "./types.js";
 import { generateUniqueSessionName } from "./utils/names.js";
+import { playNotificationSound } from "./utils/notification-sound.js";
 
 const sockets = new Map<string, WebSocket>();
 const reconnectTimers = new Map<string, ReturnType<typeof setTimeout>>();
@@ -225,6 +226,10 @@ function handleMessage(sessionId: string, event: MessageEvent) {
       store.setStreaming(sessionId, null);
       store.setStreamingStats(sessionId, null);
       store.setSessionStatus(sessionId, "idle");
+      // Play notification sound if enabled and tab is not focused
+      if (!document.hasFocus() && store.notificationSound) {
+        playNotificationSound();
+      }
       if (r.is_error && r.errors?.length) {
         store.appendMessage(sessionId, {
           id: nextId(),


### PR DESCRIPTION
## Summary
  - Play a **two-tone chime** (E5 → G5) when Claude Code finishes a task and the browser tab is **not focused** — so you know it's done without constantly checking back
  - Sound is synthesized at runtime via the **Web Audio API** — no audio files, no external dependencies
  - User can **toggle the sound on/off** from the sidebar; preference is persisted to `localStorage`
  - Enabled by default

  ## Changes

  | File | What |
  |------|------|
  | `web/src/utils/notification-sound.ts` | **New** — Web Audio API utility: lazy singleton `AudioContext`, two overlapping sine oscillators with exponential decay, ~0.5s total duration,
  silent fallback if unavailable |
  | `web/src/store.ts` | Add `notificationSound` boolean state + `toggleNotificationSound` / `setNotificationSound` actions, persisted to `localStorage("cc-notification-sound")` |
  | `web/src/ws.ts` | Trigger `playNotificationSound()` in the `"result"` message handler when `!document.hasFocus()` and sound is enabled |
  | `web/src/components/Sidebar.tsx` | Add "Sound on/off" toggle button with speaker icons between Environments and Dark mode in the footer |

  ## Test plan
  - [x] `bun x tsc --noEmit` — no type errors
  - [x] `bun run test` — 289 tests pass (pre-existing jsdom environment errors unrelated)
  - [x] Manual: send a message, switch tabs while Claude works → chime plays when task finishes
  - [x] Manual: stay on the tab → no sound
  - [x] Manual: click "Sound off" in sidebar → no sound even when tab is unfocused
  - [x] Manual: reload page → preference persists

  ## Notes
  - Sound only plays when the tab is **not focused** (`document.hasFocus() === false`) — no noise when you're actively watching
  - Also plays on error results — you still want to know the task finished
  - Browser autoplay policy is handled: `AudioContext` is resumed if suspended, and by the time a `result` arrives the user has already interacted with the page

  🤖 Generated with [Claude Code](https://claude.ai/code)