### PR TITLE
feat(web): group sidebar sessions by project directory

### DIFF
--- a/web/src/components/ProjectGroup.tsx
+++ b/web/src/components/ProjectGroup.tsx
@@ -1,0 +1,118 @@
+import type { RefObject } from "react";
+import type { ProjectGroup as ProjectGroupType } from "../utils/project-grouping.js";
+import { SessionItem } from "./SessionItem.js";
+
+interface ProjectGroupProps {
+  group: ProjectGroupType;
+  isCollapsed: boolean;
+  onToggleCollapse: (projectKey: string) => void;
+  currentSessionId: string | null;
+  sessionNames: Map<string, string>;
+  pendingPermissions: Map<string, Map<string, unknown>>;
+  recentlyRenamed: Set<string>;
+  onSelect: (id: string) => void;
+  onStartRename: (id: string, currentName: string) => void;
+  onArchive: (e: React.MouseEvent, id: string) => void;
+  onUnarchive: (e: React.MouseEvent, id: string) => void;
+  onDelete: (e: React.MouseEvent, id: string) => void;
+  editingSessionId: string | null;
+  editingName: string;
+  setEditingName: (name: string) => void;
+  onConfirmRename: () => void;
+  onCancelRename: () => void;
+  editInputRef: RefObject<HTMLInputElement | null>;
+  isFirst: boolean;
+}
+
+export function ProjectGroup({
+  group,
+  isCollapsed,
+  onToggleCollapse,
+  currentSessionId,
+  sessionNames,
+  pendingPermissions,
+  recentlyRenamed,
+  onSelect,
+  onStartRename,
+  onArchive,
+  onUnarchive,
+  onDelete,
+  editingSessionId,
+  editingName,
+  setEditingName,
+  onConfirmRename,
+  onCancelRename,
+  editInputRef,
+  isFirst,
+}: ProjectGroupProps) {
+  // Build summary badges
+  const summaryParts: string[] = [];
+  if (group.runningCount > 0) summaryParts.push(`${group.runningCount} running`);
+  if (group.permCount > 0) summaryParts.push(`${group.permCount} waiting`);
+
+  return (
+    <div className={!isFirst ? "mt-1 pt-1 border-t border-cc-border/50" : ""}>
+      {/* Group header */}
+      <button
+        onClick={() => onToggleCollapse(group.key)}
+        className="w-full px-2 py-1.5 flex items-center gap-1.5 hover:bg-cc-hover rounded-md transition-colors cursor-pointer"
+      >
+        <svg
+          viewBox="0 0 16 16"
+          fill="currentColor"
+          className={`w-3 h-3 text-cc-muted transition-transform ${isCollapsed ? "" : "rotate-90"}`}
+        >
+          <path d="M6 4l4 4-4 4" />
+        </svg>
+        <span className="text-[11px] font-semibold text-cc-fg/80 truncate">
+          {group.label}
+        </span>
+        {summaryParts.length > 0 && (
+          <span className="text-[10px] text-cc-muted ml-auto shrink-0">
+            {summaryParts.map((part, i) => (
+              <span key={i}>
+                {i > 0 && ", "}
+                <span className={part.includes("running") ? "text-cc-success" : "text-cc-warning"}>
+                  {part}
+                </span>
+              </span>
+            ))}
+          </span>
+        )}
+        <span className="text-[10px] text-cc-muted/60 shrink-0 ml-1">
+          {group.sessions.length}
+        </span>
+      </button>
+
+      {/* Session list */}
+      {!isCollapsed && (
+        <div className="space-y-0.5 mt-0.5">
+          {group.sessions.map((s) => {
+            const permCount = pendingPermissions.get(s.id)?.size ?? 0;
+            return (
+              <SessionItem
+                key={s.id}
+                session={s}
+                isActive={currentSessionId === s.id}
+                sessionName={sessionNames.get(s.id)}
+                permCount={permCount}
+                isRecentlyRenamed={recentlyRenamed.has(s.id)}
+                onSelect={onSelect}
+                onStartRename={onStartRename}
+                onArchive={onArchive}
+                onUnarchive={onUnarchive}
+                onDelete={onDelete}
+                editingSessionId={editingSessionId}
+                editingName={editingName}
+                setEditingName={setEditingName}
+                onConfirmRename={onConfirmRename}
+                onCancelRename={onCancelRename}
+                editInputRef={editInputRef}
+              />
+            );
+          })}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/web/src/components/SessionItem.tsx
+++ b/web/src/components/SessionItem.tsx
@@ -1,0 +1,239 @@
+import type { RefObject } from "react";
+import { useStore } from "../store.js";
+import type { SessionItem as SessionItemType } from "../utils/project-grouping.js";
+
+interface SessionItemProps {
+  session: SessionItemType;
+  isActive: boolean;
+  isArchived?: boolean;
+  sessionName: string | undefined;
+  permCount: number;
+  isRecentlyRenamed: boolean;
+  onSelect: (id: string) => void;
+  onStartRename: (id: string, currentName: string) => void;
+  onArchive: (e: React.MouseEvent, id: string) => void;
+  onUnarchive: (e: React.MouseEvent, id: string) => void;
+  onDelete: (e: React.MouseEvent, id: string) => void;
+  editingSessionId: string | null;
+  editingName: string;
+  setEditingName: (name: string) => void;
+  onConfirmRename: () => void;
+  onCancelRename: () => void;
+  editInputRef: RefObject<HTMLInputElement | null>;
+}
+
+export function SessionItem({
+  session: s,
+  isActive,
+  isArchived: archived,
+  sessionName,
+  permCount,
+  isRecentlyRenamed,
+  onSelect,
+  onStartRename,
+  onArchive,
+  onUnarchive,
+  onDelete,
+  editingSessionId,
+  editingName,
+  setEditingName,
+  onConfirmRename,
+  onCancelRename,
+  editInputRef,
+}: SessionItemProps) {
+  const shortId = s.id.slice(0, 8);
+  const label = sessionName || s.model || shortId;
+  const isRunning = s.status === "running";
+  const isCompacting = s.status === "compacting";
+  const isEditing = editingSessionId === s.id;
+
+  // Status dot class
+  const statusDotClass = archived
+    ? "bg-cc-muted/40"
+    : permCount > 0
+    ? "bg-cc-warning"
+    : s.sdkState === "exited"
+    ? "bg-cc-muted/40"
+    : isRunning
+    ? "bg-cc-success"
+    : isCompacting
+    ? "bg-cc-warning"
+    : "bg-cc-success/60";
+
+  // Pulse animation for running or permissions
+  const showPulse = !archived && (
+    permCount > 0 || (isRunning && s.isConnected)
+  );
+  const pulseClass = permCount > 0
+    ? "bg-cc-warning/40"
+    : "bg-cc-success/40";
+
+  // Backend pill colors
+  const pillColors = s.backendType === "codex"
+    ? "text-blue-500 bg-blue-500/10"
+    : "text-[#5BA8A0] bg-[#5BA8A0]/10";
+
+  return (
+    <div className={`relative group ${archived ? "opacity-50" : ""}`}>
+      <button
+        onClick={() => onSelect(s.id)}
+        onDoubleClick={(e) => {
+          e.preventDefault();
+          onStartRename(s.id, label);
+        }}
+        className={`w-full pl-3.5 pr-8 py-2 ${archived ? "pr-14" : ""} text-left rounded-lg transition-all duration-100 cursor-pointer ${
+          isActive
+            ? "bg-cc-active"
+            : "hover:bg-cc-hover"
+        }`}
+      >
+        {/* Left accent border */}
+        <span
+          className={`absolute left-0 top-2 bottom-2 w-[2px] rounded-full ${
+            s.backendType === "codex"
+              ? "bg-blue-500"
+              : "bg-[#5BA8A0]"
+          } ${isActive ? "opacity-100" : "opacity-40 group-hover:opacity-70"} transition-opacity`}
+        />
+
+        <div className="flex items-start gap-2">
+          {/* Status dot (replaces avatar) */}
+          <div className="relative shrink-0 mt-[7px]">
+            <span
+              className={`block w-2 h-2 rounded-full ${statusDotClass}`}
+            />
+            {showPulse && (
+              <span className={`absolute inset-0 w-2 h-2 rounded-full ${pulseClass} animate-[pulse-dot_1.5s_ease-in-out_infinite]`} />
+            )}
+          </div>
+
+          {/* Content */}
+          <div className="flex-1 min-w-0">
+            {/* Row 1: Name + Backend pill */}
+            <div className="flex items-center gap-1.5">
+              {isEditing ? (
+                <input
+                  ref={editInputRef}
+                  value={editingName}
+                  onChange={(e) => setEditingName(e.target.value)}
+                  onKeyDown={(e) => {
+                    if (e.key === "Enter") {
+                      e.preventDefault();
+                      onConfirmRename();
+                    } else if (e.key === "Escape") {
+                      e.preventDefault();
+                      onCancelRename();
+                    }
+                    e.stopPropagation();
+                  }}
+                  onBlur={onConfirmRename}
+                  onClick={(e) => e.stopPropagation()}
+                  onDoubleClick={(e) => e.stopPropagation()}
+                  className="text-[13px] font-medium flex-1 min-w-0 text-cc-fg bg-transparent border border-cc-border rounded px-1 py-0 outline-none focus:border-cc-primary/50"
+                />
+              ) : (
+                <>
+                  <span
+                    className={`text-[13px] font-medium truncate text-cc-fg leading-snug ${
+                      isRecentlyRenamed ? "animate-name-appear" : ""
+                    }`}
+                    onAnimationEnd={() => useStore.getState().clearRecentlyRenamed(s.id)}
+                  >
+                    {label}
+                  </span>
+                  <span className={`text-[9px] font-medium px-1.5 rounded-full leading-[16px] shrink-0 ${pillColors}`}>
+                    {s.backendType === "codex" ? "Codex" : "Claude"}
+                  </span>
+                </>
+              )}
+            </div>
+
+            {/* Row 2: Branch (directory already shown in group header) */}
+            {s.gitBranch && (
+              <div className="flex items-center gap-1 mt-0.5 text-[10.5px] text-cc-muted leading-tight truncate">
+                {s.gitBranch && (
+                  <>
+                    {s.isWorktree ? (
+                      <svg viewBox="0 0 16 16" fill="currentColor" className="w-2.5 h-2.5 shrink-0 opacity-50">
+                        <path d="M5 3.25a.75.75 0 11-1.5 0 .75.75 0 011.5 0zm0 2.122a2.25 2.25 0 10-1.5 0v5.256a2.25 2.25 0 101.5 0V5.372zM4.25 12a.75.75 0 100 1.5.75.75 0 000-1.5zm7.5-9.5a.75.75 0 100 1.5.75.75 0 000-1.5zm-2.25.75a2.25 2.25 0 113 2.122V7A2.5 2.5 0 0110 9.5H6a1 1 0 000 2h4a2.5 2.5 0 012.5 2.5v.628a2.25 2.25 0 11-1.5 0V14a1 1 0 00-1-1H6a2.5 2.5 0 01-2.5-2.5V10a2.5 2.5 0 012.5-2.5h4a1 1 0 001-1V5.372a2.25 2.25 0 01-1.5-2.122z" />
+                      </svg>
+                    ) : (
+                      <svg viewBox="0 0 16 16" fill="currentColor" className="w-2.5 h-2.5 shrink-0 opacity-50">
+                        <path d="M11.75 2.5a.75.75 0 100 1.5.75.75 0 000-1.5zm-2.116.862a2.25 2.25 0 10-.862.862A4.48 4.48 0 007.25 7.5h-1.5A2.25 2.25 0 003.5 9.75v.318a2.25 2.25 0 101.5 0V9.75a.75.75 0 01.75-.75h1.5a5.98 5.98 0 003.884-1.435A2.25 2.25 0 109.634 3.362zM4.25 12a.75.75 0 100 1.5.75.75 0 000-1.5z" />
+                      </svg>
+                    )}
+                    <span className="truncate">{s.gitBranch}</span>
+                    {s.isWorktree && (
+                      <span className="text-[8px] bg-cc-primary/10 text-cc-primary px-0.5 rounded shrink-0">wt</span>
+                    )}
+                  </>
+                )}
+              </div>
+            )}
+
+            {/* Row 3: Git stats (conditional) */}
+            {(s.gitAhead > 0 || s.gitBehind > 0 || s.linesAdded > 0 || s.linesRemoved > 0) && (
+              <div className="flex items-center gap-1.5 mt-px text-[10px] text-cc-muted">
+                {(s.gitAhead > 0 || s.gitBehind > 0) && (
+                  <span className="flex items-center gap-0.5">
+                    {s.gitAhead > 0 && <span className="text-green-500">{s.gitAhead}&#8593;</span>}
+                    {s.gitBehind > 0 && <span className="text-cc-warning">{s.gitBehind}&#8595;</span>}
+                  </span>
+                )}
+                {(s.linesAdded > 0 || s.linesRemoved > 0) && (
+                  <span className="flex items-center gap-1 shrink-0">
+                    <span className="text-green-500">+{s.linesAdded}</span>
+                    <span className="text-red-400">-{s.linesRemoved}</span>
+                  </span>
+                )}
+              </div>
+            )}
+          </div>
+        </div>
+      </button>
+
+      {/* Permission badge */}
+      {!archived && permCount > 0 && (
+        <span className="absolute right-2 top-1/2 -translate-y-1/2 min-w-[18px] h-[18px] flex items-center justify-center rounded-full bg-cc-warning text-white text-[10px] font-bold leading-none px-1 group-hover:opacity-0 transition-opacity pointer-events-none">
+          {permCount}
+        </span>
+      )}
+
+      {/* Action buttons */}
+      {archived ? (
+        <>
+          <button
+            onClick={(e) => onUnarchive(e, s.id)}
+            className="absolute right-8 top-1/2 -translate-y-1/2 p-1 rounded-md opacity-0 group-hover:opacity-100 hover:bg-cc-border text-cc-muted hover:text-cc-fg transition-all cursor-pointer"
+            title="Restore session"
+          >
+            <svg viewBox="0 0 16 16" fill="none" stroke="currentColor" strokeWidth="1.5" className="w-3.5 h-3.5">
+              <path d="M8 10V3M5 5l3-3 3 3" strokeLinecap="round" strokeLinejoin="round" />
+              <path d="M3 13h10" strokeLinecap="round" />
+            </svg>
+          </button>
+          <button
+            onClick={(e) => onDelete(e, s.id)}
+            className="absolute right-2 top-1/2 -translate-y-1/2 p-1 rounded-md opacity-0 group-hover:opacity-100 hover:bg-cc-border text-cc-muted hover:text-red-400 transition-all cursor-pointer"
+            title="Delete permanently"
+          >
+            <svg viewBox="0 0 16 16" fill="none" stroke="currentColor" strokeWidth="1.5" className="w-3.5 h-3.5">
+              <path d="M4 4l8 8M12 4l-8 8" />
+            </svg>
+          </button>
+        </>
+      ) : (
+        <button
+          onClick={(e) => onArchive(e, s.id)}
+          className="absolute right-2 top-1/2 -translate-y-1/2 p-1 rounded-md opacity-0 group-hover:opacity-100 hover:bg-cc-border text-cc-muted hover:text-cc-fg transition-all cursor-pointer"
+          title="Archive session"
+        >
+          <svg viewBox="0 0 16 16" fill="none" stroke="currentColor" strokeWidth="1.5" className="w-3.5 h-3.5">
+            <path d="M3 3h10v2H3zM4 5v7a1 1 0 001 1h6a1 1 0 001-1V5" strokeLinecap="round" strokeLinejoin="round" />
+            <path d="M6.5 8h3" strokeLinecap="round" />
+          </svg>
+        </button>
+      )}
+    </div>
+  );
+}

--- a/web/src/components/Sidebar.tsx
+++ b/web/src/components/Sidebar.tsx
@@ -1,8 +1,11 @@
-import { useState, useEffect, useCallback, useRef } from "react";
+import { useState, useEffect, useCallback, useRef, useMemo } from "react";
 import { useStore } from "../store.js";
 import { api } from "../api.js";
 import { connectSession, connectAllSessions, disconnectSession } from "../ws.js";
 import { EnvManager } from "./EnvManager.js";
+import { ProjectGroup } from "./ProjectGroup.js";
+import { SessionItem } from "./SessionItem.js";
+import { groupSessionsByProject, type SessionItem as SessionItemType } from "../utils/project-grouping.js";
 
 export function Sidebar() {
   const [editingSessionId, setEditingSessionId] = useState<string | null>(null);
@@ -25,6 +28,8 @@ export function Sidebar() {
   const sessionNames = useStore((s) => s.sessionNames);
   const recentlyRenamed = useStore((s) => s.recentlyRenamed);
   const pendingPermissions = useStore((s) => s.pendingPermissions);
+  const collapsedProjects = useStore((s) => s.collapsedProjects);
+  const toggleProjectCollapse = useStore((s) => s.toggleProjectCollapse);
 
   // Poll for SDK sessions on mount
   useEffect(() => {
@@ -103,6 +108,11 @@ export function Sidebar() {
     setEditingName("");
   }
 
+  function handleStartRename(id: string, currentName: string) {
+    setEditingSessionId(id);
+    setEditingName(currentName);
+  }
+
   const handleDeleteSession = useCallback(async (e: React.MouseEvent, sessionId: string) => {
     e.stopPropagation();
     try {
@@ -176,7 +186,7 @@ export function Sidebar() {
   for (const id of sessions.keys()) allSessionIds.add(id);
   for (const s of sdkSessions) allSessionIds.add(s.sessionId);
 
-  const allSessionList = Array.from(allSessionIds).map((id) => {
+  const allSessionList: SessionItemType[] = Array.from(allSessionIds).map((id) => {
     const bridgeState = sessions.get(id);
     const sdkInfo = sdkSessions.find((s) => s.sessionId === id);
     return {
@@ -195,6 +205,8 @@ export function Sidebar() {
       createdAt: sdkInfo?.createdAt ?? 0,
       archived: sdkInfo?.archived ?? false,
       backendType: bridgeState?.backend_type || sdkInfo?.backendType || "claude",
+      repoRoot: bridgeState?.repo_root || sdkInfo?.repoRoot || "",
+      permCount: pendingPermissions.get(id)?.size ?? 0,
     };
   }).sort((a, b) => b.createdAt - a.createdAt);
 
@@ -203,209 +215,26 @@ export function Sidebar() {
   const currentSession = currentSessionId ? allSessionList.find((s) => s.id === currentSessionId) : null;
   const logoSrc = currentSession?.backendType === "codex" ? "/logo-codex.svg" : "/logo.svg";
 
-  function renderSessionItem(s: typeof allSessionList[number], options?: { isArchived?: boolean }) {
-    const isActive = currentSessionId === s.id;
-    const name = sessionNames.get(s.id);
-    const shortId = s.id.slice(0, 8);
-    const label = name || s.model || shortId;
-    const dirName = s.cwd ? s.cwd.split("/").pop() : "";
-    const isRunning = s.status === "running";
-    const isCompacting = s.status === "compacting";
-    const isEditing = editingSessionId === s.id;
-    const permCount = pendingPermissions.get(s.id)?.size ?? 0;
-    const archived = options?.isArchived;
-    const avatarSrc = s.backendType === "codex" ? "/logo-codex.svg" : "/logo.svg";
+  // Group active sessions by project
+  const projectGroups = useMemo(
+    () => groupSessionsByProject(activeSessions),
+    [activeSessions],
+  );
 
-    // Status dot class
-    const statusDotClass = archived
-      ? "bg-cc-muted/40"
-      : permCount > 0
-      ? "bg-cc-warning"
-      : s.sdkState === "exited"
-      ? "bg-cc-muted/40"
-      : isRunning
-      ? "bg-cc-success"
-      : isCompacting
-      ? "bg-cc-warning"
-      : "bg-cc-success/60";
-
-    // Pulse animation for running or permissions
-    const showPulse = !archived && (
-      permCount > 0 || (isRunning && s.isConnected)
-    );
-    const pulseClass = permCount > 0
-      ? "bg-cc-warning/40"
-      : "bg-cc-success/40";
-
-    return (
-      <div key={s.id} className={`relative group ${archived ? "opacity-50" : ""}`}>
-        <button
-          onClick={() => handleSelectSession(s.id)}
-          onDoubleClick={(e) => {
-            e.preventDefault();
-            setEditingSessionId(s.id);
-            setEditingName(label);
-          }}
-          className={`w-full pl-3.5 pr-8 py-2 ${archived ? "pr-14" : ""} text-left rounded-lg transition-all duration-100 cursor-pointer ${
-            isActive
-              ? "bg-cc-active"
-              : "hover:bg-cc-hover"
-          }`}
-        >
-          {/* Left accent border */}
-          <span
-            className={`absolute left-0 top-2 bottom-2 w-[2px] rounded-full ${
-              s.backendType === "codex"
-                ? "bg-blue-500"
-                : "bg-[#5BA8A0]"
-            } ${isActive ? "opacity-100" : "opacity-40 group-hover:opacity-70"} transition-opacity`}
-          />
-
-          <div className="flex items-start gap-2.5">
-            {/* Avatar with status dot overlay */}
-            <div className="relative shrink-0 w-6 h-6 mt-0.5">
-              <img
-                src={avatarSrc}
-                alt=""
-                className="w-6 h-6 rounded-[5px]"
-              />
-              <span
-                className={`absolute -bottom-0.5 -right-0.5 w-[7px] h-[7px] rounded-full ring-[1.5px] ring-cc-sidebar ${statusDotClass}`}
-              />
-              {showPulse && (
-                <span className={`absolute -bottom-0.5 -right-0.5 w-[7px] h-[7px] rounded-full ${pulseClass} animate-[pulse-dot_1.5s_ease-in-out_infinite]`} />
-              )}
-            </div>
-
-            {/* Content */}
-            <div className="flex-1 min-w-0">
-              {/* Row 1: Name */}
-              {isEditing ? (
-                <input
-                  ref={editInputRef}
-                  value={editingName}
-                  onChange={(e) => setEditingName(e.target.value)}
-                  onKeyDown={(e) => {
-                    if (e.key === "Enter") {
-                      e.preventDefault();
-                      confirmRename();
-                    } else if (e.key === "Escape") {
-                      e.preventDefault();
-                      cancelRename();
-                    }
-                    e.stopPropagation();
-                  }}
-                  onBlur={confirmRename}
-                  onClick={(e) => e.stopPropagation()}
-                  onDoubleClick={(e) => e.stopPropagation()}
-                  className="text-[13px] font-medium w-full text-cc-fg bg-transparent border border-cc-border rounded px-1 py-0 outline-none focus:border-cc-primary/50 min-w-0"
-                />
-              ) : (
-                <span
-                  className={`text-[13px] font-medium truncate block text-cc-fg leading-snug ${
-                    recentlyRenamed.has(s.id) ? "animate-name-appear" : ""
-                  }`}
-                  onAnimationEnd={() => useStore.getState().clearRecentlyRenamed(s.id)}
-                >
-                  {label}
-                </span>
-              )}
-
-              {/* Row 2: Directory + Branch inline */}
-              {(dirName || s.gitBranch) && (
-                <div className="flex items-center gap-1 mt-0.5 text-[10.5px] text-cc-muted leading-tight truncate">
-                  {dirName && (
-                    <span className="truncate shrink-0 max-w-[80px]">{dirName}</span>
-                  )}
-                  {dirName && s.gitBranch && (
-                    <span className="text-cc-muted/40 shrink-0">/</span>
-                  )}
-                  {s.gitBranch && (
-                    <>
-                      {s.isWorktree ? (
-                        <svg viewBox="0 0 16 16" fill="currentColor" className="w-2.5 h-2.5 shrink-0 opacity-50">
-                          <path d="M5 3.25a.75.75 0 11-1.5 0 .75.75 0 011.5 0zm0 2.122a2.25 2.25 0 10-1.5 0v5.256a2.25 2.25 0 101.5 0V5.372zM4.25 12a.75.75 0 100 1.5.75.75 0 000-1.5zm7.5-9.5a.75.75 0 100 1.5.75.75 0 000-1.5zm-2.25.75a2.25 2.25 0 113 2.122V7A2.5 2.5 0 0110 9.5H6a1 1 0 000 2h4a2.5 2.5 0 012.5 2.5v.628a2.25 2.25 0 11-1.5 0V14a1 1 0 00-1-1H6a2.5 2.5 0 01-2.5-2.5V10a2.5 2.5 0 012.5-2.5h4a1 1 0 001-1V5.372a2.25 2.25 0 01-1.5-2.122z" />
-                        </svg>
-                      ) : (
-                        <svg viewBox="0 0 16 16" fill="currentColor" className="w-2.5 h-2.5 shrink-0 opacity-50">
-                          <path d="M11.75 2.5a.75.75 0 100 1.5.75.75 0 000-1.5zm-2.116.862a2.25 2.25 0 10-.862.862A4.48 4.48 0 007.25 7.5h-1.5A2.25 2.25 0 003.5 9.75v.318a2.25 2.25 0 101.5 0V9.75a.75.75 0 01.75-.75h1.5a5.98 5.98 0 003.884-1.435A2.25 2.25 0 109.634 3.362zM4.25 12a.75.75 0 100 1.5.75.75 0 000-1.5z" />
-                        </svg>
-                      )}
-                      <span className="truncate">{s.gitBranch}</span>
-                      {s.isWorktree && (
-                        <span className="text-[8px] bg-cc-primary/10 text-cc-primary px-0.5 rounded shrink-0">wt</span>
-                      )}
-                    </>
-                  )}
-                </div>
-              )}
-
-              {/* Row 3: Git stats (conditional) */}
-              {(s.gitAhead > 0 || s.gitBehind > 0 || s.linesAdded > 0 || s.linesRemoved > 0) && (
-                <div className="flex items-center gap-1.5 mt-px text-[10px] text-cc-muted">
-                  {(s.gitAhead > 0 || s.gitBehind > 0) && (
-                    <span className="flex items-center gap-0.5">
-                      {s.gitAhead > 0 && <span className="text-green-500">{s.gitAhead}&#8593;</span>}
-                      {s.gitBehind > 0 && <span className="text-cc-warning">{s.gitBehind}&#8595;</span>}
-                    </span>
-                  )}
-                  {(s.linesAdded > 0 || s.linesRemoved > 0) && (
-                    <span className="flex items-center gap-1 shrink-0">
-                      <span className="text-green-500">+{s.linesAdded}</span>
-                      <span className="text-red-400">-{s.linesRemoved}</span>
-                    </span>
-                  )}
-                </div>
-              )}
-            </div>
-          </div>
-        </button>
-
-        {/* Permission badge */}
-        {!archived && permCount > 0 && (
-          <span className="absolute right-2 top-1/2 -translate-y-1/2 min-w-[18px] h-[18px] flex items-center justify-center rounded-full bg-cc-warning text-white text-[10px] font-bold leading-none px-1 group-hover:opacity-0 transition-opacity pointer-events-none">
-            {permCount}
-          </span>
-        )}
-
-        {/* Action buttons */}
-        {archived ? (
-          <>
-            <button
-              onClick={(e) => handleUnarchiveSession(e, s.id)}
-              className="absolute right-8 top-1/2 -translate-y-1/2 p-1 rounded-md opacity-0 group-hover:opacity-100 hover:bg-cc-border text-cc-muted hover:text-cc-fg transition-all cursor-pointer"
-              title="Restore session"
-            >
-              <svg viewBox="0 0 16 16" fill="none" stroke="currentColor" strokeWidth="1.5" className="w-3.5 h-3.5">
-                <path d="M8 10V3M5 5l3-3 3 3" strokeLinecap="round" strokeLinejoin="round" />
-                <path d="M3 13h10" strokeLinecap="round" />
-              </svg>
-            </button>
-            <button
-              onClick={(e) => handleDeleteSession(e, s.id)}
-              className="absolute right-2 top-1/2 -translate-y-1/2 p-1 rounded-md opacity-0 group-hover:opacity-100 hover:bg-cc-border text-cc-muted hover:text-red-400 transition-all cursor-pointer"
-              title="Delete permanently"
-            >
-              <svg viewBox="0 0 16 16" fill="none" stroke="currentColor" strokeWidth="1.5" className="w-3.5 h-3.5">
-                <path d="M4 4l8 8M12 4l-8 8" />
-              </svg>
-            </button>
-          </>
-        ) : (
-          <button
-            onClick={(e) => handleArchiveSession(e, s.id)}
-            className="absolute right-2 top-1/2 -translate-y-1/2 p-1 rounded-md opacity-0 group-hover:opacity-100 hover:bg-cc-border text-cc-muted hover:text-cc-fg transition-all cursor-pointer"
-            title="Archive session"
-          >
-            <svg viewBox="0 0 16 16" fill="none" stroke="currentColor" strokeWidth="1.5" className="w-3.5 h-3.5">
-              <path d="M3 3h10v2H3zM4 5v7a1 1 0 001 1h6a1 1 0 001-1V5" strokeLinecap="round" strokeLinejoin="round" />
-              <path d="M6.5 8h3" strokeLinecap="round" />
-            </svg>
-          </button>
-        )}
-      </div>
-    );
-  }
+  // Shared props for SessionItem / ProjectGroup
+  const sessionItemProps = {
+    onSelect: handleSelectSession,
+    onStartRename: handleStartRename,
+    onArchive: handleArchiveSession,
+    onUnarchive: handleUnarchiveSession,
+    onDelete: handleDeleteSession,
+    editingSessionId,
+    editingName,
+    setEditingName,
+    onConfirmRename: confirmRename,
+    onCancelRename: cancelRename,
+    editInputRef,
+  };
 
   return (
     <aside className="w-[260px] h-full flex flex-col bg-cc-sidebar border-r border-cc-border">
@@ -465,9 +294,20 @@ export function Sidebar() {
           </p>
         ) : (
           <>
-            <div className="space-y-0.5">
-              {activeSessions.map((s) => renderSessionItem(s))}
-            </div>
+            {projectGroups.map((group, i) => (
+              <ProjectGroup
+                key={group.key}
+                group={group}
+                isCollapsed={collapsedProjects.has(group.key)}
+                onToggleCollapse={toggleProjectCollapse}
+                currentSessionId={currentSessionId}
+                sessionNames={sessionNames}
+                pendingPermissions={pendingPermissions}
+                recentlyRenamed={recentlyRenamed}
+                isFirst={i === 0}
+                {...sessionItemProps}
+              />
+            ))}
 
             {archivedSessions.length > 0 && (
               <div className="mt-2 pt-2 border-t border-cc-border">
@@ -482,7 +322,18 @@ export function Sidebar() {
                 </button>
                 {showArchived && (
                   <div className="space-y-0.5 mt-1">
-                    {archivedSessions.map((s) => renderSessionItem(s, { isArchived: true }))}
+                    {archivedSessions.map((s) => (
+                      <SessionItem
+                        key={s.id}
+                        session={s}
+                        isActive={currentSessionId === s.id}
+                        isArchived
+                        sessionName={sessionNames.get(s.id)}
+                        permCount={pendingPermissions.get(s.id)?.size ?? 0}
+                        isRecentlyRenamed={recentlyRenamed.has(s.id)}
+                        {...sessionItemProps}
+                      />
+                    ))}
                   </div>
                 )}
               </div>

--- a/web/src/store.ts
+++ b/web/src/store.ts
@@ -41,6 +41,9 @@ interface AppState {
   // Track sessions that were just renamed (for animation)
   recentlyRenamed: Set<string>;
 
+  // Sidebar project grouping
+  collapsedProjects: Set<string>;
+
   // UI
   darkMode: boolean;
   notificationSound: boolean;
@@ -93,6 +96,9 @@ interface AppState {
   markRecentlyRenamed: (sessionId: string) => void;
   clearRecentlyRenamed: (sessionId: string) => void;
 
+  // Sidebar project grouping actions
+  toggleProjectCollapse: (projectKey: string) => void;
+
   // Plan mode actions
   setPreviousPermissionMode: (sessionId: string, mode: string) => void;
 
@@ -138,6 +144,15 @@ function getInitialNotificationSound(): boolean {
   return true;
 }
 
+function getInitialCollapsedProjects(): Set<string> {
+  if (typeof window === "undefined") return new Set();
+  try {
+    return new Set(JSON.parse(localStorage.getItem("cc-collapsed-projects") || "[]"));
+  } catch {
+    return new Set();
+  }
+}
+
 export const useStore = create<AppState>((set) => ({
   sessions: new Map(),
   sdkSessions: [],
@@ -155,6 +170,7 @@ export const useStore = create<AppState>((set) => ({
   changedFiles: new Map(),
   sessionNames: getInitialSessionNames(),
   recentlyRenamed: new Set(),
+  collapsedProjects: getInitialCollapsedProjects(),
   darkMode: getInitialDarkMode(),
   notificationSound: getInitialNotificationSound(),
   sidebarOpen: typeof window !== "undefined" ? window.innerWidth >= 768 : true,
@@ -422,6 +438,18 @@ export const useStore = create<AppState>((set) => ({
       const recentlyRenamed = new Set(s.recentlyRenamed);
       recentlyRenamed.delete(sessionId);
       return { recentlyRenamed };
+    }),
+
+  toggleProjectCollapse: (projectKey) =>
+    set((s) => {
+      const collapsedProjects = new Set(s.collapsedProjects);
+      if (collapsedProjects.has(projectKey)) {
+        collapsedProjects.delete(projectKey);
+      } else {
+        collapsedProjects.add(projectKey);
+      }
+      localStorage.setItem("cc-collapsed-projects", JSON.stringify(Array.from(collapsedProjects)));
+      return { collapsedProjects };
     }),
 
   setPreviousPermissionMode: (sessionId, mode) =>

--- a/web/src/utils/project-grouping.test.ts
+++ b/web/src/utils/project-grouping.test.ts
@@ -1,0 +1,149 @@
+import { describe, it, expect } from "vitest";
+import {
+  extractProjectKey,
+  extractProjectLabel,
+  groupSessionsByProject,
+  type SessionItem,
+} from "./project-grouping.js";
+
+function makeItem(overrides: Partial<SessionItem> = {}): SessionItem {
+  return {
+    id: "s1",
+    model: "claude-sonnet-4-5-20250929",
+    cwd: "/home/user/projects/myapp",
+    gitBranch: "",
+    isWorktree: false,
+    gitAhead: 0,
+    gitBehind: 0,
+    linesAdded: 0,
+    linesRemoved: 0,
+    isConnected: false,
+    status: null,
+    sdkState: null,
+    createdAt: 1000,
+    archived: false,
+    backendType: "claude",
+    repoRoot: "",
+    permCount: 0,
+    ...overrides,
+  };
+}
+
+describe("extractProjectKey", () => {
+  it("uses repoRoot when available (worktree normalization)", () => {
+    expect(
+      extractProjectKey("/home/user/myapp-wt-1234", "/home/user/myapp"),
+    ).toBe("/home/user/myapp");
+  });
+
+  it("falls back to cwd when repoRoot is undefined", () => {
+    expect(extractProjectKey("/home/user/projects/myapp")).toBe(
+      "/home/user/projects/myapp",
+    );
+  });
+
+  it("removes trailing slashes", () => {
+    expect(extractProjectKey("/home/user/myapp/")).toBe("/home/user/myapp");
+  });
+
+  it("returns / for empty cwd", () => {
+    expect(extractProjectKey("")).toBe("/");
+  });
+
+  it("prefers repoRoot over cwd even when both are valid", () => {
+    expect(
+      extractProjectKey("/home/user/myapp/web", "/home/user/myapp"),
+    ).toBe("/home/user/myapp");
+  });
+});
+
+describe("extractProjectLabel", () => {
+  it("returns last path component for normal paths", () => {
+    expect(extractProjectLabel("/home/user/projects/myapp")).toBe("myapp");
+  });
+
+  it("returns / for root path", () => {
+    expect(extractProjectLabel("/")).toBe("/");
+  });
+
+  it("handles single component path", () => {
+    expect(extractProjectLabel("/myapp")).toBe("myapp");
+  });
+
+  it("handles deep nested paths", () => {
+    expect(extractProjectLabel("/a/b/c/d/e")).toBe("e");
+  });
+});
+
+describe("groupSessionsByProject", () => {
+  it("groups sessions sharing the same cwd into one group", () => {
+    const sessions = [
+      makeItem({ id: "s1", cwd: "/home/user/myapp" }),
+      makeItem({ id: "s2", cwd: "/home/user/myapp" }),
+    ];
+    const groups = groupSessionsByProject(sessions);
+    expect(groups).toHaveLength(1);
+    expect(groups[0].sessions).toHaveLength(2);
+    expect(groups[0].label).toBe("myapp");
+  });
+
+  it("groups worktree sessions with their parent repo", () => {
+    const sessions = [
+      makeItem({ id: "s1", cwd: "/home/user/myapp", repoRoot: "/home/user/myapp" }),
+      makeItem({ id: "s2", cwd: "/home/user/myapp-wt-1234", repoRoot: "/home/user/myapp", isWorktree: true }),
+    ];
+    const groups = groupSessionsByProject(sessions);
+    expect(groups).toHaveLength(1);
+    expect(groups[0].sessions).toHaveLength(2);
+  });
+
+  it("sorts groups alphabetically by label", () => {
+    const sessions = [
+      makeItem({ id: "s1", cwd: "/a/zebra", createdAt: 200 }),
+      makeItem({ id: "s2", cwd: "/a/alpha", createdAt: 100 }),
+    ];
+    const groups = groupSessionsByProject(sessions);
+    expect(groups[0].label).toBe("alpha");
+    expect(groups[1].label).toBe("zebra");
+  });
+
+  it("sorts sessions within group: running first, then by createdAt desc", () => {
+    const sessions = [
+      makeItem({ id: "s1", cwd: "/a/app", createdAt: 300, status: null }),
+      makeItem({ id: "s2", cwd: "/a/app", createdAt: 100, status: "running" }),
+      makeItem({ id: "s3", cwd: "/a/app", createdAt: 200, status: null }),
+    ];
+    const groups = groupSessionsByProject(sessions);
+    expect(groups[0].sessions.map((s) => s.id)).toEqual(["s2", "s1", "s3"]);
+  });
+
+  it("handles sessions with empty cwd as a separate group", () => {
+    const sessions = [
+      makeItem({ id: "s1", cwd: "/a/app" }),
+      makeItem({ id: "s2", cwd: "" }),
+    ];
+    const groups = groupSessionsByProject(sessions);
+    expect(groups).toHaveLength(2);
+  });
+
+  it("computes aggregate runningCount and permCount", () => {
+    const sessions = [
+      makeItem({ id: "s1", cwd: "/a/app", status: "running", permCount: 1 }),
+      makeItem({ id: "s2", cwd: "/a/app", status: "running", permCount: 2 }),
+      makeItem({ id: "s3", cwd: "/a/app", status: null, permCount: 0 }),
+    ];
+    const groups = groupSessionsByProject(sessions);
+    expect(groups[0].runningCount).toBe(2);
+    expect(groups[0].permCount).toBe(3);
+  });
+
+  it("creates separate groups for different directories", () => {
+    const sessions = [
+      makeItem({ id: "s1", cwd: "/a/app1" }),
+      makeItem({ id: "s2", cwd: "/a/app2" }),
+      makeItem({ id: "s3", cwd: "/a/app1" }),
+    ];
+    const groups = groupSessionsByProject(sessions);
+    expect(groups).toHaveLength(2);
+  });
+});

--- a/web/src/utils/project-grouping.ts
+++ b/web/src/utils/project-grouping.ts
@@ -1,0 +1,98 @@
+import type { SdkSessionInfo } from "../types.js";
+
+export interface SessionItem {
+  id: string;
+  model: string;
+  cwd: string;
+  gitBranch: string;
+  isWorktree: boolean;
+  gitAhead: number;
+  gitBehind: number;
+  linesAdded: number;
+  linesRemoved: number;
+  isConnected: boolean;
+  status: "idle" | "running" | "compacting" | null;
+  sdkState: "starting" | "connected" | "running" | "exited" | null;
+  createdAt: number;
+  archived: boolean;
+  backendType: "claude" | "codex";
+  repoRoot: string;
+  permCount: number;
+}
+
+export interface ProjectGroup {
+  key: string;
+  label: string;
+  sessions: SessionItem[];
+  runningCount: number;
+  permCount: number;
+  mostRecentActivity: number;
+}
+
+/**
+ * Extracts a project key from a cwd path.
+ * Uses repoRoot when available (normalizes worktrees to their parent repo).
+ */
+export function extractProjectKey(cwd: string, repoRoot?: string): string {
+  const basePath = repoRoot || cwd;
+  return basePath.replace(/\/+$/, "") || "/";
+}
+
+/**
+ * Extracts a display label from a project key (last path component).
+ */
+export function extractProjectLabel(projectKey: string): string {
+  if (projectKey === "/") return "/";
+  const parts = projectKey.split("/").filter(Boolean);
+  if (parts.length === 0) return "/";
+  return parts[parts.length - 1];
+}
+
+/**
+ * Groups sessions by project directory, sorts groups by most recent activity,
+ * and sorts sessions within each group (running first, then by createdAt desc).
+ */
+export function groupSessionsByProject(
+  sessions: SessionItem[],
+): ProjectGroup[] {
+  const groups = new Map<string, ProjectGroup>();
+
+  for (const session of sessions) {
+    const key = extractProjectKey(session.cwd, session.repoRoot || undefined);
+    const label = extractProjectLabel(key);
+
+    if (!groups.has(key)) {
+      groups.set(key, {
+        key,
+        label,
+        sessions: [],
+        runningCount: 0,
+        permCount: 0,
+        mostRecentActivity: 0,
+      });
+    }
+
+    const group = groups.get(key)!;
+    group.sessions.push(session);
+    if (session.status === "running") group.runningCount++;
+    group.permCount += session.permCount;
+    group.mostRecentActivity = Math.max(group.mostRecentActivity, session.createdAt);
+  }
+
+  // Sort groups alphabetically by label (stable, predictable order)
+  const sorted = Array.from(groups.values()).sort(
+    (a, b) => a.label.localeCompare(b.label),
+  );
+
+  // Within each group, sort sessions: running first, then by createdAt desc
+  for (const group of sorted) {
+    group.sessions.sort((a, b) => {
+      const aRunning = a.status === "running" ? 1 : 0;
+      const bRunning = b.status === "running" ? 1 : 0;
+      if (aRunning !== bRunning) return bRunning - aRunning;
+      return b.createdAt - a.createdAt;
+    });
+  }
+
+  return sorted;
+}


### PR DESCRIPTION
## Summary

- **Group sessions by project**: Sessions sharing the same working directory are grouped under a collapsible header showing the project name, session count, and running status (e.g. "2 running", "1 waiting")
- **Replace avatar with backend pill**: Remove the per-session Claude/Codex logo (24x24 avatar) and replace with a clear text pill ("Claude" in teal, "Codex" in blue) + a status dot (8px) for connection/running state
- **Stable alphabetical ordering**: Groups are sorted alphabetically by project name so they don't jump around when sessions start/stop
- **Remove redundant directory name**: The working directory name is no longer shown in each session row since it's already in the group header

### Architecture changes

- Extract `SessionItem` and `ProjectGroup` into dedicated components
- New `project-grouping.ts` utility with pure grouping/sorting functions (16 unit tests)
- Add `collapsedProjects` state to Zustand store, persisted in localStorage
- Worktree sessions are normalized to their parent repo via `repoRoot`

## Test plan

- [x] `bun run typecheck` — 0 errors
- [x] `bun run test` — 655/655 tests pass (24 test files)
- [x] `bun run build` — production build succeeds
- [ ] Visual check: sessions grouped by project, groups collapsible
- [ ] Visual check: Claude/Codex pills render correctly
- [ ] Visual check: rename (double-click), archive, permissions all work

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/the-vibe-company/companion/pull/117" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
