### PR TITLE
feat(web): add update-available banner with auto-update for service mode

### DIFF
--- a/web/server/index.ts
+++ b/web/server/index.ts
@@ -12,6 +12,8 @@ import { SessionStore } from "./session-store.js";
 import { WorktreeTracker } from "./worktree-tracker.js";
 import { generateSessionTitle } from "./auto-namer.js";
 import * as sessionNames from "./session-names.js";
+import { startPeriodicCheck, setServiceMode } from "./update-checker.js";
+import { isRunningAsService } from "./service.js";
 import type { SocketData } from "./ws-bridge.js";
 import type { ServerWebSocket } from "bun";
 
@@ -156,6 +158,13 @@ console.log(`  Browser WebSocket: ws://localhost:${server.port}/ws/browser/:sess
 
 if (process.env.NODE_ENV !== "production") {
   console.log("Dev mode: frontend at http://localhost:5174");
+}
+
+// ── Update checker ──────────────────────────────────────────────────────────
+startPeriodicCheck();
+if (isRunningAsService()) {
+  setServiceMode(true);
+  console.log("[server] Running as launchd service (auto-update available)");
 }
 
 // ── Reconnection watchdog ────────────────────────────────────────────────────

--- a/web/server/routes.test.ts
+++ b/web/server/routes.test.ts
@@ -47,6 +47,20 @@ vi.mock("./usage-limits.js", () => ({
   getUsageLimits: mockGetUsageLimits,
 }));
 
+vi.mock("./update-checker.js", () => ({
+  getUpdateState: vi.fn(() => ({
+    currentVersion: "0.22.1",
+    latestVersion: null,
+    lastChecked: 0,
+    isServiceMode: false,
+    checking: false,
+    updateInProgress: false,
+  })),
+  checkForUpdate: vi.fn(async () => {}),
+  isUpdateAvailable: vi.fn(() => false),
+  setUpdateInProgress: vi.fn(),
+}));
+
 import { Hono } from "hono";
 import { execSync } from "node:child_process";
 import { existsSync, readFileSync } from "node:fs";

--- a/web/server/service.ts
+++ b/web/server/service.ts
@@ -193,6 +193,24 @@ export interface ServiceStatus {
   port?: number;
 }
 
+/**
+ * Safe check for whether the current process is running as a launchd service.
+ * Unlike status(), this never calls process.exit() and works on all platforms.
+ */
+export function isRunningAsService(): boolean {
+  if (process.platform !== "darwin") return false;
+  if (!existsSync(PLIST_PATH)) return false;
+  try {
+    const output = execSync(`launchctl list "${LABEL}"`, {
+      encoding: "utf-8",
+      stdio: ["pipe", "pipe", "pipe"],
+    });
+    return /"PID"\s*=\s*\d+/.test(output);
+  } catch {
+    return false;
+  }
+}
+
 export async function status(): Promise<ServiceStatus> {
   ensureMacOS();
 

--- a/web/server/update-checker.test.ts
+++ b/web/server/update-checker.test.ts
@@ -1,0 +1,151 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+
+// Mock fetch globally
+const mockFetch = vi.fn();
+vi.stubGlobal("fetch", mockFetch);
+
+let checker: typeof import("./update-checker.js");
+
+beforeEach(async () => {
+  vi.resetModules();
+  mockFetch.mockReset();
+  checker = await import("./update-checker.js");
+});
+
+afterEach(() => {
+  checker.stopPeriodicCheck();
+});
+
+// ===========================================================================
+// isNewerVersion
+// ===========================================================================
+describe("isNewerVersion", () => {
+  it("returns true when major version is higher", () => {
+    expect(checker.isNewerVersion("2.0.0", "1.0.0")).toBe(true);
+  });
+
+  it("returns true when minor version is higher", () => {
+    expect(checker.isNewerVersion("1.1.0", "1.0.0")).toBe(true);
+  });
+
+  it("returns true when patch version is higher", () => {
+    expect(checker.isNewerVersion("1.0.1", "1.0.0")).toBe(true);
+  });
+
+  it("returns false when versions are equal", () => {
+    expect(checker.isNewerVersion("1.0.0", "1.0.0")).toBe(false);
+  });
+
+  it("returns false when version is lower", () => {
+    expect(checker.isNewerVersion("1.0.0", "1.0.1")).toBe(false);
+    expect(checker.isNewerVersion("0.9.0", "1.0.0")).toBe(false);
+  });
+});
+
+// ===========================================================================
+// getCurrentVersion
+// ===========================================================================
+describe("getCurrentVersion", () => {
+  it("returns a semver string", () => {
+    const version = checker.getCurrentVersion();
+    expect(version).toMatch(/^\d+\.\d+\.\d+/);
+  });
+});
+
+// ===========================================================================
+// getUpdateState
+// ===========================================================================
+describe("getUpdateState", () => {
+  it("returns initial state with current version and no latest version", () => {
+    const state = checker.getUpdateState();
+    expect(state.currentVersion).toBe(checker.getCurrentVersion());
+    expect(state.latestVersion).toBeNull();
+    expect(state.isServiceMode).toBe(false);
+    expect(state.checking).toBe(false);
+    expect(state.updateInProgress).toBe(false);
+  });
+});
+
+// ===========================================================================
+// checkForUpdate
+// ===========================================================================
+describe("checkForUpdate", () => {
+  it("sets latestVersion when fetch succeeds", async () => {
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      json: () => Promise.resolve({ version: "99.0.0" }),
+    });
+
+    await checker.checkForUpdate();
+
+    const state = checker.getUpdateState();
+    expect(state.latestVersion).toBe("99.0.0");
+    expect(state.lastChecked).toBeGreaterThan(0);
+  });
+
+  it("handles fetch errors gracefully", async () => {
+    mockFetch.mockRejectedValueOnce(new Error("Network error"));
+
+    await checker.checkForUpdate();
+
+    const state = checker.getUpdateState();
+    expect(state.latestVersion).toBeNull();
+  });
+
+  it("handles non-ok response gracefully", async () => {
+    mockFetch.mockResolvedValueOnce({ ok: false, status: 500 });
+
+    await checker.checkForUpdate();
+
+    const state = checker.getUpdateState();
+    expect(state.latestVersion).toBeNull();
+  });
+});
+
+// ===========================================================================
+// isUpdateAvailable
+// ===========================================================================
+describe("isUpdateAvailable", () => {
+  it("returns false when no latest version is set", () => {
+    expect(checker.isUpdateAvailable()).toBe(false);
+  });
+
+  it("returns true when latest is newer than current", async () => {
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      json: () => Promise.resolve({ version: "99.0.0" }),
+    });
+
+    await checker.checkForUpdate();
+    expect(checker.isUpdateAvailable()).toBe(true);
+  });
+
+  it("returns false when latest equals current", async () => {
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      json: () => Promise.resolve({ version: checker.getCurrentVersion() }),
+    });
+
+    await checker.checkForUpdate();
+    expect(checker.isUpdateAvailable()).toBe(false);
+  });
+});
+
+// ===========================================================================
+// setServiceMode / setUpdateInProgress
+// ===========================================================================
+describe("state setters", () => {
+  it("setServiceMode updates isServiceMode", () => {
+    checker.setServiceMode(true);
+    expect(checker.getUpdateState().isServiceMode).toBe(true);
+    checker.setServiceMode(false);
+    expect(checker.getUpdateState().isServiceMode).toBe(false);
+  });
+
+  it("setUpdateInProgress updates updateInProgress", () => {
+    checker.setUpdateInProgress(true);
+    expect(checker.getUpdateState().updateInProgress).toBe(true);
+    checker.setUpdateInProgress(false);
+    expect(checker.getUpdateState().updateInProgress).toBe(false);
+  });
+});

--- a/web/server/update-checker.ts
+++ b/web/server/update-checker.ts
@@ -1,0 +1,115 @@
+import { readFileSync } from "node:fs";
+import { resolve, dirname } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+
+// Read current version from package.json
+const packageJsonPath = resolve(__dirname, "..", "package.json");
+const currentVersion: string = JSON.parse(
+  readFileSync(packageJsonPath, "utf-8"),
+).version;
+
+const NPM_REGISTRY_URL =
+  "https://registry.npmjs.org/the-vibe-companion/latest";
+const CHECK_INTERVAL_MS = 60 * 60 * 1000; // 1 hour
+const INITIAL_DELAY_MS = 10_000; // 10 seconds after boot
+
+interface UpdateState {
+  currentVersion: string;
+  latestVersion: string | null;
+  lastChecked: number;
+  isServiceMode: boolean;
+  checking: boolean;
+  updateInProgress: boolean;
+}
+
+const state: UpdateState = {
+  currentVersion,
+  latestVersion: null,
+  lastChecked: 0,
+  isServiceMode: false,
+  checking: false,
+  updateInProgress: false,
+};
+
+export function getUpdateState(): Readonly<UpdateState> {
+  return { ...state };
+}
+
+export function getCurrentVersion(): string {
+  return currentVersion;
+}
+
+export async function checkForUpdate(): Promise<void> {
+  if (state.checking) return;
+  state.checking = true;
+  try {
+    const res = await fetch(NPM_REGISTRY_URL, {
+      headers: { Accept: "application/json" },
+      signal: AbortSignal.timeout(10_000),
+    });
+    if (res.ok) {
+      const data = (await res.json()) as { version: string };
+      state.latestVersion = data.version;
+      state.lastChecked = Date.now();
+      if (isUpdateAvailable()) {
+        console.log(
+          `[update-checker] Update available: ${currentVersion} -> ${state.latestVersion}`,
+        );
+      }
+    }
+  } catch (err) {
+    console.warn(
+      "[update-checker] Failed to check for updates:",
+      err instanceof Error ? err.message : String(err),
+    );
+  } finally {
+    state.checking = false;
+  }
+}
+
+export function setServiceMode(isService: boolean): void {
+  state.isServiceMode = isService;
+}
+
+export function setUpdateInProgress(inProgress: boolean): void {
+  state.updateInProgress = inProgress;
+}
+
+export function isUpdateAvailable(): boolean {
+  if (!state.latestVersion) return false;
+  return isNewerVersion(state.latestVersion, currentVersion);
+}
+
+/** Simple semver comparison: returns true if a > b */
+export function isNewerVersion(a: string, b: string): boolean {
+  const pa = a.split(".").map(Number);
+  const pb = b.split(".").map(Number);
+  for (let i = 0; i < 3; i++) {
+    if ((pa[i] || 0) > (pb[i] || 0)) return true;
+    if ((pa[i] || 0) < (pb[i] || 0)) return false;
+  }
+  return false;
+}
+
+let intervalId: ReturnType<typeof setInterval> | null = null;
+
+export function startPeriodicCheck(): void {
+  // Initial check after a short delay
+  setTimeout(() => {
+    checkForUpdate();
+  }, INITIAL_DELAY_MS);
+
+  // Periodic checks
+  intervalId = setInterval(() => {
+    checkForUpdate();
+  }, CHECK_INTERVAL_MS);
+}
+
+export function stopPeriodicCheck(): void {
+  if (intervalId) {
+    clearInterval(intervalId);
+    intervalId = null;
+  }
+}

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useSyncExternalStore } from "react";
 import { useStore } from "./store.js";
 import { connectSession } from "./ws.js";
+import { api } from "./api.js";
 import { Sidebar } from "./components/Sidebar.js";
 import { ChatView } from "./components/ChatView.js";
 import { TopBar } from "./components/TopBar.js";
@@ -8,6 +9,7 @@ import { HomePage } from "./components/HomePage.js";
 import { TaskPanel } from "./components/TaskPanel.js";
 import { EditorPanel } from "./components/EditorPanel.js";
 import { Playground } from "./components/Playground.js";
+import { UpdateBanner } from "./components/UpdateBanner.js";
 
 function useHash() {
   return useSyncExternalStore(
@@ -35,6 +37,18 @@ export default function App() {
     if (restoredId) {
       connectSession(restoredId);
     }
+  }, []);
+
+  // Poll for updates
+  useEffect(() => {
+    const check = () => {
+      api.checkForUpdate().then((info) => {
+        useStore.getState().setUpdateInfo(info);
+      }).catch(() => {});
+    };
+    check();
+    const interval = setInterval(check, 5 * 60 * 1000);
+    return () => clearInterval(interval);
   }, []);
 
   if (hash === "#/playground") {
@@ -66,6 +80,7 @@ export default function App() {
       {/* Main area */}
       <div className="flex-1 flex flex-col min-w-0 overflow-hidden">
         <TopBar />
+        <UpdateBanner />
         <div className="flex-1 overflow-hidden relative">
           {/* Chat tab — visible when activeTab is "chat" or no session */}
           <div className={`absolute inset-0 ${activeTab === "chat" || !currentSessionId ? "" : "hidden"}`}>

--- a/web/src/api.ts
+++ b/web/src/api.ts
@@ -145,6 +145,15 @@ export interface TreeNode {
   children?: TreeNode[];
 }
 
+export interface UpdateInfo {
+  currentVersion: string;
+  latestVersion: string | null;
+  updateAvailable: boolean;
+  isServiceMode: boolean;
+  updateInProgress: boolean;
+  lastChecked: number;
+}
+
 export interface UsageLimits {
   five_hour: { utilization: number; resets_at: string | null } | null;
   seven_day: { utilization: number; resets_at: string | null } | null;
@@ -269,4 +278,10 @@ export const api = {
   getUsageLimits: () => get<UsageLimits>("/usage-limits"),
   getSessionUsageLimits: (sessionId: string) =>
     get<UsageLimits>(`/sessions/${encodeURIComponent(sessionId)}/usage-limits`),
+
+  // Update checking
+  checkForUpdate: () => get<UpdateInfo>("/update-check"),
+  forceCheckForUpdate: () => post<UpdateInfo>("/update-check"),
+  triggerUpdate: () =>
+    post<{ ok: boolean; message: string }>("/update"),
 };

--- a/web/src/components/Playground.tsx
+++ b/web/src/components/Playground.tsx
@@ -2,8 +2,11 @@ import { useState, useEffect } from "react";
 import { PermissionBanner } from "./PermissionBanner.js";
 import { MessageBubble } from "./MessageBubble.js";
 import { ToolBlock, getToolIcon, getToolLabel, getPreview, ToolIcon } from "./ToolBlock.js";
+import { UpdateBanner } from "./UpdateBanner.js";
+import { useStore } from "../store.js";
 import type { PermissionRequest, ChatMessage, ContentBlock } from "../types.js";
 import type { TaskItem } from "../types.js";
+import type { UpdateInfo } from "../api.js";
 
 // ─── Mock Data ──────────────────────────────────────────────────────────────
 
@@ -437,6 +440,48 @@ export function Playground() {
           </div>
         </Section>
 
+        {/* ─── Update Banner ──────────────────────────────── */}
+        <Section title="Update Banner" description="Notification banner for available updates">
+          <div className="space-y-4 max-w-3xl">
+            <Card label="Service mode (auto-update)">
+              <PlaygroundUpdateBanner
+                updateInfo={{
+                  currentVersion: "0.22.1",
+                  latestVersion: "0.23.0",
+                  updateAvailable: true,
+                  isServiceMode: true,
+                  updateInProgress: false,
+                  lastChecked: Date.now(),
+                }}
+              />
+            </Card>
+            <Card label="Foreground mode (manual)">
+              <PlaygroundUpdateBanner
+                updateInfo={{
+                  currentVersion: "0.22.1",
+                  latestVersion: "0.23.0",
+                  updateAvailable: true,
+                  isServiceMode: false,
+                  updateInProgress: false,
+                  lastChecked: Date.now(),
+                }}
+              />
+            </Card>
+            <Card label="Update in progress">
+              <PlaygroundUpdateBanner
+                updateInfo={{
+                  currentVersion: "0.22.1",
+                  latestVersion: "0.23.0",
+                  updateAvailable: true,
+                  isServiceMode: true,
+                  updateInProgress: true,
+                  lastChecked: Date.now(),
+                }}
+              />
+            </Card>
+          </div>
+        </Section>
+
         {/* ─── Status Indicators ──────────────────────────────── */}
         <Section title="Status Indicators" description="Connection and session status banners">
           <div className="space-y-3 max-w-3xl">
@@ -809,6 +854,28 @@ function PlaygroundSubagentGroup({ description, agentType, items }: { descriptio
       )}
     </div>
   );
+}
+
+// ─── Inline UpdateBanner (sets store state for playground preview) ───────────
+
+function PlaygroundUpdateBanner({ updateInfo }: { updateInfo: UpdateInfo }) {
+  useEffect(() => {
+    const prev = useStore.getState().updateInfo;
+    const prevDismissed = useStore.getState().updateDismissedVersion;
+    useStore.getState().setUpdateInfo(updateInfo);
+    // Clear any dismiss so the banner shows
+    if (prevDismissed) {
+      useStore.setState({ updateDismissedVersion: null });
+    }
+    return () => {
+      useStore.getState().setUpdateInfo(prev);
+      if (prevDismissed) {
+        useStore.setState({ updateDismissedVersion: prevDismissed });
+      }
+    };
+  }, [updateInfo]);
+
+  return <UpdateBanner />;
 }
 
 // ─── Inline TaskRow (avoids store dependency from TaskPanel) ────────────────

--- a/web/src/components/UpdateBanner.test.tsx
+++ b/web/src/components/UpdateBanner.test.tsx
@@ -1,0 +1,134 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/react";
+import type { UpdateInfo } from "../api.js";
+
+const mockSetUpdateInfo = vi.fn();
+const mockDismissUpdate = vi.fn();
+const mockTriggerUpdate = vi.fn();
+
+let storeState: Record<string, unknown> = {};
+
+vi.mock("../store.js", () => ({
+  useStore: (selector: (state: Record<string, unknown>) => unknown) =>
+    selector(storeState),
+}));
+
+vi.mock("../api.js", () => ({
+  api: {
+    triggerUpdate: () => mockTriggerUpdate(),
+  },
+}));
+
+import { UpdateBanner } from "./UpdateBanner.js";
+
+function makeUpdateInfo(overrides: Partial<UpdateInfo> = {}): UpdateInfo {
+  return {
+    currentVersion: "0.22.1",
+    latestVersion: "0.23.0",
+    updateAvailable: true,
+    isServiceMode: false,
+    updateInProgress: false,
+    lastChecked: Date.now(),
+    ...overrides,
+  };
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  storeState = {
+    updateInfo: null,
+    updateDismissedVersion: null,
+    dismissUpdate: mockDismissUpdate,
+  };
+});
+
+// ─── Visibility ────────────────────────────────────────────────────────────
+
+describe("UpdateBanner visibility", () => {
+  it("renders nothing when updateInfo is null", () => {
+    storeState.updateInfo = null;
+    const { container } = render(<UpdateBanner />);
+    expect(container.innerHTML).toBe("");
+  });
+
+  it("renders nothing when updateAvailable is false", () => {
+    storeState.updateInfo = makeUpdateInfo({ updateAvailable: false });
+    const { container } = render(<UpdateBanner />);
+    expect(container.innerHTML).toBe("");
+  });
+
+  it("renders nothing when latestVersion is null", () => {
+    storeState.updateInfo = makeUpdateInfo({ latestVersion: null });
+    const { container } = render(<UpdateBanner />);
+    expect(container.innerHTML).toBe("");
+  });
+
+  it("renders nothing when the version is dismissed", () => {
+    storeState.updateInfo = makeUpdateInfo();
+    storeState.updateDismissedVersion = "0.23.0";
+    const { container } = render(<UpdateBanner />);
+    expect(container.innerHTML).toBe("");
+  });
+
+  it("renders banner when update is available and not dismissed", () => {
+    storeState.updateInfo = makeUpdateInfo();
+    render(<UpdateBanner />);
+    expect(screen.getByText("v0.23.0")).toBeTruthy();
+    expect(screen.getByText(/v0\.22\.1/)).toBeTruthy();
+  });
+
+  it("reappears when a newer version supersedes the dismissed one", () => {
+    storeState.updateInfo = makeUpdateInfo({ latestVersion: "0.24.0" });
+    storeState.updateDismissedVersion = "0.23.0";
+    render(<UpdateBanner />);
+    expect(screen.getByText("v0.24.0")).toBeTruthy();
+  });
+});
+
+// ─── Service mode ──────────────────────────────────────────────────────────
+
+describe("UpdateBanner service mode", () => {
+  it("shows Update & Restart button in service mode", () => {
+    storeState.updateInfo = makeUpdateInfo({ isServiceMode: true });
+    render(<UpdateBanner />);
+    expect(screen.getByText("Update & Restart")).toBeTruthy();
+  });
+
+  it("shows install hint in foreground mode", () => {
+    storeState.updateInfo = makeUpdateInfo({ isServiceMode: false });
+    render(<UpdateBanner />);
+    expect(screen.getByText("the-vibe-companion install")).toBeTruthy();
+  });
+
+  it("shows Updating... when update is in progress", () => {
+    storeState.updateInfo = makeUpdateInfo({
+      isServiceMode: true,
+      updateInProgress: true,
+    });
+    render(<UpdateBanner />);
+    expect(screen.getByText("Updating...")).toBeTruthy();
+  });
+});
+
+// ─── Interactions ──────────────────────────────────────────────────────────
+
+describe("UpdateBanner interactions", () => {
+  it("calls triggerUpdate when Update & Restart is clicked", () => {
+    mockTriggerUpdate.mockResolvedValue({ ok: true });
+    storeState.updateInfo = makeUpdateInfo({ isServiceMode: true });
+    render(<UpdateBanner />);
+
+    fireEvent.click(screen.getByText("Update & Restart"));
+    expect(mockTriggerUpdate).toHaveBeenCalledOnce();
+  });
+
+  it("calls dismissUpdate with the latest version when dismiss is clicked", () => {
+    storeState.updateInfo = makeUpdateInfo();
+    render(<UpdateBanner />);
+
+    const dismissBtn = screen.getByTitle("Dismiss");
+    fireEvent.click(dismissBtn);
+    expect(mockDismissUpdate).toHaveBeenCalledWith("0.23.0");
+  });
+});

--- a/web/src/components/UpdateBanner.tsx
+++ b/web/src/components/UpdateBanner.tsx
@@ -1,0 +1,70 @@
+import { useState } from "react";
+import { useStore } from "../store.js";
+import { api } from "../api.js";
+
+export function UpdateBanner() {
+  const updateInfo = useStore((s) => s.updateInfo);
+  const dismissedVersion = useStore((s) => s.updateDismissedVersion);
+  const dismissUpdate = useStore((s) => s.dismissUpdate);
+  const [updating, setUpdating] = useState(false);
+
+  if (!updateInfo?.updateAvailable || !updateInfo.latestVersion) return null;
+  if (dismissedVersion === updateInfo.latestVersion) return null;
+
+  const handleUpdate = async () => {
+    setUpdating(true);
+    try {
+      await api.triggerUpdate();
+    } catch (err) {
+      console.error("Update failed:", err);
+      setUpdating(false);
+    }
+  };
+
+  const handleDismiss = () => {
+    dismissUpdate(updateInfo.latestVersion!);
+  };
+
+  const inProgress = updating || updateInfo.updateInProgress;
+
+  return (
+    <div className="px-4 py-1.5 bg-cc-primary/10 border-b border-cc-primary/20 flex items-center justify-center gap-3 animate-[fadeSlideIn_0.2s_ease-out]">
+      <svg viewBox="0 0 16 16" fill="currentColor" className="w-3.5 h-3.5 text-cc-primary shrink-0">
+        <path d="M8 1a7 7 0 1 1 0 14A7 7 0 0 1 8 1zm0 2a.75.75 0 0 0-.75.75v3.69L5.78 6.15a.75.75 0 0 0-.96 1.15l2.5 2.08a.75.75 0 0 0 1.08-.12l2-2.5a.75.75 0 1 0-1.17-.94L8.75 6.5V3.75A.75.75 0 0 0 8 3z" />
+      </svg>
+
+      <span className="text-xs text-cc-fg">
+        <span className="font-medium">v{updateInfo.latestVersion}</span> available
+        <span className="text-cc-muted ml-1">(current: v{updateInfo.currentVersion})</span>
+      </span>
+
+      {updateInfo.isServiceMode ? (
+        <button
+          onClick={handleUpdate}
+          disabled={inProgress}
+          className="text-xs font-medium px-2.5 py-0.5 rounded-md bg-cc-primary hover:bg-cc-primary-hover text-white transition-colors cursor-pointer disabled:opacity-50 disabled:cursor-not-allowed"
+        >
+          {inProgress ? "Updating..." : "Update & Restart"}
+        </button>
+      ) : (
+        <span className="text-xs text-cc-muted">
+          Run{" "}
+          <code className="font-mono-code bg-cc-code-bg px-1 py-0.5 rounded text-cc-code-fg">
+            the-vibe-companion install
+          </code>{" "}
+          for auto-updates
+        </span>
+      )}
+
+      <button
+        onClick={handleDismiss}
+        className="text-cc-muted hover:text-cc-fg transition-colors cursor-pointer ml-auto"
+        title="Dismiss"
+      >
+        <svg viewBox="0 0 16 16" fill="none" stroke="currentColor" strokeWidth="2" className="w-3 h-3">
+          <path d="M4 4l8 8M12 4l-8 8" />
+        </svg>
+      </button>
+    </div>
+  );
+}

--- a/web/src/store.ts
+++ b/web/src/store.ts
@@ -1,5 +1,6 @@
 import { create } from "zustand";
 import type { SessionState, PermissionRequest, ChatMessage, SdkSessionInfo, TaskItem } from "./types.js";
+import type { UpdateInfo } from "./api.js";
 
 interface AppState {
   // Sessions
@@ -43,6 +44,10 @@ interface AppState {
 
   // Sidebar project grouping
   collapsedProjects: Set<string>;
+
+  // Update info
+  updateInfo: UpdateInfo | null;
+  updateDismissedVersion: string | null;
 
   // UI
   darkMode: boolean;
@@ -107,6 +112,10 @@ interface AppState {
   setCliConnected: (sessionId: string, connected: boolean) => void;
   setSessionStatus: (sessionId: string, status: "idle" | "running" | "compacting" | null) => void;
 
+  // Update actions
+  setUpdateInfo: (info: UpdateInfo | null) => void;
+  dismissUpdate: (version: string) => void;
+
   // Editor actions
   setActiveTab: (tab: "chat" | "editor") => void;
   setEditorOpenFile: (sessionId: string, filePath: string | null) => void;
@@ -144,6 +153,11 @@ function getInitialNotificationSound(): boolean {
   return true;
 }
 
+function getInitialDismissedVersion(): string | null {
+  if (typeof window === "undefined") return null;
+  return localStorage.getItem("cc-update-dismissed") || null;
+}
+
 function getInitialCollapsedProjects(): Set<string> {
   if (typeof window === "undefined") return new Set();
   try {
@@ -171,6 +185,8 @@ export const useStore = create<AppState>((set) => ({
   sessionNames: getInitialSessionNames(),
   recentlyRenamed: new Set(),
   collapsedProjects: getInitialCollapsedProjects(),
+  updateInfo: null,
+  updateDismissedVersion: getInitialDismissedVersion(),
   darkMode: getInitialDarkMode(),
   notificationSound: getInitialNotificationSound(),
   sidebarOpen: typeof window !== "undefined" ? window.innerWidth >= 768 : true,
@@ -483,6 +499,12 @@ export const useStore = create<AppState>((set) => ({
       sessionStatus.set(sessionId, status);
       return { sessionStatus };
     }),
+
+  setUpdateInfo: (info) => set({ updateInfo: info }),
+  dismissUpdate: (version) => {
+    localStorage.setItem("cc-update-dismissed", version);
+    set({ updateDismissedVersion: version });
+  },
 
   setActiveTab: (tab) => set({ activeTab: tab }),
 


### PR DESCRIPTION
## Summary

- Adds an **update-available banner** below the top bar that checks the npm registry for new versions of `the-vibe-companion`
- **Service mode (launchd)**: one-click "Update & Restart" — runs `bun install -g`, then exits with code 42 so launchd auto-restarts
- **Foreground mode**: shows update notification with a nudge to run `the-vibe-companion install` for auto-updates
- Banner is **dismissible per-version** (stored in localStorage, reappears on next version bump)
- Server polls npm every 1 hour; frontend polls the backend every 5 minutes
- Includes Playground mocks for all banner states

## Test plan

- [x] `bun run typecheck` — no errors
- [x] `bun run test -- server/` — 428 tests passing (13 files)
- [x] `bun run test -- server/update-checker.test.ts` — 15 tests for semver, state, fetch
- [x] `bun run test -- server/service.test.ts` — 25 tests including new `isRunningAsService()`
- [ ] Manual: `bun run dev`, open browser, verify banner appears when version mismatch exists
- [ ] Manual: dismiss banner, reload page — stays dismissed
- [ ] Manual: verify "Update & Restart" button only appears in service mode
- [ ] Manual: check Playground (`#/playground`) shows all 3 banner variants

> **Note**: Component tests (`src/components/*.test.tsx`) are affected by a pre-existing `React.act is not a function` issue with React 19 + @testing-library/react — this is not caused by this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/the-vibe-company/companion/pull/158" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
