### PR TITLE
fix(cli): expose stop/restart in help and add test

### DIFF
--- a/web/bin/cli.ts
+++ b/web/bin/cli.ts
@@ -8,7 +8,33 @@ process.env.__COMPANION_PACKAGE_ROOT = resolve(__dirname, "..");
 
 const command = process.argv[2];
 
+function printUsage(): void {
+  console.log(`
+Usage: the-companion [command]
+
+Commands:
+  (none)      Start the server in foreground (default)
+  start       Start the server in foreground
+  install     Install as a background service (launchd/systemd)
+  stop        Stop the background service
+  restart     Restart the background service
+  uninstall   Remove the background service
+  status      Show service status
+  logs        Tail service log files
+  help        Show this help message
+
+Options:
+  --port <n>  Override the default port (default: 3456)
+`);
+}
+
 switch (command) {
+  case "help":
+  case "-h":
+  case "--help":
+    printUsage();
+    break;
+
   case "install": {
     const { install } = await import("../server/service.js");
     const portIdx = process.argv.indexOf("--port");
@@ -80,21 +106,6 @@ switch (command) {
 
   default:
     console.error(`Unknown command: ${command}`);
-    console.log(`
-Usage: the-companion [command]
-
-Commands:
-  (none)      Start the server in foreground (default)
-  start       Start the server in foreground
-  install     Install as a background service (launchd/systemd)
-  stop        Stop the background service
-  restart     Restart the background service
-  uninstall   Remove the background service
-  status      Show service status
-  logs        Tail service log files
-
-Options:
-  --port <n>  Override the default port (default: 3456)
-`);
+    printUsage();
     process.exit(1);
 }

--- a/web/server/cli.test.ts
+++ b/web/server/cli.test.ts
@@ -1,0 +1,14 @@
+import { spawnSync } from "node:child_process";
+import { fileURLToPath } from "node:url";
+
+describe("CLI help output", () => {
+  it("lists stop and restart commands", () => {
+    const cliPath = fileURLToPath(new URL("../bin/cli.ts", import.meta.url));
+    const result = spawnSync("bun", [cliPath, "--help"], { encoding: "utf-8" });
+
+    expect(result.status).toBe(0);
+    expect(result.stdout).toContain("stop        Stop the background service");
+    expect(result.stdout).toContain("restart     Restart the background service");
+    expect(result.stdout).toContain("help        Show this help message");
+  });
+});


### PR DESCRIPTION
## Summary
- add explicit help, -h, and --help handling in the-companion CLI
- keep CLI usage text centralized via printUsage()
- add a CLI integration test asserting help output includes stop and restart

## Testing
- bun run --cwd web vitest run server/cli.test.ts
- pre-commit hook ran full web tests (vitest run) and typecheck (tsc --noEmit)

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/the-vibe-company/companion/pull/188" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
