### PR TITLE
fix(web): unset CLAUDECODE env var to prevent CLI nesting guard rejec…

### DIFF
--- a/web/server/cli-launcher.test.ts
+++ b/web/server/cli-launcher.test.ts
@@ -337,11 +337,11 @@ describe("launch", () => {
     expect(info.pid).toBe(99999);
   });
 
-  it("includes CLAUDECODE=1 in environment", () => {
+  it("unsets CLAUDECODE to avoid CLI nesting guard", () => {
     launcher.launch({ cwd: "/tmp" });
 
     const [, options] = mockSpawn.mock.calls[0];
-    expect(options.env.CLAUDECODE).toBe("1");
+    expect(options.env.CLAUDECODE).toBeUndefined();
   });
 
   it("merges custom env variables", () => {
@@ -352,7 +352,7 @@ describe("launch", () => {
 
     const [, options] = mockSpawn.mock.calls[0];
     expect(options.env.MY_VAR).toBe("hello");
-    expect(options.env.CLAUDECODE).toBe("1");
+    expect(options.env.CLAUDECODE).toBeUndefined();
   });
 
   it("enables Codex web search when codexInternetAccess=true", () => {

--- a/web/server/cli-launcher.ts
+++ b/web/server/cli-launcher.ts
@@ -284,7 +284,7 @@ export class CliLauncher {
 
     const env: Record<string, string | undefined> = {
       ...process.env,
-      CLAUDECODE: "1",
+      CLAUDECODE: undefined,
       ...options.env,
     };
 
@@ -347,6 +347,7 @@ export class CliLauncher {
 
     const env: Record<string, string | undefined> = {
       ...process.env,
+      CLAUDECODE: undefined,
       ...options.env,
     };
 

--- a/web/server/terminal-manager.ts
+++ b/web/server/terminal-manager.ts
@@ -43,7 +43,7 @@ export class TerminalManager {
 
     const proc = Bun.spawn([shell, "-l"], {
       cwd,
-      env: { ...process.env, TERM: "xterm-256color" },
+      env: { ...process.env, TERM: "xterm-256color", CLAUDECODE: undefined },
       terminal: {
         cols,
         rows,


### PR DESCRIPTION
## Summary

  - Unset `CLAUDECODE` environment variable in all process spawn sites to prevent the CLI's nesting guard from rejecting Companion-managed sessions
  - Affects Claude Code CLI launcher, Codex launcher, and the embedded terminal

  ## Problem

  Recent Claude Code CLI versions added a startup guard that checks for the `CLAUDECODE` environment variable. If present, the CLI refuses to launch with:

  Error: Claude Code cannot be launched inside another Claude Code session.
  Nested sessions share runtime resources and will crash all active sessions.
  To bypass this check, unset the CLAUDECODE environment variable.

  The Companion was explicitly setting `CLAUDECODE: "1"` in the spawned CLI environment (`cli-launcher.ts:287`), and also inheriting it via `...process.env` when the server itself runs inside a Claude Code terminal.

  ## Fix

  Explicitly set `CLAUDECODE: undefined` in all three spawn sites, which strips the variable from the child process environment:

  | File | Spawn site |
  |------|------------|
  | `web/server/cli-launcher.ts` | `spawnCLI()` — Claude Code sessions |
  | `web/server/cli-launcher.ts` | `spawnCodex()` — Codex backend sessions |
  | `web/server/terminal-manager.ts` | `spawn()` — Embedded terminal |

  ## Test plan

  - [x] TypeScript typecheck passes
  - [x] All 854 tests pass (33 test files)
  - [x] Updated 2 existing tests to assert `CLAUDECODE` is `undefined` instead of `"1"`
  - [x] Manual: start Companion, create a new Claude Code session, verify no nesting guard error in stderr
