### PR TITLE
fix(web): stable session ordering — sort by creation date only

### DIFF
--- a/web/src/utils/project-grouping.test.ts
+++ b/web/src/utils/project-grouping.test.ts
@@ -107,14 +107,14 @@ describe("groupSessionsByProject", () => {
     expect(groups[1].label).toBe("zebra");
   });
 
-  it("sorts sessions within group: running first, then by createdAt desc", () => {
+  it("sorts sessions within group by createdAt desc regardless of status", () => {
     const sessions = [
       makeItem({ id: "s1", cwd: "/a/app", createdAt: 300, status: null }),
       makeItem({ id: "s2", cwd: "/a/app", createdAt: 100, status: "running" }),
       makeItem({ id: "s3", cwd: "/a/app", createdAt: 200, status: null }),
     ];
     const groups = groupSessionsByProject(sessions);
-    expect(groups[0].sessions.map((s) => s.id)).toEqual(["s2", "s1", "s3"]);
+    expect(groups[0].sessions.map((s) => s.id)).toEqual(["s1", "s3", "s2"]);
   });
 
   it("handles sessions with empty cwd as a separate group", () => {
@@ -145,5 +145,111 @@ describe("groupSessionsByProject", () => {
     ];
     const groups = groupSessionsByProject(sessions);
     expect(groups).toHaveLength(2);
+  });
+
+  it("does not reorder sessions when status changes from idle to running", () => {
+    // Simulate initial state: all idle, ordered by createdAt
+    const sessionsIdle = [
+      makeItem({ id: "s1", cwd: "/a/app", createdAt: 300, status: null }),
+      makeItem({ id: "s2", cwd: "/a/app", createdAt: 200, status: null }),
+      makeItem({ id: "s3", cwd: "/a/app", createdAt: 100, status: null }),
+    ];
+    const groupsBefore = groupSessionsByProject(sessionsIdle);
+    const orderBefore = groupsBefore[0].sessions.map((s) => s.id);
+
+    // Simulate s3 (oldest) starting to run
+    const sessionsWithRunning = [
+      makeItem({ id: "s1", cwd: "/a/app", createdAt: 300, status: null }),
+      makeItem({ id: "s2", cwd: "/a/app", createdAt: 200, status: null }),
+      makeItem({ id: "s3", cwd: "/a/app", createdAt: 100, status: "running" }),
+    ];
+    const groupsAfter = groupSessionsByProject(sessionsWithRunning);
+    const orderAfter = groupsAfter[0].sessions.map((s) => s.id);
+
+    expect(orderBefore).toEqual(orderAfter);
+  });
+
+  it("maintains stable order with mixed running/idle/compacting statuses", () => {
+    const sessions = [
+      makeItem({ id: "s1", cwd: "/a/app", createdAt: 500, status: "idle" }),
+      makeItem({ id: "s2", cwd: "/a/app", createdAt: 400, status: "running" }),
+      makeItem({ id: "s3", cwd: "/a/app", createdAt: 300, status: "compacting" }),
+      makeItem({ id: "s4", cwd: "/a/app", createdAt: 200, status: null }),
+      makeItem({ id: "s5", cwd: "/a/app", createdAt: 100, status: "running" }),
+    ];
+    const groups = groupSessionsByProject(sessions);
+    expect(groups[0].sessions.map((s) => s.id)).toEqual(["s1", "s2", "s3", "s4", "s5"]);
+  });
+
+  it("tracks mostRecentActivity as max createdAt in group", () => {
+    const sessions = [
+      makeItem({ id: "s1", cwd: "/a/app", createdAt: 100 }),
+      makeItem({ id: "s2", cwd: "/a/app", createdAt: 500 }),
+      makeItem({ id: "s3", cwd: "/a/app", createdAt: 300 }),
+    ];
+    const groups = groupSessionsByProject(sessions);
+    expect(groups[0].mostRecentActivity).toBe(500);
+  });
+
+  it("returns empty array for empty input", () => {
+    expect(groupSessionsByProject([])).toEqual([]);
+  });
+
+  it("handles a single session as its own group", () => {
+    const sessions = [makeItem({ id: "s1", cwd: "/a/solo" })];
+    const groups = groupSessionsByProject(sessions);
+    expect(groups).toHaveLength(1);
+    expect(groups[0].sessions).toHaveLength(1);
+    expect(groups[0].label).toBe("solo");
+  });
+
+  it("order is stable across repeated calls with same input", () => {
+    const sessions = [
+      makeItem({ id: "s1", cwd: "/a/app", createdAt: 300, status: "running" }),
+      makeItem({ id: "s2", cwd: "/a/app", createdAt: 200, status: null }),
+      makeItem({ id: "s3", cwd: "/a/app", createdAt: 100, status: "running" }),
+      makeItem({ id: "s4", cwd: "/b/other", createdAt: 400, status: null }),
+    ];
+    const first = groupSessionsByProject(sessions);
+    const second = groupSessionsByProject(sessions);
+    expect(first.map((g) => g.key)).toEqual(second.map((g) => g.key));
+    for (let i = 0; i < first.length; i++) {
+      expect(first[i].sessions.map((s) => s.id)).toEqual(second[i].sessions.map((s) => s.id));
+    }
+  });
+
+  it("sessions with identical createdAt maintain consistent order", () => {
+    const sessions = [
+      makeItem({ id: "s1", cwd: "/a/app", createdAt: 100 }),
+      makeItem({ id: "s2", cwd: "/a/app", createdAt: 100 }),
+      makeItem({ id: "s3", cwd: "/a/app", createdAt: 100 }),
+    ];
+    const groups = groupSessionsByProject(sessions);
+    expect(groups[0].sessions).toHaveLength(3);
+  });
+
+  it("groups across multiple projects each sort independently by createdAt", () => {
+    const sessions = [
+      makeItem({ id: "s1", cwd: "/a/proj-a", createdAt: 100 }),
+      makeItem({ id: "s2", cwd: "/a/proj-b", createdAt: 400 }),
+      makeItem({ id: "s3", cwd: "/a/proj-a", createdAt: 300 }),
+      makeItem({ id: "s4", cwd: "/a/proj-b", createdAt: 200 }),
+    ];
+    const groups = groupSessionsByProject(sessions);
+    expect(groups[0].label).toBe("proj-a");
+    expect(groups[1].label).toBe("proj-b");
+    expect(groups[0].sessions.map((s) => s.id)).toEqual(["s3", "s1"]);
+    expect(groups[1].sessions.map((s) => s.id)).toEqual(["s2", "s4"]);
+  });
+
+  it("multiple worktrees of the same repo all land in one group", () => {
+    const sessions = [
+      makeItem({ id: "s1", cwd: "/home/user/repo", repoRoot: "/home/user/repo", createdAt: 300 }),
+      makeItem({ id: "s2", cwd: "/home/user/repo-wt-feat1", repoRoot: "/home/user/repo", isWorktree: true, createdAt: 200 }),
+      makeItem({ id: "s3", cwd: "/home/user/repo-wt-feat2", repoRoot: "/home/user/repo", isWorktree: true, createdAt: 100 }),
+    ];
+    const groups = groupSessionsByProject(sessions);
+    expect(groups).toHaveLength(1);
+    expect(groups[0].sessions.map((s) => s.id)).toEqual(["s1", "s2", "s3"]);
   });
 });

--- a/web/src/utils/project-grouping.ts
+++ b/web/src/utils/project-grouping.ts
@@ -84,14 +84,9 @@ export function groupSessionsByProject(
     (a, b) => a.label.localeCompare(b.label),
   );
 
-  // Within each group, sort sessions: running first, then by createdAt desc
+  // Within each group, sort sessions by createdAt desc (stable order, no reordering on status change)
   for (const group of sorted) {
-    group.sessions.sort((a, b) => {
-      const aRunning = a.status === "running" ? 1 : 0;
-      const bRunning = b.status === "running" ? 1 : 0;
-      if (aRunning !== bRunning) return bRunning - aRunning;
-      return b.createdAt - a.createdAt;
-    });
+    group.sessions.sort((a, b) => b.createdAt - a.createdAt);
   }
 
   return sorted;


### PR DESCRIPTION
## Summary
- Sessions in the sidebar no longer jump around when they start or stop running
- Removed the "running first" sort priority from `groupSessionsByProject()` — sessions are now sorted purely by `createdAt` descending within each project group
- Added 9 new tests covering stable ordering, edge cases (empty input, single session, identical timestamps), multi-project sorting, and worktree grouping

## Test plan
- [x] `bun run test` — all 25 project-grouping tests pass (was 16, now 25)
- [ ] Manual: start multiple sessions in the same project, verify that running/stopping a session does not change its position in the sidebar

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/the-vibe-company/companion/pull/173" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
