### PR TITLE
feat(server): thread environment variables through git-utils

### DIFF
--- a/web/server/routes.test.ts
+++ b/web/server/routes.test.ts
@@ -199,6 +199,36 @@ describe("POST /api/sessions/create", () => {
     );
   });
 
+  it("passes env vars to git operations when envSlug is provided with branch", async () => {
+    vi.mocked(envManager.getEnv).mockReturnValue({
+      name: "Production",
+      slug: "production",
+      variables: { GH_TOKEN: "ghp_abc123" },
+      createdAt: 1000,
+      updatedAt: 1000,
+    });
+    vi.mocked(gitUtils.getRepoInfo).mockReturnValue({
+      repoRoot: "/repo",
+      repoName: "my-repo",
+      currentBranch: "develop",
+      defaultBranch: "main",
+      isWorktree: false,
+    });
+
+    const res = await app.request("/api/sessions/create", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ cwd: "/repo", branch: "main", envSlug: "production" }),
+    });
+
+    expect(res.status).toBe(200);
+    const expectedEnv = { GH_TOKEN: "ghp_abc123" };
+    expect(gitUtils.getRepoInfo).toHaveBeenCalledWith("/repo", { env: expectedEnv });
+    expect(gitUtils.gitFetch).toHaveBeenCalledWith("/repo", { env: expectedEnv });
+    expect(gitUtils.checkoutBranch).toHaveBeenCalledWith("/repo", "main", { env: expectedEnv });
+    expect(gitUtils.gitPull).toHaveBeenCalledWith("/repo", { env: expectedEnv });
+  });
+
   it("sets up a worktree when branch is specified", async () => {
     vi.mocked(gitUtils.getRepoInfo).mockReturnValue({
       repoRoot: "/repo",
@@ -221,11 +251,12 @@ describe("POST /api/sessions/create", () => {
     });
 
     expect(res.status).toBe(200);
-    expect(gitUtils.getRepoInfo).toHaveBeenCalledWith("/repo");
+    expect(gitUtils.getRepoInfo).toHaveBeenCalledWith("/repo", { env: undefined });
     expect(gitUtils.ensureWorktree).toHaveBeenCalledWith("/repo", "feat-branch", {
       baseBranch: "main",
       createBranch: undefined,
       forceNew: true,
+      env: undefined,
     });
     expect(launcher.launch).toHaveBeenCalledWith(
       expect.objectContaining({
@@ -265,9 +296,9 @@ describe("POST /api/sessions/create", () => {
     });
 
     expect(res.status).toBe(200);
-    expect(gitUtils.gitFetch).toHaveBeenCalledWith("/repo");
+    expect(gitUtils.gitFetch).toHaveBeenCalledWith("/repo", { env: undefined });
     expect(gitUtils.checkoutBranch).not.toHaveBeenCalled();
-    expect(gitUtils.gitPull).toHaveBeenCalledWith("/repo");
+    expect(gitUtils.gitPull).toHaveBeenCalledWith("/repo", { env: undefined });
   });
 
   it("fetches, checks out selected branch, then pulls before create", async () => {
@@ -286,9 +317,9 @@ describe("POST /api/sessions/create", () => {
     });
 
     expect(res.status).toBe(200);
-    expect(gitUtils.gitFetch).toHaveBeenCalledWith("/repo");
-    expect(gitUtils.checkoutBranch).toHaveBeenCalledWith("/repo", "main");
-    expect(gitUtils.gitPull).toHaveBeenCalledWith("/repo");
+    expect(gitUtils.gitFetch).toHaveBeenCalledWith("/repo", { env: undefined });
+    expect(gitUtils.checkoutBranch).toHaveBeenCalledWith("/repo", "main", { env: undefined });
+    expect(gitUtils.gitPull).toHaveBeenCalledWith("/repo", { env: undefined });
     expect(vi.mocked(gitUtils.gitFetch).mock.invocationCallOrder[0]).toBeLessThan(
       vi.mocked(gitUtils.checkoutBranch).mock.invocationCallOrder[0],
     );
@@ -909,7 +940,81 @@ describe("POST /api/git/worktree", () => {
     expect(gitUtils.ensureWorktree).toHaveBeenCalledWith("/repo", "feat", {
       baseBranch: "main",
       createBranch: undefined,
+      env: undefined,
     });
+  });
+});
+
+describe("POST /api/git/worktree with envSlug", () => {
+  it("passes env vars from envSlug to ensureWorktree", async () => {
+    vi.mocked(envManager.getEnv).mockReturnValue({
+      name: "CI",
+      slug: "ci",
+      variables: { GH_TOKEN: "ghp_test" },
+      createdAt: 1000,
+      updatedAt: 1000,
+    });
+    vi.mocked(gitUtils.ensureWorktree).mockReturnValue({
+      worktreePath: "/wt/feat",
+      branch: "feat",
+      actualBranch: "feat",
+      isNew: true,
+    });
+
+    const res = await app.request("/api/git/worktree", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ repoRoot: "/repo", branch: "feat", envSlug: "ci" }),
+    });
+
+    expect(res.status).toBe(200);
+    expect(gitUtils.ensureWorktree).toHaveBeenCalledWith("/repo", "feat", {
+      baseBranch: undefined,
+      createBranch: undefined,
+      env: { GH_TOKEN: "ghp_test" },
+    });
+  });
+});
+
+describe("POST /api/git/fetch with envSlug", () => {
+  it("passes env vars from envSlug to gitFetch", async () => {
+    vi.mocked(envManager.getEnv).mockReturnValue({
+      name: "CI",
+      slug: "ci",
+      variables: { GH_TOKEN: "ghp_test" },
+      createdAt: 1000,
+      updatedAt: 1000,
+    });
+
+    const res = await app.request("/api/git/fetch", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ repoRoot: "/repo", envSlug: "ci" }),
+    });
+
+    expect(res.status).toBe(200);
+    expect(gitUtils.gitFetch).toHaveBeenCalledWith("/repo", { env: { GH_TOKEN: "ghp_test" } });
+  });
+});
+
+describe("POST /api/git/pull with envSlug", () => {
+  it("passes env vars from envSlug to gitPull", async () => {
+    vi.mocked(envManager.getEnv).mockReturnValue({
+      name: "CI",
+      slug: "ci",
+      variables: { GH_TOKEN: "ghp_test" },
+      createdAt: 1000,
+      updatedAt: 1000,
+    });
+
+    const res = await app.request("/api/git/pull", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ cwd: "/repo", envSlug: "ci" }),
+    });
+
+    expect(res.status).toBe(200);
+    expect(gitUtils.gitPull).toHaveBeenCalledWith("/repo", { env: { GH_TOKEN: "ghp_test" } });
   });
 });
 

