### PR TITLE
feat(web): adaptive server-side PR polling with WebSocket push

### DIFF
--- a/web/server/pr-poller.test.ts
+++ b/web/server/pr-poller.test.ts
@@ -1,0 +1,191 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+
+// ─── Mocks ──────────────────────────────────────────────────────────────────
+
+const mockFetchPRInfoAsync = vi.hoisted(() => vi.fn());
+const mockComputeAdaptiveTTL = vi.hoisted(() => vi.fn());
+
+vi.mock("./github-pr.js", () => ({
+  fetchPRInfoAsync: mockFetchPRInfoAsync,
+  computeAdaptiveTTL: mockComputeAdaptiveTTL,
+}));
+
+import { PRPoller } from "./pr-poller.js";
+import type { GitHubPRInfo } from "./github-pr.js";
+
+function makeMockBridge() {
+  return {
+    broadcastToSession: vi.fn(),
+  } as any;
+}
+
+function makePR(overrides?: Partial<GitHubPRInfo>): GitHubPRInfo {
+  return {
+    number: 42,
+    title: "test pr",
+    url: "https://github.com/org/repo/pull/42",
+    state: "OPEN",
+    isDraft: false,
+    reviewDecision: null,
+    additions: 10,
+    deletions: 5,
+    changedFiles: 2,
+    checks: [],
+    checksSummary: { total: 0, success: 0, failure: 0, pending: 0 },
+    reviewThreads: { total: 0, resolved: 0, unresolved: 0 },
+    ...overrides,
+  };
+}
+
+/** Flush microtasks so async callbacks in the poller can settle. */
+async function flushMicrotasks() {
+  await new Promise((r) => setTimeout(r, 0));
+}
+
+// ─── Tests ──────────────────────────────────────────────────────────────────
+
+describe("PRPoller", () => {
+  let poller: PRPoller;
+  let bridge: ReturnType<typeof makeMockBridge>;
+
+  beforeEach(() => {
+    mockFetchPRInfoAsync.mockReset();
+    mockComputeAdaptiveTTL.mockReset();
+    mockComputeAdaptiveTTL.mockReturnValue(30_000);
+    bridge = makeMockBridge();
+    poller = new PRPoller(bridge);
+  });
+
+  afterEach(() => {
+    poller.destroy();
+  });
+
+  it("returns null on initial watch (no cached data)", () => {
+    mockFetchPRInfoAsync.mockResolvedValue(null);
+    const result = poller.watch("s1", "/repo", "main");
+    expect(result).toBeNull();
+  });
+
+  it("fetches and broadcasts PR data after watch", async () => {
+    const pr = makePR();
+    mockFetchPRInfoAsync.mockResolvedValue(pr);
+
+    poller.watch("s1", "/repo", "feat/test");
+
+    // Let the async fetch settle
+    await flushMicrotasks();
+
+    expect(mockFetchPRInfoAsync).toHaveBeenCalledWith("/repo", "feat/test");
+    expect(bridge.broadcastToSession).toHaveBeenCalledWith("s1", {
+      type: "pr_status_update",
+      pr,
+      available: true,
+    });
+  });
+
+  it("shares one timer across multiple sessions watching the same branch", async () => {
+    const pr = makePR();
+    mockFetchPRInfoAsync.mockResolvedValue(pr);
+
+    poller.watch("s1", "/repo", "main");
+    poller.watch("s2", "/repo", "main");
+
+    await flushMicrotasks();
+
+    // Should only have fetched once (shared timer)
+    expect(mockFetchPRInfoAsync).toHaveBeenCalledTimes(1);
+    // But should broadcast to both sessions
+    expect(bridge.broadcastToSession).toHaveBeenCalledWith("s1", expect.objectContaining({ type: "pr_status_update" }));
+    expect(bridge.broadcastToSession).toHaveBeenCalledWith("s2", expect.objectContaining({ type: "pr_status_update" }));
+  });
+
+  it("returns cached data on subsequent watch calls", async () => {
+    const pr = makePR();
+    mockFetchPRInfoAsync.mockResolvedValue(pr);
+
+    poller.watch("s1", "/repo", "main");
+    await flushMicrotasks();
+
+    // Second session watches the same branch — should get cached data
+    const cached = poller.watch("s2", "/repo", "main");
+    expect(cached).toEqual(pr);
+  });
+
+  it("cleans up when last session unwatches", async () => {
+    mockFetchPRInfoAsync.mockResolvedValue(makePR());
+
+    poller.watch("s1", "/repo", "main");
+    poller.watch("s2", "/repo", "main");
+    await flushMicrotasks();
+
+    poller.unwatch("s1");
+    // Still one session watching — cache should remain
+    expect(poller.getCached("/repo", "main")).not.toBeNull();
+
+    poller.unwatch("s2");
+    // No sessions left — should be cleaned up
+    expect(poller.getCached("/repo", "main")).toBeNull();
+  });
+
+  it("getCached returns null for unknown branches", () => {
+    expect(poller.getCached("/repo", "nonexistent")).toBeNull();
+  });
+
+  it("uses computeAdaptiveTTL for scheduling", async () => {
+    const pr = makePR({ checksSummary: { total: 3, success: 1, failure: 0, pending: 2 } });
+    mockFetchPRInfoAsync.mockResolvedValue(pr);
+    mockComputeAdaptiveTTL.mockReturnValue(10_000);
+
+    poller.watch("s1", "/repo", "feat/ci");
+    await flushMicrotasks();
+
+    expect(mockComputeAdaptiveTTL).toHaveBeenCalledWith(pr);
+  });
+
+  it("handles session switching branches (unwatches old, watches new)", async () => {
+    mockFetchPRInfoAsync.mockResolvedValue(makePR());
+
+    poller.watch("s1", "/repo", "branch-a");
+    await flushMicrotasks();
+
+    // Same session now watches a different branch
+    poller.watch("s1", "/repo", "branch-b");
+    await flushMicrotasks();
+
+    // Old branch should have been cleaned up (only session was s1)
+    expect(poller.getCached("/repo", "branch-a")).toBeNull();
+    expect(poller.getCached("/repo", "branch-b")).not.toBeNull();
+  });
+
+  it("handles fetch errors gracefully", async () => {
+    mockFetchPRInfoAsync.mockRejectedValue(new Error("network error"));
+
+    poller.watch("s1", "/repo", "main");
+    await flushMicrotasks();
+
+    // Should not throw, should not broadcast (no data on error)
+    expect(bridge.broadcastToSession).not.toHaveBeenCalled();
+  });
+
+  it("prevents concurrent fetches for the same key", async () => {
+    // Create a fetch that takes time to resolve
+    let resolveFirst: (value: GitHubPRInfo) => void;
+    mockFetchPRInfoAsync.mockReturnValueOnce(
+      new Promise<GitHubPRInfo>((r) => { resolveFirst = r; }),
+    );
+
+    poller.watch("s1", "/repo", "main");
+    // Try to trigger another fetch immediately (e.g., from a second session)
+    poller.watch("s2", "/repo", "main");
+
+    // Only one fetch should have started
+    expect(mockFetchPRInfoAsync).toHaveBeenCalledTimes(1);
+
+    // Resolve the first fetch
+    resolveFirst!(makePR());
+    await flushMicrotasks();
+
+    // Now broadcast should have gone to both sessions
+    expect(bridge.broadcastToSession).toHaveBeenCalledTimes(2);
+  });
+});

