### PR TITLE
feat(web): add browser web notifications

### DIFF
--- a/web/src/components/Sidebar.tsx
+++ b/web/src/components/Sidebar.tsx
@@ -24,6 +24,8 @@ export function Sidebar() {
   const toggleDarkMode = useStore((s) => s.toggleDarkMode);
   const notificationSound = useStore((s) => s.notificationSound);
   const toggleNotificationSound = useStore((s) => s.toggleNotificationSound);
+  const notificationDesktop = useStore((s) => s.notificationDesktop);
+  const setNotificationDesktop = useStore((s) => s.setNotificationDesktop);
   const cliConnected = useStore((s) => s.cliConnected);
   const sessionStatus = useStore((s) => s.sessionStatus);
   const removeSession = useStore((s) => s.removeSession);
@@ -386,6 +388,33 @@ export function Sidebar() {
           )}
           <span>{notificationSound ? "Sound on" : "Sound off"}</span>
         </button>
+        {typeof Notification !== "undefined" && (
+          <button
+            onClick={async () => {
+              if (!notificationDesktop) {
+                if (Notification.permission !== "granted") {
+                  const result = await Notification.requestPermission();
+                  if (result !== "granted") return;
+                }
+                setNotificationDesktop(true);
+              } else {
+                setNotificationDesktop(false);
+              }
+            }}
+            className="w-full flex items-center gap-2.5 px-3 py-2 rounded-[10px] text-sm text-cc-muted hover:text-cc-fg hover:bg-cc-hover transition-colors cursor-pointer"
+          >
+            {notificationDesktop ? (
+              <svg viewBox="0 0 20 20" fill="currentColor" className="w-4 h-4">
+                <path d="M10 2a6 6 0 00-6 6v3.586l-.707.707A1 1 0 004 14h12a1 1 0 00.707-1.707L16 11.586V8a6 6 0 00-6-6zM10 18a3 3 0 01-3-3h6a3 3 0 01-3 3z" />
+              </svg>
+            ) : (
+              <svg viewBox="0 0 20 20" fill="currentColor" className="w-4 h-4">
+                <path d="M10 2a6 6 0 00-6 6v3.586l-.707.707A1 1 0 004 14h12a1 1 0 00.707-1.707L16 11.586V8a6 6 0 00-6-6zM10 18a3 3 0 01-3-3h6a3 3 0 01-3 3z" opacity="0.4" />
+              </svg>
+            )}
+            <span>{notificationDesktop ? "Alerts on" : "Alerts off"}</span>
+          </button>
+        )}
         <button
           onClick={toggleDarkMode}
           className="w-full flex items-center gap-2.5 px-3 py-2 rounded-[10px] text-sm text-cc-muted hover:text-cc-fg hover:bg-cc-hover transition-colors cursor-pointer"

--- a/web/src/store.ts
+++ b/web/src/store.ts
@@ -55,6 +55,7 @@ interface AppState {
   // UI
   darkMode: boolean;
   notificationSound: boolean;
+  notificationDesktop: boolean;
   sidebarOpen: boolean;
   taskPanelOpen: boolean;
   homeResetKey: number;
@@ -66,6 +67,8 @@ interface AppState {
   toggleDarkMode: () => void;
   setNotificationSound: (v: boolean) => void;
   toggleNotificationSound: () => void;
+  setNotificationDesktop: (v: boolean) => void;
+  toggleNotificationDesktop: () => void;
   setSidebarOpen: (v: boolean) => void;
   setTaskPanelOpen: (open: boolean) => void;
   newSession: () => void;
@@ -167,6 +170,13 @@ function getInitialNotificationSound(): boolean {
   return true;
 }
 
+function getInitialNotificationDesktop(): boolean {
+  if (typeof window === "undefined") return false;
+  const stored = localStorage.getItem("cc-notification-desktop");
+  if (stored !== null) return stored === "true";
+  return false;
+}
+
 function getInitialDismissedVersion(): string | null {
   if (typeof window === "undefined") return null;
   return localStorage.getItem("cc-update-dismissed") || null;
@@ -204,6 +214,7 @@ export const useStore = create<AppState>((set) => ({
   updateDismissedVersion: getInitialDismissedVersion(),
   darkMode: getInitialDarkMode(),
   notificationSound: getInitialNotificationSound(),
+  notificationDesktop: getInitialNotificationDesktop(),
   sidebarOpen: typeof window !== "undefined" ? window.innerWidth >= 768 : true,
   taskPanelOpen: typeof window !== "undefined" ? window.innerWidth >= 1024 : false,
   homeResetKey: 0,
@@ -232,6 +243,16 @@ export const useStore = create<AppState>((set) => ({
       const next = !s.notificationSound;
       localStorage.setItem("cc-notification-sound", String(next));
       return { notificationSound: next };
+    }),
+  setNotificationDesktop: (v) => {
+    localStorage.setItem("cc-notification-desktop", String(v));
+    set({ notificationDesktop: v });
+  },
+  toggleNotificationDesktop: () =>
+    set((s) => {
+      const next = !s.notificationDesktop;
+      localStorage.setItem("cc-notification-desktop", String(next));
+      return { notificationDesktop: next };
     }),
   setSidebarOpen: (v) => set({ sidebarOpen: v }),
   setTaskPanelOpen: (open) => set({ taskPanelOpen: open }),


### PR DESCRIPTION
## Summary
- Native OS notifications via browser `Notification` API when tab is unfocused
- Fires on **session completion** and **permission requests**
- "Alerts on/off" toggle in sidebar footer, hidden on mobile (API unavailable)
- Requests permission on first enable; preference persisted to localStorage

## Test plan
- [ ] Enable alerts in sidebar, start a session, switch tabs — verify OS notification on completion
- [ ] Trigger a permission request while unfocused — verify "Permission needed" notification
- [ ] Open on mobile — verify the alerts toggle is not shown
- [ ] Deny browser permission prompt — verify toggle stays off