### PR TITLE
feat(telemetry): add posthog analytics, opt-out controls, and CI env wiring

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,3 +34,10 @@ jobs:
       - name: Run tests
         working-directory: web
         run: bun run test
+
+      - name: Build frontend
+        working-directory: web
+        run: bun run build
+        env:
+          VITE_POSTHOG_KEY: ${{ secrets.VITE_POSTHOG_KEY }}
+          VITE_POSTHOG_HOST: ${{ vars.VITE_POSTHOG_HOST || 'https://us.i.posthog.com' }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -43,6 +43,9 @@ jobs:
       - name: Build frontend
         working-directory: web
         run: bun run build
+        env:
+          VITE_POSTHOG_KEY: ${{ secrets.VITE_POSTHOG_KEY }}
+          VITE_POSTHOG_HOST: ${{ vars.VITE_POSTHOG_HOST || 'https://us.i.posthog.com' }}
 
       - name: Verify dist exists
         working-directory: web

--- a/.gitignore
+++ b/.gitignore
@@ -8,5 +8,6 @@ package-lock.json
 test-live.ts
 web/dist/
 .env
+web/.env.local
 .dev-*.pid
 .dev-*.log

--- a/README.md
+++ b/README.md
@@ -100,6 +100,19 @@ Dev uses port 3457 for the backend and 5174 for Vite HMR, so both dev and prod c
 
 Bun runtime, Hono server, React 19, Zustand, Tailwind v4, Vite.
 
+## Telemetry
+
+The Companion can send product analytics and frontend crash reports to PostHog so we can improve reliability and UX.
+
+- Telemetry is configured via `VITE_POSTHOG_KEY` (and optional `VITE_POSTHOG_HOST`).
+- In this open-source repo, telemetry is optional: if no key is configured, nothing is sent.
+- Users can disable telemetry anytime in `Settings -> Telemetry`.
+- Browser Do Not Track is respected (`respect_dnt` is enabled).
+
+## Cloud
+
+See [`cloud.md`](cloud.md) for the cloud environment roadmap and core image strategy.
+
 ## Contributing
 
 Check [open issues](https://github.com/The-Vibe-Company/companion/issues), fork, branch, PR. For protocol-level work, read the [WebSocket spec](WEBSOCKET_PROTOCOL_REVERSED.md) first.

--- a/web/.env.example
+++ b/web/.env.example
@@ -1,0 +1,2 @@
+VITE_POSTHOG_KEY=phc_your_project_key
+VITE_POSTHOG_HOST=https://us.i.posthog.com

--- a/web/package.json
+++ b/web/package.json
@@ -38,7 +38,8 @@
   },
   "dependencies": {
     "diff": "^8.0.3",
-    "hono": "^4.7.0"
+    "hono": "^4.7.0",
+    "posthog-js": "^1.347.2"
   },
   "devDependencies": {
     "@tailwindcss/vite": "^4.0.0",

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -2,6 +2,7 @@ import { useEffect, useSyncExternalStore } from "react";
 import { useStore } from "./store.js";
 import { connectSession } from "./ws.js";
 import { api } from "./api.js";
+import { capturePageView } from "./analytics.js";
 import { Sidebar } from "./components/Sidebar.js";
 import { ChatView } from "./components/ChatView.js";
 import { TopBar } from "./components/TopBar.js";
@@ -33,6 +34,10 @@ export default function App() {
   const isTerminalPage = hash === "#/terminal";
   const isEnvironmentsPage = hash === "#/environments";
   const isSessionView = !isSettingsPage && !isTerminalPage && !isEnvironmentsPage;
+
+  useEffect(() => {
+    capturePageView(hash || "#/");
+  }, [hash]);
 
   useEffect(() => {
     document.documentElement.classList.toggle("dark", darkMode);

--- a/web/src/analytics.test.ts
+++ b/web/src/analytics.test.ts
@@ -1,0 +1,87 @@
+// @vitest-environment jsdom
+const posthogInitMock = vi.fn();
+const posthogCaptureMock = vi.fn();
+const posthogCaptureExceptionMock = vi.fn();
+const posthogOptInMock = vi.fn();
+const posthogOptOutMock = vi.fn();
+
+vi.mock("posthog-js", () => ({
+  default: {
+    init: posthogInitMock,
+    capture: posthogCaptureMock,
+    captureException: posthogCaptureExceptionMock,
+    opt_in_capturing: posthogOptInMock,
+    opt_out_capturing: posthogOptOutMock,
+  },
+}));
+
+describe("analytics", () => {
+  beforeEach(() => {
+    vi.resetModules();
+    vi.unstubAllEnvs();
+    localStorage.clear();
+    posthogInitMock.mockReset();
+    posthogCaptureMock.mockReset();
+    posthogCaptureExceptionMock.mockReset();
+    posthogOptInMock.mockReset();
+    posthogOptOutMock.mockReset();
+  });
+
+  it("stays disabled without a PostHog key", async () => {
+    // Validates that telemetry is a hard no-op unless a project key is configured.
+    vi.stubEnv("VITE_POSTHOG_KEY", "");
+    vi.stubEnv("VITE_PUBLIC_POSTHOG_KEY", "");
+    const mod = await import("./analytics.js");
+
+    expect(mod.initAnalytics()).toBe(false);
+    expect(mod.isAnalyticsEnabled()).toBe(false);
+    mod.captureEvent("event");
+    mod.captureException(new Error("boom"));
+
+    expect(posthogInitMock).not.toHaveBeenCalled();
+    expect(posthogCaptureMock).not.toHaveBeenCalled();
+    expect(posthogCaptureExceptionMock).not.toHaveBeenCalled();
+  });
+
+  it("initializes PostHog and captures events when key is configured", async () => {
+    // Validates successful initialization and the main event/error/pageview wrappers.
+    vi.stubEnv("VITE_POSTHOG_KEY", "phc_test_key");
+    vi.stubEnv("VITE_POSTHOG_HOST", "https://eu.i.posthog.com");
+    const mod = await import("./analytics.js");
+
+    expect(mod.initAnalytics()).toBe(true);
+    expect(mod.isAnalyticsEnabled()).toBe(true);
+    expect(posthogOptInMock).toHaveBeenCalled();
+
+    expect(posthogInitMock).toHaveBeenCalledWith(
+      "phc_test_key",
+      expect.objectContaining({
+        api_host: "https://eu.i.posthog.com",
+        capture_pageview: false,
+        capture_exceptions: true,
+        respect_dnt: true,
+      }),
+    );
+
+    mod.captureEvent("test_event", { foo: "bar" });
+    mod.captureException(new Error("boom"), { source: "unit_test" });
+    mod.capturePageView("#/settings");
+
+    expect(posthogCaptureMock).toHaveBeenCalledWith("test_event", { foo: "bar" });
+    expect(posthogCaptureExceptionMock).toHaveBeenCalled();
+    expect(posthogCaptureMock).toHaveBeenCalledWith("$pageview", { $current_url: "#/settings" });
+  });
+
+  it("respects telemetry preference opt-out", async () => {
+    // Validates persisted user opt-out prevents all event capture even when key exists.
+    vi.stubEnv("VITE_POSTHOG_KEY", "phc_test_key");
+    localStorage.setItem("cc-telemetry-enabled", "false");
+    const mod = await import("./analytics.js");
+
+    expect(mod.initAnalytics()).toBe(true);
+    expect(mod.isAnalyticsEnabled()).toBe(false);
+    expect(posthogOptOutMock).toHaveBeenCalled();
+    mod.captureEvent("test_event");
+    expect(posthogCaptureMock).not.toHaveBeenCalled();
+  });
+});

--- a/web/src/analytics.ts
+++ b/web/src/analytics.ts
@@ -1,0 +1,85 @@
+import posthog from "posthog-js";
+
+const POSTHOG_DEFAULT_HOST = "https://us.i.posthog.com";
+const TELEMETRY_STORAGE_KEY = "cc-telemetry-enabled";
+
+let analyticsInitialized = false;
+let analyticsEnabled = false;
+
+function getPostHogKey(): string | undefined {
+  const key = import.meta.env.VITE_POSTHOG_KEY || import.meta.env.VITE_PUBLIC_POSTHOG_KEY;
+  if (!key || !key.trim()) return undefined;
+  return key.trim();
+}
+
+function getPostHogHost(): string {
+  const host = import.meta.env.VITE_POSTHOG_HOST || import.meta.env.VITE_PUBLIC_POSTHOG_HOST;
+  if (!host || !host.trim()) return POSTHOG_DEFAULT_HOST;
+  return host.trim();
+}
+
+export function isAnalyticsEnabled(): boolean {
+  return analyticsEnabled;
+}
+
+export function getTelemetryPreferenceEnabled(): boolean {
+  if (typeof localStorage === "undefined") return true;
+  const stored = localStorage.getItem(TELEMETRY_STORAGE_KEY);
+  if (stored === null) return true;
+  return stored === "true";
+}
+
+function applyTelemetryPreference(enabled: boolean): void {
+  if (!analyticsInitialized) return;
+  if (enabled) {
+    posthog.opt_in_capturing({ captureEventName: null });
+    analyticsEnabled = true;
+  } else {
+    posthog.opt_out_capturing();
+    analyticsEnabled = false;
+  }
+}
+
+export function setTelemetryPreferenceEnabled(enabled: boolean): void {
+  if (typeof localStorage !== "undefined") {
+    localStorage.setItem(TELEMETRY_STORAGE_KEY, String(enabled));
+  }
+  applyTelemetryPreference(enabled);
+}
+
+export function initAnalytics(): boolean {
+  const key = getPostHogKey();
+  if (!key) {
+    analyticsInitialized = false;
+    analyticsEnabled = false;
+    return false;
+  }
+
+  posthog.init(key, {
+    api_host: getPostHogHost(),
+    defaults: "2026-01-30",
+    capture_pageview: false,
+    capture_pageleave: true,
+    capture_exceptions: true,
+    autocapture: true,
+    respect_dnt: true,
+  });
+
+  analyticsInitialized = true;
+  applyTelemetryPreference(getTelemetryPreferenceEnabled());
+  return true;
+}
+
+export function captureEvent(event: string, properties?: Record<string, unknown>): void {
+  if (!analyticsEnabled) return;
+  posthog.capture(event, properties);
+}
+
+export function captureException(error: unknown, properties?: Record<string, unknown>): void {
+  if (!analyticsEnabled) return;
+  posthog.captureException(error, properties);
+}
+
+export function capturePageView(path: string): void {
+  captureEvent("$pageview", { $current_url: path });
+}

--- a/web/src/components/AppErrorBoundary.test.tsx
+++ b/web/src/components/AppErrorBoundary.test.tsx
@@ -1,0 +1,36 @@
+// @vitest-environment jsdom
+import type { ReactElement } from "react";
+import { render, screen } from "@testing-library/react";
+import { AppErrorBoundary } from "./AppErrorBoundary.js";
+
+const { captureExceptionMock } = vi.hoisted(() => ({
+  captureExceptionMock: vi.fn(),
+}));
+
+vi.mock("../analytics.js", () => ({
+  captureException: captureExceptionMock,
+}));
+
+function Crasher(): ReactElement {
+  throw new Error("render failed");
+}
+
+describe("AppErrorBoundary", () => {
+  beforeEach(() => {
+    captureExceptionMock.mockReset();
+  });
+
+  it("shows fallback UI and reports exceptions", () => {
+    // Validates React render-time crashes are both user-visible and reported to telemetry.
+    const consoleErrorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    render(
+      <AppErrorBoundary>
+        <Crasher />
+      </AppErrorBoundary>,
+    );
+
+    expect(screen.getByText("A runtime error occurred")).toBeTruthy();
+    expect(captureExceptionMock).toHaveBeenCalled();
+    consoleErrorSpy.mockRestore();
+  });
+});

--- a/web/src/components/AppErrorBoundary.tsx
+++ b/web/src/components/AppErrorBoundary.tsx
@@ -1,0 +1,53 @@
+import type { ErrorInfo, ReactNode } from "react";
+import { Component } from "react";
+import { captureException } from "../analytics.js";
+
+interface Props {
+  children: ReactNode;
+}
+
+interface State {
+  hasError: boolean;
+}
+
+export class AppErrorBoundary extends Component<Props, State> {
+  constructor(props: Props) {
+    super(props);
+    this.state = { hasError: false };
+  }
+
+  static getDerivedStateFromError(): State {
+    return { hasError: true };
+  }
+
+  componentDidCatch(error: Error, info: ErrorInfo) {
+    captureException(error, {
+      source: "react_error_boundary",
+      componentStack: info.componentStack,
+    });
+  }
+
+  render() {
+    if (this.state.hasError) {
+      return (
+        <div className="h-[100dvh] flex items-center justify-center bg-cc-bg text-cc-fg px-4">
+          <div className="max-w-md w-full rounded-xl border border-cc-border bg-cc-card p-5 shadow-sm">
+            <h1 className="text-base font-semibold">A runtime error occurred</h1>
+            <p className="text-sm text-cc-muted mt-2">
+              Reload the page to recover. The error has been reported.
+            </p>
+            <button
+              type="button"
+              onClick={() => window.location.reload()}
+              className="mt-4 inline-flex items-center rounded-md bg-cc-primary px-3 py-1.5 text-sm text-white hover:bg-cc-primary-hover cursor-pointer"
+            >
+              Reload
+            </button>
+          </div>
+        </div>
+      );
+    }
+
+    return this.props.children;
+  }
+}

--- a/web/src/components/SettingsPage.test.tsx
+++ b/web/src/components/SettingsPage.test.tsx
@@ -43,6 +43,11 @@ const mockApi = {
   triggerUpdate: vi.fn(),
 };
 
+const mockTelemetry = {
+  getTelemetryPreferenceEnabled: vi.fn(),
+  setTelemetryPreferenceEnabled: vi.fn(),
+};
+
 vi.mock("../api.js", () => ({
   api: {
     getSettings: (...args: unknown[]) => mockApi.getSettings(...args),
@@ -50,6 +55,11 @@ vi.mock("../api.js", () => ({
     forceCheckForUpdate: (...args: unknown[]) => mockApi.forceCheckForUpdate(...args),
     triggerUpdate: (...args: unknown[]) => mockApi.triggerUpdate(...args),
   },
+}));
+
+vi.mock("../analytics.js", () => ({
+  getTelemetryPreferenceEnabled: (...args: unknown[]) => mockTelemetry.getTelemetryPreferenceEnabled(...args),
+  setTelemetryPreferenceEnabled: (...args: unknown[]) => mockTelemetry.setTelemetryPreferenceEnabled(...args),
 }));
 
 vi.mock("../store.js", () => {
@@ -84,6 +94,7 @@ beforeEach(() => {
     ok: true,
     message: "Update started. Server will restart shortly.",
   });
+  mockTelemetry.getTelemetryPreferenceEnabled.mockReturnValue(true);
 });
 
 describe("SettingsPage", () => {
@@ -247,6 +258,14 @@ describe("SettingsPage", () => {
 
     fireEvent.click(screen.getByRole("button", { name: /Theme/i }));
     expect(mockState.toggleDarkMode).toHaveBeenCalledTimes(1);
+  });
+
+  it("toggles telemetry preference from settings", async () => {
+    render(<SettingsPage />);
+    await screen.findByText("OpenRouter key configured");
+
+    fireEvent.click(screen.getByRole("button", { name: /Usage analytics and errors/i }));
+    expect(mockTelemetry.setTelemetryPreferenceEnabled).toHaveBeenCalledWith(false);
   });
 
   it("navigates to environments page from settings", async () => {

--- a/web/src/components/SettingsPage.tsx
+++ b/web/src/components/SettingsPage.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useState } from "react";
 import { api } from "../api.js";
 import { useStore } from "../store.js";
+import { getTelemetryPreferenceEnabled, setTelemetryPreferenceEnabled } from "../analytics.js";
 
 interface SettingsPageProps {
   embedded?: boolean;
@@ -27,6 +28,7 @@ export function SettingsPage({ embedded = false }: SettingsPageProps) {
   const [updatingApp, setUpdatingApp] = useState(false);
   const [updateStatus, setUpdateStatus] = useState("");
   const [updateError, setUpdateError] = useState("");
+  const [telemetryEnabled, setTelemetryEnabled] = useState(getTelemetryPreferenceEnabled());
 
   useEffect(() => {
     api
@@ -285,6 +287,28 @@ export function SettingsPage({ embedded = false }: SettingsPageProps) {
             <span>Theme</span>
             <span className="text-xs text-cc-muted">{darkMode ? "Dark" : "Light"}</span>
           </button>
+        </div>
+
+        <div className="mt-4 bg-cc-card border border-cc-border rounded-xl p-4 sm:p-5 space-y-3">
+          <h2 className="text-sm font-semibold text-cc-fg">Telemetry</h2>
+          <p className="text-xs text-cc-muted">
+            Anonymous product analytics and crash reports via PostHog to improve reliability.
+          </p>
+          <button
+            type="button"
+            onClick={() => {
+              const next = !telemetryEnabled;
+              setTelemetryPreferenceEnabled(next);
+              setTelemetryEnabled(next);
+            }}
+            className="w-full flex items-center justify-between px-3 py-2 rounded-lg text-sm bg-cc-hover text-cc-fg hover:bg-cc-active transition-colors cursor-pointer"
+          >
+            <span>Usage analytics and errors</span>
+            <span className="text-xs text-cc-muted">{telemetryEnabled ? "On" : "Off"}</span>
+          </button>
+          <p className="text-xs text-cc-muted">
+            Browser Do Not Track is respected automatically.
+          </p>
         </div>
 
         <div className="mt-4 bg-cc-card border border-cc-border rounded-xl p-4 sm:p-5 space-y-3">

--- a/web/src/main.tsx
+++ b/web/src/main.tsx
@@ -1,10 +1,16 @@
 import { StrictMode } from "react";
 import { createRoot } from "react-dom/client";
 import App from "./App.js";
+import { initAnalytics } from "./analytics.js";
+import { AppErrorBoundary } from "./components/AppErrorBoundary.js";
 import "./index.css";
+
+initAnalytics();
 
 createRoot(document.getElementById("root")!).render(
   <StrictMode>
-    <App />
+    <AppErrorBoundary>
+      <App />
+    </AppErrorBoundary>
   </StrictMode>
 );

--- a/web/src/vite-env.d.ts
+++ b/web/src/vite-env.d.ts
@@ -1,0 +1,12 @@
+/// <reference types="vite/client" />
+
+interface ImportMetaEnv {
+  readonly VITE_POSTHOG_KEY?: string;
+  readonly VITE_POSTHOG_HOST?: string;
+  readonly VITE_PUBLIC_POSTHOG_KEY?: string;
+  readonly VITE_PUBLIC_POSTHOG_HOST?: string;
+}
+
+interface ImportMeta {
+  readonly env: ImportMetaEnv;
+}


### PR DESCRIPTION
## Summary
- add PostHog telemetry to The Companion frontend for product analytics and frontend crash reporting
- add user telemetry preference in `Settings -> Telemetry` (opt-out supported)
- respect browser Do Not Track
- wire CI and release builds to inject `VITE_POSTHOG_KEY` / `VITE_POSTHOG_HOST` from GitHub secrets/vars
- document telemetry behavior in README

## Why
- improve reliability by surfacing frontend runtime failures
- understand usage patterns to prioritize product work
- keep OSS defaults clean: telemetry is optional and disabled when no key is configured

## Visual
- Settings now includes a new **Telemetry** section with a single toggle (`Usage analytics and errors`)
- Screenshot: not attached in this PR description

## Testing
- `cd web && bun run typecheck`
- `cd web && bun run test src/analytics.test.ts src/components/AppErrorBoundary.test.tsx src/api.test.ts src/components/SettingsPage.test.tsx`
- pre-commit hook full suite passed: 1009 tests

## Review provenance
- Implemented by AI agent
- Human review: no

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/the-vibe-company/companion/pull/238" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
