### PR TITLE
web: rebrand landing to The Companion + add Codex support copy

### DIFF
--- a/landing/index.html
+++ b/landing/index.html
@@ -4,15 +4,15 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
-    <meta name="description" content="A web UI for Claude Code. Multiple sessions, real-time streaming, visual tool calls, permission control. No API key needed." />
-    <meta property="og:title" content="The Companion — Claude Code in Your Browser" />
-    <meta property="og:description" content="A web UI for Claude Code. Multiple sessions, real-time streaming, and visual tool calls. No API key needed." />
+    <meta name="description" content="A web UI for Claude Code and Codex. Multiple sessions, real-time streaming, visual tool calls, permission control. No API key needed." />
+    <meta property="og:title" content="The Companion — Claude Code + Codex in Your Browser" />
+    <meta property="og:description" content="A web UI for Claude Code and Codex. Multiple sessions, real-time streaming, and visual tool calls. No API key needed." />
     <meta property="og:image" content="https://thecompanion.sh/screenshot.png" />
     <meta property="og:url" content="https://thecompanion.sh" />
     <meta property="og:type" content="website" />
     <meta name="twitter:card" content="summary_large_image" />
     <meta name="theme-color" content="#ae5630" />
-    <title>The Companion — Claude Code in Your Browser</title>
+    <title>The Companion — Claude Code + Codex in Your Browser</title>
   </head>
   <body>
     <div id="root"></div>

