### PR TITLE
feat(cli): start and stop Companion via daemon service

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,12 @@ bunx the-companion
 
 Open [localhost:3456](http://localhost:3456). That's it.
 
+Foreground mode is also available explicitly with:
+
+```bash
+the-companion serve
+```
+
 ## Why
 
 Claude Code is powerful but stuck in a terminal. You can't easily run multiple sessions, there's no visual feedback on tool calls, and if the process dies your context is gone.
@@ -78,6 +84,7 @@ the-companion install
 Other commands:
 
 ```bash
+the-companion start       # start the installed background service
 the-companion status      # check if the service is running
 the-companion stop        # stop the service (keeps it installed)
 the-companion restart     # restart the service

--- a/web/server/cli.test.ts
+++ b/web/server/cli.test.ts
@@ -2,11 +2,13 @@ import { spawnSync } from "node:child_process";
 import { fileURLToPath } from "node:url";
 
 describe("CLI help output", () => {
-  it("lists stop and restart commands", () => {
+  it("lists daemon and foreground commands", () => {
     const cliPath = fileURLToPath(new URL("../bin/cli.ts", import.meta.url));
     const result = spawnSync("bun", [cliPath, "--help"], { encoding: "utf-8" });
 
     expect(result.status).toBe(0);
+    expect(result.stdout).toContain("serve       Start the server in foreground");
+    expect(result.stdout).toContain("start       Start the background service");
     expect(result.stdout).toContain("stop        Stop the background service");
     expect(result.stdout).toContain("restart     Restart the background service");
     expect(result.stdout).toContain("help        Show this help message");


### PR DESCRIPTION
## Summary
- make `the-companion start` start the installed background service instead of running in foreground
- add explicit `the-companion serve` command for foreground mode
- keep launchd/systemd units stable by using `start --foreground` internally
- add service start coverage in tests and update CLI help/readme docs

## Why
Starting with `start` was currently foreground for users, which is confusing when they expect daemon behavior with matching stop/restart flow.

## Testing
- `cd web && bun run test` (via pre-commit hook)
- `cd web && bun run typecheck`

## Visual Changes
- None

## Review provenance
- Code generated with AI assistance
- Human-reviewed: no