--- a/web/server/routes.ts
+++ b/web/server/routes.ts
@@ -90,7 +90,7 @@ export function createRoutes(
 
       // If worktree is requested, set up a worktree for the selected branch
       if (body.useWorktree && body.branch && cwd) {
-        const repoInfo = gitUtils.getRepoInfo(cwd);
+        const repoInfo = gitUtils.getRepoInfo(cwd, { env: envVars });
         if (repoInfo) {
           const result = gitUtils.ensureWorktree(
             repoInfo.repoRoot,
@@ -99,6 +99,7 @@ export function createRoutes(
               baseBranch: repoInfo.defaultBranch,
               createBranch: body.createBranch,
               forceNew: true,
+              env: envVars,
             },
           );
           cwd = result.worktreePath;
@@ -112,18 +113,18 @@ export function createRoutes(
         }
       } else if (body.branch && cwd) {
         // Non-worktree: checkout the selected branch in-place
-        const repoInfo = gitUtils.getRepoInfo(cwd);
+        const repoInfo = gitUtils.getRepoInfo(cwd, { env: envVars });
         if (repoInfo) {
-          const fetchResult = gitUtils.gitFetch(repoInfo.repoRoot);
+          const fetchResult = gitUtils.gitFetch(repoInfo.repoRoot, { env: envVars });
           if (!fetchResult.success) {
             throw new Error(`git fetch failed before session create: ${fetchResult.output}`);
           }
 
           if (repoInfo.currentBranch !== body.branch) {
-            gitUtils.checkoutBranch(repoInfo.repoRoot, body.branch);
+            gitUtils.checkoutBranch(repoInfo.repoRoot, body.branch, { env: envVars });
           }
 
-          const pullResult = gitUtils.gitPull(repoInfo.repoRoot);
+          const pullResult = gitUtils.gitPull(repoInfo.repoRoot, { env: envVars });
           if (!pullResult.success) {
             throw new Error(`git pull failed before session create: ${pullResult.output}`);
           }
@@ -712,13 +713,15 @@ export function createRoutes(
 
   api.post("/git/worktree", async (c) => {
     const body = await c.req.json().catch(() => ({}));
-    const { repoRoot, branch, baseBranch, createBranch } = body;
+    const { repoRoot, branch, baseBranch, createBranch, envSlug } = body;
     if (!repoRoot || !branch)
       return c.json({ error: "repoRoot and branch required" }, 400);
     try {
+      const env = envSlug ? envManager.getEnv(envSlug)?.variables : undefined;
       const result = gitUtils.ensureWorktree(repoRoot, branch, {
         baseBranch,
         createBranch,
+        env,
       });
       return c.json(result);
     } catch (e: unknown) {
@@ -737,16 +740,18 @@ export function createRoutes(
 
   api.post("/git/fetch", async (c) => {
     const body = await c.req.json().catch(() => ({}));
-    const { repoRoot } = body;
+    const { repoRoot, envSlug } = body;
     if (!repoRoot) return c.json({ error: "repoRoot required" }, 400);
-    return c.json(gitUtils.gitFetch(repoRoot));
+    const env = envSlug ? envManager.getEnv(envSlug)?.variables : undefined;
+    return c.json(gitUtils.gitFetch(repoRoot, { env }));
   });
 
   api.post("/git/pull", async (c) => {
     const body = await c.req.json().catch(() => ({}));
-    const { cwd } = body;
+    const { cwd, envSlug } = body;
     if (!cwd) return c.json({ error: "cwd required" }, 400);
-    const result = gitUtils.gitPull(cwd);
+    const env = envSlug ? envManager.getEnv(envSlug)?.variables : undefined;
+    const result = gitUtils.gitPull(cwd, { env });
     // Return refreshed ahead/behind counts
     let git_ahead = 0,
       git_behind = 0;


### PR DESCRIPTION
## Summary

- Add optional `env` parameter to all `git-utils.ts` functions, merging with `process.env` in `execSync` calls
- Thread `envVars` (resolved from `envSlug` environment profiles) through session creation git operations in `routes.ts`
- Add `envSlug` support to standalone `/git/fetch`, `/git/pull`, and `/git/worktree` API endpoints
- Add tests verifying env threading in both `git-utils.test.ts` and `routes.test.ts`

This allows git commands (fetch, pull, worktree creation, checkout) to authenticate using credentials from companion environment profiles (e.g. `GH_TOKEN`), which were previously only injected into the CLI launcher subprocess.

## Test plan

- [x] `bun run typecheck` passes
- [x] All 543 server tests pass
- [ ] Manual: Create an environment with `GH_TOKEN`, create a session with that env, verify git fetch/pull use the token

🤖 Generated with [Claude Code](https://claude.com/claude-code)