### PR TITLE
feat(web): redesign session list with avatars, auto-reconnect, and git info

### DIFF
--- a/web/server/cli-launcher.ts
+++ b/web/server/cli-launcher.ts
@@ -31,6 +31,16 @@ export interface SdkSessionInfo {
   name?: string;
   /** Which backend this session uses */
   backendType?: BackendType;
+  /** Git branch from bridge state (enriched by REST API) */
+  gitBranch?: string;
+  /** Git ahead count (enriched by REST API) */
+  gitAhead?: number;
+  /** Git behind count (enriched by REST API) */
+  gitBehind?: number;
+  /** Total lines added (enriched by REST API) */
+  totalLinesAdded?: number;
+  /** Total lines removed (enriched by REST API) */
+  totalLinesRemoved?: number;
 }
 
 export interface LaunchOptions {

--- a/web/server/routes.ts
+++ b/web/server/routes.ts
@@ -127,10 +127,20 @@ export function createRoutes(
   api.get("/sessions", (c) => {
     const sessions = launcher.listSessions();
     const names = sessionNames.getAllNames();
-    const enriched = sessions.map((s) => ({
-      ...s,
-      name: names[s.sessionId] ?? s.name,
-    }));
+    const bridgeStates = wsBridge.getAllSessions();
+    const bridgeMap = new Map(bridgeStates.map((s) => [s.session_id, s]));
+    const enriched = sessions.map((s) => {
+      const bridge = bridgeMap.get(s.sessionId);
+      return {
+        ...s,
+        name: names[s.sessionId] ?? s.name,
+        gitBranch: bridge?.git_branch || "",
+        gitAhead: bridge?.git_ahead || 0,
+        gitBehind: bridge?.git_behind || 0,
+        totalLinesAdded: bridge?.total_lines_added || 0,
+        totalLinesRemoved: bridge?.total_lines_removed || 0,
+      };
+    });
     return c.json(enriched);
   });
 

--- a/web/server/ws-bridge.test.ts
+++ b/web/server/ws-bridge.test.ts
@@ -101,6 +101,34 @@ describe("Session management", () => {
     expect(second.state.model).toBe("modified");
   });
 
+  it("getOrCreateSession: sets backendType when creating a new session", () => {
+    const session = bridge.getOrCreateSession("s1", "codex");
+    expect(session.backendType).toBe("codex");
+    expect(session.state.backend_type).toBe("codex");
+  });
+
+  it("getOrCreateSession: does NOT overwrite backendType when called without explicit type", () => {
+    // Simulate: attachCodexAdapter creates session as "codex"
+    const session = bridge.getOrCreateSession("s1", "codex");
+    expect(session.backendType).toBe("codex");
+    expect(session.state.backend_type).toBe("codex");
+
+    // Simulate: handleBrowserOpen calls getOrCreateSession without backendType
+    const same = bridge.getOrCreateSession("s1");
+    expect(same.backendType).toBe("codex");
+    expect(same.state.backend_type).toBe("codex");
+  });
+
+  it("getOrCreateSession: overwrites backendType when explicitly provided on existing session", () => {
+    const session = bridge.getOrCreateSession("s1");
+    expect(session.backendType).toBe("claude");
+
+    // Explicit override (e.g. attachCodexAdapter)
+    bridge.getOrCreateSession("s1", "codex");
+    expect(session.backendType).toBe("codex");
+    expect(session.state.backend_type).toBe("codex");
+  });
+
   it("getSession: returns undefined for unknown session", () => {
     expect(bridge.getSession("nonexistent")).toBeUndefined();
   });

--- a/web/src/components/Sidebar.test.tsx
+++ b/web/src/components/Sidebar.test.tsx
@@ -6,10 +6,12 @@ import type { SessionState, SdkSessionInfo } from "../types.js";
 // ─── Mock setup ──────────────────────────────────────────────────────────────
 
 const mockConnectSession = vi.fn();
+const mockConnectAllSessions = vi.fn();
 const mockDisconnectSession = vi.fn();
 
 vi.mock("../ws.js", () => ({
   connectSession: (...args: unknown[]) => mockConnectSession(...args),
+  connectAllSessions: (...args: unknown[]) => mockConnectAllSessions(...args),
   disconnectSession: (...args: unknown[]) => mockDisconnectSession(...args),
 }));
 
@@ -243,10 +245,10 @@ describe("Sidebar", () => {
     });
 
     render(<Sidebar />);
-    // The component renders "3↑" and "2↓" using HTML entities
-    const container = screen.getByText("main").closest("div")!;
-    expect(container.textContent).toContain("3");
-    expect(container.textContent).toContain("2");
+    // The component renders "3↑" and "2↓" using HTML entities in a stats row
+    const sessionButton = screen.getByText("main").closest("button")!;
+    expect(sessionButton.textContent).toContain("3");
+    expect(sessionButton.textContent).toContain("2");
   });
 
   it("session items show lines added/removed", () => {
@@ -467,5 +469,80 @@ describe("Sidebar", () => {
     render(<Sidebar />);
     // The permission count badge shows "2"
     expect(screen.getByText("2")).toBeInTheDocument();
+  });
+
+  it("session shows git branch from sdkInfo when bridgeState is unavailable", () => {
+    // No bridgeState — only sdkInfo (REST API) data available
+    const sdk = makeSdkSession("s1", {
+      gitBranch: "feature/from-rest",
+      gitAhead: 5,
+      gitBehind: 2,
+      totalLinesAdded: 100,
+      totalLinesRemoved: 20,
+    });
+    mockState = createMockState({
+      sessions: new Map(), // no bridge state
+      sdkSessions: [sdk],
+    });
+
+    render(<Sidebar />);
+    expect(screen.getByText("feature/from-rest")).toBeInTheDocument();
+    const sessionButton = screen.getByText("feature/from-rest").closest("button")!;
+    expect(sessionButton.textContent).toContain("5");
+    expect(sessionButton.textContent).toContain("2");
+    expect(sessionButton.textContent).toContain("+100");
+    expect(sessionButton.textContent).toContain("-20");
+  });
+
+  it("session prefers bridgeState git data over sdkInfo", () => {
+    const session = makeSession("s1", {
+      git_branch: "from-bridge",
+      git_ahead: 1,
+    });
+    const sdk = makeSdkSession("s1", {
+      gitBranch: "from-rest",
+      gitAhead: 99,
+    });
+    mockState = createMockState({
+      sessions: new Map([["s1", session]]),
+      sdkSessions: [sdk],
+    });
+
+    render(<Sidebar />);
+    // Bridge data should win over REST API data
+    expect(screen.getByText("from-bridge")).toBeInTheDocument();
+    expect(screen.queryByText("from-rest")).not.toBeInTheDocument();
+  });
+
+  it("codex session preserves backendType when bridgeState is missing", () => {
+    // Only sdkInfo available (no WS session_init received yet)
+    const sdk = makeSdkSession("s1", { backendType: "codex" });
+    mockState = createMockState({
+      sessions: new Map(), // no bridge state
+      sdkSessions: [sdk],
+    });
+
+    const { container } = render(<Sidebar />);
+    const avatar = container.querySelector("button img");
+    expect(avatar?.getAttribute("src")).toBe("/logo-codex.svg");
+  });
+
+  it("session avatar shows correct logo based on backendType", () => {
+    const session1 = makeSession("s1", { backend_type: "claude" });
+    const session2 = makeSession("s2", { backend_type: "codex" });
+    const sdk1 = makeSdkSession("s1", { backendType: "claude" });
+    const sdk2 = makeSdkSession("s2", { backendType: "codex" });
+    mockState = createMockState({
+      sessions: new Map([["s1", session1], ["s2", session2]]),
+      sdkSessions: [sdk1, sdk2],
+    });
+
+    const { container } = render(<Sidebar />);
+    // Find avatar images inside session buttons
+    const avatars = container.querySelectorAll("button img");
+    expect(avatars).toHaveLength(2);
+    const srcs = Array.from(avatars).map((img) => img.getAttribute("src"));
+    expect(srcs).toContain("/logo.svg");
+    expect(srcs).toContain("/logo-codex.svg");
   });
 });

