### PR TITLE
feat(web): add effort level selector for Opus model

### DIFF
--- a/web/server/cli-launcher.test.ts
+++ b/web/server/cli-launcher.test.ts
@@ -192,6 +192,22 @@ describe("launch", () => {
     expect(toolFlags).toEqual(["Read", "Write", "Bash"]);
   });
 
+  it("passes --effort when effortLevel provided", () => {
+    launcher.launch({ effortLevel: "high", cwd: "/tmp" });
+
+    const [cmdAndArgs] = mockSpawn.mock.calls[0];
+    const effortIdx = cmdAndArgs.indexOf("--effort");
+    expect(effortIdx).toBeGreaterThan(-1);
+    expect(cmdAndArgs[effortIdx + 1]).toBe("high");
+  });
+
+  it("does not pass --effort when effortLevel not provided", () => {
+    launcher.launch({ cwd: "/tmp" });
+
+    const [cmdAndArgs] = mockSpawn.mock.calls[0];
+    expect(cmdAndArgs).not.toContain("--effort");
+  });
+
   it("resolves binary path via resolveBinary when not absolute", () => {
     mockResolveBinary.mockReturnValue("/usr/local/bin/claude-dev");
     launcher.launch({ claudeBinary: "claude-dev", cwd: "/tmp" });

--- a/web/server/cli-launcher.ts
+++ b/web/server/cli-launcher.ts
@@ -75,6 +75,7 @@ export interface LaunchOptions {
   codexInternetAccess?: boolean;
   /** Optional override for CODEX_HOME used by Codex sessions. */
   codexHome?: string;
+  effortLevel?: string;
   /** Pre-resolved worktree info from the session creation flow */
   worktreeInfo?: {
     isWorktree: boolean;
@@ -219,11 +220,11 @@ export class CliLauncher {
           oldProc.exited,
           new Promise((r) => setTimeout(r, 2000)),
         ]);
-      } catch {}
+      } catch { }
       this.processes.delete(sessionId);
     } else if (info.pid) {
       // Process from a previous server instance — kill by PID
-      try { process.kill(info.pid, "SIGTERM"); } catch {}
+      try { process.kill(info.pid, "SIGTERM"); } catch { }
     }
 
     info.state = "starting";
@@ -287,6 +288,10 @@ export class CliLauncher {
       for (const tool of options.allowedTools) {
         args.push("--allowedTools", tool);
       }
+    }
+
+    if (options.effortLevel) {
+      args.push("--effort", options.effortLevel);
     }
 
     // Inject CLAUDE.md guardrails for worktree sessions

--- a/web/server/routes.ts
+++ b/web/server/routes.ts
@@ -189,6 +189,7 @@ export function createRoutes(
         allowedTools: body.allowedTools,
         env: envVars,
         backendType: backend,
+        effortLevel: body.effortLevel,
         worktreeInfo,
       });
 

