### PR TITLE
chore: revert package name to the-companion

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -82,7 +82,7 @@ Browser (React) ←→ WebSocket ←→ Hono Server (Bun) ←→ WebSocket (NDJS
   - `App.tsx` — Root layout with sidebar, chat view, task panel. Hash routing (`#/playground`).
   - `components/` — UI: `ChatView`, `MessageFeed`, `MessageBubble`, `ToolBlock`, `Composer`, `Sidebar`, `TopBar`, `HomePage`, `TaskPanel`, `PermissionBanner`, `EnvManager`, `Playground`.
 
-- **`web/bin/cli.ts`** — CLI entry point (`bunx thecompanion`). Sets `__COMPANION_PACKAGE_ROOT` and imports the server.
+- **`web/bin/cli.ts`** — CLI entry point (`bunx the-companion`). Sets `__COMPANION_PACKAGE_ROOT` and imports the server.
 
 ### WebSocket Protocol
 

--- a/README.md
+++ b/README.md
@@ -5,8 +5,8 @@
 <h1 align="center">The Companion</h1>
 
 <p align="center">
-  <a href="https://www.npmjs.com/package/thecompanion"><img src="https://img.shields.io/npm/v/thecompanion.svg" alt="npm version" /></a>
-  <a href="https://www.npmjs.com/package/thecompanion"><img src="https://img.shields.io/npm/dm/thecompanion.svg" alt="npm downloads" /></a>
+  <a href="https://www.npmjs.com/package/the-companion"><img src="https://img.shields.io/npm/v/the-companion.svg" alt="npm version" /></a>
+  <a href="https://www.npmjs.com/package/the-companion"><img src="https://img.shields.io/npm/dm/the-companion.svg" alt="npm downloads" /></a>
   <a href="LICENSE"><img src="https://img.shields.io/badge/License-MIT-blue.svg" alt="MIT License" /></a>
 </p>
 
@@ -15,7 +15,7 @@
 Claude Code in your browser. We reverse-engineered the undocumented WebSocket protocol hidden inside the CLI and built a web UI on top of it. No API key needed, it runs on your existing Claude Code subscription.
 
 ```bash
-bunx thecompanion
+bunx the-companion
 ```
 
 Open [localhost:3456](http://localhost:3456). That's it.
@@ -23,7 +23,7 @@ Open [localhost:3456](http://localhost:3456). That's it.
 Foreground mode is also available explicitly with:
 
 ```bash
-thecompanion serve
+the-companion serve
 ```
 
 ## Why
@@ -77,19 +77,19 @@ Production: `bun run build && bun run start` serves everything on `:3456`.
 Install as a launchd service that starts on login and restarts on crash:
 
 ```bash
-bun install -g thecompanion
-thecompanion install
+bun install -g the-companion
+the-companion install
 ```
 
 Other commands:
 
 ```bash
-thecompanion start       # start the installed background service
-thecompanion status      # check if the service is running
-thecompanion stop        # stop the service (keeps it installed)
-thecompanion restart     # restart the service
-thecompanion logs        # tail stdout/stderr logs
-thecompanion uninstall   # remove the service
+the-companion start       # start the installed background service
+the-companion status      # check if the service is running
+the-companion stop        # stop the service (keeps it installed)
+the-companion restart     # restart the service
+the-companion logs        # tail stdout/stderr logs
+the-companion uninstall   # remove the service
 ```
 
 Use `--port <n>` with `install` to override the default port (3456).

--- a/landing/src/components/Footer.tsx
+++ b/landing/src/components/Footer.tsx
@@ -11,7 +11,7 @@ export function Footer() {
         <a href="https://github.com/The-Vibe-Company/companion" target="_blank" rel="noopener" className="text-cc-muted hover:text-cc-fg transition-colors">
           GitHub
         </a>
-        <a href="https://www.npmjs.com/package/thecompanion" target="_blank" rel="noopener" className="text-cc-muted hover:text-cc-fg transition-colors">
+        <a href="https://www.npmjs.com/package/the-companion" target="_blank" rel="noopener" className="text-cc-muted hover:text-cc-fg transition-colors">
           npm
         </a>
         <a href="https://github.com/The-Vibe-Company/companion/blob/main/LICENSE" target="_blank" rel="noopener" className="text-cc-muted hover:text-cc-fg transition-colors">

--- a/landing/src/components/HowItWorks.tsx
+++ b/landing/src/components/HowItWorks.tsx
@@ -35,7 +35,7 @@ export function HowItWorks() {
                 title: "Launch",
                 description: (
                   <>
-                    Run <code className="font-mono-code text-xs bg-cc-code-bg text-cc-code-fg px-1.5 py-0.5 rounded">bunx thecompanion</code> in
+                    Run <code className="font-mono-code text-xs bg-cc-code-bg text-cc-code-fg px-1.5 py-0.5 rounded">bunx the-companion</code> in
                     your terminal.
                   </>
                 ),

--- a/landing/src/components/InstallBlock.tsx
+++ b/landing/src/components/InstallBlock.tsx
@@ -1,6 +1,6 @@
 import { CopyButton } from "./CopyButton";
 
-const COMMAND = "bunx thecompanion";
+const COMMAND = "bunx the-companion";
 
 export function InstallBlock({ large }: { large?: boolean }) {
   return (

--- a/landing/src/components/Nav.tsx
+++ b/landing/src/components/Nav.tsx
@@ -26,7 +26,7 @@ export function Nav() {
             GitHub
           </a>
           <a
-            href="https://www.npmjs.com/package/thecompanion"
+            href="https://www.npmjs.com/package/the-companion"
             target="_blank"
             rel="noopener"
             className="text-sm text-cc-muted hover:text-cc-fg transition-colors hidden sm:block font-mono-code"

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "thecompanion",
+  "name": "the-companion",
   "version": "0.35.0",
   "private": true,
   "description": "Web UI for Claude Code agents",
@@ -12,7 +12,7 @@
   "author": "The Vibe Company",
   "license": "MIT",
   "dependencies": {
-    "thecompanion": "^0.2.2"
+    "the-companion": "^0.2.2"
   },
   "devDependencies": {
     "husky": "^9.1.7"

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -1,7 +1,7 @@
 {
   "packages": {
     ".": {
-      "package-name": "thecompanion",
+      "package-name": "the-companion",
       "release-type": "node",
       "changelog-path": "CHANGELOG.md",
       "bump-minor-pre-major": true,

--- a/web/CODEX_MAPPING.md
+++ b/web/CODEX_MAPPING.md
@@ -23,7 +23,7 @@ The Codex adapter communicates with the `codex app-server` binary via stdin/stdo
 ## Initialization Sequence
 
 ```
-Server → Codex:  {"method":"initialize","id":1,"params":{"clientInfo":{"name":"thecompanion",...},"capabilities":{}}}
+Server → Codex:  {"method":"initialize","id":1,"params":{"clientInfo":{"name":"the-companion",...},"capabilities":{}}}
 Codex → Server:  {"id":1,"result":{...capabilities...}}
 Server → Codex:  {"method":"initialized","params":{}}
 Server → Codex:  {"method":"thread/start","id":2,"params":{"model":"...","cwd":"...","approvalPolicy":"...","sandbox":"workspace-write"}}

--- a/web/bin/cli.ts
+++ b/web/bin/cli.ts
@@ -10,7 +10,7 @@ const command = process.argv[2];
 
 function printUsage(): void {
   console.log(`
-Usage: thecompanion [command]
+Usage: the-companion [command]
 
 Commands:
   (none)      Start the server in foreground (default)
@@ -87,7 +87,7 @@ switch (command) {
     const result = await status();
     if (!result.installed) {
       console.log("The Companion is not installed as a service.");
-      console.log("Run: thecompanion install");
+      console.log("Run: the-companion install");
     } else if (result.running) {
       console.log(`The Companion is running (PID: ${result.pid})`);
       console.log(`  URL: http://localhost:${result.port}`);

--- a/web/package.json
+++ b/web/package.json
@@ -1,12 +1,12 @@
 {
-  "name": "thecompanion",
+  "name": "the-companion",
   "version": "0.35.0",
   "type": "module",
   "description": "Web UI for launching and interacting with Claude Code agents",
   "license": "MIT",
   "author": "The Vibe Company",
   "bin": {
-    "thecompanion": "./bin/cli.ts"
+    "the-companion": "./bin/cli.ts"
   },
   "files": [
     "bin/",

--- a/web/server/routes.ts
+++ b/web/server/routes.ts
@@ -870,10 +870,10 @@ export function createRoutes(
     setTimeout(async () => {
       try {
         console.log(
-          `[update] Updating thecompanion to ${state.latestVersion}...`,
+          `[update] Updating the-companion to ${state.latestVersion}...`,
         );
         const proc = Bun.spawn(
-          ["bun", "install", "-g", `thecompanion@${state.latestVersion}`],
+          ["bun", "install", "-g", `the-companion@${state.latestVersion}`],
           { stdout: "pipe", stderr: "pipe" },
         );
         const exitCode = await proc.exited;
@@ -905,7 +905,7 @@ export function createRoutes(
         const isLinux = process.platform === "linux";
         const uid = typeof process.getuid === "function" ? process.getuid() : undefined;
         const restartCmd = isLinux
-          ? ["systemctl", "--user", "restart", "thecompanion.service"]
+          ? ["systemctl", "--user", "restart", "the-companion.service"]
           : uid !== undefined
             ? ["launchctl", "kickstart", "-k", `gui/${uid}/sh.thecompanion.app`]
             : ["launchctl", "kickstart", "-k", "sh.thecompanion.app"];

--- a/web/server/service.test.ts
+++ b/web/server/service.test.ts
@@ -107,7 +107,7 @@ function oldPlistPath(): string {
 }
 
 function unitPath(): string {
-  return join(tempDir, ".config", "systemd", "user", "thecompanion.service");
+  return join(tempDir, ".config", "systemd", "user", "the-companion.service");
 }
 
 function logDir(): string {
@@ -119,62 +119,62 @@ function logDir(): string {
 // ===========================================================================
 describe("generatePlist", () => {
   it("generates valid XML with the correct label", () => {
-    const plist = service.generatePlist({ binPath: "/usr/local/bin/thecompanion" });
+    const plist = service.generatePlist({ binPath: "/usr/local/bin/the-companion" });
     expect(plist).toContain('<?xml version="1.0"');
     expect(plist).toContain("<string>sh.thecompanion.app</string>");
   });
 
   it("includes RunAtLoad true", () => {
-    const plist = service.generatePlist({ binPath: "/usr/local/bin/thecompanion" });
+    const plist = service.generatePlist({ binPath: "/usr/local/bin/the-companion" });
     expect(plist).toContain("<key>RunAtLoad</key>");
     expect(plist).toContain("<true/>");
   });
 
   it("includes KeepAlive with SuccessfulExit false", () => {
-    const plist = service.generatePlist({ binPath: "/usr/local/bin/thecompanion" });
+    const plist = service.generatePlist({ binPath: "/usr/local/bin/the-companion" });
     expect(plist).toContain("<key>KeepAlive</key>");
     expect(plist).toContain("<key>SuccessfulExit</key>");
     expect(plist).toContain("<false/>");
   });
 
   it("uses the provided binary path in ProgramArguments", () => {
-    const plist = service.generatePlist({ binPath: "/opt/homebrew/bin/thecompanion" });
-    expect(plist).toContain("<string>/opt/homebrew/bin/thecompanion</string>");
+    const plist = service.generatePlist({ binPath: "/opt/homebrew/bin/the-companion" });
+    expect(plist).toContain("<string>/opt/homebrew/bin/the-companion</string>");
     expect(plist).toContain("<string>start</string>");
     expect(plist).toContain("<string>--foreground</string>");
   });
 
   it("uses the default production port when none specified", () => {
-    const plist = service.generatePlist({ binPath: "/usr/local/bin/thecompanion" });
+    const plist = service.generatePlist({ binPath: "/usr/local/bin/the-companion" });
     expect(plist).toContain("<key>PORT</key>");
     expect(plist).toContain("<string>3456</string>");
   });
 
   it("uses a custom port when specified", () => {
-    const plist = service.generatePlist({ binPath: "/usr/local/bin/thecompanion", port: 8080 });
+    const plist = service.generatePlist({ binPath: "/usr/local/bin/the-companion", port: 8080 });
     expect(plist).toContain("<string>8080</string>");
   });
 
   it("includes NODE_ENV production", () => {
-    const plist = service.generatePlist({ binPath: "/usr/local/bin/thecompanion" });
+    const plist = service.generatePlist({ binPath: "/usr/local/bin/the-companion" });
     expect(plist).toContain("<key>NODE_ENV</key>");
     expect(plist).toContain("<string>production</string>");
   });
 
   it("uses enriched PATH from path-resolver when no path option given", () => {
-    const plist = service.generatePlist({ binPath: "/usr/local/bin/thecompanion" });
+    const plist = service.generatePlist({ binPath: "/usr/local/bin/the-companion" });
     expect(plist).toContain(MOCK_SERVICE_PATH);
   });
 
   it("uses custom path option when provided", () => {
     const customPath = "/custom/bin:/other/bin";
-    const plist = service.generatePlist({ binPath: "/usr/local/bin/thecompanion", path: customPath });
+    const plist = service.generatePlist({ binPath: "/usr/local/bin/the-companion", path: customPath });
     expect(plist).toContain(customPath);
     expect(plist).not.toContain(MOCK_SERVICE_PATH);
   });
 
   it("includes ThrottleInterval", () => {
-    const plist = service.generatePlist({ binPath: "/usr/local/bin/thecompanion" });
+    const plist = service.generatePlist({ binPath: "/usr/local/bin/the-companion" });
     expect(plist).toContain("<key>ThrottleInterval</key>");
     expect(plist).toContain("<integer>5</integer>");
   });
@@ -185,58 +185,58 @@ describe("generatePlist", () => {
 // ===========================================================================
 describe("generateSystemdUnit", () => {
   it("generates a valid systemd unit with correct sections", () => {
-    const unit = service.generateSystemdUnit({ binPath: "/usr/local/bin/thecompanion" });
+    const unit = service.generateSystemdUnit({ binPath: "/usr/local/bin/the-companion" });
     expect(unit).toContain("[Unit]");
     expect(unit).toContain("[Service]");
     expect(unit).toContain("[Install]");
   });
 
   it("includes the description", () => {
-    const unit = service.generateSystemdUnit({ binPath: "/usr/local/bin/thecompanion" });
+    const unit = service.generateSystemdUnit({ binPath: "/usr/local/bin/the-companion" });
     expect(unit).toContain("Description=The Companion");
   });
 
   it("uses the provided binary path in ExecStart", () => {
-    const unit = service.generateSystemdUnit({ binPath: "/home/user/.bun/bin/thecompanion" });
-    expect(unit).toContain("ExecStart=/home/user/.bun/bin/thecompanion start --foreground");
+    const unit = service.generateSystemdUnit({ binPath: "/home/user/.bun/bin/the-companion" });
+    expect(unit).toContain("ExecStart=/home/user/.bun/bin/the-companion start --foreground");
   });
 
   it("uses the default production port when none specified", () => {
-    const unit = service.generateSystemdUnit({ binPath: "/usr/local/bin/thecompanion" });
+    const unit = service.generateSystemdUnit({ binPath: "/usr/local/bin/the-companion" });
     expect(unit).toContain("Environment=PORT=3456");
   });
 
   it("uses a custom port when specified", () => {
-    const unit = service.generateSystemdUnit({ binPath: "/usr/local/bin/thecompanion", port: 8080 });
+    const unit = service.generateSystemdUnit({ binPath: "/usr/local/bin/the-companion", port: 8080 });
     expect(unit).toContain("Environment=PORT=8080");
   });
 
   it("includes NODE_ENV production", () => {
-    const unit = service.generateSystemdUnit({ binPath: "/usr/local/bin/thecompanion" });
+    const unit = service.generateSystemdUnit({ binPath: "/usr/local/bin/the-companion" });
     expect(unit).toContain("Environment=NODE_ENV=production");
   });
 
   it("includes restart always with graceful update exit code", () => {
-    const unit = service.generateSystemdUnit({ binPath: "/usr/local/bin/thecompanion" });
+    const unit = service.generateSystemdUnit({ binPath: "/usr/local/bin/the-companion" });
     expect(unit).toContain("Restart=always");
     expect(unit).toContain("RestartSec=5");
     expect(unit).toContain("SuccessExitStatus=42");
   });
 
   it("uses enriched PATH from path-resolver when no path option given", () => {
-    const unit = service.generateSystemdUnit({ binPath: "/usr/local/bin/thecompanion" });
+    const unit = service.generateSystemdUnit({ binPath: "/usr/local/bin/the-companion" });
     expect(unit).toContain(`Environment=PATH=${MOCK_SERVICE_PATH}`);
   });
 
   it("uses custom path option when provided", () => {
     const customPath = "/custom/bin:/other/bin";
-    const unit = service.generateSystemdUnit({ binPath: "/usr/local/bin/thecompanion", path: customPath });
+    const unit = service.generateSystemdUnit({ binPath: "/usr/local/bin/the-companion", path: customPath });
     expect(unit).toContain(`Environment=PATH=${customPath}`);
     expect(unit).not.toContain(MOCK_SERVICE_PATH);
   });
 
   it("targets default.target for user service", () => {
-    const unit = service.generateSystemdUnit({ binPath: "/usr/local/bin/thecompanion" });
+    const unit = service.generateSystemdUnit({ binPath: "/usr/local/bin/the-companion" });
     expect(unit).toContain("WantedBy=default.target");
   });
 });
@@ -247,7 +247,7 @@ describe("generateSystemdUnit", () => {
 describe("install", () => {
   it("creates log directory and writes plist file", async () => {
     mockExecSync.mockImplementation((cmd: string) => {
-      if (cmd.startsWith("which")) return "/usr/local/bin/thecompanion\n";
+      if (cmd.startsWith("which")) return "/usr/local/bin/the-companion\n";
       if (cmd.startsWith("launchctl load")) return "";
       return "";
     });
@@ -263,7 +263,7 @@ describe("install", () => {
 
   it("calls launchctl load with the plist path", async () => {
     mockExecSync.mockImplementation((cmd: string) => {
-      if (cmd.startsWith("which")) return "/usr/local/bin/thecompanion\n";
+      if (cmd.startsWith("which")) return "/usr/local/bin/the-companion\n";
       if (cmd.startsWith("launchctl load")) return "";
       return "";
     });
@@ -280,7 +280,7 @@ describe("install", () => {
   it("exits with error if already installed", async () => {
     // First install
     mockExecSync.mockImplementation((cmd: string) => {
-      if (cmd.startsWith("which")) return "/usr/local/bin/thecompanion\n";
+      if (cmd.startsWith("which")) return "/usr/local/bin/the-companion\n";
       if (cmd.startsWith("launchctl")) return "";
       return "";
     });
@@ -303,7 +303,7 @@ describe("install", () => {
 
   it("uses custom port when provided", async () => {
     mockExecSync.mockImplementation((cmd: string) => {
-      if (cmd.startsWith("which")) return "/usr/local/bin/thecompanion\n";
+      if (cmd.startsWith("which")) return "/usr/local/bin/the-companion\n";
       if (cmd.startsWith("launchctl")) return "";
       return "";
     });
@@ -316,7 +316,7 @@ describe("install", () => {
 
   it("cleans up plist if launchctl load fails", async () => {
     mockExecSync.mockImplementation((cmd: string) => {
-      if (cmd.startsWith("which")) return "/usr/local/bin/thecompanion\n";
+      if (cmd.startsWith("which")) return "/usr/local/bin/the-companion\n";
       if (cmd.startsWith("launchctl load")) throw new Error("launchctl failed");
       return "";
     });
@@ -330,14 +330,14 @@ describe("install", () => {
     const launchAgentsDir = join(tempDir, "Library", "LaunchAgents");
     rmSync(launchAgentsDir, { recursive: true, force: true });
     mockExecSync.mockImplementation((cmd: string) => {
-      if (cmd.startsWith("which")) return "/usr/local/bin/thecompanion\n";
+      if (cmd.startsWith("which")) return "/usr/local/bin/the-companion\n";
       if (cmd.startsWith("launchctl unload")) return "";
       if (cmd.startsWith("launchctl load")) return "";
       return "";
     });
 
     // Create a legacy plist to simulate pre-rename installs
-    const plist = service.generatePlist({ binPath: "/usr/local/bin/thecompanion" })
+    const plist = service.generatePlist({ binPath: "/usr/local/bin/the-companion" })
       .replaceAll("sh.thecompanion.app", "co.thevibecompany.companion");
     mkdirSync(launchAgentsDir, { recursive: true });
     writeFileSync(oldPath, plist, "utf-8");
@@ -366,7 +366,7 @@ describe("install (linux)", () => {
 
   it("creates log directory and writes systemd unit file", async () => {
     mockExecSync.mockImplementation((cmd: string) => {
-      if (cmd.startsWith("which")) return "/usr/local/bin/thecompanion\n";
+      if (cmd.startsWith("which")) return "/usr/local/bin/the-companion\n";
       if (cmd.startsWith("systemctl")) return "";
       return "";
     });
@@ -377,12 +377,12 @@ describe("install (linux)", () => {
     expect(existsSync(unitPath())).toBe(true);
 
     const content = readFileSync(unitPath(), "utf-8");
-    expect(content).toContain("ExecStart=/usr/local/bin/thecompanion start --foreground");
+    expect(content).toContain("ExecStart=/usr/local/bin/the-companion start --foreground");
   });
 
   it("calls systemctl daemon-reload and enable --now", async () => {
     mockExecSync.mockImplementation((cmd: string) => {
-      if (cmd.startsWith("which")) return "/usr/local/bin/thecompanion\n";
+      if (cmd.startsWith("which")) return "/usr/local/bin/the-companion\n";
       if (cmd.startsWith("systemctl")) return "";
       return "";
     });
@@ -402,7 +402,7 @@ describe("install (linux)", () => {
 
   it("exits with error if already installed", async () => {
     mockExecSync.mockImplementation((cmd: string) => {
-      if (cmd.startsWith("which")) return "/usr/local/bin/thecompanion\n";
+      if (cmd.startsWith("which")) return "/usr/local/bin/the-companion\n";
       if (cmd.startsWith("systemctl")) return "";
       return "";
     });
@@ -424,7 +424,7 @@ describe("install (linux)", () => {
 
   it("uses custom port when provided", async () => {
     mockExecSync.mockImplementation((cmd: string) => {
-      if (cmd.startsWith("which")) return "/usr/local/bin/thecompanion\n";
+      if (cmd.startsWith("which")) return "/usr/local/bin/the-companion\n";
       if (cmd.startsWith("systemctl")) return "";
       return "";
     });
@@ -437,7 +437,7 @@ describe("install (linux)", () => {
 
   it("cleans up unit file if systemctl enable fails", async () => {
     mockExecSync.mockImplementation((cmd: string) => {
-      if (cmd.startsWith("which")) return "/usr/local/bin/thecompanion\n";
+      if (cmd.startsWith("which")) return "/usr/local/bin/the-companion\n";
       if (cmd.includes("daemon-reload")) return "";
       if (cmd.includes("enable --now")) throw new Error("systemctl failed");
       return "";
@@ -455,7 +455,7 @@ describe("uninstall", () => {
   it("calls launchctl unload and removes plist", async () => {
     // Install first
     mockExecSync.mockImplementation((cmd: string) => {
-      if (cmd.startsWith("which")) return "/usr/local/bin/thecompanion\n";
+      if (cmd.startsWith("which")) return "/usr/local/bin/the-companion\n";
       if (cmd.startsWith("launchctl")) return "";
       return "";
     });
@@ -512,7 +512,7 @@ describe("uninstall (linux)", () => {
   it("calls systemctl disable --now and removes unit file", async () => {
     // Install first
     mockExecSync.mockImplementation((cmd: string) => {
-      if (cmd.startsWith("which")) return "/usr/local/bin/thecompanion\n";
+      if (cmd.startsWith("which")) return "/usr/local/bin/the-companion\n";
       if (cmd.startsWith("systemctl")) return "";
       return "";
     });
@@ -535,7 +535,7 @@ describe("uninstall (linux)", () => {
   it("calls daemon-reload after removing unit file", async () => {
     // Install first
     mockExecSync.mockImplementation((cmd: string) => {
-      if (cmd.startsWith("which")) return "/usr/local/bin/thecompanion\n";
+      if (cmd.startsWith("which")) return "/usr/local/bin/the-companion\n";
       if (cmd.startsWith("systemctl")) return "";
       return "";
     });
@@ -567,7 +567,7 @@ describe("start", () => {
   it("calls launchctl kickstart when installed", async () => {
     // Install first
     mockExecSync.mockImplementation((cmd: string) => {
-      if (cmd.startsWith("which")) return "/usr/local/bin/thecompanion\n";
+      if (cmd.startsWith("which")) return "/usr/local/bin/the-companion\n";
       if (cmd.startsWith("launchctl")) return "";
       return "";
     });
@@ -589,7 +589,7 @@ describe("start", () => {
   it("falls back to launchctl bootstrap when kickstart fails", async () => {
     // Install first
     mockExecSync.mockImplementation((cmd: string) => {
-      if (cmd.startsWith("which")) return "/usr/local/bin/thecompanion\n";
+      if (cmd.startsWith("which")) return "/usr/local/bin/the-companion\n";
       if (cmd.startsWith("launchctl")) return "";
       return "";
     });
@@ -632,7 +632,7 @@ describe("start (linux)", () => {
   it("calls systemctl start when installed", async () => {
     // Install first
     mockExecSync.mockImplementation((cmd: string) => {
-      if (cmd.startsWith("which")) return "/usr/local/bin/thecompanion\n";
+      if (cmd.startsWith("which")) return "/usr/local/bin/the-companion\n";
       if (cmd.startsWith("systemctl")) return "";
       return "";
     });
@@ -643,14 +643,14 @@ describe("start (linux)", () => {
     mockExecSync.mockReset();
     // start() now calls refreshServiceDefinition() which needs `which`
     mockExecSync.mockImplementation((cmd: string) => {
-      if (cmd.startsWith("which")) return "/usr/local/bin/thecompanion\n";
+      if (cmd.startsWith("which")) return "/usr/local/bin/the-companion\n";
       return "";
     });
 
     await service.start();
 
     const startCall = mockExecSync.mock.calls.find(
-      ([cmd]) => typeof cmd === "string" && cmd.includes("start thecompanion.service"),
+      ([cmd]) => typeof cmd === "string" && cmd.includes("start the-companion.service"),
     );
     expect(startCall).toBeDefined();
   });
@@ -659,7 +659,7 @@ describe("start (linux)", () => {
     // When the service is not installed, start() should auto-install it.
     // Mock `which` to return a valid binary path so install can proceed.
     mockExecSync.mockImplementation((cmd: string) => {
-      if (cmd.startsWith("which")) return "/usr/local/bin/thecompanion\n";
+      if (cmd.startsWith("which")) return "/usr/local/bin/the-companion\n";
       if (cmd.startsWith("systemctl")) return "";
       if (cmd.startsWith("loginctl")) return "";
       return "";
@@ -682,7 +682,7 @@ describe("start (linux)", () => {
     // start() should rewrite the unit via refreshServiceDefinition() so that
     // stale definitions from older versions don't cause restart loops.
     mockExecSync.mockImplementation((cmd: string) => {
-      if (cmd.startsWith("which")) return "/usr/local/bin/thecompanion\n";
+      if (cmd.startsWith("which")) return "/usr/local/bin/the-companion\n";
       if (cmd.startsWith("systemctl")) return "";
       return "";
     });
@@ -699,7 +699,7 @@ describe("start (linux)", () => {
     service = await import("./service.js");
     mockExecSync.mockReset();
     mockExecSync.mockImplementation((cmd: string) => {
-      if (cmd.startsWith("which")) return "/usr/local/bin/thecompanion\n";
+      if (cmd.startsWith("which")) return "/usr/local/bin/the-companion\n";
       if (cmd.startsWith("systemctl")) return "";
       return "";
     });
@@ -720,7 +720,7 @@ describe("stop", () => {
   it("calls launchctl bootout when installed", async () => {
     // Install first
     mockExecSync.mockImplementation((cmd: string) => {
-      if (cmd.startsWith("which")) return "/usr/local/bin/thecompanion\n";
+      if (cmd.startsWith("which")) return "/usr/local/bin/the-companion\n";
       if (cmd.startsWith("launchctl")) return "";
       return "";
     });
@@ -742,7 +742,7 @@ describe("stop", () => {
   it("falls back to launchctl unload when bootout fails", async () => {
     // Install first
     mockExecSync.mockImplementation((cmd: string) => {
-      if (cmd.startsWith("which")) return "/usr/local/bin/thecompanion\n";
+      if (cmd.startsWith("which")) return "/usr/local/bin/the-companion\n";
       if (cmd.startsWith("launchctl")) return "";
       return "";
     });
@@ -785,7 +785,7 @@ describe("stop (linux)", () => {
   it("calls systemctl stop when installed", async () => {
     // Install first
     mockExecSync.mockImplementation((cmd: string) => {
-      if (cmd.startsWith("which")) return "/usr/local/bin/thecompanion\n";
+      if (cmd.startsWith("which")) return "/usr/local/bin/the-companion\n";
       if (cmd.startsWith("systemctl")) return "";
       return "";
     });
@@ -799,7 +799,7 @@ describe("stop (linux)", () => {
     await service.stop();
 
     const stopCall = mockExecSync.mock.calls.find(
-      ([cmd]) => typeof cmd === "string" && cmd.includes("stop thecompanion.service"),
+      ([cmd]) => typeof cmd === "string" && cmd.includes("stop the-companion.service"),
     );
     expect(stopCall).toBeDefined();
   });
@@ -817,7 +817,7 @@ describe("restart", () => {
   it("calls launchctl kickstart when installed", async () => {
     // Install first
     mockExecSync.mockImplementation((cmd: string) => {
-      if (cmd.startsWith("which")) return "/usr/local/bin/thecompanion\n";
+      if (cmd.startsWith("which")) return "/usr/local/bin/the-companion\n";
       if (cmd.startsWith("launchctl")) return "";
       return "";
     });
@@ -856,7 +856,7 @@ describe("restart (linux)", () => {
   it("calls systemctl restart when installed", async () => {
     // Install first
     mockExecSync.mockImplementation((cmd: string) => {
-      if (cmd.startsWith("which")) return "/usr/local/bin/thecompanion\n";
+      if (cmd.startsWith("which")) return "/usr/local/bin/the-companion\n";
       if (cmd.startsWith("systemctl")) return "";
       return "";
     });
@@ -867,14 +867,14 @@ describe("restart (linux)", () => {
     mockExecSync.mockReset();
     // restart() now calls refreshServiceDefinition() which needs `which`
     mockExecSync.mockImplementation((cmd: string) => {
-      if (cmd.startsWith("which")) return "/usr/local/bin/thecompanion\n";
+      if (cmd.startsWith("which")) return "/usr/local/bin/the-companion\n";
       return "";
     });
 
     await service.restart();
 
     const restartCall = mockExecSync.mock.calls.find(
-      ([cmd]) => typeof cmd === "string" && cmd.includes("restart thecompanion.service"),
+      ([cmd]) => typeof cmd === "string" && cmd.includes("restart the-companion.service"),
     );
     expect(restartCall).toBeDefined();
   });
@@ -887,7 +887,7 @@ describe("restart (linux)", () => {
   it("refreshes the service definition before restarting", async () => {
     // Install first
     mockExecSync.mockImplementation((cmd: string) => {
-      if (cmd.startsWith("which")) return "/usr/local/bin/thecompanion\n";
+      if (cmd.startsWith("which")) return "/usr/local/bin/the-companion\n";
       if (cmd.startsWith("systemctl")) return "";
       return "";
     });
@@ -903,7 +903,7 @@ describe("restart (linux)", () => {
     service = await import("./service.js");
     mockExecSync.mockReset();
     mockExecSync.mockImplementation((cmd: string) => {
-      if (cmd.startsWith("which")) return "/usr/local/bin/thecompanion\n";
+      if (cmd.startsWith("which")) return "/usr/local/bin/the-companion\n";
       if (cmd.startsWith("systemctl")) return "";
       return "";
     });
@@ -928,7 +928,7 @@ describe("status", () => {
   it("returns installed: true, running: true with PID", async () => {
     // Install first
     mockExecSync.mockImplementation((cmd: string) => {
-      if (cmd.startsWith("which")) return "/usr/local/bin/thecompanion\n";
+      if (cmd.startsWith("which")) return "/usr/local/bin/the-companion\n";
       if (cmd.startsWith("launchctl load")) return "";
       return "";
     });
@@ -954,7 +954,7 @@ describe("status", () => {
   it("returns installed: true, running: false when service is loaded but not running", async () => {
     // Install first
     mockExecSync.mockImplementation((cmd: string) => {
-      if (cmd.startsWith("which")) return "/usr/local/bin/thecompanion\n";
+      if (cmd.startsWith("which")) return "/usr/local/bin/the-companion\n";
       if (cmd.startsWith("launchctl load")) return "";
       return "";
     });
@@ -1031,7 +1031,7 @@ describe("status (linux)", () => {
   it("returns installed: true, running: true with PID", async () => {
     // Install first
     mockExecSync.mockImplementation((cmd: string) => {
-      if (cmd.startsWith("which")) return "/usr/local/bin/thecompanion\n";
+      if (cmd.startsWith("which")) return "/usr/local/bin/the-companion\n";
       if (cmd.startsWith("systemctl")) return "";
       return "";
     });
@@ -1041,7 +1041,7 @@ describe("status (linux)", () => {
     service = await import("./service.js");
     mockExecSync.mockReset();
     mockExecSync.mockImplementation((cmd: string) => {
-      if (typeof cmd === "string" && cmd.includes("show thecompanion.service")) {
+      if (typeof cmd === "string" && cmd.includes("show the-companion.service")) {
         return "ActiveState=active\nMainPID=54321\n";
       }
       return "";
@@ -1057,7 +1057,7 @@ describe("status (linux)", () => {
   it("returns installed: true, running: false when service is inactive", async () => {
     // Install first
     mockExecSync.mockImplementation((cmd: string) => {
-      if (cmd.startsWith("which")) return "/usr/local/bin/thecompanion\n";
+      if (cmd.startsWith("which")) return "/usr/local/bin/the-companion\n";
       if (cmd.startsWith("systemctl")) return "";
       return "";
     });
@@ -1067,7 +1067,7 @@ describe("status (linux)", () => {
     service = await import("./service.js");
     mockExecSync.mockReset();
     mockExecSync.mockImplementation((cmd: string) => {
-      if (typeof cmd === "string" && cmd.includes("show thecompanion.service")) {
+      if (typeof cmd === "string" && cmd.includes("show the-companion.service")) {
         return "ActiveState=inactive\nMainPID=0\n";
       }
       return "";
@@ -1080,7 +1080,7 @@ describe("status (linux)", () => {
 
   it("reads custom port from unit file", async () => {
     mockExecSync.mockImplementation((cmd: string) => {
-      if (cmd.startsWith("which")) return "/usr/local/bin/thecompanion\n";
+      if (cmd.startsWith("which")) return "/usr/local/bin/the-companion\n";
       if (cmd.startsWith("systemctl")) return "";
       return "";
     });
@@ -1090,7 +1090,7 @@ describe("status (linux)", () => {
     service = await import("./service.js");
     mockExecSync.mockReset();
     mockExecSync.mockImplementation((cmd: string) => {
-      if (typeof cmd === "string" && cmd.includes("show thecompanion.service")) {
+      if (typeof cmd === "string" && cmd.includes("show the-companion.service")) {
         return "ActiveState=active\nMainPID=1234\n";
       }
       return "";
@@ -1122,7 +1122,7 @@ describe("isRunningAsService", () => {
   it("returns true when plist exists and service has a PID", async () => {
     // Install first
     mockExecSync.mockImplementation((cmd: string) => {
-      if (cmd.startsWith("which")) return "/usr/local/bin/thecompanion\n";
+      if (cmd.startsWith("which")) return "/usr/local/bin/the-companion\n";
       if (cmd.startsWith("launchctl load")) return "";
       return "";
     });
@@ -1144,7 +1144,7 @@ describe("isRunningAsService", () => {
   it("returns false when plist exists but no PID (not running)", async () => {
     // Install first
     mockExecSync.mockImplementation((cmd: string) => {
-      if (cmd.startsWith("which")) return "/usr/local/bin/thecompanion\n";
+      if (cmd.startsWith("which")) return "/usr/local/bin/the-companion\n";
       if (cmd.startsWith("launchctl load")) return "";
       return "";
     });
@@ -1182,7 +1182,7 @@ describe("isRunningAsService (linux)", () => {
   it("returns true when unit file exists and service is active", async () => {
     // Install first
     mockExecSync.mockImplementation((cmd: string) => {
-      if (cmd.startsWith("which")) return "/usr/local/bin/thecompanion\n";
+      if (cmd.startsWith("which")) return "/usr/local/bin/the-companion\n";
       if (cmd.includes("daemon-reload")) return "";
       if (cmd.includes("enable --now")) return "";
       return "";
@@ -1205,7 +1205,7 @@ describe("isRunningAsService (linux)", () => {
   it("returns false when unit file exists but service is inactive", async () => {
     // Install first
     mockExecSync.mockImplementation((cmd: string) => {
-      if (cmd.startsWith("which")) return "/usr/local/bin/thecompanion\n";
+      if (cmd.startsWith("which")) return "/usr/local/bin/the-companion\n";
       if (cmd.includes("daemon-reload")) return "";
       if (cmd.includes("enable --now")) return "";
       return "";
@@ -1233,7 +1233,7 @@ describe("refreshServiceDefinition (macOS)", () => {
   it("rewrites plist with current binary path", async () => {
     // Install first
     mockExecSync.mockImplementation((cmd: string) => {
-      if (cmd.startsWith("which")) return "/usr/local/bin/thecompanion\n";
+      if (cmd.startsWith("which")) return "/usr/local/bin/the-companion\n";
       if (cmd.startsWith("launchctl")) return "";
       return "";
     });
@@ -1241,27 +1241,27 @@ describe("refreshServiceDefinition (macOS)", () => {
 
     // Verify plist exists with original binary
     const originalContent = readFileSync(plistPath(), "utf-8");
-    expect(originalContent).toContain("/usr/local/bin/thecompanion");
+    expect(originalContent).toContain("/usr/local/bin/the-companion");
 
     // Now refresh with a different binary path
     vi.resetModules();
     service = await import("./service.js");
     mockExecSync.mockReset();
     mockExecSync.mockImplementation((cmd: string) => {
-      if (cmd.startsWith("which")) return "/new/path/thecompanion\n";
+      if (cmd.startsWith("which")) return "/new/path/the-companion\n";
       return "";
     });
 
     service.refreshServiceDefinition();
 
     const updatedContent = readFileSync(plistPath(), "utf-8");
-    expect(updatedContent).toContain("/new/path/thecompanion");
+    expect(updatedContent).toContain("/new/path/the-companion");
   });
 
   it("preserves custom port from existing plist", async () => {
     // Install with custom port
     mockExecSync.mockImplementation((cmd: string) => {
-      if (cmd.startsWith("which")) return "/usr/local/bin/thecompanion\n";
+      if (cmd.startsWith("which")) return "/usr/local/bin/the-companion\n";
       if (cmd.startsWith("launchctl")) return "";
       return "";
     });
@@ -1275,7 +1275,7 @@ describe("refreshServiceDefinition (macOS)", () => {
     service = await import("./service.js");
     mockExecSync.mockReset();
     mockExecSync.mockImplementation((cmd: string) => {
-      if (cmd.startsWith("which")) return "/usr/local/bin/thecompanion\n";
+      if (cmd.startsWith("which")) return "/usr/local/bin/the-companion\n";
       return "";
     });
 
@@ -1305,7 +1305,7 @@ describe("refreshServiceDefinition (linux)", () => {
   it("rewrites unit file and calls daemon-reload", async () => {
     // Install first
     mockExecSync.mockImplementation((cmd: string) => {
-      if (cmd.startsWith("which")) return "/usr/local/bin/thecompanion\n";
+      if (cmd.startsWith("which")) return "/usr/local/bin/the-companion\n";
       if (cmd.startsWith("systemctl")) return "";
       return "";
     });
@@ -1316,7 +1316,7 @@ describe("refreshServiceDefinition (linux)", () => {
     service = await import("./service.js");
     mockExecSync.mockReset();
     mockExecSync.mockImplementation((cmd: string) => {
-      if (cmd.startsWith("which")) return "/new/path/thecompanion\n";
+      if (cmd.startsWith("which")) return "/new/path/the-companion\n";
       if (cmd.startsWith("systemctl")) return "";
       return "";
     });
@@ -1324,7 +1324,7 @@ describe("refreshServiceDefinition (linux)", () => {
     service.refreshServiceDefinition();
 
     const updatedContent = readFileSync(unitPath(), "utf-8");
-    expect(updatedContent).toContain("/new/path/thecompanion");
+    expect(updatedContent).toContain("/new/path/the-companion");
 
     // Verify daemon-reload was called
     const daemonReloadCall = mockExecSync.mock.calls.find(
@@ -1336,7 +1336,7 @@ describe("refreshServiceDefinition (linux)", () => {
   it("preserves custom port from existing unit", async () => {
     // Install with custom port
     mockExecSync.mockImplementation((cmd: string) => {
-      if (cmd.startsWith("which")) return "/usr/local/bin/thecompanion\n";
+      if (cmd.startsWith("which")) return "/usr/local/bin/the-companion\n";
       if (cmd.startsWith("systemctl")) return "";
       return "";
     });
@@ -1350,7 +1350,7 @@ describe("refreshServiceDefinition (linux)", () => {
     service = await import("./service.js");
     mockExecSync.mockReset();
     mockExecSync.mockImplementation((cmd: string) => {
-      if (cmd.startsWith("which")) return "/usr/local/bin/thecompanion\n";
+      if (cmd.startsWith("which")) return "/usr/local/bin/the-companion\n";
       if (cmd.startsWith("systemctl")) return "";
       return "";
     });
@@ -1389,7 +1389,7 @@ describe("platform check", () => {
     service = await import("./service.js");
 
     mockExecSync.mockImplementation((cmd: string) => {
-      if (cmd.startsWith("which")) return "/usr/local/bin/thecompanion\n";
+      if (cmd.startsWith("which")) return "/usr/local/bin/the-companion\n";
       if (cmd.startsWith("launchctl")) return "";
       return "";
     });
@@ -1407,7 +1407,7 @@ describe("platform check", () => {
     service = await import("./service.js");
 
     mockExecSync.mockImplementation((cmd: string) => {
-      if (cmd.startsWith("which")) return "/usr/local/bin/thecompanion\n";
+      if (cmd.startsWith("which")) return "/usr/local/bin/the-companion\n";
       if (cmd.startsWith("systemctl")) return "";
       return "";
     });

--- a/web/server/service.ts
+++ b/web/server/service.ts
@@ -29,7 +29,7 @@ const OLD_PLIST_PATH = join(PLIST_DIR, `${OLD_LABEL}.plist`);
 // ─── Linux (systemd) Constants ──────────────────────────────────────────────────
 
 const SYSTEMD_DIR = join(homedir(), ".config", "systemd", "user");
-const UNIT_NAME = "thecompanion.service";
+const UNIT_NAME = "the-companion.service";
 const UNIT_PATH = join(SYSTEMD_DIR, UNIT_NAME);
 
 // ─── Platform check ─────────────────────────────────────────────────────────────
@@ -155,19 +155,19 @@ WantedBy=default.target
 
 function resolveBinPath(): string {
   try {
-    const binPath = execSync("which thecompanion", { encoding: "utf-8" }).trim();
+    const binPath = execSync("which the-companion", { encoding: "utf-8" }).trim();
     if (binPath) return binPath;
   } catch {
     // not found globally
   }
 
-  console.error("thecompanion must be installed globally for service mode.");
+  console.error("the-companion must be installed globally for service mode.");
   console.error("");
-  console.error("  bun install -g thecompanion");
+  console.error("  bun install -g the-companion");
   console.error("");
   console.error("Then retry:");
   console.error("");
-  console.error("  thecompanion install");
+  console.error("  the-companion install");
   process.exit(1);
 }
 
@@ -241,7 +241,7 @@ async function installDarwin(opts?: { port?: number }): Promise<void> {
 
   if (existsSync(PLIST_PATH)) {
     console.error("The Companion is already installed as a service.");
-    console.error("Run 'thecompanion uninstall' first to reinstall.");
+    console.error("Run 'the-companion uninstall' first to reinstall.");
     process.exit(1);
   }
 
@@ -275,13 +275,13 @@ async function installDarwin(opts?: { port?: number }): Promise<void> {
   console.log(`  Plist:  ${PLIST_PATH}`);
   console.log("");
   console.log("The service will start automatically on login.");
-  console.log("Use 'thecompanion status' to check if it's running.");
+  console.log("Use 'the-companion status' to check if it's running.");
 }
 
 async function installLinux(opts?: { port?: number }): Promise<void> {
   if (isSystemdUnitInstalled()) {
     console.error("The Companion is already installed as a service.");
-    console.error("Run 'thecompanion uninstall' first to reinstall.");
+    console.error("Run 'the-companion uninstall' first to reinstall.");
     process.exit(1);
   }
 
@@ -326,7 +326,7 @@ async function installLinux(opts?: { port?: number }): Promise<void> {
   console.log(`  Unit:   ${UNIT_PATH}`);
   console.log("");
   console.log("The service will start automatically on login.");
-  console.log("Use 'thecompanion status' to check if it's running.");
+  console.log("Use 'the-companion status' to check if it's running.");
 }
 
 // ─── Uninstall ──────────────────────────────────────────────────────────────────
@@ -397,7 +397,7 @@ async function startDarwin(): Promise<void> {
   const installedService = getInstalledLaunchdService();
   if (!installedService) {
     console.log("The Companion is not installed as a service.");
-    console.log("Run 'thecompanion install' first.");
+    console.log("Run 'the-companion install' first.");
     return;
   }
 
@@ -479,7 +479,7 @@ async function stopDarwin(): Promise<void> {
   }
 
   console.log("The Companion service has been stopped.");
-  console.log("Run 'thecompanion restart' to start it again.");
+  console.log("Run 'the-companion restart' to start it again.");
 }
 
 async function stopLinux(): Promise<void> {
@@ -497,7 +497,7 @@ async function stopLinux(): Promise<void> {
   }
 
   console.log("The Companion service has been stopped.");
-  console.log("Run 'thecompanion restart' to start it again.");
+  console.log("Run 'the-companion restart' to start it again.");
 }
 
 export async function restart(): Promise<void> {

--- a/web/server/update-checker.test.ts
+++ b/web/server/update-checker.test.ts
@@ -79,7 +79,7 @@ describe("checkForUpdate", () => {
     await checker.checkForUpdate();
 
     expect(mockFetch).toHaveBeenCalledWith(
-      "https://registry.npmjs.org/thecompanion/latest",
+      "https://registry.npmjs.org/the-companion/latest",
       expect.objectContaining({
         headers: { Accept: "application/json" },
       }),

--- a/web/server/update-checker.ts
+++ b/web/server/update-checker.ts
@@ -10,7 +10,7 @@ const currentVersion: string = JSON.parse(
   readFileSync(packageJsonPath, "utf-8"),
 ).version;
 
-const NPM_REGISTRY_URL = "https://registry.npmjs.org/thecompanion/latest";
+const NPM_REGISTRY_URL = "https://registry.npmjs.org/the-companion/latest";
 const CHECK_INTERVAL_MS = 60 * 60 * 1000; // 1 hour
 const INITIAL_DELAY_MS = 10_000; // 10 seconds after boot
 

--- a/web/src/components/UpdateBanner.test.tsx
+++ b/web/src/components/UpdateBanner.test.tsx
@@ -98,7 +98,7 @@ describe("UpdateBanner service mode", () => {
   it("shows install hint in foreground mode", () => {
     storeState.updateInfo = makeUpdateInfo({ isServiceMode: false });
     render(<UpdateBanner />);
-    expect(screen.getByText("thecompanion install")).toBeTruthy();
+    expect(screen.getByText("the-companion install")).toBeTruthy();
   });
 
   it("shows Updating... when update is in progress", () => {

--- a/web/src/components/UpdateBanner.tsx
+++ b/web/src/components/UpdateBanner.tsx
@@ -50,7 +50,7 @@ export function UpdateBanner() {
         <span className="text-xs text-cc-muted">
           Run{" "}
           <code className="font-mono-code bg-cc-code-bg px-1 py-0.5 rounded text-cc-code-fg">
-            thecompanion install
+            the-companion install
           </code>{" "}
           for auto-updates
         </span>


### PR DESCRIPTION
## Summary
- Revert package naming change from `thecompanion` back to `the-companion`.

## Why
- `npm publish` for `thecompanion` is blocked with `E403` (`name too similar to existing package`).

## Testing
- Not run in this pass (requested quickly after publish error).

## Review provenance
- Implemented by AI agent
- Human review: no

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/the-vibe-company/companion/pull/219" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
