### PR TITLE
fix(web): fix Codex approval policy and Composer mode labels

### DIFF
--- a/web/CODEX_MAPPING.md
+++ b/web/CODEX_MAPPING.md
@@ -42,13 +42,13 @@ The UI permission modes map to Codex approval policies via `mapApprovalPolicy()`
 | UI Permission Mode | Codex `approvalPolicy` | Behavior |
 |---|---|---|
 | `bypassPermissions` | `"never"` | Auto-approve all tool calls |
-| `acceptEdits` | `"unless-trusted"` | Prompt for untrusted operations |
-| `plan` | `"unless-trusted"` | Prompt for untrusted operations |
-| `default` | `"unless-trusted"` | Prompt for untrusted operations |
+| `acceptEdits` | `"untrusted"` | Prompt for untrusted operations |
+| `plan` | `"untrusted"` | Prompt for untrusted operations |
+| `default` | `"untrusted"` | Prompt for untrusted operations |
 
 Valid Codex enum values (kebab-case only):
 - **sandbox**: `"read-only"`, `"workspace-write"`, `"danger-full-access"`
-- **approvalPolicy**: `"never"`, `"unless-trusted"`, `"on-failure"`, `"on-request"`
+- **approvalPolicy**: `"never"`, `"untrusted"`, `"on-failure"`, `"on-request"`
 
 ## Message Translation: Codex → Browser
 

