### PR TITLE
fix: make service stop actually stop on macOS and refresh stale update checks

### DIFF
--- a/web/server/routes.test.ts
+++ b/web/server/routes.test.ts
@@ -57,22 +57,27 @@ vi.mock("./settings-manager.js", () => ({
 }));
 
 const mockGetUsageLimits = vi.hoisted(() => vi.fn());
+const mockUpdateCheckerState = vi.hoisted(() => ({
+  currentVersion: "0.22.1",
+  latestVersion: null as string | null,
+  lastChecked: 0,
+  isServiceMode: false,
+  checking: false,
+  updateInProgress: false,
+}));
+const mockCheckForUpdate = vi.hoisted(() => vi.fn(async () => {}));
+const mockIsUpdateAvailable = vi.hoisted(() => vi.fn(() => false));
+const mockSetUpdateInProgress = vi.hoisted(() => vi.fn());
+
 vi.mock("./usage-limits.js", () => ({
   getUsageLimits: mockGetUsageLimits,
 }));
 
 vi.mock("./update-checker.js", () => ({
-  getUpdateState: vi.fn(() => ({
-    currentVersion: "0.22.1",
-    latestVersion: null,
-    lastChecked: 0,
-    isServiceMode: false,
-    checking: false,
-    updateInProgress: false,
-  })),
-  checkForUpdate: vi.fn(async () => {}),
-  isUpdateAvailable: vi.fn(() => false),
-  setUpdateInProgress: vi.fn(),
+  getUpdateState: vi.fn(() => ({ ...mockUpdateCheckerState })),
+  checkForUpdate: mockCheckForUpdate,
+  isUpdateAvailable: mockIsUpdateAvailable,
+  setUpdateInProgress: mockSetUpdateInProgress,
 }));
 
 import { Hono } from "hono";
@@ -137,6 +142,12 @@ let tracker: ReturnType<typeof createMockTracker>;
 
 beforeEach(() => {
   vi.clearAllMocks();
+  mockUpdateCheckerState.currentVersion = "0.22.1";
+  mockUpdateCheckerState.latestVersion = null;
+  mockUpdateCheckerState.lastChecked = 0;
+  mockUpdateCheckerState.isServiceMode = false;
+  mockUpdateCheckerState.checking = false;
+  mockUpdateCheckerState.updateInProgress = false;
   launcher = createMockLauncher();
   bridge = createMockBridge();
   sessionStore = createMockStore();
@@ -986,6 +997,39 @@ describe("PATCH /api/sessions/:id/name", () => {
     });
 
     expect(res.status).toBe(400);
+  });
+});
+
+// ─── Update checking ────────────────────────────────────────────────────────
+
+describe("GET /api/update-check", () => {
+  it("triggers a refresh when never checked", async () => {
+    mockUpdateCheckerState.lastChecked = 0;
+
+    const res = await app.request("/api/update-check", { method: "GET" });
+
+    expect(res.status).toBe(200);
+    expect(mockCheckForUpdate).toHaveBeenCalledOnce();
+  });
+
+  it("does not trigger a refresh when the previous check is fresh", async () => {
+    mockUpdateCheckerState.lastChecked = Date.now();
+
+    const res = await app.request("/api/update-check", { method: "GET" });
+
+    expect(res.status).toBe(200);
+    expect(mockCheckForUpdate).not.toHaveBeenCalled();
+  });
+});
+
+describe("POST /api/update-check", () => {
+  it("always forces a refresh", async () => {
+    mockUpdateCheckerState.lastChecked = Date.now();
+
+    const res = await app.request("/api/update-check", { method: "POST" });
+
+    expect(res.status).toBe(200);
+    expect(mockCheckForUpdate).toHaveBeenCalledOnce();
   });
 });
 

--- a/web/server/routes.ts
+++ b/web/server/routes.ts
@@ -22,6 +22,8 @@ import {
   setUpdateInProgress,
 } from "./update-checker.js";
 