--- a/web/src/types.ts
+++ b/web/src/types.ts
@@ -48,4 +48,9 @@ export interface SdkSessionInfo {
   actualBranch?: string;
   name?: string;
   backendType?: BackendType;
+  gitBranch?: string;
+  gitAhead?: number;
+  gitBehind?: number;
+  totalLinesAdded?: number;
+  totalLinesRemoved?: number;
 }


### PR DESCRIPTION
## Summary

- Redesign sidebar session items with Clawd avatars (teal for Claude, blue for Codex), colored accent borders, status dot overlays, and compact directory + branch layout
- Auto-connect all active (non-archived) sessions so permission notifications arrive for every session, not just the selected one
- Fix Codex sessions not showing git branch: enrich REST API with bridge git data, add sdkInfo fallback in Sidebar, fix `getOrCreateSession` overwriting Codex `backendType` to "claude"

### Screenshot

![sidebar](https://github.com/user-attachments/assets/placeholder)

*Sidebar showing session items with avatars, git branches, and status dots*

## Test plan

- [x] Typecheck passes (`bun run typecheck`)
- [x] All 636 tests pass (`bun run test`) — 7 new regression tests added
- [x] Visual verification with agent-browser on localhost:5174
- [ ] Verify Codex sessions show blue avatar and git branch
- [ ] Verify Claude sessions show teal avatar and git branch
- [ ] Verify auto-reconnect works (all active sessions get green status dot)

### New tests

**ws-bridge.test.ts** (+3):
- `getOrCreateSession: sets backendType when creating a new session`
- `getOrCreateSession: does NOT overwrite backendType when called without explicit type`
- `getOrCreateSession: overwrites backendType when explicitly provided on existing session`

**routes.test.ts** (+1):
- `enriches sessions with git data from bridge state`

**Sidebar.test.tsx** (+3):
- `session shows git branch from sdkInfo when bridgeState is unavailable`
- `session prefers bridgeState git data over sdkInfo`
- `codex session preserves backendType when bridgeState is missing`

---

Code generated by AI (Claude Opus 4.6), not reviewed by a human.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/the-vibe-company/companion/pull/111" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
