### PR TITLE
fix(web): polyfill localStorage for Node.js 22+

### DIFF
--- a/web/src/store.test.ts
+++ b/web/src/store.test.ts
@@ -1,8 +1,8 @@
 // @vitest-environment jsdom
 
-// jsdom does not implement window.matchMedia, which the store uses for initial dark mode detection.
-// vi.hoisted runs before any imports, ensuring matchMedia is available when store.ts initializes.
+// vi.hoisted runs before any imports, ensuring browser globals are available when store.ts initializes.
 vi.hoisted(() => {
+  // jsdom does not implement matchMedia
   Object.defineProperty(globalThis.window, "matchMedia", {
     writable: true,
     configurable: true,
@@ -17,6 +17,27 @@ vi.hoisted(() => {
       dispatchEvent: () => false,
     }),
   });
+
+  // Node.js 22+ native localStorage may be broken (invalid --localstorage-file).
+  // Polyfill before store.ts import triggers getInitialSessionId().
+  if (
+    typeof globalThis.localStorage === "undefined" ||
+    typeof globalThis.localStorage.getItem !== "function"
+  ) {
+    const store = new Map<string, string>();
+    Object.defineProperty(globalThis, "localStorage", {
+      value: {
+        getItem: (key: string) => store.get(key) ?? null,
+        setItem: (key: string, value: string) => { store.set(key, String(value)); },
+        removeItem: (key: string) => { store.delete(key); },
+        clear: () => { store.clear(); },
+        get length() { return store.size; },
+        key: (index: number) => [...store.keys()][index] ?? null,
+      },
+      writable: true,
+      configurable: true,
+    });
+  }
 });
 
 import { useStore } from "./store.js";

--- a/web/src/test-setup.ts
+++ b/web/src/test-setup.ts
@@ -15,4 +15,27 @@ if (typeof window !== "undefined") {
       dispatchEvent: () => false,
     }),
   });
+
+  // Node.js 22+ ships native localStorage that requires --localstorage-file.
+  // Vitest may provide an invalid path, leaving a broken global that shadows
+  // jsdom's working implementation. Polyfill when getItem is missing.
+  if (
+    typeof globalThis.localStorage === "undefined" ||
+    typeof globalThis.localStorage.getItem !== "function"
+  ) {
+    const store = new Map<string, string>();
+    const storage = {
+      getItem: (key: string) => store.get(key) ?? null,
+      setItem: (key: string, value: string) => { store.set(key, String(value)); },
+      removeItem: (key: string) => { store.delete(key); },
+      clear: () => { store.clear(); },
+      get length() { return store.size; },
+      key: (index: number) => [...store.keys()][index] ?? null,
+    };
+    Object.defineProperty(globalThis, "localStorage", {
+      value: storage,
+      writable: true,
+      configurable: true,
+    });
+  }
 }


### PR DESCRIPTION
  ## Summary

  - Polyfill `localStorage` in test setup files to fix 31 test failures on Node.js 22+

  ## Problem

  Node.js 22+ ships a native `globalThis.localStorage` that requires the `--localstorage-file` CLI flag to function. Without it, `localStorage` exists but `getItem()` throws — which is worse than not having it at
   all, because it shadows jsdom's working implementation.

  This breaks any test that imports `store.ts`, since Zustand's module-level initialization calls `localStorage.getItem()` via `getInitialSessionId()` at import time.

  TypeError: localStorage.getItem is not a function
    ❯ getInitialSessionId src/store.ts:130:23

  **Affected:** `src/ws.test.ts` (20 tests), `src/store.test.ts` (11 tests) — 31 total failures.

  ## Solution

  Add a `localStorage` polyfill that activates only when the native implementation is broken (`getItem` is not a function):

  - **`test-setup.ts`** — Global polyfill for all jsdom test files (covers `ws.test.ts` and others)
  - **`store.test.ts`** — Hoisted polyfill via `vi.hoisted()` that runs before `store.ts` import triggers `getInitialSessionId()`

  The polyfill uses a simple `Map`-backed storage object that implements the full `Storage` interface.

  ## Test plan

  - [x] All 669 tests pass on Node.js 25.6.0 (previously 31 failing)
  - [ ] Verify tests still pass on Node.js 20/21 (polyfill is a no-op when `localStorage` works)

  ---

  *Code was AI-generated and human-reviewed.*
