### PR TITLE
feat(web): implement /clear slash command to reset session state

### DIFF
--- a/web/server/cli-launcher.ts
+++ b/web/server/cli-launcher.ts
@@ -227,6 +227,20 @@ export class CliLauncher {
   }
 
   /**
+   * Clear session context and relaunch CLI fresh (no --resume).
+   * Used by /clear command to start a clean conversation.
+   */
+  async clearAndRelaunch(sessionId: string): Promise<boolean> {
+    const info = this.sessions.get(sessionId);
+    if (!info) return false;
+
+    // Clear the CLI session ID so relaunch() won't use --resume
+    info.cliSessionId = undefined;
+
+    return this.relaunch(sessionId);
+  }
+
+  /**
    * Get all sessions in "starting" state (awaiting CLI WebSocket connection).
    */
   getStartingSessions(): SdkSessionInfo[] {

--- a/web/server/index.ts
+++ b/web/server/index.ts
@@ -72,6 +72,11 @@ wsBridge.onCLIRelaunchNeededCallback(async (sessionId) => {
   }
 });
 
+// Handle /clear command — relaunch CLI without --resume for a fresh session
+wsBridge.onClearSessionCallback(async (sessionId) => {
+  await launcher.clearAndRelaunch(sessionId);
+});
+
 // Auto-generate session title after first turn completes
 wsBridge.onFirstTurnCompletedCallback(async (sessionId, firstUserMessage) => {
   // Don't overwrite a name that was already set (manual rename or prior auto-name)

--- a/web/server/session-types.ts
+++ b/web/server/session-types.ts
@@ -185,7 +185,8 @@ export type BrowserIncomingMessage =
   | { type: "user_message"; content: string; timestamp: number; id?: string }
   | { type: "message_history"; messages: BrowserIncomingMessage[] }
   | { type: "session_name_update"; name: string }
-  | { type: "pr_status_update"; pr: import("./github-pr.js").GitHubPRInfo | null; available: boolean };
+  | { type: "pr_status_update"; pr: import("./github-pr.js").GitHubPRInfo | null; available: boolean }
+  | { type: "session_cleared" };
 
 // ─── Session State ────────────────────────────────────────────────────────────
 

--- a/web/server/ws-bridge.test.ts
+++ b/web/server/ws-bridge.test.ts
@@ -2457,3 +2457,189 @@ describe("broadcastNameUpdate", () => {
     bridge.broadcastNameUpdate("nonexistent", "Name");
   });
 });
