### PR TITLE
Hide successful no-output command results

### DIFF
--- a/web/server/codex-adapter.ts
+++ b/web/server/codex-adapter.ts
@@ -1105,9 +1105,8 @@ export class CodexAdapter {
         const exitCode = typeof cmd.exitCode === "number" ? cmd.exitCode : 0;
         const failed = cmd.status === "failed" || cmd.status === "declined" || exitCode !== 0;
 
-        // Always emit tool_result so the browser shows a complete tool block.
+        // Keep successful no-output commands silent in the chat feed.
         if (!combinedOutput && !failed) {
-          this.emitToolResult(item.id, "Command completed successfully.", false);
           break;
         }
 


### PR DESCRIPTION
## Summary
- stop emitting synthetic `tool_result` for successful commands with empty stdout/stderr
- keep `tool_use` emission so the executed command remains visible
- update adapter test to assert silent-success behavior

## Validation
- bun run test server/codex-adapter.test.ts
- bun run typecheck
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/the-vibe-company/companion/pull/139" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
