### PR TITLE
fix(ui): move terminal, settings, and environments to full pages

### DIFF
--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -10,8 +10,9 @@ import { TaskPanel } from "./components/TaskPanel.js";
 import { DiffPanel } from "./components/DiffPanel.js";
 import { Playground } from "./components/Playground.js";
 import { UpdateBanner } from "./components/UpdateBanner.js";
-import { TerminalView } from "./components/TerminalView.js";
 import { SettingsPage } from "./components/SettingsPage.js";
+import { EnvManager } from "./components/EnvManager.js";
+import { TerminalPage } from "./components/TerminalPage.js";
 
 function useHash() {
   return useSyncExternalStore(
@@ -27,9 +28,11 @@ export default function App() {
   const taskPanelOpen = useStore((s) => s.taskPanelOpen);
   const homeResetKey = useStore((s) => s.homeResetKey);
   const activeTab = useStore((s) => s.activeTab);
-  const terminalOpen = useStore((s) => s.terminalOpen);
-  const terminalCwd = useStore((s) => s.terminalCwd);
   const hash = useHash();
+  const isSettingsPage = hash === "#/settings";
+  const isTerminalPage = hash === "#/terminal";
+  const isEnvironmentsPage = hash === "#/environments";
+  const isSessionView = !isSettingsPage && !isTerminalPage && !isEnvironmentsPage;
 
   useEffect(() => {
     document.documentElement.classList.toggle("dark", darkMode);
@@ -57,9 +60,6 @@ export default function App() {
 
   if (hash === "#/playground") {
     return <Playground />;
-  }
-  if (hash === "#/settings") {
-    return <SettingsPage />;
   }
 
   return (
@@ -89,26 +89,48 @@ export default function App() {
         <TopBar />
         <UpdateBanner />
         <div className="flex-1 overflow-hidden relative">
-          {/* Chat tab — visible when activeTab is "chat" or no session */}
-          <div className={`absolute inset-0 ${activeTab === "chat" || !currentSessionId ? "" : "hidden"}`}>
-            {currentSessionId ? (
-              <ChatView sessionId={currentSessionId} />
-            ) : (
-              <HomePage key={homeResetKey} />
-            )}
-          </div>
-
-          {/* Diff tab */}
-          {currentSessionId && activeTab === "diff" && (
+          {isSettingsPage && (
             <div className="absolute inset-0">
-              <DiffPanel sessionId={currentSessionId} />
+              <SettingsPage embedded />
             </div>
+          )}
+
+          {isTerminalPage && (
+            <div className="absolute inset-0">
+              <TerminalPage />
+            </div>
+          )}
+
+          {isEnvironmentsPage && (
+            <div className="absolute inset-0">
+              <EnvManager embedded />
+            </div>
+          )}
+
+          {isSessionView && (
+            <>
+              {/* Chat tab — visible when activeTab is "chat" or no session */}
+              <div className={`absolute inset-0 ${activeTab === "chat" || !currentSessionId ? "" : "hidden"}`}>
+                {currentSessionId ? (
+                  <ChatView sessionId={currentSessionId} />
+                ) : (
+                  <HomePage key={homeResetKey} />
+                )}
+              </div>
+
+              {/* Diff tab */}
+              {currentSessionId && activeTab === "diff" && (
+                <div className="absolute inset-0">
+                  <DiffPanel sessionId={currentSessionId} />
+                </div>
+              )}
+            </>
           )}
         </div>
       </div>
 
       {/* Task panel — overlay on mobile, inline on desktop */}
-      {currentSessionId && (
+      {currentSessionId && isSessionView && (
         <>
           {/* Mobile overlay backdrop */}
           {taskPanelOpen && (
@@ -129,14 +151,6 @@ export default function App() {
             <TaskPanel sessionId={currentSessionId} />
           </div>
         </>
-      )}
-
-      {/* Global terminal overlay */}
-      {terminalOpen && terminalCwd && (
-        <TerminalView
-          cwd={terminalCwd}
-          onClose={() => useStore.getState().closeTerminal()}
-        />
       )}
     </div>
   );

--- a/web/src/components/SettingsPage.tsx
+++ b/web/src/components/SettingsPage.tsx
@@ -1,7 +1,12 @@
 import { useEffect, useState } from "react";
 import { api } from "../api.js";
+import { useStore } from "../store.js";
 
-export function SettingsPage() {
+interface SettingsPageProps {
+  embedded?: boolean;
+}
+
+export function SettingsPage({ embedded = false }: SettingsPageProps) {
   const [openrouterApiKey, setOpenrouterApiKey] = useState("");
   const [openrouterModel, setOpenrouterModel] = useState("openrouter/free");
   const [configured, setConfigured] = useState(false);
@@ -9,6 +14,13 @@ export function SettingsPage() {
   const [saving, setSaving] = useState(false);
   const [error, setError] = useState("");
   const [saved, setSaved] = useState(false);
+  const darkMode = useStore((s) => s.darkMode);
+  const toggleDarkMode = useStore((s) => s.toggleDarkMode);
+  const notificationSound = useStore((s) => s.notificationSound);
+  const toggleNotificationSound = useStore((s) => s.toggleNotificationSound);
+  const notificationDesktop = useStore((s) => s.notificationDesktop);
+  const setNotificationDesktop = useStore((s) => s.setNotificationDesktop);
+  const notificationApiAvailable = typeof Notification !== "undefined";
 
   useEffect(() => {
     api
@@ -48,24 +60,32 @@ export function SettingsPage() {
   }
 
   return (
-    <div className="h-[100dvh] bg-cc-bg text-cc-fg font-sans-ui antialiased overflow-y-auto">
-      <div className="max-w-2xl mx-auto px-4 py-6 sm:py-10">
-        <div className="flex items-center justify-between gap-3 mb-6">
-          <h1 className="text-lg font-semibold">Settings</h1>
-          <button
-            onClick={() => {
-              window.location.hash = "";
-            }}
-            className="px-3 py-1.5 rounded-lg text-sm text-cc-muted hover:text-cc-fg hover:bg-cc-hover transition-colors cursor-pointer"
-          >
-            Back
-          </button>
+    <div className={`${embedded ? "h-full" : "h-[100dvh]"} bg-cc-bg text-cc-fg font-sans-ui antialiased overflow-y-auto`}>
+      <div className="max-w-5xl mx-auto px-4 sm:px-8 py-6 sm:py-10">
+        <div className="flex items-start justify-between gap-3 mb-6">
+          <div>
+            <h1 className="text-xl font-semibold text-cc-fg">Settings</h1>
+            <p className="mt-1 text-sm text-cc-muted">
+              Configure API access, notifications, appearance, and workspace defaults.
+            </p>
+          </div>
+          {!embedded && (
+            <button
+              onClick={() => {
+                window.location.hash = "";
+              }}
+              className="px-3 py-1.5 rounded-lg text-sm text-cc-muted hover:text-cc-fg hover:bg-cc-hover transition-colors cursor-pointer"
+            >
+              Back
+            </button>
+          )}
         </div>
 
         <form
           onSubmit={onSave}
           className="bg-cc-card border border-cc-border rounded-xl p-4 sm:p-5 space-y-4"
         >
+          <h2 className="text-sm font-semibold text-cc-fg">OpenRouter</h2>
           <div>
             <label className="block text-sm font-medium mb-1.5" htmlFor="openrouter-key">
               OpenRouter API Key
@@ -126,6 +146,66 @@ export function SettingsPage() {
             </button>
           </div>
         </form>
+
+        <div className="mt-4 bg-cc-card border border-cc-border rounded-xl p-4 sm:p-5 space-y-3">
+          <h2 className="text-sm font-semibold text-cc-fg">Notifications</h2>
+          <button
+            type="button"
+            onClick={toggleNotificationSound}
+            className="w-full flex items-center justify-between px-3 py-2 rounded-lg text-sm bg-cc-hover text-cc-fg hover:bg-cc-active transition-colors cursor-pointer"
+          >
+            <span>Sound</span>
+            <span className="text-xs text-cc-muted">{notificationSound ? "On" : "Off"}</span>
+          </button>
+          {notificationApiAvailable && (
+            <button
+              type="button"
+              onClick={async () => {
+                if (!notificationDesktop) {
+                  if (Notification.permission !== "granted") {
+                    const result = await Notification.requestPermission();
+                    if (result !== "granted") return;
+                  }
+                  setNotificationDesktop(true);
+                } else {
+                  setNotificationDesktop(false);
+                }
+              }}
+              className="w-full flex items-center justify-between px-3 py-2 rounded-lg text-sm bg-cc-hover text-cc-fg hover:bg-cc-active transition-colors cursor-pointer"
+            >
+              <span>Desktop Alerts</span>
+              <span className="text-xs text-cc-muted">{notificationDesktop ? "On" : "Off"}</span>
+            </button>
+          )}
+        </div>
+
+        <div className="mt-4 bg-cc-card border border-cc-border rounded-xl p-4 sm:p-5 space-y-3">
+          <h2 className="text-sm font-semibold text-cc-fg">Appearance</h2>
+          <button
+            type="button"
+            onClick={toggleDarkMode}
+            className="w-full flex items-center justify-between px-3 py-2 rounded-lg text-sm bg-cc-hover text-cc-fg hover:bg-cc-active transition-colors cursor-pointer"
+          >
+            <span>Theme</span>
+            <span className="text-xs text-cc-muted">{darkMode ? "Dark" : "Light"}</span>
+          </button>
+        </div>
+
+        <div className="mt-4 bg-cc-card border border-cc-border rounded-xl p-4 sm:p-5 space-y-3">
+          <h2 className="text-sm font-semibold text-cc-fg">Environments</h2>
+          <p className="text-xs text-cc-muted">
+            Manage reusable environment profiles used when creating sessions.
+          </p>
+          <button
+            type="button"
+            onClick={() => {
+              window.location.hash = "#/environments";
+            }}
+            className="px-3 py-2 rounded-lg text-sm font-medium bg-cc-primary hover:bg-cc-primary-hover text-white transition-colors cursor-pointer"
+          >
+            Open Environments Page
+          </button>
+        </div>
       </div>
     </div>
   );

--- a/web/src/components/Sidebar.tsx
+++ b/web/src/components/Sidebar.tsx
@@ -2,8 +2,6 @@ import { useState, useEffect, useCallback, useRef, useMemo } from "react";
 import { useStore } from "../store.js";
 import { api } from "../api.js";
 import { connectSession, connectAllSessions, disconnectSession } from "../ws.js";
-import { EnvManager } from "./EnvManager.js";
-import { FolderPicker } from "./FolderPicker.js";
 import { ProjectGroup } from "./ProjectGroup.js";
 import { SessionItem } from "./SessionItem.js";
 import { groupSessionsByProject, type SessionItem as SessionItemType } from "../utils/project-grouping.js";
@@ -11,22 +9,14 @@ import { groupSessionsByProject, type SessionItem as SessionItemType } from "../
 export function Sidebar() {
   const [editingSessionId, setEditingSessionId] = useState<string | null>(null);
   const [editingName, setEditingName] = useState("");
-  const [showEnvManager, setShowEnvManager] = useState(false);
-  const [showTerminalPicker, setShowTerminalPicker] = useState(false);
   const [showArchived, setShowArchived] = useState(false);
   const [confirmArchiveId, setConfirmArchiveId] = useState<string | null>(null);
-  const [notificationMenuOpen, setNotificationMenuOpen] = useState(false);
+  const [hash, setHash] = useState(() => (typeof window !== "undefined" ? window.location.hash : ""));
   const editInputRef = useRef<HTMLInputElement>(null);
   const sessions = useStore((s) => s.sessions);
   const sdkSessions = useStore((s) => s.sdkSessions);
   const currentSessionId = useStore((s) => s.currentSessionId);
   const setCurrentSession = useStore((s) => s.setCurrentSession);
-  const darkMode = useStore((s) => s.darkMode);
-  const toggleDarkMode = useStore((s) => s.toggleDarkMode);
-  const notificationSound = useStore((s) => s.notificationSound);
-  const toggleNotificationSound = useStore((s) => s.toggleNotificationSound);
-  const notificationDesktop = useStore((s) => s.notificationDesktop);
-  const setNotificationDesktop = useStore((s) => s.setNotificationDesktop);
   const cliConnected = useStore((s) => s.cliConnected);
   const sessionStatus = useStore((s) => s.sessionStatus);
   const removeSession = useStore((s) => s.removeSession);
@@ -35,10 +25,9 @@ export function Sidebar() {
   const pendingPermissions = useStore((s) => s.pendingPermissions);
   const collapsedProjects = useStore((s) => s.collapsedProjects);
   const toggleProjectCollapse = useStore((s) => s.toggleProjectCollapse);
-  const terminalOpen = useStore((s) => s.terminalOpen);
-  const notificationApiAvailable = typeof Notification !== "undefined";
-  const notificationEnabledCount = Number(notificationSound) + (notificationApiAvailable ? Number(notificationDesktop) : 0);
-  const notificationSummary = notificationEnabledCount === 0 ? "Off" : `${notificationEnabledCount} on`;
+  const isSettingsPage = hash === "#/settings";
+  const isTerminalPage = hash === "#/terminal";
+  const isEnvironmentsPage = hash === "#/environments";
 
   // Poll for SDK sessions on mount
   useEffect(() => {
@@ -77,7 +66,15 @@ export function Sidebar() {
     };
   }, []);
 
+  useEffect(() => {
+    const onHashChange = () => setHash(window.location.hash);
+    window.addEventListener("hashchange", onHashChange);
+    return () => window.removeEventListener("hashchange", onHashChange);
+  }, []);
+
   function handleSelectSession(sessionId: string) {
+    useStore.getState().closeTerminal();
+    window.location.hash = "";
     if (currentSessionId === sessionId) return;
     setCurrentSession(sessionId);
     // Ensure connected (idempotent — no-op if already connected)
@@ -89,6 +86,8 @@ export function Sidebar() {
   }
 
   function handleNewSession() {
+    useStore.getState().closeTerminal();
+    window.location.hash = "";
     useStore.getState().newSession();
     if (window.innerWidth < 768) {
       useStore.getState().setSidebarOpen(false);
@@ -355,111 +354,48 @@ export function Sidebar() {
       <div className="p-3 border-t border-cc-border space-y-0.5">
         <button
           onClick={() => {
-            if (terminalOpen) {
-              useStore.getState().closeTerminal();
-            } else {
-              setShowTerminalPicker(true);
+            window.location.hash = "#/terminal";
+            if (window.innerWidth < 768) {
+              useStore.getState().setSidebarOpen(false);
             }
           }}
-          className="w-full flex items-center gap-2.5 px-3 py-2 rounded-[10px] text-sm text-cc-muted hover:text-cc-fg hover:bg-cc-hover transition-colors cursor-pointer"
+          className={`w-full flex items-center gap-2.5 px-3 py-2 rounded-[10px] text-sm transition-colors cursor-pointer ${
+            isTerminalPage
+              ? "bg-cc-active text-cc-fg"
+              : "text-cc-muted hover:text-cc-fg hover:bg-cc-hover"
+          }`}
         >
           <svg viewBox="0 0 16 16" fill="currentColor" className="w-4 h-4">
             <path d="M2 3a1 1 0 011-1h10a1 1 0 011 1v10a1 1 0 01-1 1H3a1 1 0 01-1-1V3zm2 1.5l3 2.5-3 2.5V4.5zM8.5 10h3v1h-3v-1z" />
           </svg>
-          <span>{terminalOpen ? "Close Terminal" : "Terminal"}</span>
+          <span>Terminal</span>
         </button>
         <button
-          onClick={() => setShowEnvManager(true)}
-          className="w-full flex items-center gap-2.5 px-3 py-2 rounded-[10px] text-sm text-cc-muted hover:text-cc-fg hover:bg-cc-hover transition-colors cursor-pointer"
+          onClick={() => {
+            useStore.getState().closeTerminal();
+            window.location.hash = "#/environments";
+          }}
+          className={`w-full flex items-center gap-2.5 px-3 py-2 rounded-[10px] text-sm transition-colors cursor-pointer ${
+            isEnvironmentsPage
+              ? "bg-cc-active text-cc-fg"
+              : "text-cc-muted hover:text-cc-fg hover:bg-cc-hover"
+          }`}
         >
           <svg viewBox="0 0 16 16" fill="currentColor" className="w-4 h-4">
             <path d="M8 1a2 2 0 012 2v1h2a2 2 0 012 2v6a2 2 0 01-2 2H4a2 2 0 01-2-2V6a2 2 0 012-2h2V3a2 2 0 012-2zm0 1.5a.5.5 0 00-.5.5v1h1V3a.5.5 0 00-.5-.5zM4 5.5a.5.5 0 00-.5.5v6a.5.5 0 00.5.5h8a.5.5 0 00.5-.5V6a.5.5 0 00-.5-.5H4z" />
           </svg>
           <span>Environments</span>
         </button>
-        <div className="pt-1">
-          <button
-            onClick={() => setNotificationMenuOpen((open) => !open)}
-            aria-expanded={notificationMenuOpen}
-            aria-controls="notification-settings"
-            className="w-full flex items-center gap-2.5 px-3 py-2 rounded-[10px] text-sm text-cc-muted hover:text-cc-fg hover:bg-cc-hover transition-colors cursor-pointer"
-          >
-            <svg viewBox="0 0 20 20" fill="currentColor" className="w-4 h-4">
-              <path d="M10 2a6 6 0 00-6 6v3.586l-.707.707A1 1 0 004 14h12a1 1 0 00.707-1.707L16 11.586V8a6 6 0 00-6-6zM10 18a3 3 0 01-3-3h6a3 3 0 01-3 3z" />
-            </svg>
-            <span className="flex-1 text-left">Notification</span>
-            <span className="text-xs">{notificationSummary}</span>
-            <svg viewBox="0 0 16 16" fill="currentColor" className={`w-3 h-3 transition-transform ${notificationMenuOpen ? "rotate-180" : ""}`}>
-              <path d="M4 6l4 4 4-4" />
-            </svg>
-          </button>
-          {notificationMenuOpen && (
-            <div id="notification-settings" className="mt-1 space-y-0.5 border-l border-cc-border ml-5 pl-3">
-              <button
-                onClick={toggleNotificationSound}
-                className="w-full flex items-center gap-2.5 px-3 py-2 rounded-[10px] text-sm text-cc-muted hover:text-cc-fg hover:bg-cc-hover transition-colors cursor-pointer"
-              >
-                {notificationSound ? (
-                  <svg viewBox="0 0 20 20" fill="currentColor" className="w-4 h-4">
-                    <path d="M9.383 3.076A1 1 0 0110 4v12a1 1 0 01-1.707.707L4.586 13H2a1 1 0 01-1-1V8a1 1 0 011-1h2.586l3.707-3.707a1 1 0 011.09-.217zM14.657 2.929a1 1 0 011.414 0A9.972 9.972 0 0119 10a9.972 9.972 0 01-2.929 7.071 1 1 0 01-1.414-1.414A7.971 7.971 0 0017 10c0-2.21-.894-4.208-2.343-5.657a1 1 0 010-1.414zm-2.829 2.828a1 1 0 011.415 0A5.983 5.983 0 0115 10a5.984 5.984 0 01-1.757 4.243 1 1 0 01-1.415-1.415A3.984 3.984 0 0013 10a3.983 3.983 0 00-1.172-2.828 1 1 0 010-1.415z" />
-                  </svg>
-                ) : (
-                  <svg viewBox="0 0 20 20" fill="currentColor" className="w-4 h-4">
-                    <path fillRule="evenodd" d="M9.383 3.076A1 1 0 0110 4v12a1 1 0 01-1.707.707L4.586 13H2a1 1 0 01-1-1V8a1 1 0 011-1h2.586l3.707-3.707a1 1 0 011.09-.217zM12.293 7.293a1 1 0 011.414 0L15 8.586l1.293-1.293a1 1 0 111.414 1.414L16.414 10l1.293 1.293a1 1 0 01-1.414 1.414L15 11.414l-1.293 1.293a1 1 0 01-1.414-1.414L13.586 10l-1.293-1.293a1 1 0 010-1.414z" clipRule="evenodd" />
-                  </svg>
-                )}
-                <span>{notificationSound ? "Sound on" : "Sound off"}</span>
-              </button>
-              {notificationApiAvailable && (
-                <button
-                  onClick={async () => {
-                    if (!notificationDesktop) {
-                      if (Notification.permission !== "granted") {
-                        const result = await Notification.requestPermission();
-                        if (result !== "granted") return;
-                      }
-                      setNotificationDesktop(true);
-                    } else {
-                      setNotificationDesktop(false);
-                    }
-                  }}
-                  className="w-full flex items-center gap-2.5 px-3 py-2 rounded-[10px] text-sm text-cc-muted hover:text-cc-fg hover:bg-cc-hover transition-colors cursor-pointer"
-                >
-                  {notificationDesktop ? (
-                    <svg viewBox="0 0 20 20" fill="currentColor" className="w-4 h-4">
-                      <path d="M10 2a6 6 0 00-6 6v3.586l-.707.707A1 1 0 004 14h12a1 1 0 00.707-1.707L16 11.586V8a6 6 0 00-6-6zM10 18a3 3 0 01-3-3h6a3 3 0 01-3 3z" />
-                    </svg>
-                  ) : (
-                    <svg viewBox="0 0 20 20" fill="currentColor" className="w-4 h-4">
-                      <path d="M10 2a6 6 0 00-6 6v3.586l-.707.707A1 1 0 004 14h12a1 1 0 00.707-1.707L16 11.586V8a6 6 0 00-6-6zM10 18a3 3 0 01-3-3h6a3 3 0 01-3 3z" opacity="0.4" />
-                    </svg>
-                  )}
-                  <span>{notificationDesktop ? "Alerts on" : "Alerts off"}</span>
-                </button>
-              )}
-            </div>
-          )}
-        </div>
-        <button
-          onClick={toggleDarkMode}
-          className="w-full flex items-center gap-2.5 px-3 py-2 rounded-[10px] text-sm text-cc-muted hover:text-cc-fg hover:bg-cc-hover transition-colors cursor-pointer"
-        >
-          {darkMode ? (
-            <svg viewBox="0 0 20 20" fill="currentColor" className="w-4 h-4">
-              <path fillRule="evenodd" d="M10 2a1 1 0 011 1v1a1 1 0 11-2 0V3a1 1 0 011-1zm4 8a4 4 0 11-8 0 4 4 0 018 0zm-.464 4.95l.707.707a1 1 0 001.414-1.414l-.707-.707a1 1 0 00-1.414 1.414zm2.12-10.607a1 1 0 010 1.414l-.706.707a1 1 0 11-1.414-1.414l.707-.707a1 1 0 011.414 0zM17 11a1 1 0 100-2h-1a1 1 0 100 2h1zm-7 4a1 1 0 011 1v1a1 1 0 11-2 0v-1a1 1 0 011-1zM5.05 6.464A1 1 0 106.465 5.05l-.708-.707a1 1 0 00-1.414 1.414l.707.707zm1.414 8.486l-.707.707a1 1 0 01-1.414-1.414l.707-.707a1 1 0 011.414 1.414zM4 11a1 1 0 100-2H3a1 1 0 000 2h1z" clipRule="evenodd" />
-            </svg>
-          ) : (
-            <svg viewBox="0 0 20 20" fill="currentColor" className="w-4 h-4">
-              <path d="M17.293 13.293A8 8 0 016.707 2.707a8.001 8.001 0 1010.586 10.586z" />
-            </svg>
-          )}
-          <span>{darkMode ? "Light mode" : "Dark mode"}</span>
-        </button>
         <button
           onClick={() => {
+            useStore.getState().closeTerminal();
             window.location.hash = "#/settings";
           }}
-          className="w-full flex items-center gap-2.5 px-3 py-2 rounded-[10px] text-sm text-cc-muted hover:text-cc-fg hover:bg-cc-hover transition-colors cursor-pointer"
+          className={`w-full flex items-center gap-2.5 px-3 py-2 rounded-[10px] text-sm transition-colors cursor-pointer ${
+            isSettingsPage
+              ? "bg-cc-active text-cc-fg"
+              : "text-cc-muted hover:text-cc-fg hover:bg-cc-hover"
+          }`}
         >
           <svg viewBox="0 0 20 20" fill="currentColor" className="w-4 h-4">
             <path fillRule="evenodd" d="M11.49 3.17c-.38-1.56-2.6-1.56-2.98 0a1.53 1.53 0 01-2.29.95c-1.35-.8-2.92.77-2.12 2.12.54.9.07 2.04-.95 2.29-1.56.38-1.56 2.6 0 2.98 1.02.25 1.49 1.39.95 2.29-.8 1.35.77 2.92 2.12 2.12.9-.54 2.04-.07 2.29.95.38 1.56 2.6 1.56 2.98 0 .25-1.02 1.39-1.49 2.29-.95 1.35.8 2.92-.77 2.12-2.12-.54-.9-.07-2.04.95-2.29 1.56-.38 1.56-2.6 0-2.98-1.02-.25-1.49-1.39-.95-2.29.8-1.35-.77-2.92-2.12-2.12-.9.54-2.04.07-2.29-.95zM10 13a3 3 0 100-6 3 3 0 000 6z" clipRule="evenodd" />
@@ -467,23 +403,6 @@ export function Sidebar() {
           <span>Settings</span>
         </button>
       </div>
-
-      {/* Environment manager modal */}
-      {showEnvManager && (
-        <EnvManager onClose={() => setShowEnvManager(false)} />
-      )}
-
-      {/* Terminal folder picker */}
-      {showTerminalPicker && (
-        <FolderPicker
-          initialPath=""
-          onSelect={(path) => {
-            useStore.getState().openTerminal(path);
-            setShowTerminalPicker(false);
-          }}
-          onClose={() => setShowTerminalPicker(false)}
-        />
-      )}
     </aside>
   );
 }

--- a/web/src/components/TerminalPage.test.tsx
+++ b/web/src/components/TerminalPage.test.tsx
@@ -1,0 +1,69 @@
+// @vitest-environment jsdom
+import { render, screen, fireEvent } from "@testing-library/react";
+import "@testing-library/jest-dom";
+
+interface MockStoreState {
+  terminalCwd: string | null;
+  openTerminal: ReturnType<typeof vi.fn>;
+}
+
+let mockState: MockStoreState;
+
+function createMockState(overrides: Partial<MockStoreState> = {}): MockStoreState {
+  return {
+    terminalCwd: null,
+    openTerminal: vi.fn(),
+    ...overrides,
+  };
+}
+
+vi.mock("../store.js", () => {
+  const useStoreFn = (selector: (state: MockStoreState) => unknown) => selector(mockState);
+  useStoreFn.getState = () => mockState;
+  return { useStore: useStoreFn };
+});
+
+vi.mock("./TerminalView.js", () => ({
+  TerminalView: ({ cwd }: { cwd: string }) => <div data-testid="terminal-view">{cwd}</div>,
+}));
+
+vi.mock("./FolderPicker.js", () => ({
+  FolderPicker: ({ onSelect }: { onSelect: (path: string) => void }) => (
+    <div data-testid="folder-picker">
+      <button onClick={() => onSelect("/tmp/terminal-project")}>Pick folder</button>
+    </div>
+  ),
+}));
+
+import { TerminalPage } from "./TerminalPage.js";
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockState = createMockState();
+  window.location.hash = "#/terminal";
+});
+
+describe("TerminalPage", () => {
+  it("shows empty state when no terminal folder is selected", () => {
+    render(<TerminalPage />);
+    expect(screen.getByText("No terminal started yet")).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Choose Folder" })).toBeInTheDocument();
+  });
+
+  it("renders terminal view when a folder is selected", () => {
+    mockState = createMockState({ terminalCwd: "/tmp/existing" });
+    render(<TerminalPage />);
+    expect(screen.getByTestId("terminal-view")).toHaveTextContent("/tmp/existing");
+    expect(screen.getByRole("button", { name: "Change Folder" })).toBeInTheDocument();
+  });
+
+  it("opens picker and starts terminal with selected folder", () => {
+    render(<TerminalPage />);
+
+    fireEvent.click(screen.getByRole("button", { name: "Choose Folder" }));
+    fireEvent.click(screen.getByText("Pick folder"));
+
+    expect(mockState.openTerminal).toHaveBeenCalledWith("/tmp/terminal-project");
+    expect(window.location.hash).toBe("#/terminal");
+  });
+});

--- a/web/src/components/TerminalPage.tsx
+++ b/web/src/components/TerminalPage.tsx
@@ -1,0 +1,58 @@
+import { useState } from "react";
+import { useStore } from "../store.js";
+import { FolderPicker } from "./FolderPicker.js";
+import { TerminalView } from "./TerminalView.js";
+
+export function TerminalPage() {
+  const terminalCwd = useStore((s) => s.terminalCwd);
+  const [showTerminalPicker, setShowTerminalPicker] = useState(false);
+
+  return (
+    <div className="h-full bg-cc-bg overflow-y-auto">
+      <div className="max-w-5xl mx-auto px-4 sm:px-8 py-6 sm:py-10 h-full flex flex-col">
+        <div className="flex items-start justify-between gap-3 mb-6 shrink-0">
+          <div>
+            <h1 className="text-xl font-semibold text-cc-fg">Terminal</h1>
+            <p className="mt-1 text-sm text-cc-muted">
+              Run shell commands in a project folder without leaving the Companion.
+            </p>
+          </div>
+          <button
+            type="button"
+            onClick={() => setShowTerminalPicker(true)}
+            className="px-3 py-2 rounded-lg text-sm font-medium bg-cc-primary hover:bg-cc-primary-hover text-white transition-colors cursor-pointer whitespace-nowrap"
+          >
+            {terminalCwd ? "Change Folder" : "Choose Folder"}
+          </button>
+        </div>
+
+        <div className="flex-1 min-h-[420px]">
+          {terminalCwd ? (
+            <TerminalView cwd={terminalCwd} embedded />
+          ) : (
+            <div className="h-full bg-cc-card border border-cc-border rounded-xl p-6 sm:p-8 flex items-center justify-center text-center">
+              <div className="max-w-md">
+                <h2 className="text-lg font-semibold text-cc-fg mb-2">No terminal started yet</h2>
+                <p className="text-sm text-cc-muted">
+                  Choose a folder to start a terminal session. You can switch folders anytime.
+                </p>
+              </div>
+            </div>
+          )}
+        </div>
+      </div>
+
+      {showTerminalPicker && (
+        <FolderPicker
+          initialPath={terminalCwd || ""}
+          onSelect={(path) => {
+            useStore.getState().openTerminal(path);
+            window.location.hash = "#/terminal";
+            setShowTerminalPicker(false);
+          }}
+          onClose={() => setShowTerminalPicker(false)}
+        />
+      )}
+    </div>
+  );
+}

--- a/web/src/components/TerminalView.tsx
+++ b/web/src/components/TerminalView.tsx
@@ -1,5 +1,4 @@
 import { useEffect, useRef } from "react";
-import { createPortal } from "react-dom";
 import { Terminal } from "@xterm/xterm";
 import { FitAddon } from "@xterm/addon-fit";
 import "@xterm/xterm/css/xterm.css";
@@ -14,7 +13,8 @@ import {
 
 interface TerminalViewProps {
   cwd: string;
-  onClose: () => void;
+  onClose?: () => void;
+  embedded?: boolean;
 }
 
 function getTerminalTheme(dark: boolean) {
@@ -26,7 +26,7 @@ function getTerminalTheme(dark: boolean) {
   };
 }
 
-export function TerminalView({ cwd, onClose }: TerminalViewProps) {
+export function TerminalView({ cwd, onClose, embedded = false }: TerminalViewProps) {
   const terminalRef = useRef<HTMLDivElement>(null);
   const xtermRef = useRef<Terminal | null>(null);
   const fitRef = useRef<FitAddon | null>(null);
@@ -112,27 +112,29 @@ export function TerminalView({ cwd, onClose }: TerminalViewProps) {
     }
   }, [darkMode]);
 
-  return createPortal(
-    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/50">
-      <div
-        className="w-[90vw] max-w-4xl h-[70vh] flex flex-col rounded-[14px] shadow-2xl overflow-hidden border border-cc-border"
-        style={{ background: darkMode ? "#141413" : "#1e1e1e" }}
-        onClick={(e) => e.stopPropagation()}
-      >
-        {/* Header */}
-        <div className="flex items-center justify-between px-4 py-2 border-b border-cc-border bg-cc-sidebar shrink-0">
-          <div className="flex items-center gap-2 min-w-0">
-            <svg
-              viewBox="0 0 16 16"
-              fill="currentColor"
-              className="w-4 h-4 text-cc-muted shrink-0"
-            >
-              <path d="M2 3a1 1 0 011-1h10a1 1 0 011 1v10a1 1 0 01-1 1H3a1 1 0 01-1-1V3zm2 1.5l3 2.5-3 2.5V4.5zM8.5 10h3v1h-3v-1z" />
-            </svg>
-            <span className="text-xs text-cc-muted font-mono-code truncate">
-              {cwd}
-            </span>
-          </div>
+  const terminalFrame = (
+    <div
+      className={`flex flex-col rounded-[14px] shadow-2xl overflow-hidden border border-cc-border ${
+        embedded ? "h-full" : "w-[90vw] max-w-4xl h-[70vh]"
+      }`}
+      style={{ background: darkMode ? "#141413" : "#1e1e1e" }}
+      onClick={(e) => e.stopPropagation()}
+    >
+      {/* Header */}
+      <div className="flex items-center justify-between px-4 py-2 border-b border-cc-border bg-cc-sidebar shrink-0">
+        <div className="flex items-center gap-2 min-w-0">
+          <svg
+            viewBox="0 0 16 16"
+            fill="currentColor"
+            className="w-4 h-4 text-cc-muted shrink-0"
+          >
+            <path d="M2 3a1 1 0 011-1h10a1 1 0 011 1v10a1 1 0 01-1 1H3a1 1 0 01-1-1V3zm2 1.5l3 2.5-3 2.5V4.5zM8.5 10h3v1h-3v-1z" />
+          </svg>
+          <span className="text-xs text-cc-muted font-mono-code truncate">
+            {cwd}
+          </span>
+        </div>
+        {onClose && (
           <button
             onClick={onClose}
             className="w-6 h-6 flex items-center justify-center rounded-md text-cc-muted hover:text-cc-fg hover:bg-cc-hover transition-colors cursor-pointer shrink-0"
@@ -147,12 +149,25 @@ export function TerminalView({ cwd, onClose }: TerminalViewProps) {
               <path d="M4 4l8 8M12 4l-8 8" strokeLinecap="round" />
             </svg>
           </button>
-        </div>
-
-        {/* Terminal container */}
-        <div ref={terminalRef} className="flex-1 min-h-0 p-1" />
+        )}
       </div>
-    </div>,
-    document.body,
+
+      {/* Terminal container */}
+      <div ref={terminalRef} className="flex-1 min-h-0 p-1" />
+    </div>
+  );
+
+  if (embedded) {
+    return (
+      <div className="h-full">
+        {terminalFrame}
+      </div>
+    );
+  }
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/50">
+      {terminalFrame}
+    </div>
   );
 }

--- a/web/src/components/TopBar.tsx
+++ b/web/src/components/TopBar.tsx
@@ -1,9 +1,17 @@
-import { useState } from "react";
+import { useState, useSyncExternalStore } from "react";
 import { useStore } from "../store.js";
 import { api } from "../api.js";
 import { ClaudeMdEditor } from "./ClaudeMdEditor.js";
 
 export function TopBar() {
+  const hash = useSyncExternalStore(
+    (cb) => {
+      window.addEventListener("hashchange", cb);
+      return () => window.removeEventListener("hashchange", cb);
+    },
+    () => window.location.hash,
+  );
+  const isSessionView = hash !== "#/settings" && hash !== "#/terminal" && hash !== "#/environments";
   const currentSessionId = useStore((s) => s.currentSessionId);
   const cliConnected = useStore((s) => s.cliConnected);
   const sessionStatus = useStore((s) => s.sessionStatus);
@@ -74,7 +82,7 @@ export function TopBar() {
       </div>
 
       {/* Right side */}
-      {currentSessionId && (
+      {currentSessionId && isSessionView && (
         <div className="flex items-center gap-2 sm:gap-3 text-[12px] text-cc-muted">
           {status === "compacting" && (
             <span className="text-cc-warning font-medium animate-pulse">Compacting...</span>


### PR DESCRIPTION
## Summary
- convert `Settings`, `Environments`, and `Terminal` into full in-app pages that replace the main content area
- move notification/theme/environment controls out of the sidebar into `Settings`
- add a dedicated `Environments` page layout and refactor `EnvManager` to support both modal and embedded modes
- add a dedicated `TerminalPage` with page-level folder selection and empty state
- fix terminal navigation flow so clicking `Terminal` in sidebar goes directly to `#/terminal` (no intermediate modal)
- hide top-bar session controls on non-session pages (`#/settings`, `#/environments`, `#/terminal`)
- add/update frontend tests for the new navigation and page behaviors

## Why
- the previous flow mixed modal and page navigation patterns, which made navigation feel inconsistent
- terminal flow in particular was confusing because it opened a modal before the page
- settings/environment surfaces looked like nested cards rather than first-class pages
- this unifies navigation and gives each area a clear, dedicated page experience

## Screenshots
- Settings (desktop): `/tmp/ux-pass/settings-desktop-final.png`
- Environments (desktop): `/tmp/ux-pass/environments-desktop-final.png`
- Terminal (desktop): `/tmp/ux-pass/terminal-desktop-final.png`
- Terminal (mobile): `/tmp/ux-pass/terminal-mobile-final.png`

## Testing
- pre-commit hook ran full checks during commit:
  - `cd web && bun run typecheck`
  - `cd web && bun run test`
- additional targeted checks run during implementation:
  - `cd web && bun run test -- src/components/TerminalPage.test.tsx src/components/SettingsPage.test.tsx src/components/Sidebar.test.tsx src/components/TopBar.test.tsx`

## Review provenance
- Implemented by AI agent
- Human review: no

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/the-vibe-company/companion/pull/224" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