--- a/web/server/pr-poller.ts
+++ b/web/server/pr-poller.ts
@@ -1,0 +1,162 @@
+import { fetchPRInfoAsync, computeAdaptiveTTL, type GitHubPRInfo } from "./github-pr.js";
+import type { WsBridge } from "./ws-bridge.js";
+
+// ─── Types ───────────────────────────────────────────────────────────────────
+
+interface WatchedPR {
+  cwd: string;
+  branch: string;
+  /** Sessions interested in this PR (same cwd:branch may be shared) */
+  sessionIds: Set<string>;
+  lastData: GitHubPRInfo | null;
+  timer: ReturnType<typeof setTimeout> | null;
+  lastFetchTime: number;
+  currentInterval: number;
+  fetching: boolean;
+}
+
+// ─── PR Poller ───────────────────────────────────────────────────────────────
+
+/**
+ * Server-side poller that fetches GitHub PR status at adaptive intervals
+ * and pushes updates to browsers via WebSocket.
+ *
+ * One timer per unique cwd:branch — shared across sessions on the same branch.
+ */
+export class PRPoller {
+  private watched = new Map<string, WatchedPR>();
+  private wsBridge: WsBridge;
+  /** Reverse index: sessionId → cwd:branch key (a session can only watch one PR at a time) */
+  private sessionToKey = new Map<string, string>();
+
+  constructor(wsBridge: WsBridge) {
+    this.wsBridge = wsBridge;
+  }
+
+  /**
+   * Start watching a PR for a session.
+   * Returns cached data immediately if available.
+   * Triggers an async fetch if cache is stale or missing.
+   */
+  watch(sessionId: string, cwd: string, branch: string): GitHubPRInfo | null {
+    const key = `${cwd}:${branch}`;
+
+    // If this session was watching a different PR, unregister from the old one
+    const prevKey = this.sessionToKey.get(sessionId);
+    if (prevKey && prevKey !== key) {
+      this.unwatchKey(sessionId, prevKey);
+    }
+    this.sessionToKey.set(sessionId, key);
+
+    const existing = this.watched.get(key);
+    if (existing) {
+      existing.sessionIds.add(sessionId);
+      // If cache is stale, trigger a refresh
+      if (Date.now() - existing.lastFetchTime > existing.currentInterval) {
+        this.fetchAndBroadcast(key);
+      }
+      return existing.lastData;
+    }
+
+    // New watch — create entry and fetch immediately
+    const entry: WatchedPR = {
+      cwd,
+      branch,
+      sessionIds: new Set([sessionId]),
+      lastData: null,
+      timer: null,
+      lastFetchTime: 0,
+      currentInterval: 10_000, // start aggressive for fast initial load
+      fetching: false,
+    };
+    this.watched.set(key, entry);
+    this.fetchAndBroadcast(key);
+
+    return null;
+  }
+
+  /** Stop watching for a specific session. */
+  unwatch(sessionId: string): void {
+    const key = this.sessionToKey.get(sessionId);
+    if (!key) return;
+    this.sessionToKey.delete(sessionId);
+    this.unwatchKey(sessionId, key);
+  }
+
+  /** Get current cached data for a cwd:branch pair (for REST fallback). */
+  getCached(cwd: string, branch: string): { available: boolean; pr: GitHubPRInfo | null } | null {
+    const key = `${cwd}:${branch}`;
+    const entry = this.watched.get(key);
+    if (!entry) return null;
+    return { available: true, pr: entry.lastData };
+  }
+
+  /** Stop all timers (for testing / cleanup). */
+  destroy(): void {
+    for (const entry of this.watched.values()) {
+      if (entry.timer) clearTimeout(entry.timer);
+    }
+    this.watched.clear();
+    this.sessionToKey.clear();
+  }
+
+  // ─── Internal ──────────────────────────────────────────────────────────
+
+  private unwatchKey(sessionId: string, key: string): void {
+    const entry = this.watched.get(key);
+    if (!entry) return;
+    entry.sessionIds.delete(sessionId);
+    if (entry.sessionIds.size === 0) {
+      if (entry.timer) clearTimeout(entry.timer);
+      this.watched.delete(key);
+    }
+  }
+
+  private async fetchAndBroadcast(key: string): Promise<void> {
+    const entry = this.watched.get(key);
+    if (!entry) return;
+
+    // Prevent concurrent fetches for the same key
+    if (entry.fetching) return;
+    entry.fetching = true;
+
+    // Clear existing timer (will be rescheduled after fetch)
+    if (entry.timer) {
+      clearTimeout(entry.timer);
+      entry.timer = null;
+    }
+
+    try {
+      const prInfo = await fetchPRInfoAsync(entry.cwd, entry.branch);
+      // Re-check entry still exists (may have been unwatched during async fetch)
+      const current = this.watched.get(key);
+      if (!current) return;
+
+      current.lastData = prInfo;
+      current.lastFetchTime = Date.now();
+      current.currentInterval = computeAdaptiveTTL(prInfo);
+
+      // Push to all sessions watching this PR
+      for (const sessionId of current.sessionIds) {
+        this.wsBridge.broadcastToSession(sessionId, {
+          type: "pr_status_update",
+          pr: prInfo,
+          available: true,
+        });
+      }
+    } catch {
+      // On error, use a moderate interval
+      const current = this.watched.get(key);
+      if (current) {
+        current.currentInterval = 30_000;
+      }
+    } finally {
+      const current = this.watched.get(key);
+      if (current) {
+        current.fetching = false;
+        // Schedule next fetch
+        current.timer = setTimeout(() => this.fetchAndBroadcast(key), current.currentInterval);
+      }
+    }
+  }
+}