+
+// ─── /clear command interception ──────────────────────────────────────────────
+
+describe("/clear command interception", () => {
+  it("intercepts /clear and does not forward to CLI", () => {
+    const cli = makeCliSocket("s1");
+    bridge.handleCLIOpen(cli, "s1");
+
+    // Send system.init so session has some state
+    bridge.handleCLIMessage(cli, makeInitMsg());
+
+    // Add a message to history first
+    const session = bridge.getSession("s1")!;
+    session.messageHistory.push({ type: "user_message", content: "hello", timestamp: Date.now() });
+
+    // Reset CLI send mock to track only new calls
+    cli.send.mockClear();
+
+    // Send /clear
+    const browser = makeBrowserSocket("s1");
+    bridge.handleBrowserOpen(browser, "s1");
+    browser.send.mockClear();
+
+    bridge.handleBrowserMessage(browser, JSON.stringify({
+      type: "user_message",
+      content: "/clear",
+    }));
+
+    // CLI should NOT have received any message
+    expect(cli.send).not.toHaveBeenCalled();
+  });
+
+  it("resets session state but preserves cwd and model", () => {
+    const cli = makeCliSocket("s1");
+    bridge.handleCLIOpen(cli, "s1");
+    bridge.handleCLIMessage(cli, makeInitMsg({ cwd: "/my/project", model: "claude-opus-4-6" }));
+
+    const session = bridge.getSession("s1")!;
+    session.messageHistory.push({ type: "user_message", content: "hello", timestamp: Date.now() });
+    session.state.total_cost_usd = 1.5;
+    session.state.num_turns = 5;
+
+    bridge.clearSession("s1");
+
+    expect(session.messageHistory).toEqual([]);
+    expect(session.pendingMessages).toEqual([]);
+    expect(session.pendingPermissions.size).toBe(0);
+    expect(session.state.cwd).toBe("/my/project");
+    expect(session.state.model).toBe("claude-opus-4-6");
+    expect(session.state.total_cost_usd).toBe(0);
+    expect(session.state.num_turns).toBe(0);
+    expect(session.state.context_used_percent).toBe(0);
+  });
+
+  it("broadcasts session_cleared to browsers", () => {
+    const cli = makeCliSocket("s1");
+    bridge.handleCLIOpen(cli, "s1");
+    bridge.handleCLIMessage(cli, makeInitMsg());
+
+    const browser = makeBrowserSocket("s1");
+    bridge.handleBrowserOpen(browser, "s1");
+    browser.send.mockClear();
+
+    bridge.clearSession("s1");
+
+    const calls = browser.send.mock.calls.map((c: unknown[]) => JSON.parse(c[0] as string));
+    const cleared = calls.find((m: { type: string }) => m.type === "session_cleared");
+    expect(cleared).toEqual({ type: "session_cleared" });
+  });
+
+  it("calls onClearSession callback", () => {
+    const callback = vi.fn();
+    bridge.onClearSessionCallback(callback);
+
+    const cli = makeCliSocket("s1");
+    bridge.handleCLIOpen(cli, "s1");
+    bridge.handleCLIMessage(cli, makeInitMsg());
+
+    bridge.clearSession("s1");
+
+    expect(callback).toHaveBeenCalledWith("s1");
+  });
+
+  it("does not intercept regular messages starting with /", () => {
+    const cli = makeCliSocket("s1");
+    bridge.handleCLIOpen(cli, "s1");
+    bridge.handleCLIMessage(cli, makeInitMsg());
+    cli.send.mockClear();
+
+    const browser = makeBrowserSocket("s1");
+    bridge.handleBrowserOpen(browser, "s1");
+
+    bridge.handleBrowserMessage(browser, JSON.stringify({
+      type: "user_message",
+      content: "/commit fix the bug",
+    }));
+
+    // CLI should have received the message (forwarded normally)
+    expect(cli.send).toHaveBeenCalled();
+    const sent = cli.send.mock.calls[0][0] as string;
+    const parsed = JSON.parse(sent.trim());
+    expect(parsed.type).toBe("user");
+    expect(parsed.message.content).toBe("/commit fix the bug");
+  });
+
+  it("handles /clear with extra whitespace", () => {
+    const callback = vi.fn();
+    bridge.onClearSessionCallback(callback);
+
+    const cli = makeCliSocket("s1");
+    bridge.handleCLIOpen(cli, "s1");
+    bridge.handleCLIMessage(cli, makeInitMsg());
+    cli.send.mockClear();
+
+    const browser = makeBrowserSocket("s1");
+    bridge.handleBrowserOpen(browser, "s1");
+
+    bridge.handleBrowserMessage(browser, JSON.stringify({
+      type: "user_message",
+      content: "  /clear  ",
+    }));
+
+    // Should be intercepted (trimmed match)
+    expect(cli.send).not.toHaveBeenCalled();
+    expect(callback).toHaveBeenCalledWith("s1");
+  });
+
+  it("allows auto-naming again after clear", () => {
+    const cli = makeCliSocket("s1");
+    bridge.handleCLIOpen(cli, "s1");
+    bridge.handleCLIMessage(cli, makeInitMsg());
+
+    // Simulate first turn completion triggering auto-naming
+    const namingCallback = vi.fn();
+    bridge.onFirstTurnCompletedCallback(namingCallback);
+
+    // Send a user message + result to trigger auto-naming
+    const browser = makeBrowserSocket("s1");
+    bridge.handleBrowserOpen(browser, "s1");
+    bridge.handleBrowserMessage(browser, JSON.stringify({
+      type: "user_message",
+      content: "hello",
+    }));
+    bridge.handleCLIMessage(cli, JSON.stringify({
+      type: "result",
+      subtype: "success",
+      is_error: false,
+      duration_ms: 100,
+      duration_api_ms: 80,
+      num_turns: 1,
+      total_cost_usd: 0.01,
+      stop_reason: "end_turn",
+      usage: { input_tokens: 10, output_tokens: 20, cache_creation_input_tokens: 0, cache_read_input_tokens: 0 },
+      uuid: "uuid-result",
+      session_id: "cli-123",
+    }));
+
+    expect(namingCallback).toHaveBeenCalledTimes(1);
+    namingCallback.mockClear();
+
+    // Now clear the session
+    bridge.clearSession("s1");
+
+    // After clear, a new first turn should trigger auto-naming again
+    bridge.handleBrowserMessage(browser, JSON.stringify({
+      type: "user_message",
+      content: "new conversation",
+    }));
+    bridge.handleCLIMessage(cli, JSON.stringify({
+      type: "result",
+      subtype: "success",
+      is_error: false,
+      duration_ms: 100,
+      duration_api_ms: 80,
+      num_turns: 1,
+      total_cost_usd: 0.01,
+      stop_reason: "end_turn",
+      usage: { input_tokens: 10, output_tokens: 20, cache_creation_input_tokens: 0, cache_read_input_tokens: 0 },
+      uuid: "uuid-result-2",
+      session_id: "cli-123",
+    }));
+
+    expect(namingCallback).toHaveBeenCalledTimes(1);
+    expect(namingCallback).toHaveBeenCalledWith("s1", "new conversation");
+  });
+});

