### PR TITLE
fix(cli): fix Linux systemd service management (start, auto-restart)

### DIFF
--- a/web/server/index.ts
+++ b/web/server/index.ts
@@ -191,7 +191,7 @@ if (process.env.NODE_ENV !== "production") {
 startPeriodicCheck();
 if (isRunningAsService()) {
   setServiceMode(true);
-  console.log("[server] Running as launchd service (auto-update available)");
+  console.log("[server] Running as background service (auto-update available)");
 }
 
 // ── Reconnection watchdog ────────────────────────────────────────────────────

--- a/web/server/routes.ts
+++ b/web/server/routes.ts
@@ -926,6 +926,14 @@ export function createRoutes(
           stdout: "ignore",
           stderr: "ignore",
           stdin: "ignore",
+          env: isLinux
+            ? {
+                ...process.env,
+                XDG_RUNTIME_DIR:
+                  process.env.XDG_RUNTIME_DIR ||
+                  `/run/user/${uid ?? 1000}`,
+              }
+            : undefined,
         });
 
         // Give the spawn a moment to dispatch, then exit cleanly.


### PR DESCRIPTION
## Summary
- Fix `the-companion start` and auto-restart on Linux — only foreground mode was working
- Fix `process.ppid === 1` detection which is wrong for user-level systemd (parent is `systemd --user`, not PID 1)
- Add `XDG_RUNTIME_DIR` to all `systemctl --user` calls (required in SSH sessions)
- Enable `loginctl enable-linger` during install so services survive logout
- Auto-install systemd unit when `the-companion start` is called without prior `install`
- Fix log message saying "launchd" on Linux

## Why
On this Linux machine, an older version installed a systemd unit with `ExecStart=the-companion start` (no `--foreground`) and `Restart=on-failure`. After updating, systemd ran `the-companion start` → ppid was 10411 (user systemd, not PID 1) → ppid check failed → it called `systemctl --user start` again → infinite loop → exited 0 → `Restart=on-failure` didn't restart → service stayed dead.

## Testing
- `bun run typecheck` passes
- `bun run test` — 878 tests pass (1 pre-existing failure in `cli-launcher.test.ts` unrelated to this change)
- Updated `service.test.ts` to validate the new auto-install behavior

## Review provenance
- Implemented by AI agent
- Human review: no

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/the-vibe-company/companion/pull/213" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