--- a/web/src/api.ts
+++ b/web/src/api.ts
@@ -196,6 +196,7 @@ export interface CreateSessionOpts {
   useWorktree?: boolean;
   backend?: "claude" | "codex";
   container?: ContainerCreateOpts;
+  effortLevel?: string;
 }
 
 export interface BackendInfo {

--- a/web/src/utils/backends.test.ts
+++ b/web/src/utils/backends.test.ts
@@ -9,6 +9,8 @@ import {
   CODEX_MODELS,
   CLAUDE_MODES,
   CODEX_MODES,
+  EFFORT_LEVELS,
+  isOpusModel,
 } from "./backends.js";
 
 describe("toModelOptions", () => {
@@ -107,6 +109,37 @@ describe("getDefaultMode", () => {
 
   it("returns first codex mode for codex backend", () => {
     expect(getDefaultMode("codex")).toBe(CODEX_MODES[0].value);
+  });
+});
+
+describe("EFFORT_LEVELS", () => {
+  it("has exactly 3 levels: low, medium, high", () => {
+    expect(EFFORT_LEVELS).toHaveLength(3);
+    expect(EFFORT_LEVELS.map(l => l.value)).toEqual(["low", "medium", "high"]);
+  });
+
+  it("each level has a value and label", () => {
+    for (const level of EFFORT_LEVELS) {
+      expect(level.value).toBeTruthy();
+      expect(level.label).toBeTruthy();
+    }
+  });
+});
+
+describe("isOpusModel", () => {
+  it("returns true for opus model slugs", () => {
+    expect(isOpusModel("claude-opus-4-6")).toBe(true);
+    expect(isOpusModel("claude-opus-4-20250514")).toBe(true);
+  });
+
+  it("returns false for non-opus model slugs", () => {
+    expect(isOpusModel("claude-sonnet-4-5-20250929")).toBe(false);
+    expect(isOpusModel("claude-haiku-4-5-20251001")).toBe(false);
+    expect(isOpusModel("gpt-5.2-codex")).toBe(false);
+  });
+
+  it("returns false for empty string", () => {
+    expect(isOpusModel("")).toBe(false);
   });
 });
 

--- a/web/src/utils/backends.ts
+++ b/web/src/utils/backends.ts
@@ -64,6 +64,20 @@ export const CODEX_MODES: ModeOption[] = [
   { value: "plan", label: "Suggest" },
 ];
 
+// ─── Effort levels (Claude Opus only) ─────────────────────────────────────────
+
+export const EFFORT_LEVELS = [
+  { value: "low", label: "Low" },
+  { value: "medium", label: "Medium" },
+  { value: "high", label: "High" },
+] as const;
+
+export type EffortLevel = typeof EFFORT_LEVELS[number]["value"];
+
+export function isOpusModel(model: string): boolean {
+  return model.includes("opus");
+}
+
 // ─── Getters ─────────────────────────────────────────────────────────────────
 
 export function getModelsForBackend(backend: BackendType): ModelOption[] {


### PR DESCRIPTION
## Summary
Add conditional effort level dropdown (low/medium/high) next to model selector. Only visible when Claude backend + Opus model is selected. Passes `--effort` flag to Claude CLI at session spawn. Default: medium, persisted to localStorage.

### What is Effort Level?

The [effort parameter](https://platform.claude.com/docs/en/build-with-claude/effort) controls how many tokens Claude uses when responding — trading off between thoroughness and token efficiency. Supported on **Opus 4.5** and **Opus 4.6** only.

| Level | Behavior | Use case |
|-------|----------|----------|
| **Low** | Most efficient, significant token savings | Simple tasks, subagents, speed-sensitive work |
| **Medium** | Balanced approach, moderate savings | Agentic tasks balancing speed/cost/performance |
| **High** | Full capability (API default) | Complex reasoning, difficult coding, quality-first tasks |

> Effort is a behavioral signal, not a strict token budget. At lower levels, Claude still thinks on hard problems — just less.

## Changes
- **`backends.ts`** — `EFFORT_LEVELS` constant, `EffortLevel` type, `isOpusModel()` helper
- **`api.ts`** — `effortLevel` field in `CreateSessionOpts`
- **`cli-launcher.ts`** — `effortLevel` in `LaunchOptions`, pushes `--effort` CLI arg
- **`routes.ts`** — passes `body.effortLevel` through to launcher
- **`HomePage.tsx`** — effort dropdown UI with bar indicators, outside-click, reset on backend switch
- **Tests** — 7 new tests for `isOpusModel`, `EFFORT_LEVELS`, `--effort` flag

## Screenshots

### 1. Effort dropdown (Opus selected)
<!-- screenshot: dropdown visible next to Opus model selector -->
<img width="1680" height="1232" alt="image" src="https://github.com/user-attachments/assets/f779fe98-27a7-4a72-b915-57863a955973" />

### 2. Level options
<!-- screenshot: expanded dropdown showing Low/Medium/High -->
`high`
<img width="899" height="192" alt="image" src="https://github.com/user-attachments/assets/b9ef164c-fc02-4297-a624-6a3862129b4c" />
`medium`
<img width="901" height="232" alt="image" src="https://github.com/user-attachments/assets/79bb5cbb-a559-4ce5-abb9-63f09c66eff8" />
`low`
<img width="896" height="230" alt="image" src="https://github.com/user-attachments/assets/4796af89-9e08-4111-9983-2de784ca17f9" />



## Test plan
- [x] Typecheck passes
- [x] 635/635 tests pass
- [x] Manual: select Opus → effort dropdown appears with bar indicators
- [x] Manual: select Sonnet/Haiku → effort dropdown hidden
- [ ] Manual: switch to Codex backend → effort resets to medium
- [x] Manual: effort level persists across page reloads
- [x] Manual: spawned CLI includes `--effort medium` in args

> Code generated by AI, not reviewed by a human.