--- a/web/server/session-types.ts
+++ b/web/server/session-types.ts
@@ -184,7 +184,8 @@ export type BrowserIncomingMessage =
   | { type: "cli_connected" }
   | { type: "user_message"; content: string; timestamp: number; id?: string }
   | { type: "message_history"; messages: BrowserIncomingMessage[] }
-  | { type: "session_name_update"; name: string };
+  | { type: "session_name_update"; name: string }
+  | { type: "pr_status_update"; pr: import("./github-pr.js").GitHubPRInfo | null; available: boolean };
 
 // ─── Session State ────────────────────────────────────────────────────────────
 

--- a/web/src/ws.ts
+++ b/web/src/ws.ts
@@ -360,6 +360,11 @@ function handleMessage(sessionId: string, event: MessageEvent) {
       break;
     }
 
+    case "pr_status_update": {
+      store.setPRStatus(sessionId, { available: data.available, pr: data.pr });
+      break;
+    }
+
     case "message_history": {
       const chatMessages: ChatMessage[] = [];
       for (let i = 0; i < data.messages.length; i++) {


### PR DESCRIPTION
## Summary

- **Server-side adaptive polling**: Replaces the fixed 30s client-side `setInterval` with a `PRPoller` class that runs on the server and pushes `pr_status_update` messages over WebSocket
- **Adaptive intervals based on PR state**: 10s when CI is pending, 30s for failures/changes requested, 45s for review pending, 2min for approved, 5min for merged/closed
- **Non-blocking `gh` CLI calls**: Uses `Bun.spawn` instead of `execFileSync` to avoid blocking the event loop
- **Shared timers**: Multiple sessions watching the same branch share a single poller timer
- **REST fallback**: The `/api/git/pr-status` endpoint checks the poller cache first for instant response

| PR State | Polling Interval |
|---|---|
| CI pending | **10s** |
| CI failed / Changes requested | 30s |
| Review pending | 45s |
| Approved + checks passed | 2min |
| Merged / Closed | 5min |
| No PR found | 60s |

## Test plan

- [x] `bun run typecheck` — no type errors
- [x] `bun run test` — 806 tests pass (10 new: computeAdaptiveTTL + PRPoller)
- [ ] Open a session on a branch with an open PR — PR status should appear within ~1-2 seconds
- [ ] Push a commit to trigger CI — PR status should update to "pending" within ~10 seconds
- [ ] Check a merged PR — should show merged status with infrequent polling (5 min)
- [ ] Open multiple sessions on the same branch — should share one poller timer

Code was generated by AI, not reviewed by a human.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/the-vibe-company/companion/pull/178" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
