### PR TITLE
fix(settings): correct auto-renaming helper copy

### DIFF
--- a/web/src/components/SettingsPage.test.tsx
+++ b/web/src/components/SettingsPage.test.tsx
@@ -79,6 +79,12 @@ describe("SettingsPage", () => {
     await screen.findByText("OpenRouter key not configured");
   });
 
+  it("shows the auto-renaming helper copy under the API key input", async () => {
+    render(<SettingsPage />);
+
+    expect(await screen.findByText("Auto-renaming is disabled until this key is configured.")).toBeInTheDocument();
+  });
+
   it("saves settings with trimmed values", async () => {
     render(<SettingsPage />);
     await screen.findByText("OpenRouter key configured");

--- a/web/src/components/SettingsPage.tsx
+++ b/web/src/components/SettingsPage.tsx
@@ -99,7 +99,7 @@ export function SettingsPage({ embedded = false }: SettingsPageProps) {
               className="w-full px-3 py-2.5 text-sm bg-cc-input-bg border border-cc-border rounded-lg text-cc-fg placeholder:text-cc-muted focus:outline-none focus:border-cc-primary/60"
             />
             <p className="mt-1.5 text-xs text-cc-muted">
-              Automatic session renaming is disabled until this key is configured.
+              Auto-renaming is disabled until this key is configured.
             </p>
           </div>
 


### PR DESCRIPTION
## Summary
- update the OpenRouter helper text in Settings from `Automatic session renaming is disabled...` to `Auto-renaming is disabled...`
- add a UI test that asserts the updated helper copy is rendered

## Why
- standardize the wording to the requested label (`Auto-renaming`) and fix the UI copy consistently

## Testing
- `cd web && bun run test src/components/SettingsPage.test.tsx`

## Screenshot
- N/A (text-only copy change)

## Review provenance
- Implemented by AI agent (Codex)
- Human review: no

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/the-vibe-company/companion/pull/230" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
