### PR TITLE
 fix(web): bind server to localhost and resolve --sdk-url hostname

### DIFF
--- a/web/server/cli-launcher.test.ts
+++ b/web/server/cli-launcher.test.ts
@@ -138,7 +138,7 @@ describe("launch", () => {
 
     // Core required flags
     expect(cmdAndArgs).toContain("--sdk-url");
-    expect(cmdAndArgs).toContain("ws://localhost:3456/ws/cli/test-session-id");
+    expect(cmdAndArgs).toContain("ws://127.0.0.1:3456/ws/cli/test-session-id");
     expect(cmdAndArgs).toContain("--print");
     expect(cmdAndArgs).toContain("--output-format");
     expect(cmdAndArgs).toContain("stream-json");

--- a/web/server/cli-launcher.ts
+++ b/web/server/cli-launcher.ts
@@ -78,11 +78,16 @@ export class CliLauncher {
   private sessions = new Map<string, SdkSessionInfo>();
   private processes = new Map<string, Subprocess>();
   private port: number;
+  private hostname: string;
   private store: SessionStore | null = null;
   private onCodexAdapter: ((sessionId: string, adapter: CodexAdapter) => void) | null = null;
 
-  constructor(port: number) {
+  constructor(port: number, hostname?: string) {
     this.port = port;
+    // For the CLI's --sdk-url: if the server binds to 0.0.0.0 or localhost,
+    // use 127.0.0.1 (guaranteed loopback). Otherwise use the specific host.
+    const host = hostname || "localhost";
+    this.hostname = (host === "0.0.0.0" || host === "localhost") ? "127.0.0.1" : host;
   }
 
   /** Register a callback for when a CodexAdapter is created (WsBridge needs to attach it). */
@@ -243,7 +248,7 @@ export class CliLauncher {
       }
     }
 
-    const sdkUrl = `ws://localhost:${this.port}/ws/cli/${sessionId}`;
+    const sdkUrl = `ws://${this.hostname}:${this.port}/ws/cli/${sessionId}`;
 
     const args: string[] = [
       "--sdk-url", sdkUrl,

--- a/web/server/index.ts
+++ b/web/server/index.ts
@@ -19,9 +19,10 @@ const __dirname = dirname(fileURLToPath(import.meta.url));
 const packageRoot = process.env.__VIBE_PACKAGE_ROOT || resolve(__dirname, "..");
 
 const port = Number(process.env.PORT) || 3456;
+const hostname = process.env.HOST || "localhost";
 const sessionStore = new SessionStore();
 const wsBridge = new WsBridge();
-const launcher = new CliLauncher(port);
+const launcher = new CliLauncher(port, hostname);
 const worktreeTracker = new WorktreeTracker();
 
 // ── Restore persisted sessions from disk ────────────────────────────────────
@@ -87,8 +88,6 @@ if (process.env.NODE_ENV === "production") {
   app.use("/*", serveStatic({ root: distDir }));
   app.get("/*", serveStatic({ path: resolve(distDir, "index.html") }));
 }
-
-const hostname = process.env.HOST || "localhost";
 
 const server = Bun.serve<SocketData>({
   port,


### PR DESCRIPTION
  ## Summary

  - Bind `Bun.serve` to `localhost` by default instead of `0.0.0.0`, preventing unintentional network exposure
  - Resolve the correct hostname for CLI `--sdk-url` so the CLI can connect when `HOST` is set to a specific IP

  ## Problem

  1. `Bun.serve` defaults to `0.0.0.0`, which exposes the Companion server to the entire local network — anyone on the same Wi-Fi/LAN can access it
  2. When `HOST` is set to a non-localhost address (e.g. `192.168.1.5`), the CLI's `--sdk-url` was still hardcoded to `ws://localhost:PORT`, causing connection failures since the server isn't listening on
  localhost

  ## Solution

  - **`index.ts`**: Add `hostname` option to `Bun.serve`, defaulting to `localhost` (loopback only). Users can opt-in to network access via `HOST` env var
  - **`cli-launcher.ts`**: Accept `hostname` in constructor and resolve it for `--sdk-url`: `0.0.0.0`/`localhost` map to `127.0.0.1` (guaranteed loopback), specific IPs pass through

  ## Test plan

  - [x] `bun run dev` starts server on `localhost:3456` (not `0.0.0.0`)
  - [x] `HOST=0.0.0.0 bun run dev` binds to all interfaces, CLI connects via `127.0.0.1`
  - [x] `HOST=192.168.x.x bun run dev` binds to specific IP, CLI connects to that IP
  - [x] Existing cli-launcher test updated to expect `127.0.0.1`

  ---

  *Code was AI-generated and human-reviewed.*
