### PR TITLE
feat(cli): add stop and restart service commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,8 @@ Other commands:
 
 ```bash
 the-companion status      # check if the service is running
+the-companion stop        # stop the service (keeps it installed)
+the-companion restart     # restart the service
 the-companion logs        # tail stdout/stderr logs
 the-companion uninstall   # remove the service
 ```

--- a/web/bin/cli.ts
+++ b/web/bin/cli.ts
@@ -40,6 +40,18 @@ switch (command) {
     break;
   }
 
+  case "stop": {
+    const { stop } = await import("../server/service.js");
+    await stop();
+    break;
+  }
+
+  case "restart": {
+    const { restart } = await import("../server/service.js");
+    await restart();
+    break;
+  }
+
   case "logs": {
     const { join } = await import("node:path");
     const { homedir } = await import("node:os");
@@ -75,6 +87,8 @@ Commands:
   (none)      Start the server in foreground (default)
   start       Start the server in foreground
   install     Install as a background service (launchd/systemd)
+  stop        Stop the background service
+  restart     Restart the background service
   uninstall   Remove the background service
   status      Show service status
   logs        Tail service log files

--- a/web/server/service.test.ts
+++ b/web/server/service.test.ts
@@ -541,6 +541,174 @@ describe("uninstall (linux)", () => {
 });
 
 // ===========================================================================
+// stop (macOS)
+// ===========================================================================
+describe("stop", () => {
+  it("calls launchctl stop when installed", async () => {
+    // Install first
+    mockExecSync.mockImplementation((cmd: string) => {
+      if (cmd.startsWith("which")) return "/usr/local/bin/the-companion\n";
+      if (cmd.startsWith("launchctl")) return "";
+      return "";
+    });
+    await service.install();
+
+    vi.resetModules();
+    service = await import("./service.js");
+    mockExecSync.mockReset();
+    mockExecSync.mockImplementation(() => "");
+
+    await service.stop();
+
+    const stopCall = mockExecSync.mock.calls.find(
+      ([cmd]) => typeof cmd === "string" && cmd.startsWith("launchctl stop"),
+    );
+    expect(stopCall).toBeDefined();
+  });
+
+  it("falls back to launchctl unload when stop fails", async () => {
+    // Install first
+    mockExecSync.mockImplementation((cmd: string) => {
+      if (cmd.startsWith("which")) return "/usr/local/bin/the-companion\n";
+      if (cmd.startsWith("launchctl")) return "";
+      return "";
+    });
+    await service.install();
+
+    vi.resetModules();
+    service = await import("./service.js");
+    mockExecSync.mockReset();
+    mockExecSync.mockImplementation((cmd: string) => {
+      if (cmd.startsWith("launchctl stop")) throw new Error("stop failed");
+      if (cmd.startsWith("launchctl unload")) return "";
+      return "";
+    });
+
+    await service.stop();
+
+    const unloadCall = mockExecSync.mock.calls.find(
+      ([cmd]) => typeof cmd === "string" && cmd.startsWith("launchctl unload"),
+    );
+    expect(unloadCall).toBeDefined();
+  });
+
+  it("handles not-installed gracefully", async () => {
+    // Should not throw
+    await service.stop();
+  });
+});
+
+// ===========================================================================
+// stop (Linux)
+// ===========================================================================
+describe("stop (linux)", () => {
+  beforeEach(async () => {
+    mockPlatform.set("linux");
+    Object.defineProperty(process, "platform", { value: "linux" });
+    vi.resetModules();
+    service = await import("./service.js");
+  });
+
+  it("calls systemctl stop when installed", async () => {
+    // Install first
+    mockExecSync.mockImplementation((cmd: string) => {
+      if (cmd.startsWith("which")) return "/usr/local/bin/the-companion\n";
+      if (cmd.startsWith("systemctl")) return "";
+      return "";
+    });
+    await service.install();
+
+    vi.resetModules();
+    service = await import("./service.js");
+    mockExecSync.mockReset();
+    mockExecSync.mockImplementation(() => "");
+
+    await service.stop();
+
+    const stopCall = mockExecSync.mock.calls.find(
+      ([cmd]) => typeof cmd === "string" && cmd.includes("stop the-companion.service"),
+    );
+    expect(stopCall).toBeDefined();
+  });
+
+  it("handles not-installed gracefully", async () => {
+    // Should not throw
+    await service.stop();
+  });
+});
+
+// ===========================================================================
+// restart (macOS)
+// ===========================================================================
+describe("restart", () => {
+  it("calls launchctl kickstart when installed", async () => {
+    // Install first
+    mockExecSync.mockImplementation((cmd: string) => {
+      if (cmd.startsWith("which")) return "/usr/local/bin/the-companion\n";
+      if (cmd.startsWith("launchctl")) return "";
+      return "";
+    });
+    await service.install();
+
+    vi.resetModules();
+    service = await import("./service.js");
+    mockExecSync.mockReset();
+    mockExecSync.mockImplementation(() => "");
+
+    await service.restart();
+
+    const restartCall = mockExecSync.mock.calls.find(
+      ([cmd]) => typeof cmd === "string" && cmd.startsWith("launchctl kickstart -k"),
+    );
+    expect(restartCall).toBeDefined();
+  });
+
+  it("handles not-installed gracefully", async () => {
+    // Should not throw
+    await service.restart();
+  });
+});
+
+// ===========================================================================
+// restart (Linux)
+// ===========================================================================
+describe("restart (linux)", () => {
+  beforeEach(async () => {
+    mockPlatform.set("linux");
+    Object.defineProperty(process, "platform", { value: "linux" });
+    vi.resetModules();
+    service = await import("./service.js");
+  });
+
+  it("calls systemctl restart when installed", async () => {
+    // Install first
+    mockExecSync.mockImplementation((cmd: string) => {
+      if (cmd.startsWith("which")) return "/usr/local/bin/the-companion\n";
+      if (cmd.startsWith("systemctl")) return "";
+      return "";
+    });
+    await service.install();
+
+    vi.resetModules();
+    service = await import("./service.js");
+    mockExecSync.mockReset();
+    mockExecSync.mockImplementation(() => "");
+
+    await service.restart();
+
+    const restartCall = mockExecSync.mock.calls.find(
+      ([cmd]) => typeof cmd === "string" && cmd.includes("restart the-companion.service"),
+    );
+    expect(restartCall).toBeDefined();
+  });
+
+  it("handles not-installed gracefully", async () => {
+    // Should not throw
+    await service.restart();
+  });
+});
+
+// ===========================================================================
 // status (macOS)
 // ===========================================================================
 describe("status", () => {

--- a/web/server/service.ts
+++ b/web/server/service.ts
@@ -360,6 +360,108 @@ async function uninstallLinux(): Promise<void> {
   console.log(`Logs are preserved at ${LOG_DIR}`);
 }
 
+// ─── Stop / Restart ────────────────────────────────────────────────────────────
+
+export async function stop(): Promise<void> {
+  ensureSupportedPlatform();
+
+  if (isDarwin()) {
+    return stopDarwin();
+  }
+  return stopLinux();
+}
+
+async function stopDarwin(): Promise<void> {
+  const installedService = getInstalledLaunchdService();
+  if (!installedService) {
+    console.log("The Companion is not installed as a service.");
+    return;
+  }
+
+  try {
+    execSync(`launchctl stop "${installedService.label}"`, { stdio: "pipe" });
+  } catch {
+    // If stop is unavailable or service is unloaded, best-effort unload.
+    unloadLaunchdService(installedService.plistPath);
+  }
+
+  console.log("The Companion service has been stopped.");
+  console.log("Run 'the-companion restart' to start it again.");
+}
+
+async function stopLinux(): Promise<void> {
+  if (!isSystemdUnitInstalled()) {
+    console.log("The Companion is not installed as a service.");
+    return;
+  }
+
+  try {
+    systemctlUser(`stop ${UNIT_NAME}`);
+  } catch (err: unknown) {
+    console.error("Failed to stop the service with systemctl:");
+    console.error(err instanceof Error ? err.message : String(err));
+    process.exit(1);
+  }
+
+  console.log("The Companion service has been stopped.");
+  console.log("Run 'the-companion restart' to start it again.");
+}
+
+export async function restart(): Promise<void> {
+  ensureSupportedPlatform();
+
+  if (isDarwin()) {
+    return restartDarwin();
+  }
+  return restartLinux();
+}
+
+async function restartDarwin(): Promise<void> {
+  const installedService = getInstalledLaunchdService();
+  if (!installedService) {
+    console.log("The Companion is not installed as a service.");
+    return;
+  }
+
+  const uid = typeof process.getuid === "function" ? process.getuid() : undefined;
+  const domainTarget = uid !== undefined
+    ? `gui/${uid}/${installedService.label}`
+    : installedService.label;
+
+  try {
+    execSync(`launchctl kickstart -k "${domainTarget}"`, { stdio: "pipe" });
+  } catch {
+    // Fallback for environments where kickstart/domain targeting is unavailable.
+    unloadLaunchdService(installedService.plistPath);
+    try {
+      execSync(`launchctl load -w "${installedService.plistPath}"`, { stdio: "pipe" });
+    } catch (err: unknown) {
+      console.error("Failed to restart the service with launchctl:");
+      console.error(err instanceof Error ? err.message : String(err));
+      process.exit(1);
+    }
+  }
+
+  console.log("The Companion service has been restarted.");
+}
+
+async function restartLinux(): Promise<void> {
+  if (!isSystemdUnitInstalled()) {
+    console.log("The Companion is not installed as a service.");
+    return;
+  }
+
+  try {
+    systemctlUser(`restart ${UNIT_NAME}`);
+  } catch (err: unknown) {
+    console.error("Failed to restart the service with systemctl:");
+    console.error(err instanceof Error ? err.message : String(err));
+    process.exit(1);
+  }
+
+  console.log("The Companion service has been restarted.");
+}
+
 // ─── Status ─────────────────────────────────────────────────────────────────────
 
 export interface ServiceStatus {


### PR DESCRIPTION
## Summary
- add `the-companion stop` and `the-companion restart` CLI commands
- implement stop/restart service handlers for macOS (`launchctl`) and Linux (`systemctl --user`)
- document the new commands in `README.md`
- add service tests for stop/restart flows on macOS and Linux

## Why
Service mode already supports install, status, logs, and uninstall. This adds explicit lifecycle controls for stopping and restarting without uninstalling.

## Testing
- `bun run typecheck`
- `bun run test` (ran via pre-commit hook)
- `bun run test server/service.test.ts`

## Review
- Human code review: not yet
- Generated with AI assistance

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/the-vibe-company/companion/pull/185" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
