### PR TITLE
fix(web): prevent mobile keyboard layout shift and iOS zoom on branch selector

### DIFF
--- a/web/index.html
+++ b/web/index.html
@@ -2,7 +2,7 @@
 <html lang="en">
   <head>
     <meta charset="UTF-8" />
-    <meta name="viewport" content="width=device-width, initial-scale=1.0, interactive-widget=resizes-content" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1, interactive-widget=resizes-content" />
     <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
     <link rel="manifest" href="/manifest.json" />
     <link rel="apple-touch-icon" href="/apple-touch-icon.png" />

--- a/web/src/components/HomePage.tsx
+++ b/web/src/components/HomePage.tsx
@@ -91,9 +91,12 @@ export function HomePage() {
   const setCurrentSession = useStore((s) => s.setCurrentSession);
   const currentSessionId = useStore((s) => s.currentSessionId);
 
-  // Auto-focus textarea
+  // Auto-focus textarea (desktop only — on mobile it triggers the keyboard immediately)
   useEffect(() => {
-    textareaRef.current?.focus();
+    const isDesktop = window.matchMedia("(min-width: 640px)").matches;
+    if (isDesktop) {
+      textareaRef.current?.focus();
+    }
   }, []);
 
   // Load server home/cwd and available backends on mount
@@ -381,7 +384,7 @@ export function HomePage() {
   const canSend = text.trim().length > 0 && !sending;
 
   return (
-    <div className="flex-1 h-full flex items-center justify-center px-3 sm:px-4">
+    <div className="flex-1 h-full flex items-start justify-center px-3 sm:px-4 pt-[15vh] sm:pt-[20vh] overflow-y-auto">
       <div className="w-full max-w-2xl">
         {/* Logo + Title */}
         <div className="flex flex-col items-center justify-center mb-4 sm:mb-6">
@@ -617,7 +620,7 @@ export function HomePage() {
                       value={branchFilter}
                       onChange={(e) => setBranchFilter(e.target.value)}
                       placeholder="Filter or create branch..."
-                      className="w-full px-2 py-1 text-xs bg-cc-input-bg border border-cc-border rounded-md text-cc-fg font-mono-code placeholder:text-cc-muted focus:outline-none focus:border-cc-primary/50"
+                      className="w-full px-2 py-1 text-base sm:text-xs bg-cc-input-bg border border-cc-border rounded-md text-cc-fg font-mono-code placeholder:text-cc-muted focus:outline-none focus:border-cc-primary/50"
                       autoFocus
                       onKeyDown={(e) => {
                         if (e.key === "Escape") {


### PR DESCRIPTION
## Summary

- **Keyboard layout shift**: On mobile iOS, opening the keyboard caused the HomePage content to pivot/jump upward because `items-center justify-center` re-centered content in the shrunk viewport. Switched to `items-start` with `pt-[15vh]` padding and `overflow-y-auto` so the page scrolls naturally instead.
- **Auto-focus disabled on mobile**: The textarea auto-focus triggered the keyboard immediately on page load — now only fires on desktop (`min-width: 640px`).
- **Branch selector zoom**: The branch filter input used `text-xs` (12px), causing iOS Safari to auto-zoom on focus. Changed to `text-base sm:text-xs` (16px on mobile) matching the existing pattern in FolderPicker.
- **Viewport safety net**: Added `maximum-scale=1` to the viewport meta tag to prevent zoom on any small-font inputs we might have missed.

## Test plan

- [ ] On iOS (or mobile responsive mode): open homepage → keyboard should NOT auto-open
- [ ] Tap textarea → keyboard opens, content scrolls naturally, no "pivot" effect
- [ ] Tap branch selector → no zoom, dropdown stays in viewport
- [ ] On desktop → textarea still auto-focuses as before

Code generated by AI, not reviewed by a human.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/the-vibe-company/companion/pull/159" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
