### PR TITLE
fix(sidebar): nest notification toggles behind disclosure

### DIFF
--- a/web/src/components/Sidebar.test.tsx
+++ b/web/src/components/Sidebar.test.tsx
@@ -414,6 +414,21 @@ describe("Sidebar", () => {
     vi.unstubAllGlobals();
   });
 
+  it("does not count desktop alerts in summary when Notification API is unavailable", () => {
+    vi.stubGlobal("Notification", undefined);
+    mockState = createMockState({
+      notificationSound: true,
+      notificationDesktop: true,
+    });
+    render(<Sidebar />);
+    const notificationButton = screen.getByRole("button", { name: /Notification/i });
+    expect(notificationButton).toHaveTextContent("1 on");
+    fireEvent.click(notificationButton);
+    expect(screen.getByText("Sound on")).toBeInTheDocument();
+    expect(screen.queryByText("Alerts on")).not.toBeInTheDocument();
+    vi.unstubAllGlobals();
+  });
+
   it("session name shows animate-name-appear class when recently renamed", () => {
     const session = makeSession("s1");
     const sdk = makeSdkSession("s1");

--- a/web/src/components/Sidebar.tsx
+++ b/web/src/components/Sidebar.tsx
@@ -36,7 +36,8 @@ export function Sidebar() {
   const collapsedProjects = useStore((s) => s.collapsedProjects);
   const toggleProjectCollapse = useStore((s) => s.toggleProjectCollapse);
   const terminalOpen = useStore((s) => s.terminalOpen);
-  const notificationEnabledCount = Number(notificationSound) + Number(notificationDesktop);
+  const notificationApiAvailable = typeof Notification !== "undefined";
+  const notificationEnabledCount = Number(notificationSound) + (notificationApiAvailable ? Number(notificationDesktop) : 0);
   const notificationSummary = notificationEnabledCount === 0 ? "Off" : `${notificationEnabledCount} on`;
 
   // Poll for SDK sessions on mount
@@ -409,7 +410,7 @@ export function Sidebar() {
                 )}
                 <span>{notificationSound ? "Sound on" : "Sound off"}</span>
               </button>
-              {typeof Notification !== "undefined" && (
+              {notificationApiAvailable && (
                 <button
                   onClick={async () => {
                     if (!notificationDesktop) {


### PR DESCRIPTION
## Summary
- move notification controls behind a single `Notification` disclosure in the sidebar footer
- hide `Sound` and `Alerts` rows by default and show them only when expanded
- add a compact status summary on the disclosure button (`Off`, `1 on`, `2 on`)
- update sidebar tests to verify collapsed-by-default and expand-to-reveal behavior

## Why
- reduces persistent visual noise in the footer while keeping notification controls easy to access

## Testing
- `cd web && bun run test src/components/Sidebar.test.tsx`
- `cd web && bun run typecheck`
- pre-commit hook also ran full suite (`bun run test`) successfully

## Screenshot
- Not attached in this CLI run.

## Review provenance
- Implemented by AI agent (Codex)
- Human review: no

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/the-vibe-company/companion/pull/207" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