--- a/web/server/codex-adapter.test.ts
+++ b/web/server/codex-adapter.test.ts
@@ -651,7 +651,7 @@ describe("CodexAdapter", () => {
   // The Codex CLI uses camelCase for JSON-RPC field names (approvalPolicy, sandbox)
   // but kebab-case for enum VALUES. These tests ensure we never regress to camelCase values.
   // Valid sandbox values: "read-only", "workspace-write", "danger-full-access"
-  // Valid approvalPolicy values: "never", "unless-trusted", "on-failure", "on-request"
+  // Valid approvalPolicy values: "never", "untrusted", "on-failure", "on-request"
 
   it("sends kebab-case sandbox value, never camelCase", async () => {
     new CodexAdapter(proc as never, "test-session", { model: "gpt-5.3-codex", cwd: "/tmp" });
@@ -670,10 +670,10 @@ describe("CodexAdapter", () => {
 
   it.each([
     { approvalMode: "bypassPermissions", expected: "never" },
-    { approvalMode: "plan", expected: "unless-trusted" },
-    { approvalMode: "acceptEdits", expected: "unless-trusted" },
-    { approvalMode: "default", expected: "unless-trusted" },
-    { approvalMode: undefined, expected: "unless-trusted" },
+    { approvalMode: "plan", expected: "untrusted" },
+    { approvalMode: "acceptEdits", expected: "untrusted" },
+    { approvalMode: "default", expected: "untrusted" },
+    { approvalMode: undefined, expected: "untrusted" },
   ])("maps approvalMode=$approvalMode to kebab-case approvalPolicy=$expected", async ({ approvalMode, expected }) => {
     const mock = createMockProcess();
 

--- a/web/server/codex-adapter.ts
+++ b/web/server/codex-adapter.ts
@@ -1166,7 +1166,7 @@ export class CodexAdapter {
       case "acceptEdits":
       case "default":
       default:
-        return "unless-trusted";
+        return "untrusted";
     }
   }
 }

--- a/web/src/components/Composer.tsx
+++ b/web/src/components/Composer.tsx
@@ -2,6 +2,8 @@ import { useState, useRef, useEffect, useCallback, useMemo } from "react";
 import { useStore } from "../store.js";
 import { sendToSession } from "../ws.js";
 import { api } from "../api.js";
+import { CLAUDE_MODES, CODEX_MODES } from "../utils/backends.js";
+import type { ModeOption } from "../utils/backends.js";
 
 let idCounter = 0;
 
@@ -44,6 +46,9 @@ export function Composer({ sessionId }: { sessionId: string }) {
   const isConnected = cliConnected.get(sessionId) ?? false;
   const currentMode = sessionData?.permissionMode || "acceptEdits";
   const isPlan = currentMode === "plan";
+  const isCodex = sessionData?.backend_type === "codex";
+  const modes: ModeOption[] = isCodex ? CODEX_MODES : CLAUDE_MODES;
+  const modeLabel = modes.find((m) => m.value === currentMode)?.label?.toLowerCase() || currentMode;
 
   // Build command list from session data
   const allCommands = useMemo<CommandItem[]>(() => {
@@ -222,7 +227,7 @@ export function Composer({ sessionId }: { sessionId: string }) {
   }
 
   function toggleMode() {
-    if (!isConnected) return;
+    if (!isConnected || isCodex) return;
     const store = useStore.getState();
     if (!isPlan) {
       store.setPreviousPermissionMode(sessionId, currentMode);
@@ -327,7 +332,7 @@ export function Composer({ sessionId }: { sessionId: string }) {
             placeholder={isConnected ? "Type a message... (/ for commands)" : "Waiting for CLI connection..."}
             disabled={!isConnected}
             rows={1}
-            className="w-full px-4 pt-3 pb-1 text-sm bg-transparent resize-none focus:outline-none text-cc-fg font-sans-ui placeholder:text-cc-muted disabled:opacity-50"
+            className="w-full px-4 pt-3 pb-1 text-base bg-transparent resize-none focus:outline-none text-cc-fg font-sans-ui placeholder:text-cc-muted disabled:opacity-50"
             style={{ minHeight: "36px", maxHeight: "200px" }}
           />
 
@@ -381,15 +386,15 @@ export function Composer({ sessionId }: { sessionId: string }) {
             {/* Left: mode indicator */}
             <button
               onClick={toggleMode}
-              disabled={!isConnected}
-              className={`flex items-center gap-1.5 px-2 py-1 rounded-md text-[12px] font-medium transition-all cursor-pointer select-none ${
-                !isConnected
+              disabled={!isConnected || isCodex}
+              className={`flex items-center gap-1.5 px-2 py-1 rounded-md text-[12px] font-medium transition-all select-none ${
+                !isConnected || isCodex
                   ? "opacity-30 cursor-not-allowed text-cc-muted"
                   : isPlan
-                  ? "text-cc-primary hover:bg-cc-primary/10"
-                  : "text-cc-muted hover:text-cc-fg hover:bg-cc-hover"
+                  ? "text-cc-primary hover:bg-cc-primary/10 cursor-pointer"
+                  : "text-cc-muted hover:text-cc-fg hover:bg-cc-hover cursor-pointer"
               }`}
-              title="Toggle mode (Shift+Tab)"
+              title={isCodex ? "Mode is fixed for Codex sessions" : "Toggle mode (Shift+Tab)"}
             >
               {isPlan ? (
                 <svg viewBox="0 0 16 16" fill="currentColor" className="w-3.5 h-3.5">
@@ -402,7 +407,7 @@ export function Composer({ sessionId }: { sessionId: string }) {
                   <path d="M8.5 4l4 4-4 4" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" fill="none" />
                 </svg>
               )}
-              <span>{isPlan ? "plan mode" : "accept edits"}</span>
+              <span>{modeLabel}</span>
             </button>
 
             {/* Right: image + send/stop */}


### PR DESCRIPTION
## Summary
- Fix `mapApprovalPolicy()` to return `"untrusted"` instead of `"unless-trusted"` — the Codex CLI rejected the old value with: `unknown variant 'unless-trusted', expected one of 'untrusted', 'on-failure', 'on-request', 'never'`
- Show backend-aware mode labels in the Composer input bar (e.g. "auto" / "suggest" for Codex instead of "accept edits" / "plan mode")
- Disable the mode toggle button and Shift+Tab shortcut for Codex sessions since runtime permission switching is not supported by the Codex app-server protocol

## Test plan
- [x] All 590 existing tests pass
- [x] Codex adapter approval policy tests updated to expect `"untrusted"`
- [ ] Manual: create a Codex session with "Suggest" mode → should no longer fail on init
- [ ] Manual: verify Composer shows correct label for each Codex mode
- [ ] Manual: verify Shift+Tab is disabled in Codex sessions

AI-generated code, not human-reviewed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/the-vibe-company/companion/pull/106" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

Fixed critical Codex CLI compatibility issue by correcting the approval policy value from `"unless-trusted"` (which was rejected by Codex) to `"untrusted"`. Also improved the Composer UI to show backend-aware mode labels (e.g., "auto"/"suggest" for Codex instead of generic "accept edits"/"plan mode") and properly disabled the mode toggle button and Shift+Tab shortcut for Codex sessions where runtime permission switching isn't supported.

- Core fix: `mapApprovalPolicy()` now returns the valid `"untrusted"` value
- UI improvement: mode labels dynamically adjust based on `backend_type`
- UX fix: mode toggle disabled for Codex sessions (both button and keyboard shortcut)
- Minor style note: textarea font size increased from `text-sm` to `text-base` (unrelated change)

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- The changes fix a critical bug that prevented Codex sessions from initializing, are well-tested (40 passing tests with updated expectations), and include appropriate UI improvements. The only minor issue is an unrelated font size change that wasn't mentioned in the PR description.
- No files require special attention

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| web/CODEX_MAPPING.md | Updated documentation to reflect the correct `"untrusted"` approval policy value instead of the invalid `"unless-trusted"` value |
| web/server/codex-adapter.test.ts | Updated test expectations to match the corrected `"untrusted"` approval policy value; all 40 tests pass |
| web/server/codex-adapter.ts | Fixed `mapApprovalPolicy()` to return the valid `"untrusted"` value instead of the rejected `"unless-trusted"` value |
| web/src/components/Composer.tsx | Added backend-aware mode labels and disabled mode toggle for Codex sessions; includes unrelated textarea font size change from `text-sm` to `text-base` |

</details>


</details>


<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant Browser
    participant Server
    participant Codex CLI
    
    Note over Browser,Codex CLI: Session Initialization Flow (Fixed)
    
    Browser->>Server: Create Codex session with mode="plan"
    Server->>Server: mapApprovalPolicy("plan")<br/>returns "untrusted" ✓
    Server->>Codex CLI: init(approvalPolicy: "untrusted")
    Codex CLI-->>Server: ✓ Accepted (valid enum value)
    Server-->>Browser: Session initialized
    
    Note over Browser: Mode Toggle Behavior
    Browser->>Browser: User presses Shift+Tab
    Browser->>Browser: Check isCodex === true<br/>→ toggleMode() returns early
    Note over Browser: Mode toggle disabled for Codex<br/>(runtime switching not supported)
```

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->