--- a/web/src/store.ts
+++ b/web/src/store.ts
@@ -111,6 +111,9 @@ interface AppState {
   // Plan mode actions
   setPreviousPermissionMode: (sessionId: string, mode: string) => void;
 
+  // Session clear action (for /clear command)
+  clearSessionData: (sessionId: string) => void;
+
   // Connection actions
   setConnectionStatus: (sessionId: string, status: "connecting" | "connected" | "disconnected") => void;
   setCliConnected: (sessionId: string, connected: boolean) => void;
@@ -449,6 +452,30 @@ export const useStore = create<AppState>((set) => ({
       const changedFiles = new Map(s.changedFiles);
       changedFiles.delete(sessionId);
       return { changedFiles };
+    }),
+
+  clearSessionData: (sessionId) =>
+    set((s) => {
+      const messages = new Map(s.messages);
+      messages.set(sessionId, []);
+      const streaming = new Map(s.streaming);
+      streaming.delete(sessionId);
+      const streamingStartedAt = new Map(s.streamingStartedAt);
+      streamingStartedAt.delete(sessionId);
+      const streamingOutputTokens = new Map(s.streamingOutputTokens);
+      streamingOutputTokens.delete(sessionId);
+      const pendingPermissions = new Map(s.pendingPermissions);
+      pendingPermissions.delete(sessionId);
+      const sessionTasks = new Map(s.sessionTasks);
+      sessionTasks.delete(sessionId);
+      const changedFiles = new Map(s.changedFiles);
+      changedFiles.delete(sessionId);
+      const sessionStatus = new Map(s.sessionStatus);
+      sessionStatus.set(sessionId, "idle");
+      return {
+        messages, streaming, streamingStartedAt, streamingOutputTokens,
+        pendingPermissions, sessionTasks, changedFiles, sessionStatus,
+      };
     }),
 
   setSessionName: (sessionId, name) =>

--- a/web/src/ws.ts
+++ b/web/src/ws.ts
@@ -349,6 +349,21 @@ function handleMessage(sessionId: string, event: MessageEvent) {
       break;
     }
 
+    case "session_cleared": {
+      store.clearSessionData(sessionId);
+      // Reset task tracking for the session
+      processedToolUseIds.delete(sessionId);
+      taskCounters.delete(sessionId);
+      // Show a system message
+      store.appendMessage(sessionId, {
+        id: nextId(),
+        role: "system",
+        content: "Session cleared.",
+        timestamp: Date.now(),
+      });
+      break;
+    }
+
     case "session_name_update": {
       // Only apply auto-name if user hasn't manually renamed (still has random Adj+Noun name)
       const currentName = store.sessionNames.get(sessionId);


### PR DESCRIPTION
## Summary

  Implements the `/clear` slash command to reset a session's context window. When a user types `/clear`, the Companion intercepts the command at the WebSocket bridge layer, resets all session state, and relaunches the CLI process **without**
   `--resume` — giving the user a completely fresh conversation while keeping the same session slot in the sidebar.

  ### How it works

  Browser "/clear" → Bridge intercepts (not forwarded to CLI)
    → clearSession(): reset state, clear history, notify browsers
    → clearAndRelaunch(): kill CLI, spawn fresh process (no --resume)
    → New CLI connects → fresh system/init with empty context

  ### What gets reset
  - Message history and streaming state
  - Pending permissions and tasks
  - Cost counter, turn count, context usage %
  - Auto-naming (session gets renamed based on new conversation)

  ### What gets preserved
  - Session identity (same slot in sidebar)
  - Working directory (`cwd`), model, permission mode
  - Browser connection and session name

  ## Changes

  **Server** (4 files)
  - `ws-bridge.ts` — Intercept `/clear` in `routeBrowserMessage()` before any backend routing; add `clearSession()` method that resets state and triggers relaunch callback; works for both Claude and Codex backends
  - `cli-launcher.ts` — Add `clearAndRelaunch()` that clears `cliSessionId` (preventing `--resume`) then calls `relaunch()`
  - `session-types.ts` — Add `session_cleared` to `BrowserIncomingMessage` union
  - `index.ts` — Wire `onClearSessionCallback` to `launcher.clearAndRelaunch()`

  **Client** (2 files)
  - `ws.ts` — Handle `session_cleared` message: clear store data, reset task tracking, show "Session cleared." system message
  - `store.ts` — Add `clearSessionData()` action that resets all conversation maps while preserving session identity

  **Tests** (2 files, 238 lines)
  - `ws-bridge.test.ts` — 7 tests: interception, state reset, broadcast, callback, non-interception of other `/` commands, whitespace handling, auto-naming reset
  - `store.test.ts` — 2 tests: data clearing with identity preservation, session isolation

  ## Test plan

  - [x] Start a session, have a multi-turn conversation
  - [x] Type `/clear` in the Composer
  - [x] Verify: chat clears, "Session cleared." system message appears
  - [x] Verify: context % drops to near 0%, cost resets
  - [x] Ask "What did I say before?" — Claude should have no memory
  - [x] Verify: session stays in sidebar, cwd/model preserved
  - [x] Verify: other sessions are unaffected
  - [x] Run `bun run test` — 863 tests pass