--- a/landing/src/components/Features.tsx
+++ b/landing/src/components/Features.tsx
@@ -3,7 +3,7 @@ import { FadeIn } from "./FadeIn";
 const features = [
   {
     title: "Multiple Sessions",
-    description: "Run several Claude Code instances side by side. Each gets its own process, model, and permission settings.",
+    description: "Run Claude Code and Codex sessions side by side. Each gets its own process, model, and permission settings.",
     icon: (
       <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
         <rect x="2" y="3" width="20" height="14" rx="2" />

--- a/landing/src/components/Footer.tsx
+++ b/landing/src/components/Footer.tsx
@@ -1,7 +1,12 @@
 export function Footer() {
   return (
     <footer className="relative z-10 border-t border-cc-border py-10 px-5 sm:px-7 text-center text-sm text-cc-muted">
-      <p className="font-mono-code tracking-wide">Built by The Vibe Company</p>
+      <p className="font-mono-code tracking-wide">
+        Built by{" "}
+        <a href="https://thevibecompany.co" target="_blank" rel="noopener" className="hover:text-cc-fg transition-colors">
+          The Vibe Company
+        </a>
+      </p>
       <div className="flex justify-center gap-6 mt-2">
         <a href="https://github.com/The-Vibe-Company/companion" target="_blank" rel="noopener" className="text-cc-muted hover:text-cc-fg transition-colors">
           GitHub

--- a/landing/src/components/GetStarted.tsx
+++ b/landing/src/components/GetStarted.tsx
@@ -18,7 +18,7 @@ export function GetStarted() {
 
         <FadeIn className="mt-8">
           <div className="flex justify-center gap-6 flex-wrap text-sm text-cc-muted">
-            {["Bun runtime", "Claude Code CLI", "Active subscription"].map((req) => (
+            {["Bun runtime", "Claude Code or Codex CLI", "Active subscription"].map((req) => (
               <span key={req} className="flex items-center gap-2 bg-cc-card border border-cc-border rounded-full px-4 py-2">
                 <svg width="14" height="14" viewBox="0 0 16 16" fill="none" stroke="#1e5e73" strokeWidth="1.5">
                   <polyline points="13 4 6 11 3 8" />

--- a/landing/src/components/Hero.tsx
+++ b/landing/src/components/Hero.tsx
@@ -5,7 +5,7 @@ export function Hero() {
   return (
     <section className="pt-14 sm:pt-20 pb-16 px-5 sm:px-7">
       <div className="max-w-[1060px] mx-auto">
-        <div className="cc-label animate-fade-up-1 mb-5 text-center">Vibe Coder Companion</div>
+        <div className="cc-label animate-fade-up-1 mb-5 text-center">The Companion</div>
         <div className="animate-fade-up-2 mb-7 inline-flex w-full justify-center">
           <div className="cc-card rounded-2xl p-2 bg-cc-card">
             <div className="bg-[#efe3cd] rounded-xl px-4 py-2.5">
@@ -21,8 +21,8 @@ export function Hero() {
         </h1>
 
         <p className="text-center text-[clamp(16px,2.5vw,20px)] text-cc-muted max-w-[680px] mx-auto mb-10 leading-relaxed animate-fade-up-3">
-          A browser control room for Claude Code with real-time agent output, full tool-call transparency, and safe
-          multi-session orchestration.
+          A browser control room for Claude Code and Codex with real-time agent output, full tool-call transparency,
+          and safe multi-session orchestration.
         </p>
 
         <div className="animate-fade-up-4 text-center">

--- a/landing/src/components/HowItWorks.tsx
+++ b/landing/src/components/HowItWorks.tsx
@@ -13,7 +13,7 @@ export function HowItWorks() {
           <div className="cc-card rounded-2xl p-4 sm:p-6 mb-12 bg-cc-card">
             <div className="flex items-center justify-center gap-4 flex-wrap">
               <div className="bg-[#f0e5d2] border border-cc-border rounded-[10px] px-5 py-3.5 text-sm font-mono-code whitespace-nowrap">
-                Claude Code CLI
+                Claude Code + Codex CLI
               </div>
               <span className="text-cc-muted font-mono-code text-xs">&larr; WebSocket &rarr;</span>
               <div className="bg-cc-primary text-[#fff4eb] border border-[#8e3518] rounded-[10px] px-5 py-3.5 text-sm font-mono-code whitespace-nowrap">
@@ -43,7 +43,7 @@ export function HowItWorks() {
               {
                 step: 2,
                 title: "Bridge",
-                description: "The server starts Claude Code sessions and forwards their WebSocket channels to the web app.",
+                description: "The server starts Claude Code or Codex sessions and forwards their channels to the web app.",
               },
               {
                 step: 3,

--- a/landing/src/components/Nav.tsx
+++ b/landing/src/components/Nav.tsx
@@ -6,9 +6,17 @@ export function Nav() {
       <div className="max-w-[1060px] mx-auto w-full flex items-center justify-between">
         <a href="/" className="flex items-center gap-2.5 font-semibold text-[15px] text-cc-fg no-underline">
           <ClawdLogo size={28} />
-          <span className="font-condensed text-xl tracking-wide">Vibe Coder Companion</span>
+          <span className="font-condensed text-xl tracking-wide">The Companion</span>
         </a>
         <div className="flex items-center gap-5 sm:gap-6">
+          <a
+            href="https://thevibecompany.co"
+            target="_blank"
+            rel="noopener"
+            className="text-sm text-cc-muted hover:text-cc-fg transition-colors hidden sm:block font-mono-code"
+          >
+            The Vibe Company
+          </a>
           <a
             href="https://github.com/The-Vibe-Company/companion"
             target="_blank"


### PR DESCRIPTION
## Summary\n- replace landing branding text from `Vibe Coder Companion` to `The Companion`\n- update landing copy to mention both Claude Code and Codex\n- add a visible link to The Vibe Company (https://thevibecompany.co) in nav and footer\n- update landing metadata/title to reflect Claude Code + Codex\n\n## Files changed\n- landing/src/components/Nav.tsx\n- landing/src/components/Hero.tsx\n- landing/src/components/HowItWorks.tsx\n- landing/src/components/Features.tsx\n- landing/src/components/GetStarted.tsx\n- landing/src/components/Footer.tsx\n- landing/index.html\n\n## Validation\n- searched landing files to ensure no remaining `Vibe Coder Companion` occurrences\n- build not run locally because landing dependencies are not installed in this worktree
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/the-vibe-company/companion/pull/154" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
