### PR TITLE
fix(cli): refresh systemd unit file on start/restart to prevent restart loops

### DIFF
--- a/web/server/service.test.ts
+++ b/web/server/service.test.ts
@@ -623,7 +623,11 @@ describe("start (linux)", () => {
     vi.resetModules();
     service = await import("./service.js");
     mockExecSync.mockReset();
-    mockExecSync.mockImplementation(() => "");
+    // start() now calls refreshServiceDefinition() which needs `which`
+    mockExecSync.mockImplementation((cmd: string) => {
+      if (cmd.startsWith("which")) return "/usr/local/bin/the-companion\n";
+      return "";
+    });
 
     await service.start();
 
@@ -653,6 +657,41 @@ describe("start (linux)", () => {
       ([cmd]) => typeof cmd === "string" && cmd.includes("enable --now"),
     );
     expect(enableCall).toBeDefined();
+  });
+
+  it("refreshes the service definition before starting an already-installed service", async () => {
+    // Install first with an older-style unit file (missing SuccessExitStatus).
+    // start() should rewrite the unit via refreshServiceDefinition() so that
+    // stale definitions from older versions don't cause restart loops.
+    mockExecSync.mockImplementation((cmd: string) => {
+      if (cmd.startsWith("which")) return "/usr/local/bin/the-companion\n";
+      if (cmd.startsWith("systemctl")) return "";
+      return "";
+    });
+    await service.install();
+
+    // Manually overwrite the unit with a stale version (no SuccessExitStatus)
+    const staleUnit = readFileSync(unitPath(), "utf-8")
+      .replace("SuccessExitStatus=42\n", "")
+      .replace("Restart=always", "Restart=on-failure");
+    writeFileSync(unitPath(), staleUnit, "utf-8");
+    expect(readFileSync(unitPath(), "utf-8")).not.toContain("SuccessExitStatus=42");
+
+    vi.resetModules();
+    service = await import("./service.js");
+    mockExecSync.mockReset();
+    mockExecSync.mockImplementation((cmd: string) => {
+      if (cmd.startsWith("which")) return "/usr/local/bin/the-companion\n";
+      if (cmd.startsWith("systemctl")) return "";
+      return "";
+    });
+
+    await service.start();
+
+    // Verify the unit file was refreshed with current template values
+    const updatedContent = readFileSync(unitPath(), "utf-8");
+    expect(updatedContent).toContain("SuccessExitStatus=42");
+    expect(updatedContent).toContain("Restart=always");
   });
 });
 
@@ -808,7 +847,11 @@ describe("restart (linux)", () => {
     vi.resetModules();
     service = await import("./service.js");
     mockExecSync.mockReset();
-    mockExecSync.mockImplementation(() => "");
+    // restart() now calls refreshServiceDefinition() which needs `which`
+    mockExecSync.mockImplementation((cmd: string) => {
+      if (cmd.startsWith("which")) return "/usr/local/bin/the-companion\n";
+      return "";
+    });
 
     await service.restart();
 
@@ -821,6 +864,37 @@ describe("restart (linux)", () => {
   it("handles not-installed gracefully", async () => {
     // Should not throw
     await service.restart();
+  });
+
+  it("refreshes the service definition before restarting", async () => {
+    // Install first
+    mockExecSync.mockImplementation((cmd: string) => {
+      if (cmd.startsWith("which")) return "/usr/local/bin/the-companion\n";
+      if (cmd.startsWith("systemctl")) return "";
+      return "";
+    });
+    await service.install();
+
+    // Manually write a stale unit (no SuccessExitStatus)
+    const staleUnit = readFileSync(unitPath(), "utf-8")
+      .replace("SuccessExitStatus=42\n", "");
+    writeFileSync(unitPath(), staleUnit, "utf-8");
+    expect(readFileSync(unitPath(), "utf-8")).not.toContain("SuccessExitStatus=42");
+
+    vi.resetModules();
+    service = await import("./service.js");
+    mockExecSync.mockReset();
+    mockExecSync.mockImplementation((cmd: string) => {
+      if (cmd.startsWith("which")) return "/usr/local/bin/the-companion\n";
+      if (cmd.startsWith("systemctl")) return "";
+      return "";
+    });
+
+    await service.restart();
+
+    // Verify the unit file was refreshed with current template
+    const updatedContent = readFileSync(unitPath(), "utf-8");
+    expect(updatedContent).toContain("SuccessExitStatus=42");
   });
 });
 

--- a/web/server/service.ts
+++ b/web/server/service.ts
@@ -428,6 +428,11 @@ async function startLinux(): Promise<void> {
     return; // installLinux uses enable --now which starts the service
   }
 
+  // Ensure the installed unit file matches the latest template (e.g.
+  // SuccessExitStatus=42, Restart=always) so that stale definitions from
+  // older versions don't cause restart loops after an auto-update.
+  refreshServiceDefinition();
+
   try {
     systemctlUser(`start ${UNIT_NAME}`);
   } catch (err: unknown) {
@@ -533,6 +538,9 @@ async function restartLinux(): Promise<void> {
     console.log("The Companion is not installed as a service.");
     return;
   }
+
+  // Keep the unit file in sync with the latest template before restarting.
+  refreshServiceDefinition();
 
   try {
     systemctlUser(`restart ${UNIT_NAME}`);


### PR DESCRIPTION
## Summary
- On Linux, `startLinux()` and `restartLinux()` now call `refreshServiceDefinition()` before issuing `systemctl` commands
- This ensures the installed systemd unit file always matches the latest template (with `SuccessExitStatus=42`, `Restart=always`, `--foreground`)
- Prevents restart loops caused by stale unit files from older versions treating exit code 42 (auto-update) as a failure

## Why
After upgrading the-companion, the installed systemd unit file could remain stale (e.g. missing `SuccessExitStatus=42`). When auto-update exits with code 42, systemd treats it as a failure and triggers `Restart=on-failure`, creating an infinite restart loop. The logs show repeated "The Companion service has been started" messages and `status=42/n/a` errors.

## Testing
- Added test: `start (linux) > refreshes the service definition before starting an already-installed service`
- Added test: `restart (linux) > refreshes the service definition before restarting`
- Updated existing start/restart mocks to handle the new `refreshServiceDefinition()` call
- All 77 tests pass, typecheck clean

## Review provenance
- Implemented by AI agent (Claude Opus 4.6)
- Human review: no

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/the-vibe-company/companion/pull/215" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
