### PR TITLE
fix(web): default folder picker to home directory instead of server cwd

### DIFF
--- a/web/server/routes.ts
+++ b/web/server/routes.ts
@@ -303,7 +303,15 @@ export function createRoutes(
   });
 
   api.get("/fs/home", (c) => {
-    return c.json({ home: homedir(), cwd: process.cwd() });
+    const home = homedir();
+    const cwd = process.cwd();
+    // Only report cwd if the user launched companion from a real project directory
+    // (not from the package root or the home directory itself)
+    const packageRoot = process.env.__VIBE_PACKAGE_ROOT;
+    const isProjectDir =
+      cwd !== home &&
+      (!packageRoot || !cwd.startsWith(packageRoot));
+    return c.json({ home, cwd: isProjectDir ? cwd : home });
   });
 
   // ─── Editor filesystem APIs ─────────────────────────────────────


### PR DESCRIPTION
## Summary

- The folder picker previously opened at `process.cwd()`, which pointed to the companion's install directory — making it impossible for users to easily navigate to their project folders
- Now the `/fs/home` endpoint only returns `process.cwd()` when the user explicitly launched companion from a project directory (cwd differs from both `~` and the package root)
- Otherwise defaults to the user's home directory (`~`)

Closes #119

## Test plan

- [x] Added 4 test cases covering: cwd = package root, cwd inside package root, cwd = real project dir, cwd = home dir
- [ ] Manual: run `bunx the-vibe-companion` from home → folder picker should open at `~`
- [ ] Manual: run `cd ~/my-project && bunx the-vibe-companion` → folder picker should open at `~/my-project`

**Code generated by AI, not reviewed by a human.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/the-vibe-company/companion/pull/122" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