+const UPDATE_CHECK_STALE_MS = 5 * 60 * 1000;
+
 function execCaptureStdout(
   command: string,
   options: { cwd: string; encoding: "utf-8"; timeout: number },
@@ -824,7 +826,15 @@ export function createRoutes(
 
   // ─── Update checking ─────────────────────────────────────────────────
 
-  api.get("/update-check", (c) => {
+  api.get("/update-check", async (c) => {
+    const initialState = getUpdateState();
+    const needsRefresh =
+      initialState.lastChecked === 0
+      || Date.now() - initialState.lastChecked > UPDATE_CHECK_STALE_MS;
+    if (needsRefresh) {
+      await checkForUpdate();
+    }
+
     const state = getUpdateState();
     return c.json({
       currentVersion: state.currentVersion,

--- a/web/server/service.test.ts
+++ b/web/server/service.test.ts
@@ -544,7 +544,7 @@ describe("uninstall (linux)", () => {
 // stop (macOS)
 // ===========================================================================
 describe("stop", () => {
-  it("calls launchctl stop when installed", async () => {
+  it("calls launchctl bootout when installed", async () => {
     // Install first
     mockExecSync.mockImplementation((cmd: string) => {
       if (cmd.startsWith("which")) return "/usr/local/bin/the-companion\n";
@@ -561,12 +561,12 @@ describe("stop", () => {
     await service.stop();
 
     const stopCall = mockExecSync.mock.calls.find(
-      ([cmd]) => typeof cmd === "string" && cmd.startsWith("launchctl stop"),
+      ([cmd]) => typeof cmd === "string" && cmd.startsWith("launchctl bootout"),
     );
     expect(stopCall).toBeDefined();
   });
 
-  it("falls back to launchctl unload when stop fails", async () => {
+  it("falls back to launchctl unload when bootout fails", async () => {
     // Install first
     mockExecSync.mockImplementation((cmd: string) => {
       if (cmd.startsWith("which")) return "/usr/local/bin/the-companion\n";
@@ -579,7 +579,7 @@ describe("stop", () => {
     service = await import("./service.js");
     mockExecSync.mockReset();
     mockExecSync.mockImplementation((cmd: string) => {
-      if (cmd.startsWith("launchctl stop")) throw new Error("stop failed");
+      if (cmd.startsWith("launchctl bootout")) throw new Error("bootout failed");
       if (cmd.startsWith("launchctl unload")) return "";
       return "";
     });


### PR DESCRIPTION
## Summary\n- fix The Companion service has been stopped.
Run 'the-companion restart' to start it again. on macOS by using  (with unload fallback) so launchd KeepAlive does not immediately restart the daemon\n- make  trigger a refresh when update state is uninitialized or stale\n- add/update tests for stop behavior and update-check refresh behavior\n\n## Testing\n- 
 RUN  v4.0.18 /Users/stan/Dev/claude-code-api/web

stdout | server/cli-launcher.test.ts > launch > creates a session with a UUID and starting state
[cli-launcher] Spawning session test-session-id: /usr/bin/claude --sdk-url ws://localhost:3456/ws/cli/test-session-id --print --output-format stream-json --input-format stream-json --verbose -p 

stdout | server/cli-launcher.test.ts > launch > spawns CLI with correct --sdk-url and flags
[cli-launcher] Spawning session test-session-id: /usr/bin/claude --sdk-url ws://localhost:3456/ws/cli/test-session-id --print --output-format stream-json --input-format stream-json --verbose -p 

stdout | server/cli-launcher.test.ts > launch > passes --model when provided
[cli-launcher] Spawning session test-session-id: /usr/bin/claude --sdk-url ws://localhost:3456/ws/cli/test-session-id --print --output-format stream-json --input-format stream-json --verbose --model claude-opus-4-20250514 -p 

stdout | server/cli-launcher.test.ts > launch > passes --permission-mode when provided
[cli-launcher] Spawning session test-session-id: /usr/bin/claude --sdk-url ws://localhost:3456/ws/cli/test-session-id --print --output-format stream-json --input-format stream-json --verbose --permission-mode bypassPermissions -p 

stdout | server/cli-launcher.test.ts > launch > passes --allowedTools for each tool
[cli-launcher] Spawning session test-session-id: /usr/bin/claude --sdk-url ws://localhost:3456/ws/cli/test-session-id --print --output-format stream-json --input-format stream-json --verbose --allowedTools Read --allowedTools Write --allowedTools Bash -p 

stdout | server/service.test.ts > install > creates log directory and writes plist file
The Companion has been installed as a background service.

  URL:    http://localhost:3456
  Logs:   /var/folders/5y/rb6f6xkx4dq_pk_04jclv7pm0000gn/T/service-test-dbFYkm/.companion/logs
  Plist:  /var/folders/5y/rb6f6xkx4dq_pk_04jclv7pm0000gn/T/service-test-dbFYkm/Library/LaunchAgents/sh.thecompanion.app.plist

The service will start automatically on login.
Use 'the-companion status' to check if it's running.

stdout | server/cli-launcher.test.ts > launch > resolves binary path with `which` when not absolute
[cli-launcher] Spawning session test-session-id: /usr/bin/claude --sdk-url ws://localhost:3456/ws/cli/test-session-id --print --output-format stream-json --input-format stream-json --verbose -p 

stdout | server/cli-launcher.test.ts > launch > skips `which` resolution when binary path is absolute
[cli-launcher] Spawning session test-session-id: /opt/bin/claude --sdk-url ws://localhost:3456/ws/cli/test-session-id --print --output-format stream-json --input-format stream-json --verbose -p 

stdout | server/service.test.ts > install > calls launchctl load with the plist path
The Companion has been installed as a background service.

  URL:    http://localhost:3456
  Logs:   /var/folders/5y/rb6f6xkx4dq_pk_04jclv7pm0000gn/T/service-test-OfJNLM/.companion/logs
  Plist:  /var/folders/5y/rb6f6xkx4dq_pk_04jclv7pm0000gn/T/service-test-OfJNLM/Library/LaunchAgents/sh.thecompanion.app.plist

The service will start automatically on login.
Use 'the-companion status' to check if it's running.

stdout | server/cli-launcher.test.ts > launch > stores worktree metadata when worktreeInfo provided
[cli-launcher] Spawning session test-session-id: /usr/bin/claude --sdk-url ws://localhost:3456/ws/cli/test-session-id --print --output-format stream-json --input-format stream-json --verbose -p 

stdout | server/cli-launcher.test.ts > launch > injects worktree guardrails when isWorktree=true
[cli-launcher] Injected worktree guardrails for branch feature-x
[cli-launcher] Spawning session test-session-id: /usr/bin/claude --sdk-url ws://localhost:3456/ws/cli/test-session-id --print --output-format stream-json --input-format stream-json --verbose -p 

stdout | server/service.test.ts > install > exits with error if already installed
The Companion has been installed as a background service.

  URL:    http://localhost:3456
  Logs:   /var/folders/5y/rb6f6xkx4dq_pk_04jclv7pm0000gn/T/service-test-2yQSrA/.companion/logs
  Plist:  /var/folders/5y/rb6f6xkx4dq_pk_04jclv7pm0000gn/T/service-test-2yQSrA/Library/LaunchAgents/sh.thecompanion.app.plist

The service will start automatically on login.
Use 'the-companion status' to check if it's running.

stdout | server/cli-launcher.test.ts > launch > injects guardrails with parent branch label when actualBranch differs
[cli-launcher] Injected worktree guardrails for branch main-wt-2
[cli-launcher] Spawning session test-session-id: /usr/bin/claude --sdk-url ws://localhost:3456/ws/cli/test-session-id --print --output-format stream-json --input-format stream-json --verbose -p 

stdout | server/cli-launcher.test.ts > launch > does NOT inject guardrails when worktree path equals main repo root
[cli-launcher] Spawning session test-session-id: /usr/bin/claude --sdk-url ws://localhost:3456/ws/cli/test-session-id --print --output-format stream-json --input-format stream-json --verbose -p 

stdout | server/cli-launcher.test.ts > launch > does NOT inject guardrails when worktree path does not exist on disk
[cli-launcher] Spawning session test-session-id: /usr/bin/claude --sdk-url ws://localhost:3456/ws/cli/test-session-id --print --output-format stream-json --input-format stream-json --verbose -p 

stdout | server/service.test.ts > install > uses custom port when provided
The Companion has been installed as a background service.

  URL:    http://localhost:9000
  Logs:   /var/folders/5y/rb6f6xkx4dq_pk_04jclv7pm0000gn/T/service-test-4xqmBQ/.companion/logs
  Plist:  /var/folders/5y/rb6f6xkx4dq_pk_04jclv7pm0000gn/T/service-test-4xqmBQ/Library/LaunchAgents/sh.thecompanion.app.plist

The service will start automatically on login.
Use 'the-companion status' to check if it's running.

stdout | server/cli-launcher.test.ts > launch > sets session pid from spawned process
[cli-launcher] Spawning session test-session-id: /usr/bin/claude --sdk-url ws://localhost:3456/ws/cli/test-session-id --print --output-format stream-json --input-format stream-json --verbose -p 

stdout | server/cli-launcher.test.ts > launch > unsets CLAUDECODE to avoid CLI nesting guard
[cli-launcher] Spawning session test-session-id: /usr/bin/claude --sdk-url ws://localhost:3456/ws/cli/test-session-id --print --output-format stream-json --input-format stream-json --verbose -p 

stdout | server/cli-launcher.test.ts > launch > merges custom env variables
[cli-launcher] Spawning session test-session-id: /usr/bin/claude --sdk-url ws://localhost:3456/ws/cli/test-session-id --print --output-format stream-json --input-format stream-json --verbose -p 

stdout | server/service.test.ts > install > migrates old launchd label before installing
Found legacy The Vibe Companion service. Migrating...
The Companion has been installed as a background service.

  URL:    http://localhost:3456
  Logs:   /var/folders/5y/rb6f6xkx4dq_pk_04jclv7pm0000gn/T/service-test-BPCZEA/.companion/logs
  Plist:  /var/folders/5y/rb6f6xkx4dq_pk_04jclv7pm0000gn/T/service-test-BPCZEA/Library/LaunchAgents/sh.thecompanion.app.plist

The service will start automatically on login.
Use 'the-companion status' to check if it's running.

stdout | server/cli-launcher.test.ts > launch > enables Codex web search when codexInternetAccess=true
[cli-launcher] Spawning Codex session test-session-id: /usr/bin/codex app-server -c tools.webSearch=true

stdout | server/cli-launcher.test.ts > launch > disables Codex web search when codexInternetAccess=false
[cli-launcher] Spawning Codex session test-session-id: /usr/bin/codex app-server -c tools.webSearch=false

stdout | server/cli-launcher.test.ts > state management > markConnected > sets state to connected
[cli-launcher] Spawning session test-session-id: /usr/bin/claude --sdk-url ws://localhost:3456/ws/cli/test-session-id --print --output-format stream-json --input-format stream-json --verbose -p 
[cli-launcher] Session test-session-id connected via WebSocket

stdout | server/service.test.ts > install (linux) > creates log directory and writes systemd unit file
The Companion has been installed as a background service.

  URL:    http://localhost:3456
  Logs:   /var/folders/5y/rb6f6xkx4dq_pk_04jclv7pm0000gn/T/service-test-iz07Bw/.companion/logs
  Unit:   /var/folders/5y/rb6f6xkx4dq_pk_04jclv7pm0000gn/T/service-test-iz07Bw/.config/systemd/user/the-companion.service

The service will start automatically on login.
Use 'the-companion status' to check if it's running.

stdout | server/cli-launcher.test.ts > state management > setCLISessionId > stores the CLI session ID
[cli-launcher] Spawning session test-session-id: /usr/bin/claude --sdk-url ws://localhost:3456/ws/cli/test-session-id --print --output-format stream-json --input-format stream-json --verbose -p 

stdout | server/service.test.ts > install (linux) > calls systemctl daemon-reload and enable --now
The Companion has been installed as a background service.

  URL:    http://localhost:3456
  Logs:   /var/folders/5y/rb6f6xkx4dq_pk_04jclv7pm0000gn/T/service-test-Ed895R/.companion/logs
  Unit:   /var/folders/5y/rb6f6xkx4dq_pk_04jclv7pm0000gn/T/service-test-Ed895R/.config/systemd/user/the-companion.service

The service will start automatically on login.
Use 'the-companion status' to check if it's running.

stdout | server/cli-launcher.test.ts > state management > isAlive > returns true for non-exited session
[cli-launcher] Spawning session test-session-id: /usr/bin/claude --sdk-url ws://localhost:3456/ws/cli/test-session-id --print --output-format stream-json --input-format stream-json --verbose -p 

stdout | server/cli-launcher.test.ts > state management > isAlive > returns false for exited session
[cli-launcher] Spawning session test-session-id: /usr/bin/claude --sdk-url ws://localhost:3456/ws/cli/test-session-id --print --output-format stream-json --input-format stream-json --verbose -p 

stdout | server/cli-launcher.test.ts > state management > isAlive > returns false for exited session
[cli-launcher] Session test-session-id exited (code=0)

stdout | server/service.test.ts > install (linux) > exits with error if already installed
The Companion has been installed as a background service.

  URL:    http://localhost:3456
  Logs:   /var/folders/5y/rb6f6xkx4dq_pk_04jclv7pm0000gn/T/service-test-bcJIf2/.companion/logs
  Unit:   /var/folders/5y/rb6f6xkx4dq_pk_04jclv7pm0000gn/T/service-test-bcJIf2/.config/systemd/user/the-companion.service

The service will start automatically on login.
Use 'the-companion status' to check if it's running.

stdout | server/service.test.ts > install (linux) > uses custom port when provided
The Companion has been installed as a background service.

  URL:    http://localhost:9000
  Logs:   /var/folders/5y/rb6f6xkx4dq_pk_04jclv7pm0000gn/T/service-test-0ZjXWz/.companion/logs
  Unit:   /var/folders/5y/rb6f6xkx4dq_pk_04jclv7pm0000gn/T/service-test-0ZjXWz/.config/systemd/user/the-companion.service

The service will start automatically on login.
Use 'the-companion status' to check if it's running.

 ✓ server/env-manager.test.ts (25 tests) 77ms
stdout | server/service.test.ts > uninstall > calls launchctl unload and removes plist
The Companion has been installed as a background service.

  URL:    http://localhost:3456
  Logs:   /var/folders/5y/rb6f6xkx4dq_pk_04jclv7pm0000gn/T/service-test-Oj9FCA/.companion/logs
  Plist:  /var/folders/5y/rb6f6xkx4dq_pk_04jclv7pm0000gn/T/service-test-Oj9FCA/Library/LaunchAgents/sh.thecompanion.app.plist

The service will start automatically on login.
Use 'the-companion status' to check if it's running.

stdout | server/service.test.ts > uninstall > calls launchctl unload and removes plist
The Companion service has been removed.
Logs are preserved at /var/folders/5y/rb6f6xkx4dq_pk_04jclv7pm0000gn/T/service-test-Oj9FCA/.companion/logs

stdout | server/cli-launcher.test.ts > state management > listSessions > returns all sessions
[cli-launcher] Spawning session test-session-id: /usr/bin/claude --sdk-url ws://localhost:3456/ws/cli/test-session-id --print --output-format stream-json --input-format stream-json --verbose -p 

stdout | server/cli-launcher.test.ts > state management > getSession > returns a specific session
[cli-launcher] Spawning session test-session-id: /usr/bin/claude --sdk-url ws://localhost:3456/ws/cli/test-session-id --print --output-format stream-json --input-format stream-json --verbose -p 

stdout | server/service.test.ts > uninstall > handles not-installed gracefully
The Companion is not installed as a service.

stdout | server/cli-launcher.test.ts > state management > pruneExited > removes exited sessions and returns count
[cli-launcher] Spawning session test-session-id: /usr/bin/claude --sdk-url ws://localhost:3456/ws/cli/test-session-id --print --output-format stream-json --input-format stream-json --verbose -p 

stdout | server/cli-launcher.test.ts > state management > pruneExited > removes exited sessions and returns count
[cli-launcher] Session test-session-id exited (code=0)

stdout | server/service.test.ts > uninstall > uninstalls old launchd label when only legacy plist exists
The Companion service has been removed.
Logs are preserved at /var/folders/5y/rb6f6xkx4dq_pk_04jclv7pm0000gn/T/service-test-hT3c41/.companion/logs

stdout | server/service.test.ts > uninstall (linux) > calls systemctl disable --now and removes unit file
The Companion has been installed as a background service.

  URL:    http://localhost:3456
  Logs:   /var/folders/5y/rb6f6xkx4dq_pk_04jclv7pm0000gn/T/service-test-OISBEC/.companion/logs
  Unit:   /var/folders/5y/rb6f6xkx4dq_pk_04jclv7pm0000gn/T/service-test-OISBEC/.config/systemd/user/the-companion.service

The service will start automatically on login.
Use 'the-companion status' to check if it's running.

stdout | server/service.test.ts > uninstall (linux) > calls systemctl disable --now and removes unit file
The Companion service has been removed.
Logs are preserved at /var/folders/5y/rb6f6xkx4dq_pk_04jclv7pm0000gn/T/service-test-OISBEC/.companion/logs

stdout | server/service.test.ts > uninstall (linux) > calls daemon-reload after removing unit file
The Companion has been installed as a background service.

  URL:    http://localhost:3456
  Logs:   /var/folders/5y/rb6f6xkx4dq_pk_04jclv7pm0000gn/T/service-test-gakzMk/.companion/logs
  Unit:   /var/folders/5y/rb6f6xkx4dq_pk_04jclv7pm0000gn/T/service-test-gakzMk/.config/systemd/user/the-companion.service

The service will start automatically on login.
Use 'the-companion status' to check if it's running.

stdout | server/service.test.ts > uninstall (linux) > calls daemon-reload after removing unit file
The Companion service has been removed.
Logs are preserved at /var/folders/5y/rb6f6xkx4dq_pk_04jclv7pm0000gn/T/service-test-gakzMk/.companion/logs

stdout | server/service.test.ts > uninstall (linux) > handles not-installed gracefully
The Companion is not installed as a service.

stdout | server/service.test.ts > stop > calls launchctl bootout when installed
The Companion has been installed as a background service.

  URL:    http://localhost:3456
  Logs:   /var/folders/5y/rb6f6xkx4dq_pk_04jclv7pm0000gn/T/service-test-c5yMj0/.companion/logs
  Plist:  /var/folders/5y/rb6f6xkx4dq_pk_04jclv7pm0000gn/T/service-test-c5yMj0/Library/LaunchAgents/sh.thecompanion.app.plist

The service will start automatically on login.
Use 'the-companion status' to check if it's running.

stdout | server/service.test.ts > stop > calls launchctl bootout when installed
The Companion service has been stopped.
Run 'the-companion restart' to start it again.

stdout | server/service.test.ts > stop > falls back to launchctl unload when bootout fails
The Companion has been installed as a background service.

  URL:    http://localhost:3456
  Logs:   /var/folders/5y/rb6f6xkx4dq_pk_04jclv7pm0000gn/T/service-test-EwgOBc/.companion/logs
  Plist:  /var/folders/5y/rb6f6xkx4dq_pk_04jclv7pm0000gn/T/service-test-EwgOBc/Library/LaunchAgents/sh.thecompanion.app.plist

The service will start automatically on login.
Use 'the-companion status' to check if it's running.

stdout | server/service.test.ts > stop > falls back to launchctl unload when bootout fails
The Companion service has been stopped.
Run 'the-companion restart' to start it again.

stdout | server/service.test.ts > stop > handles not-installed gracefully
The Companion is not installed as a service.

stdout | server/cli-launcher.test.ts > state management > pruneExited > returns 0 when no sessions are exited
[cli-launcher] Spawning session test-session-id: /usr/bin/claude --sdk-url ws://localhost:3456/ws/cli/test-session-id --print --output-format stream-json --input-format stream-json --verbose -p 

stdout | server/service.test.ts > stop (linux) > calls systemctl stop when installed
The Companion has been installed as a background service.

  URL:    http://localhost:3456
  Logs:   /var/folders/5y/rb6f6xkx4dq_pk_04jclv7pm0000gn/T/service-test-a79wvv/.companion/logs
  Unit:   /var/folders/5y/rb6f6xkx4dq_pk_04jclv7pm0000gn/T/service-test-a79wvv/.config/systemd/user/the-companion.service

The service will start automatically on login.
Use 'the-companion status' to check if it's running.

stdout | server/service.test.ts > stop (linux) > calls systemctl stop when installed
The Companion service has been stopped.
Run 'the-companion restart' to start it again.

stdout | server/cli-launcher.test.ts > state management > setArchived > sets the archived flag on a session
[cli-launcher] Spawning session test-session-id: /usr/bin/claude --sdk-url ws://localhost:3456/ws/cli/test-session-id --print --output-format stream-json --input-format stream-json --verbose -p 

 ✓ server/cli.test.ts (1 test) 105ms
stdout | server/cli-launcher.test.ts > state management > setArchived > can unset the archived flag
[cli-launcher] Spawning session test-session-id: /usr/bin/claude --sdk-url ws://localhost:3456/ws/cli/test-session-id --print --output-format stream-json --input-format stream-json --verbose -p 

stdout | server/service.test.ts > stop (linux) > handles not-installed gracefully
The Companion is not installed as a service.

stdout | server/service.test.ts > restart > calls launchctl kickstart when installed
The Companion has been installed as a background service.

  URL:    http://localhost:3456
  Logs:   /var/folders/5y/rb6f6xkx4dq_pk_04jclv7pm0000gn/T/service-test-frduAN/.companion/logs
  Plist:  /var/folders/5y/rb6f6xkx4dq_pk_04jclv7pm0000gn/T/service-test-frduAN/Library/LaunchAgents/sh.thecompanion.app.plist

The service will start automatically on login.
Use 'the-companion status' to check if it's running.

stdout | server/service.test.ts > restart > calls launchctl kickstart when installed
The Companion service has been restarted.

stdout | server/service.test.ts > restart > handles not-installed gracefully
The Companion is not installed as a service.

stdout | server/cli-launcher.test.ts > state management > removeSession > deletes session from internal maps
[cli-launcher] Spawning session test-session-id: /usr/bin/claude --sdk-url ws://localhost:3456/ws/cli/test-session-id --print --output-format stream-json --input-format stream-json --verbose -p 

stdout | server/service.test.ts > restart (linux) > calls systemctl restart when installed
The Companion has been installed as a background service.

  URL:    http://localhost:3456
  Logs:   /var/folders/5y/rb6f6xkx4dq_pk_04jclv7pm0000gn/T/service-test-JGo7qr/.companion/logs
  Unit:   /var/folders/5y/rb6f6xkx4dq_pk_04jclv7pm0000gn/T/service-test-JGo7qr/.config/systemd/user/the-companion.service

The service will start automatically on login.
Use 'the-companion status' to check if it's running.

stdout | server/service.test.ts > restart (linux) > calls systemctl restart when installed
The Companion service has been restarted.

stdout | server/cli-launcher.test.ts > kill > sends SIGTERM via proc.kill
[cli-launcher] Spawning session test-session-id: /usr/bin/claude --sdk-url ws://localhost:3456/ws/cli/test-session-id --print --output-format stream-json --input-format stream-json --verbose -p 

stdout | server/service.test.ts > restart (linux) > handles not-installed gracefully
The Companion is not installed as a service.

stdout | server/service.test.ts > status > returns installed: true, running: true with PID
The Companion has been installed as a background service.

  URL:    http://localhost:3456
  Logs:   /var/folders/5y/rb6f6xkx4dq_pk_04jclv7pm0000gn/T/service-test-jGBwHn/.companion/logs
  Plist:  /var/folders/5y/rb6f6xkx4dq_pk_04jclv7pm0000gn/T/service-test-jGBwHn/Library/LaunchAgents/sh.thecompanion.app.plist

The service will start automatically on login.
Use 'the-companion status' to check if it's running.

stdout | server/service.test.ts > status > returns installed: true, running: false when service is loaded but not running
The Companion has been installed as a background service.

  URL:    http://localhost:3456
  Logs:   /var/folders/5y/rb6f6xkx4dq_pk_04jclv7pm0000gn/T/service-test-oCHd4N/.companion/logs
  Plist:  /var/folders/5y/rb6f6xkx4dq_pk_04jclv7pm0000gn/T/service-test-oCHd4N/Library/LaunchAgents/sh.thecompanion.app.plist

The service will start automatically on login.
Use 'the-companion status' to check if it's running.

stdout | server/cli-launcher.test.ts > kill > sends SIGTERM via proc.kill
[cli-launcher] Session test-session-id exited (code=0)

stdout | server/cli-launcher.test.ts > kill > marks session as exited
[cli-launcher] Spawning session test-session-id: /usr/bin/claude --sdk-url ws://localhost:3456/ws/cli/test-session-id --print --output-format stream-json --input-format stream-json --verbose -p 

stdout | server/service.test.ts > status (linux) > returns installed: true, running: true with PID
The Companion has been installed as a background service.

  URL:    http://localhost:3456
  Logs:   /var/folders/5y/rb6f6xkx4dq_pk_04jclv7pm0000gn/T/service-test-kY6wQa/.companion/logs
  Unit:   /var/folders/5y/rb6f6xkx4dq_pk_04jclv7pm0000gn/T/service-test-kY6wQa/.config/systemd/user/the-companion.service

The service will start automatically on login.
Use 'the-companion status' to check if it's running.

stdout | server/service.test.ts > status (linux) > returns installed: true, running: false when service is inactive
The Companion has been installed as a background service.

  URL:    http://localhost:3456
  Logs:   /var/folders/5y/rb6f6xkx4dq_pk_04jclv7pm0000gn/T/service-test-jOiQUk/.companion/logs
  Unit:   /var/folders/5y/rb6f6xkx4dq_pk_04jclv7pm0000gn/T/service-test-jOiQUk/.config/systemd/user/the-companion.service

The service will start automatically on login.
Use 'the-companion status' to check if it's running.

stdout | server/cli-launcher.test.ts > kill > marks session as exited
[cli-launcher] Session test-session-id exited (code=0)

stdout | server/service.test.ts > status (linux) > reads custom port from unit file
The Companion has been installed as a background service.

  URL:    http://localhost:7777
  Logs:   /var/folders/5y/rb6f6xkx4dq_pk_04jclv7pm0000gn/T/service-test-a9G9dw/.companion/logs
  Unit:   /var/folders/5y/rb6f6xkx4dq_pk_04jclv7pm0000gn/T/service-test-a9G9dw/.config/systemd/user/the-companion.service

The service will start automatically on login.
Use 'the-companion status' to check if it's running.

stdout | server/cli-launcher.test.ts > relaunch > kills old process and spawns new one with --resume
[cli-launcher] Spawning session test-session-id: /usr/bin/claude --sdk-url ws://localhost:3456/ws/cli/test-session-id --print --output-format stream-json --input-format stream-json --verbose --model claude-sonnet-4-5-20250929 -p 

stdout | server/cli-launcher.test.ts > relaunch > kills old process and spawns new one with --resume
[cli-launcher] Session test-session-id exited (code=0)

stdout | server/cli-launcher.test.ts > relaunch > kills old process and spawns new one with --resume
[cli-launcher] Spawning session test-session-id: /usr/bin/claude --sdk-url ws://localhost:3456/ws/cli/test-session-id --print --output-format stream-json --input-format stream-json --verbose --model claude-sonnet-4-5-20250929 --resume cli-resume-id -p 

stdout | server/service.test.ts > isRunningAsService > returns true when plist exists and service has a PID
The Companion has been installed as a background service.

  URL:    http://localhost:3456
  Logs:   /var/folders/5y/rb6f6xkx4dq_pk_04jclv7pm0000gn/T/service-test-RG4iRW/.companion/logs
  Plist:  /var/folders/5y/rb6f6xkx4dq_pk_04jclv7pm0000gn/T/service-test-RG4iRW/Library/LaunchAgents/sh.thecompanion.app.plist

The service will start automatically on login.
Use 'the-companion status' to check if it's running.

stdout | server/service.test.ts > isRunningAsService > returns false when plist exists but no PID (not running)
The Companion has been installed as a background service.

  URL:    http://localhost:3456
  Logs:   /var/folders/5y/rb6f6xkx4dq_pk_04jclv7pm0000gn/T/service-test-pKOclY/.companion/logs
  Plist:  /var/folders/5y/rb6f6xkx4dq_pk_04jclv7pm0000gn/T/service-test-pKOclY/Library/LaunchAgents/sh.thecompanion.app.plist

The service will start automatically on login.
Use 'the-companion status' to check if it's running.

stdout | server/service.test.ts > isRunningAsService (linux) > returns true when unit file exists and service is active
The Companion has been installed as a background service.

  URL:    http://localhost:3456
  Logs:   /var/folders/5y/rb6f6xkx4dq_pk_04jclv7pm0000gn/T/service-test-ZDoI9K/.companion/logs
  Unit:   /var/folders/5y/rb6f6xkx4dq_pk_04jclv7pm0000gn/T/service-test-ZDoI9K/.config/systemd/user/the-companion.service

The service will start automatically on login.
Use 'the-companion status' to check if it's running.

stdout | server/service.test.ts > isRunningAsService (linux) > returns false when unit file exists but service is inactive
The Companion has been installed as a background service.

  URL:    http://localhost:3456
  Logs:   /var/folders/5y/rb6f6xkx4dq_pk_04jclv7pm0000gn/T/service-test-LQbN3k/.companion/logs
  Unit:   /var/folders/5y/rb6f6xkx4dq_pk_04jclv7pm0000gn/T/service-test-LQbN3k/.config/systemd/user/the-companion.service

The service will start automatically on login.
Use 'the-companion status' to check if it's running.

stdout | server/service.test.ts > platform check > allows macOS (darwin)
The Companion has been installed as a background service.

  URL:    http://localhost:3456
  Logs:   /var/folders/5y/rb6f6xkx4dq_pk_04jclv7pm0000gn/T/service-test-lfkieP/.companion/logs
  Plist:  /var/folders/5y/rb6f6xkx4dq_pk_04jclv7pm0000gn/T/service-test-lfkieP/Library/LaunchAgents/sh.thecompanion.app.plist

The service will start automatically on login.
Use 'the-companion status' to check if it's running.

stdout | server/cli-launcher.test.ts > persistence > restoreFromDisk > recovers sessions from the store
[cli-launcher] Recovered 1 live session(s) from disk

stdout | server/service.test.ts > platform check > allows Linux
The Companion has been installed as a background service.

  URL:    http://localhost:3456
  Logs:   /var/folders/5y/rb6f6xkx4dq_pk_04jclv7pm0000gn/T/service-test-Qaiwje/.companion/logs
  Unit:   /var/folders/5y/rb6f6xkx4dq_pk_04jclv7pm0000gn/T/service-test-Qaiwje/.config/systemd/user/the-companion.service

The service will start automatically on login.
Use 'the-companion status' to check if it's running.

stdout | server/cli-launcher.test.ts > getStartingSessions > returns only sessions in starting state
[cli-launcher] Spawning session test-session-id: /usr/bin/claude --sdk-url ws://localhost:3456/ws/cli/test-session-id --print --output-format stream-json --input-format stream-json --verbose -p 

stdout | server/cli-launcher.test.ts > getStartingSessions > excludes sessions that have been connected
[cli-launcher] Spawning session test-session-id: /usr/bin/claude --sdk-url ws://localhost:3456/ws/cli/test-session-id --print --output-format stream-json --input-format stream-json --verbose -p 
[cli-launcher] Session test-session-id connected via WebSocket

 ✓ server/service.test.ts (64 tests) 134ms
 ✓ server/cli-launcher.test.ts (48 tests) 95ms
stdout | server/codex-adapter.test.ts > CodexAdapter > translates agent message streaming to content_block_delta events
[codex-adapter] ← item/started type=agentMessage id=item_1

stdout | server/codex-adapter.test.ts > CodexAdapter > translates agent message streaming to content_block_delta events
[codex-adapter] ← item/agentMessage/delta keys=[itemId,delta]

stdout | server/codex-adapter.test.ts > CodexAdapter > translates agent message streaming to content_block_delta events
[codex-adapter] ← item/agentMessage/delta keys=[itemId,delta]

stdout | server/codex-adapter.test.ts > CodexAdapter > uses stable assistant message IDs derived from Codex item IDs
[codex-adapter] ← item/started type=agentMessage id=item_1

stdout | server/codex-adapter.test.ts > CodexAdapter > uses stable assistant message IDs derived from Codex item IDs
[codex-adapter] ← item/agentMessage/delta keys=[itemId,delta]

stdout | server/routes.test.ts > POST /api/sessions/create > injects environment variables when envSlug is provided
[routes] Injecting env "Production" (2 vars): API_KEY, DB_HOST

stdout | server/routes.test.ts > DELETE /api/sessions/:id > kills, removes, cleans up worktree, and closes session
[routes] Auto-removed clean worktree /wt/feat

stdout | server/routes.test.ts > DELETE /api/sessions/:id > passes branchToDelete when actualBranch differs from branch
[routes] Auto-removed clean worktree /wt/main

stdout | server/codex-adapter.test.ts > CodexAdapter > uses stable assistant message IDs derived from Codex item IDs
[codex-adapter] ← item/completed type=agentMessage id=item_1

 ✓ server/routes.test.ts (70 tests) 62ms
 ✓ src/components/ToolBlock.test.tsx (47 tests) 128ms
 ✓ src/components/Composer.test.tsx (19 tests) 78ms
 ✓ src/components/PermissionBanner.test.tsx (23 tests) 97ms
 ✓ src/components/DiffPanel.test.tsx (7 tests) 59ms
stdout | server/ws-bridge.test.ts > Session management > closeSession: closes all sockets and removes session
[ws-bridge] CLI connected for session s1
[ws-bridge] Browser connected for session s1 (1 browsers)
[ws-bridge] Browser connected for session s1 (2 browsers)

stdout | server/ws-bridge.test.ts > CLI handlers > handleCLIOpen: sets cliSocket and broadcasts cli_connected
[ws-bridge] Browser connected for session s1 (1 browsers)
[ws-bridge] CLI connected for session s1

stdout | server/ws-bridge.test.ts > CLI handlers > handleCLIOpen: flushes pending messages
[ws-bridge] Browser connected for session s1 (1 browsers)
[ws-bridge] CLI not yet connected for session s1, queuing message
[ws-bridge] CLI connected for session s1
[ws-bridge] Flushing 1 queued message(s) for session s1

stdout | server/ws-bridge.test.ts > CLI handlers > handleCLIMessage: parses NDJSON and routes system.init
[ws-bridge] CLI connected for session s1
[ws-bridge] Browser connected for session s1 (1 browsers)

stdout | server/ws-bridge.test.ts > CLI handlers > handleCLIMessage: system.init fires onCLISessionIdReceived callback
[ws-bridge] CLI connected for session s1

stdout | server/ws-bridge.test.ts > CLI handlers > handleCLIMessage: updates state from init (model, cwd, tools, permissionMode)
[ws-bridge] CLI connected for session s1

stdout | server/ws-bridge.test.ts > CLI handlers > handleCLIMessage: system.init resolves git info via execSync (worktree)
[ws-bridge] CLI connected for session s1

stdout | server/ws-bridge.test.ts > CLI handlers > handleCLIMessage: system.init resolves repo_root via --show-toplevel for non-worktree
[ws-bridge] CLI connected for session s1

stdout | server/ws-bridge.test.ts > CLI handlers > handleCLIMessage: system.init resolves repo_root from relative --git-common-dir in worktree
[ws-bridge] CLI connected for session s1

stdout | server/ws-bridge.test.ts > CLI handlers > handleCLIMessage: system.status updates compacting and permissionMode
[ws-bridge] CLI connected for session s1
[ws-bridge] Browser connected for session s1 (1 browsers)

stdout | server/ws-bridge.test.ts > CLI handlers > handleCLIClose: nulls cliSocket and broadcasts cli_disconnected
[ws-bridge] CLI connected for session s1
[ws-bridge] Browser connected for session s1 (1 browsers)
[ws-bridge] CLI disconnected for session s1

stdout | server/ws-bridge.test.ts > CLI handlers > handleCLIClose: cancels pending permissions
[ws-bridge] CLI connected for session s1
[ws-bridge] Browser connected for session s1 (1 browsers)
[ws-bridge] CLI disconnected for session s1

stdout | server/ws-bridge.test.ts > Browser handlers > handleBrowserOpen: adds to set and sends session_init
[ws-bridge] Browser connected for session s1 (1 browsers)

stdout | server/ws-bridge.test.ts > Browser handlers > handleBrowserOpen: replays message history
[ws-bridge] CLI connected for session s1
[ws-bridge] ⚠ Broadcasting assistant to 0 browsers for session s1 (stored in history: true)
[ws-bridge] Browser connected for session s1 (1 browsers)

stdout | server/ws-bridge.test.ts > Browser handlers > handleBrowserOpen: sends pending permissions
[ws-bridge] CLI connected for session s1
[ws-bridge] Browser connected for session s1 (1 browsers)

stdout | server/ws-bridge.test.ts > Browser handlers > handleBrowserOpen: triggers relaunch callback when CLI is dead
[ws-bridge] Browser connected for session s1 (1 browsers)
[ws-bridge] Browser connected but backend is dead for session s1, requesting relaunch

stdout | server/ws-bridge.test.ts > Browser handlers > handleBrowserOpen: does NOT relaunch when Codex adapter is attached but still initializing
[ws-bridge] Browser connected for session s1 (1 browsers)

stdout | server/ws-bridge.test.ts > Browser handlers > handleBrowserClose: removes from set
[ws-bridge] Browser connected for session s1 (1 browsers)
[ws-bridge] Browser disconnected for session s1 (0 browsers)

stdout | server/ws-bridge.test.ts > CLI message routing > assistant: stores in history and broadcasts
[ws-bridge] CLI connected for session s1
[ws-bridge] Browser connected for session s1 (1 browsers)

stdout | server/ws-bridge.test.ts > CLI message routing > result: updates cost/turns/context% and stores + broadcasts
[ws-bridge] CLI connected for session s1
[ws-bridge] Browser connected for session s1 (1 browsers)

stdout | server/ws-bridge.test.ts > CLI message routing > result: computes context_used_percent from modelUsage
[ws-bridge] CLI connected for session s1
[ws-bridge] Browser connected for session s1 (1 browsers)

stdout | server/ws-bridge.test.ts > CLI message routing > stream_event: broadcasts without storing
[ws-bridge] CLI connected for session s1
[ws-bridge] Browser connected for session s1 (1 browsers)

stdout | server/ws-bridge.test.ts > CLI message routing > control_request (can_use_tool): adds to pending and broadcasts
[ws-bridge] CLI connected for session s1
[ws-bridge] Browser connected for session s1 (1 browsers)

stdout | server/ws-bridge.test.ts > CLI message routing > tool_progress: broadcasts
[ws-bridge] CLI connected for session s1
[ws-bridge] Browser connected for session s1 (1 browsers)

stdout | server/ws-bridge.test.ts > CLI message routing > tool_use_summary: broadcasts
[ws-bridge] CLI connected for session s1
[ws-bridge] Browser connected for session s1 (1 browsers)

stdout | server/ws-bridge.test.ts > CLI message routing > keep_alive: silently consumed, no broadcast
[ws-bridge] CLI connected for session s1
[ws-bridge] Browser connected for session s1 (1 browsers)

stdout | server/ws-bridge.test.ts > CLI message routing > multi-line NDJSON: processes both lines
[ws-bridge] CLI connected for session s1
[ws-bridge] Browser connected for session s1 (1 browsers)

stdout | server/ws-bridge.test.ts > CLI message routing > malformed JSON: skips gracefully without crashing
[ws-bridge] CLI connected for session s1
[ws-bridge] Browser connected for session s1 (1 browsers)

stdout | server/ws-bridge.test.ts > Browser message routing > user_message: sends NDJSON to CLI and stores in history
[ws-bridge] CLI connected for session s1
[ws-bridge] Browser connected for session s1 (1 browsers)

stdout | server/ws-bridge.test.ts > Browser message routing > user_message: queues when CLI not connected
[ws-bridge] CLI connected for session s1
[ws-bridge] Browser connected for session s1 (1 browsers)

stdout | server/ws-bridge.test.ts > Browser message routing > user_message: queues when CLI not connected
[ws-bridge] CLI disconnected for session s1
[ws-bridge] CLI not yet connected for session s1, queuing message

stdout | server/ws-bridge.test.ts > Browser message routing > user_message with images: builds content blocks
[ws-bridge] CLI connected for session s1
[ws-bridge] Browser connected for session s1 (1 browsers)

stdout | server/ws-bridge.test.ts > Browser message routing > permission_response allow: sends control_response to CLI
[ws-bridge] CLI connected for session s1
[ws-bridge] Browser connected for session s1 (1 browsers)

stdout | server/ws-bridge.test.ts > Browser message routing > permission_response deny: sends deny response to CLI
[ws-bridge] CLI connected for session s1
[ws-bridge] Browser connected for session s1 (1 browsers)

stdout | server/ws-bridge.test.ts > Browser message routing > interrupt: sends control_request with interrupt subtype to CLI
[ws-bridge] CLI connected for session s1
[ws-bridge] Browser connected for session s1 (1 browsers)

stdout | server/ws-bridge.test.ts > Browser message routing > set_model: sends control_request with set_model subtype to CLI
[ws-bridge] CLI connected for session s1
[ws-bridge] Browser connected for session s1 (1 browsers)

stdout | server/ws-bridge.test.ts > Browser message routing > set_permission_mode: sends control_request with set_permission_mode subtype to CLI
[ws-bridge] CLI connected for session s1
[ws-bridge] Browser connected for session s1 (1 browsers)

stdout | server/ws-bridge.test.ts > Persistence > restoreFromDisk: loads sessions from store
[ws-bridge] Restored 1 session(s) from disk

stdout | server/ws-bridge.test.ts > Persistence > persistSession: called after state changes (via store.save)
[ws-bridge] CLI connected for session s1
[ws-bridge] ⚠ Broadcasting assistant to 0 browsers for session s1 (stored in history: true)
[ws-bridge] ⚠ Broadcasting result to 0 browsers for session s1 (stored in history: true)
[ws-bridge] Browser connected for session s1 (1 browsers)

stdout | server/ws-bridge.test.ts > auth_status message routing > broadcasts auth_status with isAuthenticating: true
[ws-bridge] CLI connected for session s1
[ws-bridge] Browser connected for session s1 (1 browsers)

stdout | server/ws-bridge.test.ts > auth_status message routing > broadcasts auth_status with isAuthenticating: false
[ws-bridge] CLI connected for session s1
[ws-bridge] Browser connected for session s1 (1 browsers)

stdout | server/ws-bridge.test.ts > auth_status message routing > broadcasts auth_status with error field
[ws-bridge] CLI connected for session s1
[ws-bridge] Browser connected for session s1 (1 browsers)

stdout | server/ws-bridge.test.ts > permission_response with updated_permissions > allow with updated_permissions forwards updatedPermissions in control_response
[ws-bridge] CLI connected for session s1
[ws-bridge] Browser connected for session s1 (1 browsers)

stdout | server/ws-bridge.test.ts > permission_response with updated_permissions > allow without updated_permissions does not include updatedPermissions key
[ws-bridge] CLI connected for session s1
[ws-bridge] Browser connected for session s1 (1 browsers)

stdout | server/ws-bridge.test.ts > permission_response with updated_permissions > allow with empty updated_permissions does not include updatedPermissions key
[ws-bridge] CLI connected for session s1
[ws-bridge] Browser connected for session s1 (1 browsers)

stdout | server/ws-bridge.test.ts > Multiple browser sockets > broadcasts to ALL connected browsers
[ws-bridge] CLI connected for session s1
[ws-bridge] Browser connected for session s1 (1 browsers)
[ws-bridge] Browser connected for session s1 (2 browsers)
[ws-bridge] Browser connected for session s1 (3 browsers)

stdout | server/ws-bridge.test.ts > Multiple browser sockets > removes a browser whose send() throws, but others continue to receive
[ws-bridge] CLI connected for session s1
[ws-bridge] Browser connected for session s1 (1 browsers)
[ws-bridge] Browser connected for session s1 (2 browsers)
[ws-bridge] Browser connected for session s1 (3 browsers)

stdout | server/ws-bridge.test.ts > handleCLIMessage with Buffer > parses Buffer input correctly
[ws-bridge] CLI connected for session s1
[ws-bridge] Browser connected for session s1 (1 browsers)

stdout | server/ws-bridge.test.ts > handleCLIMessage with Buffer > handles multi-line NDJSON as Buffer
[ws-bridge] CLI connected for session s1
[ws-bridge] Browser connected for session s1 (1 browsers)

stdout | server/ws-bridge.test.ts > handleBrowserMessage with Buffer > parses Buffer input and routes user_message correctly
[ws-bridge] CLI connected for session s1
[ws-bridge] Browser connected for session s1 (1 browsers)

stdout | server/ws-bridge.test.ts > handleBrowserMessage with Buffer > parses Buffer input and routes interrupt correctly
[ws-bridge] CLI connected for session s1
[ws-bridge] Browser connected for session s1 (1 browsers)

stdout | server/ws-bridge.test.ts > handleBrowserMessage with malformed JSON > does not throw on invalid JSON
[ws-bridge] CLI connected for session s1
[ws-bridge] Browser connected for session s1 (1 browsers)

stdout | server/ws-bridge.test.ts > handleBrowserMessage with malformed JSON > does not throw on empty string
[ws-bridge] CLI connected for session s1
[ws-bridge] Browser connected for session s1 (1 browsers)

stdout | server/ws-bridge.test.ts > handleBrowserMessage with malformed JSON > does not throw on truncated JSON
[ws-bridge] CLI connected for session s1
[ws-bridge] Browser connected for session s1 (1 browsers)

stdout | server/ws-bridge.test.ts > Empty NDJSON lines > skips empty lines between valid NDJSON
[ws-bridge] CLI connected for session s1
[ws-bridge] Browser connected for session s1 (1 browsers)

stdout | server/ws-bridge.test.ts > Empty NDJSON lines > handles entirely empty/whitespace input without crashing
[ws-bridge] CLI connected for session s1
[ws-bridge] Browser connected for session s1 (1 browsers)

stdout | server/ws-bridge.test.ts > Empty NDJSON lines > processes valid lines around whitespace-only lines
[ws-bridge] CLI connected for session s1
[ws-bridge] Browser connected for session s1 (1 browsers)

stdout | server/ws-bridge.test.ts > Restore from disk with pendingPermissions > restores sessions with pending permissions as a Map
[ws-bridge] Restored 1 session(s) from disk

stdout | server/ws-bridge.test.ts > Restore from disk with pendingPermissions > restored pending permissions are sent to newly connected browsers
[ws-bridge] Restored 1 session(s) from disk
[ws-bridge] CLI connected for session perm-replay
[ws-bridge] Browser connected for session perm-replay (1 browsers)

stdout | server/ws-bridge.test.ts > Restore from disk with pendingPermissions > restores sessions with empty pendingPermissions array
[ws-bridge] Restored 1 session(s) from disk

stdout | server/ws-bridge.test.ts > Restore from disk with pendingPermissions > restores sessions with undefined pendingPermissions
[ws-bridge] Restored 1 session(s) from disk

stdout | server/ws-bridge.test.ts > onFirstTurnCompletedCallback > fires on first successful result regardless of num_turns
[ws-bridge] CLI connected for session s1
[ws-bridge] Browser connected for session s1 (1 browsers)

stdout | server/ws-bridge.test.ts > onFirstTurnCompletedCallback > does not fire on subsequent results for the same session
[ws-bridge] CLI connected for session s1
[ws-bridge] Browser connected for session s1 (1 browsers)

stdout | server/ws-bridge.test.ts > onFirstTurnCompletedCallback > does not fire on error results
[ws-bridge] CLI connected for session s1
[ws-bridge] Browser connected for session s1 (1 browsers)

stdout | server/ws-bridge.test.ts > onFirstTurnCompletedCallback > fires after initial error result followed by a successful result
[ws-bridge] CLI connected for session s1
[ws-bridge] Browser connected for session s1 (1 browsers)

stdout | server/ws-bridge.test.ts > onFirstTurnCompletedCallback > does not fire when there is no user message in history
[ws-bridge] CLI connected for session s1
[ws-bridge] ⚠ Broadcasting result to 0 browsers for session s1 (stored in history: true)

stdout | server/ws-bridge.test.ts > onFirstTurnCompletedCallback > fires independently for different sessions
[ws-bridge] CLI connected for session s1
[ws-bridge] Browser connected for session s1 (1 browsers)
[ws-bridge] CLI connected for session s2
[ws-bridge] Browser connected for session s2 (1 browsers)

stdout | server/ws-bridge.test.ts > onFirstTurnCompletedCallback > cleans up auto-naming tracking when session is removed
[ws-bridge] CLI connected for session s1
[ws-bridge] Browser connected for session s1 (1 browsers)
[ws-bridge] CLI connected for session s1
[ws-bridge] Browser connected for session s1 (1 browsers)

stdout | server/ws-bridge.test.ts > onFirstTurnCompletedCallback > cleans up auto-naming tracking when session is closed
[ws-bridge] CLI connected for session s1
[ws-bridge] Browser connected for session s1 (1 browsers)
[ws-bridge] CLI connected for session s1
[ws-bridge] Browser connected for session s1 (1 browsers)

stdout | server/ws-bridge.test.ts > onFirstTurnCompletedCallback > does not fire for restored sessions with completed turns
[ws-bridge] CLI connected for session restored-1
[ws-bridge] ⚠ Broadcasting result to 0 browsers for session restored-1 (stored in history: true)

stdout | server/ws-bridge.test.ts > onFirstTurnCompletedCallback > allows auto-naming for restored sessions with zero turns
[ws-bridge] CLI connected for session fresh-restored
[ws-bridge] Browser connected for session fresh-restored (1 browsers)

stdout | server/ws-bridge.test.ts > broadcastNameUpdate > sends session_name_update to connected browsers
[ws-bridge] CLI connected for session s1
[ws-bridge] Browser connected for session s1 (1 browsers)
[ws-bridge] Browser connected for session s1 (2 browsers)

 ✓ server/ws-bridge.test.ts (86 tests) 37ms
 ✓ src/ws.test.ts (37 tests) 76ms
 ✓ src/components/SettingsPage.test.tsx (9 tests) 245ms
 ✓ src/components/Sidebar.test.tsx (29 tests) 135ms
stdout | server/codex-adapter.test.ts > CodexAdapter > translates turn/completed to result message
[codex-adapter] ← turn/completed keys=[turn]

 ✓ server/worktree-tracker.test.ts (18 tests) 45ms
stdout | server/update-checker.test.ts > checkForUpdate > sets latestVersion when fetch succeeds
[update-checker] Update available: 0.30.1 -> 99.0.0

 ✓ src/components/MessageFeed.test.tsx (17 tests) 50ms
stdout | server/update-checker.test.ts > isUpdateAvailable > returns true when latest is newer than current
[update-checker] Update available: 0.30.1 -> 99.0.0

 ✓ src/components/MessageBubble.test.tsx (18 tests) 58ms
 ✓ server/update-checker.test.ts (15 tests) 19ms
 ✓ server/session-store.test.ts (19 tests) 19ms
 ✓ server/git-utils.test.ts (41 tests) 19ms
 ✓ server/github-pr.test.ts (39 tests) 12ms
 ✓ server/pr-poller.test.ts (10 tests) 22ms
stdout | server/codex-adapter.test.ts > CodexAdapter > translates command_execution item to Bash tool_use with stream_event
[codex-adapter] ← item/started type=commandExecution id=cmd_1
[codex-adapter] Emitting tool_use: Bash id=cmd_1

 ✓ server/session-names.test.ts (9 tests) 9ms
 ✓ server/usage-limits.test.ts (20 tests) 12ms
 ✓ src/utils/project-grouping.test.ts (25 tests) 17ms
 ✓ server/settings-manager.test.ts (7 tests) 6ms
 ✓ server/auto-namer.test.ts (11 tests) 5ms
 ✓ src/utils/names.test.ts (7 tests) 4ms
 ✓ src/utils/backends.test.ts (18 tests) 4ms
 ✓ src/components/DiffViewer.test.tsx (10 tests) 39ms
 ✓ src/components/UpdateBanner.test.tsx (11 tests) 31ms
 ✓ src/components/TopBar.test.tsx (2 tests) 20ms
 ✓ src/store.test.ts (35 tests) 7ms
 ✓ src/api.test.ts (18 tests) 4ms
stdout | server/codex-adapter.test.ts > CodexAdapter > translates fileChange item to Edit/Write tool_use
[codex-adapter] ← item/started type=fileChange id=fc_1
[codex-adapter] Emitting tool_use: Write id=fc_1

stdout | server/codex-adapter.test.ts > CodexAdapter > translates fileChange item to Edit/Write tool_use
[codex-adapter] ← item/started type=fileChange id=fc_2
[codex-adapter] Emitting tool_use: Edit id=fc_2

stdout | server/codex-adapter.test.ts > CodexAdapter > translates error turn/completed to error result
[codex-adapter] ← turn/completed keys=[turn]

stdout | server/codex-adapter.test.ts > CodexAdapter > translates webSearch item to WebSearch tool_use
[codex-adapter] ← item/started type=webSearch id=ws_1
[codex-adapter] Emitting tool_use: WebSearch id=ws_1

stdout | server/codex-adapter.test.ts > CodexAdapter > emits tool_result on webSearch item/completed
[codex-adapter] ← item/started type=webSearch id=ws_1
[codex-adapter] Emitting tool_use: WebSearch id=ws_1

stdout | server/codex-adapter.test.ts > CodexAdapter > emits tool_result on webSearch item/completed
[codex-adapter] ← item/completed type=webSearch id=ws_1

stdout | server/codex-adapter.test.ts > CodexAdapter > emits content_block_stop on reasoning item/completed
[codex-adapter] ← item/started type=reasoning id=r_1

stdout | server/codex-adapter.test.ts > CodexAdapter > emits content_block_stop on reasoning item/completed
[codex-adapter] ← item/completed type=reasoning id=r_1

stdout | server/codex-adapter.test.ts > CodexAdapter > backfills tool_use when item/completed arrives without item/started
[codex-adapter] ← item/completed type=commandExecution id=cmd_1
[codex-adapter] Backfilling tool_use for Bash (id=cmd_1) — item/started was missing
[codex-adapter] Emitting tool_use: Bash id=cmd_1

stdout | server/codex-adapter.test.ts > CodexAdapter > does not double-emit tool_use when item/started was received
[codex-adapter] ← item/started type=commandExecution id=cmd_2
[codex-adapter] Emitting tool_use: Bash id=cmd_2

stdout | server/codex-adapter.test.ts > CodexAdapter > does not double-emit tool_use when item/started was received
[codex-adapter] ← item/completed type=commandExecution id=cmd_2

stdout | server/codex-adapter.test.ts > CodexAdapter > handles string command (Codex format) in commandExecution item/started
[codex-adapter] ← item/started type=commandExecution id=cmd_str_1
[codex-adapter] Emitting tool_use: Bash id=cmd_str_1

stdout | server/codex-adapter.test.ts > CodexAdapter > backfills tool_use with string command when item/started is missing
[codex-adapter] ← item/completed type=commandExecution id=cmd_str_2
[codex-adapter] Backfilling tool_use for Bash (id=cmd_str_2) — item/started was missing
[codex-adapter] Emitting tool_use: Bash id=cmd_str_2

stdout | server/codex-adapter.test.ts > CodexAdapter > queues user_message sent before init completes and flushes after
[codex-adapter] Queuing user_message — adapter not yet initialized

stdout | server/codex-adapter.test.ts > CodexAdapter > queues user_message sent before init completes and flushes after
[codex-adapter] Flushing 1 queued message(s)

stdout | server/codex-adapter.test.ts > CodexAdapter > emits stream_event content_block_start for tool_use on all tool item types
[codex-adapter] ← item/started type=commandExecution id=cmd_x
[codex-adapter] Emitting tool_use: Bash id=cmd_x

stdout | server/codex-adapter.test.ts > CodexAdapter > emits stream_event content_block_start for tool_use on all tool item types
[codex-adapter] ← item/started type=webSearch id=ws_x
[codex-adapter] Emitting tool_use: WebSearch id=ws_x

stdout | server/codex-adapter.test.ts > CodexAdapter > emits stream_event content_block_start for tool_use on all tool item types
[codex-adapter] ← item/started type=fileChange id=fc_x
[codex-adapter] Emitting tool_use: Edit id=fc_x

stdout | server/codex-adapter.test.ts > CodexAdapter > emits null stop_reason in agentMessage completion (not end_turn)
[codex-adapter] ← item/started type=agentMessage id=am_1

stdout | server/codex-adapter.test.ts > CodexAdapter > emits null stop_reason in agentMessage completion (not end_turn)
[codex-adapter] ← item/completed type=agentMessage id=am_1

stdout | server/codex-adapter.test.ts > CodexAdapter > responds to item/tool/call with DynamicToolCallResponse (success: false)
[codex-adapter] Dynamic tool call received: my_custom_tool (callId=call_abc123)
[codex-adapter] Emitting tool_use: dynamic:my_custom_tool id=call_abc123

stdout | server/codex-adapter.test.ts > CodexAdapter > emits tool_use and error tool_result to browser for item/tool/call
[codex-adapter] Dynamic tool call received: code_interpreter (callId=call_def456)
[codex-adapter] Emitting tool_use: dynamic:code_interpreter id=call_def456

stdout | server/codex-adapter.test.ts > CodexAdapter > does not emit tool_result for successful command with no output
[codex-adapter] ← item/completed type=commandExecution id=cmd_silent
[codex-adapter] Backfilling tool_use for Bash (id=cmd_silent) — item/started was missing
[codex-adapter] Emitting tool_use: Bash id=cmd_silent

 ✓ server/codex-adapter.test.ts (52 tests) 8970ms

 Test Files  34 passed (34)
      Tests  867 passed (867)
   Start at  11:09:29
   Duration  9.27s (transform 1.56s, setup 284ms, import 3.12s, tests 10.70s, environment 4.86s)\n
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/the-vibe-company/companion/pull/192" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
