### PR TITLE
feat(web): add multi-provider notification system

### DIFF
--- a/web/server/index.ts
+++ b/web/server/index.ts
@@ -23,6 +23,9 @@ import { getSettings } from "./settings-manager.js";
 import { PRPoller } from "./pr-poller.js";
 import { startPeriodicCheck, setServiceMode } from "./update-checker.js";
 import { isRunningAsService } from "./service.js";
+import * as notificationManager from "./notification-manager.js";
+import { dispatchNotifications } from "./notification-sender.js";
+import type { NotificationEvent } from "./notification-types.js";
 import type { SocketData } from "./ws-bridge.js";
 import type { ServerWebSocket } from "bun";
 
@@ -93,6 +96,23 @@ wsBridge.onFirstTurnCompletedCallback(async (sessionId, firstUserMessage) => {
     sessionNames.setName(sessionId, title);
     wsBridge.broadcastNameUpdate(sessionId, title);
   }
+});
+
+// Dispatch server-side notifications on session events
+wsBridge.onNotificationTriggerCallback((trigger, sessionId, sessionCwd, message) => {
+  const providers = notificationManager.getEnabledForTrigger(trigger);
+  if (providers.length === 0) return;
+
+  const event: NotificationEvent = {
+    trigger,
+    sessionId,
+    sessionName: sessionNames.getName(sessionId) || sessionCwd,
+    message,
+  };
+
+  dispatchNotifications(providers, event).catch((err) => {
+    console.error("[server] Notification dispatch error:", err);
+  });
 });
 
 console.log(`[server] Session persistence: ${sessionStore.directory}`);

--- a/web/server/notification-manager.test.ts
+++ b/web/server/notification-manager.test.ts
@@ -1,0 +1,211 @@
+import { mkdtempSync, rmSync, readFileSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import {
+  listProviders,
+  getProvider,
+  createProvider,
+  updateProvider,
+  deleteProvider,
+  getEnabledForTrigger,
+  _resetForTest,
+} from "./notification-manager.js";
+import type { ProviderConfig } from "./notification-types.js";
+
+let tempDir: string;
+let filePath: string;
+
+beforeEach(() => {
+  tempDir = mkdtempSync(join(tmpdir(), "notif-manager-test-"));
+  filePath = join(tempDir, "notifications.json");
+  _resetForTest(filePath);
+});
+
+afterEach(() => {
+  rmSync(tempDir, { recursive: true, force: true });
+  _resetForTest();
+});
+
+const slackConfig: ProviderConfig = {
+  type: "slack",
+  webhookUrl: "https://hooks.slack.com/services/test",
+};
+
+const telegramConfig: ProviderConfig = {
+  type: "telegram",
+  botToken: "123:ABC",
+  chatId: "-100123",
+};
+
+describe("notification-manager", () => {
+  describe("listProviders", () => {
+    it("returns empty array when no file exists", () => {
+      expect(listProviders()).toEqual([]);
+    });
+
+    it("returns providers from disk", () => {
+      const provider = createProvider("Slack", slackConfig, ["session_complete"]);
+      _resetForTest(filePath);
+      const loaded = listProviders();
+      expect(loaded).toHaveLength(1);
+      expect(loaded[0].id).toBe(provider.id);
+      expect(loaded[0].name).toBe("Slack");
+    });
+
+    it("handles corrupt JSON gracefully", () => {
+      writeFileSync(filePath, "not-valid-json", "utf-8");
+      _resetForTest(filePath);
+      expect(listProviders()).toEqual([]);
+    });
+
+    it("handles non-array JSON gracefully", () => {
+      writeFileSync(filePath, JSON.stringify({ foo: "bar" }), "utf-8");
+      _resetForTest(filePath);
+      expect(listProviders()).toEqual([]);
+    });
+  });
+
+  describe("createProvider", () => {
+    it("creates with correct structure and timestamps", () => {
+      const before = Date.now();
+      const provider = createProvider("My Slack", slackConfig, ["session_complete", "session_error"]);
+
+      expect(provider.id).toBeTruthy();
+      expect(provider.type).toBe("slack");
+      expect(provider.name).toBe("My Slack");
+      expect(provider.enabled).toBe(true);
+      expect(provider.config).toEqual(slackConfig);
+      expect(provider.triggers).toEqual(["session_complete", "session_error"]);
+      expect(provider.createdAt).toBeGreaterThanOrEqual(before);
+      expect(provider.updatedAt).toBeGreaterThanOrEqual(before);
+    });
+
+    it("persists to disk as JSON", () => {
+      createProvider("Slack", slackConfig, ["session_complete"]);
+      const saved = JSON.parse(readFileSync(filePath, "utf-8"));
+      expect(saved).toHaveLength(1);
+      expect(saved[0].name).toBe("Slack");
+    });
+
+    it("throws on empty name", () => {
+      expect(() => createProvider("", slackConfig, [])).toThrow("Provider name is required");
+    });
+
+    it("throws on whitespace-only name", () => {
+      expect(() => createProvider("   ", slackConfig, [])).toThrow("Provider name is required");
+    });
+
+    it("trims name", () => {
+      const p = createProvider("  My Slack  ", slackConfig, []);
+      expect(p.name).toBe("My Slack");
+    });
+
+    it("respects enabled parameter", () => {
+      const p = createProvider("Slack", slackConfig, [], false);
+      expect(p.enabled).toBe(false);
+    });
+  });
+
+  describe("getProvider", () => {
+    it("returns provider by ID", () => {
+      const created = createProvider("Slack", slackConfig, ["session_complete"]);
+      const found = getProvider(created.id);
+      expect(found).not.toBeNull();
+      expect(found!.name).toBe("Slack");
+    });
+
+    it("returns null for nonexistent ID", () => {
+      expect(getProvider("nonexistent")).toBeNull();
+    });
+  });
+
+  describe("updateProvider", () => {
+    it("updates name, config, triggers", () => {
+      const created = createProvider("Slack", slackConfig, ["session_complete"]);
+      const updated = updateProvider(created.id, {
+        name: "Updated Slack",
+        config: telegramConfig,
+        triggers: ["session_error"],
+      });
+
+      expect(updated).not.toBeNull();
+      expect(updated!.name).toBe("Updated Slack");
+      expect(updated!.config).toEqual(telegramConfig);
+      expect(updated!.type).toBe("telegram");
+      expect(updated!.triggers).toEqual(["session_error"]);
+    });
+
+    it("preserves createdAt and advances updatedAt", () => {
+      const created = createProvider("Slack", slackConfig, []);
+      const originalCreatedAt = created.createdAt;
+
+      const updated = updateProvider(created.id, { name: "Renamed" });
+      expect(updated!.createdAt).toBe(originalCreatedAt);
+      expect(updated!.updatedAt).toBeGreaterThanOrEqual(originalCreatedAt);
+    });
+
+    it("returns null for nonexistent ID", () => {
+      expect(updateProvider("nonexistent", { name: "x" })).toBeNull();
+    });
+
+    it("partial updates keep existing values", () => {
+      const created = createProvider("Slack", slackConfig, ["session_complete"]);
+      const updated = updateProvider(created.id, { enabled: false });
+
+      expect(updated!.name).toBe("Slack");
+      expect(updated!.config).toEqual(slackConfig);
+      expect(updated!.triggers).toEqual(["session_complete"]);
+      expect(updated!.enabled).toBe(false);
+    });
+  });
+
+  describe("deleteProvider", () => {
+    it("deletes existing and returns true", () => {
+      const created = createProvider("Slack", slackConfig, []);
+      expect(deleteProvider(created.id)).toBe(true);
+      expect(listProviders()).toHaveLength(0);
+    });
+
+    it("returns false for nonexistent", () => {
+      expect(deleteProvider("nonexistent")).toBe(false);
+    });
+
+    it("persists deletion to disk", () => {
+      const created = createProvider("Slack", slackConfig, []);
+      deleteProvider(created.id);
+      const saved = JSON.parse(readFileSync(filePath, "utf-8"));
+      expect(saved).toHaveLength(0);
+    });
+  });
+
+  describe("getEnabledForTrigger", () => {
+    it("returns only enabled providers matching trigger", () => {
+      createProvider("Slack", slackConfig, ["session_complete"]);
+      createProvider("Telegram", telegramConfig, ["session_error"]);
+
+      const matches = getEnabledForTrigger("session_complete");
+      expect(matches).toHaveLength(1);
+      expect(matches[0].name).toBe("Slack");
+    });
+
+    it("excludes disabled providers", () => {
+      createProvider("Slack", slackConfig, ["session_complete"], false);
+
+      const matches = getEnabledForTrigger("session_complete");
+      expect(matches).toHaveLength(0);
+    });
+
+    it("returns empty array when no providers match", () => {
+      createProvider("Slack", slackConfig, ["session_complete"]);
+      expect(getEnabledForTrigger("permission_requested")).toHaveLength(0);
+    });
+
+    it("returns multiple matching providers", () => {
+      createProvider("Slack", slackConfig, ["session_complete"]);
+      createProvider("Telegram", telegramConfig, ["session_complete"]);
+
+      const matches = getEnabledForTrigger("session_complete");
+      expect(matches).toHaveLength(2);
+    });
+  });
+});

--- a/web/server/notification-manager.ts
+++ b/web/server/notification-manager.ts
@@ -1,0 +1,123 @@
+import {
+  mkdirSync,
+  readFileSync,
+  writeFileSync,
+  existsSync,
+} from "node:fs";
+import { join, dirname } from "node:path";
+import { homedir } from "node:os";
+import { randomUUID } from "node:crypto";
+import type {
+  NotificationProvider,
+  ProviderConfig,
+  NotificationTrigger,
+} from "./notification-types.js";
+
+const DEFAULT_PATH = join(homedir(), ".companion", "notifications.json");
+
+let loaded = false;
+let filePath = DEFAULT_PATH;
+let providers: NotificationProvider[] = [];
+
+function ensureLoaded(): void {
+  if (loaded) return;
+  try {
+    if (existsSync(filePath)) {
+      const raw = readFileSync(filePath, "utf-8");
+      const parsed = JSON.parse(raw);
+      providers = Array.isArray(parsed) ? parsed : [];
+    }
+  } catch {
+    providers = [];
+  }
+  loaded = true;
+}
+
+function persist(): void {
+  mkdirSync(dirname(filePath), { recursive: true });
+  writeFileSync(filePath, JSON.stringify(providers, null, 2), "utf-8");
+}
+
+export function listProviders(): NotificationProvider[] {
+  ensureLoaded();
+  return [...providers];
+}
+
+export function getProvider(id: string): NotificationProvider | null {
+  ensureLoaded();
+  return providers.find((p) => p.id === id) ?? null;
+}
+
+export function createProvider(
+  name: string,
+  config: ProviderConfig,
+  triggers: NotificationTrigger[],
+  enabled = true,
+): NotificationProvider {
+  ensureLoaded();
+  if (!name?.trim()) throw new Error("Provider name is required");
+
+  const now = Date.now();
+  const provider: NotificationProvider = {
+    id: randomUUID(),
+    type: config.type,
+    name: name.trim(),
+    enabled,
+    config,
+    triggers,
+    createdAt: now,
+    updatedAt: now,
+  };
+  providers.push(provider);
+  persist();
+  return provider;
+}
+
+export function updateProvider(
+  id: string,
+  updates: {
+    name?: string;
+    enabled?: boolean;
+    config?: ProviderConfig;
+    triggers?: NotificationTrigger[];
+  },
+): NotificationProvider | null {
+  ensureLoaded();
+  const idx = providers.findIndex((p) => p.id === id);
+  if (idx === -1) return null;
+
+  const existing = providers[idx];
+  providers[idx] = {
+    ...existing,
+    name: updates.name?.trim() || existing.name,
+    enabled: updates.enabled ?? existing.enabled,
+    config: updates.config ?? existing.config,
+    type: updates.config?.type ?? existing.type,
+    triggers: updates.triggers ?? existing.triggers,
+    updatedAt: Date.now(),
+  };
+  persist();
+  return { ...providers[idx] };
+}
+
+export function deleteProvider(id: string): boolean {
+  ensureLoaded();
+  const before = providers.length;
+  providers = providers.filter((p) => p.id !== id);
+  if (providers.length === before) return false;
+  persist();
+  return true;
+}
+
+export function getEnabledForTrigger(
+  trigger: NotificationTrigger,
+): NotificationProvider[] {
+  ensureLoaded();
+  return providers.filter((p) => p.enabled && p.triggers.includes(trigger));
+}
+
+export function _resetForTest(customPath?: string): void {
+  loaded = false;
+  filePath = customPath || DEFAULT_PATH;
+  providers = [];
+}

--- a/web/server/notification-sender.test.ts
+++ b/web/server/notification-sender.test.ts
@@ -1,0 +1,282 @@
+import { vi, type Mock } from "vitest";
+import { sendNotification, dispatchNotifications } from "./notification-sender.js";
+import type { NotificationProvider, NotificationEvent } from "./notification-types.js";
+
+let mockFetch: Mock;
+
+beforeEach(() => {
+  mockFetch = vi.fn().mockResolvedValue({ ok: true, text: async () => "" });
+  global.fetch = mockFetch as unknown as typeof fetch;
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+const testEvent: NotificationEvent = {
+  trigger: "session_complete",
+  sessionId: "test-session-123",
+  sessionName: "Test Session",
+  message: "Session completed (5 turns, $0.0123)",
+};
+
+function makeProvider(
+  overrides: Partial<NotificationProvider> & Pick<NotificationProvider, "config">,
+): NotificationProvider {
+  return {
+    id: "test-id",
+    type: overrides.config.type,
+    name: overrides.name ?? "Test Provider",
+    enabled: true,
+    triggers: ["session_complete"],
+    createdAt: Date.now(),
+    updatedAt: Date.now(),
+    ...overrides,
+  };
+}
+
+describe("notification-sender", () => {
+  describe("sendNotification", () => {
+    it("sends Slack notification with correct URL and body", async () => {
+      const provider = makeProvider({
+        config: {
+          type: "slack",
+          webhookUrl: "https://hooks.slack.com/services/test",
+          channel: "#alerts",
+        },
+      });
+
+      const result = await sendNotification(provider, testEvent);
+      expect(result.success).toBe(true);
+      expect(mockFetch).toHaveBeenCalledWith(
+        "https://hooks.slack.com/services/test",
+        expect.objectContaining({
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+        }),
+      );
+      const body = JSON.parse(mockFetch.mock.calls[0][1].body);
+      expect(body.text).toContain("[Companion]");
+      expect(body.channel).toBe("#alerts");
+    });
+
+    it("sends Telegram notification to correct API", async () => {
+      const provider = makeProvider({
+        config: { type: "telegram", botToken: "123:ABC", chatId: "-100123" },
+      });
+
+      const result = await sendNotification(provider, testEvent);
+      expect(result.success).toBe(true);
+      expect(mockFetch).toHaveBeenCalledWith(
+        "https://api.telegram.org/bot123:ABC/sendMessage",
+        expect.objectContaining({ method: "POST" }),
+      );
+      const body = JSON.parse(mockFetch.mock.calls[0][1].body);
+      expect(body.chat_id).toBe("-100123");
+    });
+
+    it("sends Discord notification with content field", async () => {
+      const provider = makeProvider({
+        config: { type: "discord", webhookUrl: "https://discord.com/api/webhooks/test" },
+      });
+
+      const result = await sendNotification(provider, testEvent);
+      expect(result.success).toBe(true);
+      const body = JSON.parse(mockFetch.mock.calls[0][1].body);
+      expect(body.content).toContain("[Companion]");
+    });
+
+    it("sends Lark notification with correct format", async () => {
+      const provider = makeProvider({
+        config: { type: "lark", webhookUrl: "https://open.larksuite.com/test" },
+      });
+
+      const result = await sendNotification(provider, testEvent);
+      expect(result.success).toBe(true);
+      const body = JSON.parse(mockFetch.mock.calls[0][1].body);
+      expect(body.msg_type).toBe("text");
+      expect(body.content.text).toContain("[Companion]");
+    });
+
+    it("sends Resend notification with auth header", async () => {
+      const provider = makeProvider({
+        config: {
+          type: "resend",
+          apiKey: "re_test123",
+          fromAddress: "noreply@test.com",
+          toAddresses: ["user@test.com"],
+        },
+      });
+
+      const result = await sendNotification(provider, testEvent);
+      expect(result.success).toBe(true);
+      expect(mockFetch).toHaveBeenCalledWith(
+        "https://api.resend.com/emails",
+        expect.objectContaining({
+          headers: expect.objectContaining({
+            Authorization: "Bearer re_test123",
+          }),
+        }),
+      );
+      const body = JSON.parse(mockFetch.mock.calls[0][1].body);
+      expect(body.from).toBe("noreply@test.com");
+      expect(body.to).toEqual(["user@test.com"]);
+    });
+
+    it("sends Gotify notification with X-Gotify-Key header", async () => {
+      const provider = makeProvider({
+        config: {
+          type: "gotify",
+          serverUrl: "https://gotify.example.com",
+          appToken: "gotify-token",
+          priority: 8,
+        },
+      });
+
+      const result = await sendNotification(provider, testEvent);
+      expect(result.success).toBe(true);
+      expect(mockFetch).toHaveBeenCalledWith(
+        "https://gotify.example.com/message",
+        expect.objectContaining({
+          headers: expect.objectContaining({ "X-Gotify-Key": "gotify-token" }),
+        }),
+      );
+      const body = JSON.parse(mockFetch.mock.calls[0][1].body);
+      expect(body.priority).toBe(8);
+    });
+
+    it("sends ntfy notification to topic URL with headers", async () => {
+      const provider = makeProvider({
+        config: {
+          type: "ntfy",
+          serverUrl: "https://ntfy.sh",
+          topic: "companion-alerts",
+          accessToken: "ntfy-token",
+          priority: 4,
+        },
+      });
+
+      const result = await sendNotification(provider, testEvent);
+      expect(result.success).toBe(true);
+      expect(mockFetch).toHaveBeenCalledWith(
+        "https://ntfy.sh/companion-alerts",
+        expect.objectContaining({
+          headers: expect.objectContaining({
+            Authorization: "Bearer ntfy-token",
+            Priority: "4",
+            Title: "Companion",
+          }),
+        }),
+      );
+    });
+
+    it("sends Pushover notification to API", async () => {
+      const provider = makeProvider({
+        config: { type: "pushover", userKey: "user123", apiToken: "api123" },
+      });
+
+      const result = await sendNotification(provider, testEvent);
+      expect(result.success).toBe(true);
+      expect(mockFetch).toHaveBeenCalledWith(
+        "https://api.pushover.net/1/messages.json",
+        expect.anything(),
+      );
+      const body = JSON.parse(mockFetch.mock.calls[0][1].body);
+      expect(body.token).toBe("api123");
+      expect(body.user).toBe("user123");
+    });
+
+    it("sends Custom webhook with custom method and headers", async () => {
+      const provider = makeProvider({
+        config: {
+          type: "custom",
+          webhookUrl: "https://example.com/hook",
+          headers: { "X-Custom": "value" },
+          method: "POST",
+        },
+      });
+
+      const result = await sendNotification(provider, testEvent);
+      expect(result.success).toBe(true);
+      expect(mockFetch).toHaveBeenCalledWith(
+        "https://example.com/hook",
+        expect.objectContaining({
+          method: "POST",
+          headers: expect.objectContaining({ "X-Custom": "value" }),
+        }),
+      );
+    });
+
+    it("handles Custom GET method without body", async () => {
+      const provider = makeProvider({
+        config: {
+          type: "custom",
+          webhookUrl: "https://example.com/hook",
+          headers: {},
+          method: "GET",
+        },
+      });
+
+      const result = await sendNotification(provider, testEvent);
+      expect(result.success).toBe(true);
+      const callArgs = mockFetch.mock.calls[0][1];
+      expect(callArgs.method).toBe("GET");
+      expect(callArgs.body).toBeUndefined();
+    });
+
+    it("returns error on non-ok response", async () => {
+      mockFetch.mockResolvedValue({
+        ok: false,
+        status: 403,
+        text: async () => "Forbidden",
+      });
+
+      const provider = makeProvider({
+        config: { type: "slack", webhookUrl: "https://hooks.slack.com/test" },
+      });
+
+      const result = await sendNotification(provider, testEvent);
+      expect(result.success).toBe(false);
+      expect(result.error).toContain("Slack");
+      expect(result.error).toContain("403");
+    });
+
+    it("returns error on network exception", async () => {
+      mockFetch.mockRejectedValue(new Error("Network error"));
+
+      const provider = makeProvider({
+        config: { type: "slack", webhookUrl: "https://hooks.slack.com/test" },
+      });
+
+      const result = await sendNotification(provider, testEvent);
+      expect(result.success).toBe(false);
+      expect(result.error).toBe("Network error");
+    });
+  });
+
+  describe("dispatchNotifications", () => {
+    it("sends to all providers and logs failures without throwing", async () => {
+      const consoleSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+
+      mockFetch
+        .mockResolvedValueOnce({ ok: true, text: async () => "" })
+        .mockResolvedValueOnce({ ok: false, status: 500, text: async () => "Server Error" });
+
+      const providers = [
+        makeProvider({ name: "Good", config: { type: "slack", webhookUrl: "https://good.com" } }),
+        makeProvider({ name: "Bad", config: { type: "discord", webhookUrl: "https://bad.com" } }),
+      ];
+
+      await expect(dispatchNotifications(providers, testEvent)).resolves.not.toThrow();
+      expect(mockFetch).toHaveBeenCalledTimes(2);
+      expect(consoleSpy).toHaveBeenCalled();
+
+      consoleSpy.mockRestore();
+    });
+
+    it("handles empty provider list", async () => {
+      await expect(dispatchNotifications([], testEvent)).resolves.not.toThrow();
+      expect(mockFetch).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/web/server/notification-sender.ts
+++ b/web/server/notification-sender.ts
@@ -1,0 +1,274 @@
+import type {
+  NotificationProvider,
+  NotificationEvent,
+  SlackConfig,
+  TelegramConfig,
+  DiscordConfig,
+  LarkConfig,
+  ResendConfig,
+  GotifyConfig,
+  NtfyConfig,
+  PushoverConfig,
+  CustomWebhookConfig,
+} from "./notification-types.js";
+
+export interface SendResult {
+  success: boolean;
+  error?: string;
+}
+
+export async function sendNotification(
+  provider: NotificationProvider,
+  event: NotificationEvent,
+): Promise<SendResult> {
+  try {
+    switch (provider.config.type) {
+      case "slack":
+        return await sendSlack(provider.config, event);
+      case "telegram":
+        return await sendTelegram(provider.config, event);
+      case "discord":
+        return await sendDiscord(provider.config, event);
+      case "lark":
+        return await sendLark(provider.config, event);
+      case "resend":
+        return await sendResend(provider.config, event);
+      case "gotify":
+        return await sendGotify(provider.config, event);
+      case "ntfy":
+        return await sendNtfy(provider.config, event);
+      case "pushover":
+        return await sendPushover(provider.config, event);
+      case "custom":
+        return await sendCustom(provider.config, event);
+      default:
+        return {
+          success: false,
+          error: `Unknown provider type: ${(provider.config as { type: string }).type}`,
+        };
+    }
+  } catch (err) {
+    return {
+      success: false,
+      error: err instanceof Error ? err.message : String(err),
+    };
+  }
+}
+
+function formatMessage(event: NotificationEvent): string {
+  return `[Companion] ${event.message}`;
+}
+
+async function sendSlack(
+  config: SlackConfig,
+  event: NotificationEvent,
+): Promise<SendResult> {
+  const body: Record<string, unknown> = { text: formatMessage(event) };
+  if (config.channel) body.channel = config.channel;
+
+  const res = await fetch(config.webhookUrl, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(body),
+  });
+  if (!res.ok)
+    return { success: false, error: `Slack: ${res.status} ${await res.text()}` };
+  return { success: true };
+}
+
+async function sendTelegram(
+  config: TelegramConfig,
+  event: NotificationEvent,
+): Promise<SendResult> {
+  const url = `https://api.telegram.org/bot${config.botToken}/sendMessage`;
+  const res = await fetch(url, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({
+      chat_id: config.chatId,
+      text: formatMessage(event),
+    }),
+  });
+  if (!res.ok)
+    return {
+      success: false,
+      error: `Telegram: ${res.status} ${await res.text()}`,
+    };
+  return { success: true };
+}
+
+async function sendDiscord(
+  config: DiscordConfig,
+  event: NotificationEvent,
+): Promise<SendResult> {
+  const res = await fetch(config.webhookUrl, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ content: formatMessage(event) }),
+  });
+  if (!res.ok)
+    return {
+      success: false,
+      error: `Discord: ${res.status} ${await res.text()}`,
+    };
+  return { success: true };
+}
+
+async function sendLark(
+  config: LarkConfig,
+  event: NotificationEvent,
+): Promise<SendResult> {
+  const res = await fetch(config.webhookUrl, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({
+      msg_type: "text",
+      content: { text: formatMessage(event) },
+    }),
+  });
+  if (!res.ok)
+    return { success: false, error: `Lark: ${res.status} ${await res.text()}` };
+  return { success: true };
+}
+
+async function sendResend(
+  config: ResendConfig,
+  event: NotificationEvent,
+): Promise<SendResult> {
+  const res = await fetch("https://api.resend.com/emails", {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      Authorization: `Bearer ${config.apiKey}`,
+    },
+    body: JSON.stringify({
+      from: config.fromAddress,
+      to: config.toAddresses,
+      subject: `[Companion] ${event.trigger}: ${event.sessionName || event.sessionId}`,
+      text: formatMessage(event),
+    }),
+  });
+  if (!res.ok)
+    return {
+      success: false,
+      error: `Resend: ${res.status} ${await res.text()}`,
+    };
+  return { success: true };
+}
+
+async function sendGotify(
+  config: GotifyConfig,
+  event: NotificationEvent,
+): Promise<SendResult> {
+  const url = `${config.serverUrl.replace(/\/$/, "")}/message`;
+  const res = await fetch(url, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      "X-Gotify-Key": config.appToken,
+    },
+    body: JSON.stringify({
+      title: "Companion",
+      message: formatMessage(event),
+      priority: config.priority ?? 5,
+    }),
+  });
+  if (!res.ok)
+    return {
+      success: false,
+      error: `Gotify: ${res.status} ${await res.text()}`,
+    };
+  return { success: true };
+}
+
+async function sendNtfy(
+  config: NtfyConfig,
+  event: NotificationEvent,
+): Promise<SendResult> {
+  const url = `${config.serverUrl.replace(/\/$/, "")}/${config.topic}`;
+  const headers: Record<string, string> = { Title: "Companion" };
+  if (config.accessToken) headers.Authorization = `Bearer ${config.accessToken}`;
+  if (config.priority) headers.Priority = String(config.priority);
+
+  const res = await fetch(url, {
+    method: "POST",
+    headers,
+    body: formatMessage(event),
+  });
+  if (!res.ok)
+    return { success: false, error: `ntfy: ${res.status} ${await res.text()}` };
+  return { success: true };
+}
+
+async function sendPushover(
+  config: PushoverConfig,
+  event: NotificationEvent,
+): Promise<SendResult> {
+  const res = await fetch("https://api.pushover.net/1/messages.json", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({
+      token: config.apiToken,
+      user: config.userKey,
+      title: "Companion",
+      message: formatMessage(event),
+    }),
+  });
+  if (!res.ok)
+    return {
+      success: false,
+      error: `Pushover: ${res.status} ${await res.text()}`,
+    };
+  return { success: true };
+}
+
+async function sendCustom(
+  config: CustomWebhookConfig,
+  event: NotificationEvent,
+): Promise<SendResult> {
+  const init: RequestInit = {
+    method: config.method,
+    headers: { "Content-Type": "application/json", ...config.headers },
+  };
+  if (config.method !== "GET") {
+    init.body = JSON.stringify({
+      trigger: event.trigger,
+      sessionId: event.sessionId,
+      sessionName: event.sessionName,
+      message: event.message,
+      details: event.details,
+    });
+  }
+  const res = await fetch(config.webhookUrl, init);
+  if (!res.ok)
+    return {
+      success: false,
+      error: `Custom: ${res.status} ${await res.text()}`,
+    };
+  return { success: true };
+}
+
+// ─── Dispatch to all matching providers ─────────────────────────────────────
+
+export async function dispatchNotifications(
+  providers: NotificationProvider[],
+  event: NotificationEvent,
+): Promise<void> {
+  const results = await Promise.allSettled(
+    providers.map((p) => sendNotification(p, event)),
+  );
+  for (let i = 0; i < results.length; i++) {
+    const r = results[i];
+    if (
+      r.status === "rejected" ||
+      (r.status === "fulfilled" && !r.value.success)
+    ) {
+      const error =
+        r.status === "rejected" ? r.reason : r.value.error;
+      console.error(
+        `[notification-sender] Failed to send to "${providers[i].name}" (${providers[i].type}):`,
+        error,
+      );
+    }
+  }
+}

--- a/web/server/notification-types.ts
+++ b/web/server/notification-types.ts
@@ -1,0 +1,101 @@
+// ─── Trigger Events ──────────────────────────────────────────────────────────
+
+export type NotificationTrigger =
+  | "session_complete"
+  | "session_error"
+  | "permission_requested";
+
+// ─── Provider-Specific Configs ───────────────────────────────────────────────
+
+export interface SlackConfig {
+  type: "slack";
+  webhookUrl: string;
+  channel?: string;
+}
+
+export interface TelegramConfig {
+  type: "telegram";
+  botToken: string;
+  chatId: string;
+}
+
+export interface DiscordConfig {
+  type: "discord";
+  webhookUrl: string;
+}
+
+export interface LarkConfig {
+  type: "lark";
+  webhookUrl: string;
+}
+
+export interface ResendConfig {
+  type: "resend";
+  apiKey: string;
+  fromAddress: string;
+  toAddresses: string[];
+}
+
+export interface GotifyConfig {
+  type: "gotify";
+  serverUrl: string;
+  appToken: string;
+  priority?: number;
+}
+
+export interface NtfyConfig {
+  type: "ntfy";
+  serverUrl: string;
+  topic: string;
+  accessToken?: string;
+  priority?: number;
+}
+
+export interface PushoverConfig {
+  type: "pushover";
+  userKey: string;
+  apiToken: string;
+}
+
+export interface CustomWebhookConfig {
+  type: "custom";
+  webhookUrl: string;
+  headers: Record<string, string>;
+  method: "GET" | "POST" | "PUT";
+}
+
+export type ProviderConfig =
+  | SlackConfig
+  | TelegramConfig
+  | DiscordConfig
+  | LarkConfig
+  | ResendConfig
+  | GotifyConfig
+  | NtfyConfig
+  | PushoverConfig
+  | CustomWebhookConfig;
+
+export type ProviderType = ProviderConfig["type"];
+
+// ─── Full Notification Provider Record ───────────────────────────────────────
+
+export interface NotificationProvider {
+  id: string;
+  type: ProviderType;
+  name: string;
+  enabled: boolean;
+  config: ProviderConfig;
+  triggers: NotificationTrigger[];
+  createdAt: number;
+  updatedAt: number;
+}
+
+// ─── Notification Event (passed to the sender) ──────────────────────────────
+
+export interface NotificationEvent {
+  trigger: NotificationTrigger;
+  sessionId: string;
+  sessionName?: string;
+  message: string;
+  details?: Record<string, unknown>;
+}

--- a/web/server/routes.ts
+++ b/web/server/routes.ts
@@ -16,6 +16,9 @@ import * as sessionNames from "./session-names.js";
 import { containerManager, type ContainerConfig, type ContainerInfo } from "./container-manager.js";
 import { DEFAULT_OPENROUTER_MODEL, getSettings, updateSettings } from "./settings-manager.js";
 import { getUsageLimits } from "./usage-limits.js";
+import * as notificationManager from "./notification-manager.js";
+import { sendNotification } from "./notification-sender.js";
+import type { NotificationEvent } from "./notification-types.js";
 import {
   getUpdateState,
   checkForUpdate,
@@ -703,6 +706,78 @@ export function createRoutes(
       openrouterApiKeyConfigured: !!settings.openrouterApiKey.trim(),
       openrouterModel: settings.openrouterModel || DEFAULT_OPENROUTER_MODEL,
     });
+  });
+
+  // ─── Notifications (~/.companion/notifications.json) ─────────────────
+
+  api.get("/notifications", (c) => {
+    try {
+      return c.json(notificationManager.listProviders());
+    } catch (e: unknown) {
+      return c.json({ error: e instanceof Error ? e.message : String(e) }, 500);
+    }
+  });
+
+  api.get("/notifications/:id", (c) => {
+    const provider = notificationManager.getProvider(c.req.param("id"));
+    if (!provider) return c.json({ error: "Provider not found" }, 404);
+    return c.json(provider);
+  });
+
+  api.post("/notifications", async (c) => {
+    const body = await c.req.json().catch(() => ({}));
+    try {
+      if (!body.config || !body.config.type) {
+        return c.json({ error: "Provider config with a valid type is required" }, 400);
+      }
+      const provider = notificationManager.createProvider(
+        body.name,
+        body.config,
+        body.triggers || [],
+        body.enabled,
+      );
+      return c.json(provider, 201);
+    } catch (e: unknown) {
+      return c.json({ error: e instanceof Error ? e.message : String(e) }, 400);
+    }
+  });
+
+  api.put("/notifications/:id", async (c) => {
+    const id = c.req.param("id");
+    const body = await c.req.json().catch(() => ({}));
+    try {
+      const provider = notificationManager.updateProvider(id, {
+        name: body.name,
+        config: body.config,
+        triggers: body.triggers,
+        enabled: body.enabled,
+      });
+      if (!provider) return c.json({ error: "Provider not found" }, 404);
+      return c.json(provider);
+    } catch (e: unknown) {
+      return c.json({ error: e instanceof Error ? e.message : String(e) }, 400);
+    }
+  });
+
+  api.delete("/notifications/:id", (c) => {
+    const deleted = notificationManager.deleteProvider(c.req.param("id"));
+    if (!deleted) return c.json({ error: "Provider not found" }, 404);
+    return c.json({ ok: true });
+  });
+
+  api.post("/notifications/:id/test", async (c) => {
+    const provider = notificationManager.getProvider(c.req.param("id"));
+    if (!provider) return c.json({ error: "Provider not found" }, 404);
+
+    const testEvent: NotificationEvent = {
+      trigger: "session_complete",
+      sessionId: "test-session",
+      sessionName: "Test Session",
+      message: "This is a test notification from Companion.",
+    };
+
+    const result = await sendNotification(provider, testEvent);
+    return c.json(result);
   });
 
   // ─── Git operations ─────────────────────────────────────────────────

--- a/web/server/ws-bridge.ts
+++ b/web/server/ws-bridge.ts
@@ -193,6 +193,12 @@ export class WsBridge {
     "git_ahead",
     "git_behind",
   ];
+  private onNotificationTrigger: ((
+    trigger: "session_complete" | "session_error" | "permission_requested",
+    sessionId: string,
+    sessionCwd: string,
+    message: string,
+  ) => void) | null = null;
 
   /** Register a callback for when we learn the CLI's internal session ID. */
   onCLISessionIdReceived(cb: (sessionId: string, cliSessionId: string) => void): void {
@@ -212,6 +218,16 @@ export class WsBridge {
   /** Register a callback for when git info is resolved and branch is known. */
   onSessionGitInfoReadyCallback(cb: (sessionId: string, cwd: string, branch: string) => void): void {
     this.onGitInfoReady = cb;
+  }
+
+  /** Register a callback for notification triggers (session complete/error, permission requested). */
+  onNotificationTriggerCallback(cb: (
+    trigger: "session_complete" | "session_error" | "permission_requested",
+    sessionId: string,
+    sessionCwd: string,
+    message: string,
+  ) => void): void {
+    this.onNotificationTrigger = cb;
   }
 
   /** Push a message to all connected browsers for a session (public, for PRPoller etc.). */
@@ -802,6 +818,16 @@ export class WsBridge {
     this.broadcastToBrowsers(session, browserMsg);
     this.persistSession(session);
 
+    // Fire notification trigger
+    if (this.onNotificationTrigger) {
+      const trigger = msg.is_error ? "session_error" : "session_complete";
+      const cwd = session.state.cwd || session.id;
+      const message = msg.is_error
+        ? `Session error: ${msg.errors?.join(", ") || "unknown error"}`
+        : `Session completed (${msg.num_turns} turns, $${(msg.total_cost_usd || 0).toFixed(4)})`;
+      this.onNotificationTrigger(trigger, session.id, cwd, message);
+    }
+
     // Trigger auto-naming after the first successful result for this session.
     // Note: num_turns counts all internal tool-use turns, so it's typically > 1
     // even on the first user interaction. We track per-session instead.
@@ -847,6 +873,16 @@ export class WsBridge {
         request: perm,
       });
       this.persistSession(session);
+
+      // Fire notification trigger for permission requests
+      if (this.onNotificationTrigger) {
+        this.onNotificationTrigger(
+          "permission_requested",
+          session.id,
+          session.state.cwd || session.id,
+          `Permission requested: ${msg.request.tool_name || "unknown"}`,
+        );
+      }
     }
   }
 

--- a/web/src/api.ts
+++ b/web/src/api.ts
@@ -1,5 +1,10 @@
 import type { SdkSessionInfo } from "./types.js";
 import { captureEvent, captureException } from "./analytics.js";
+import type {
+  NotificationProvider,
+  ProviderConfig,
+  NotificationTrigger,
+} from "../server/notification-types.js";
 
 const BASE = "/api";
 
@@ -366,6 +371,32 @@ export const api = {
   getSettings: () => get<AppSettings>("/settings"),
   updateSettings: (data: { openrouterApiKey?: string; openrouterModel?: string }) =>
     put<AppSettings>("/settings", data),
+
+  // Notifications
+  listNotificationProviders: () => get<NotificationProvider[]>("/notifications"),
+  getNotificationProvider: (id: string) =>
+    get<NotificationProvider>(`/notifications/${encodeURIComponent(id)}`),
+  createNotificationProvider: (data: {
+    name: string;
+    config: ProviderConfig;
+    triggers: NotificationTrigger[];
+    enabled?: boolean;
+  }) => post<NotificationProvider>("/notifications", data),
+  updateNotificationProvider: (
+    id: string,
+    data: {
+      name?: string;
+      config?: ProviderConfig;
+      triggers?: NotificationTrigger[];
+      enabled?: boolean;
+    },
+  ) => put<NotificationProvider>(`/notifications/${encodeURIComponent(id)}`, data),
+  deleteNotificationProvider: (id: string) =>
+    del(`/notifications/${encodeURIComponent(id)}`),
+  testNotificationProvider: (id: string) =>
+    post<{ success: boolean; error?: string }>(
+      `/notifications/${encodeURIComponent(id)}/test`,
+    ),
 
   // Git operations
   getRepoInfo: (path: string) =>

--- a/web/src/components/NotificationSettings.test.tsx
+++ b/web/src/components/NotificationSettings.test.tsx
@@ -1,0 +1,181 @@
+// @vitest-environment jsdom
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import "@testing-library/jest-dom";
+
+const mockApi = {
+  listNotificationProviders: vi.fn(),
+  createNotificationProvider: vi.fn(),
+  updateNotificationProvider: vi.fn(),
+  deleteNotificationProvider: vi.fn(),
+  testNotificationProvider: vi.fn(),
+};
+
+vi.mock("../api.js", () => ({
+  api: {
+    listNotificationProviders: (...args: unknown[]) =>
+      mockApi.listNotificationProviders(...args),
+    createNotificationProvider: (...args: unknown[]) =>
+      mockApi.createNotificationProvider(...args),
+    updateNotificationProvider: (...args: unknown[]) =>
+      mockApi.updateNotificationProvider(...args),
+    deleteNotificationProvider: (...args: unknown[]) =>
+      mockApi.deleteNotificationProvider(...args),
+    testNotificationProvider: (...args: unknown[]) =>
+      mockApi.testNotificationProvider(...args),
+  },
+}));
+
+import { NotificationSettings } from "./NotificationSettings.js";
+
+const slackProvider = {
+  id: "test-slack-1",
+  type: "slack" as const,
+  name: "My Slack",
+  enabled: true,
+  config: {
+    type: "slack" as const,
+    webhookUrl: "https://hooks.slack.com/services/test",
+  },
+  triggers: ["session_complete" as const],
+  createdAt: Date.now(),
+  updatedAt: Date.now(),
+};
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockApi.listNotificationProviders.mockResolvedValue([]);
+});
+
+describe("NotificationSettings", () => {
+  it("loads providers on mount and shows empty state", async () => {
+    render(<NotificationSettings />);
+
+    await waitFor(() => {
+      expect(mockApi.listNotificationProviders).toHaveBeenCalledTimes(1);
+    });
+
+    expect(
+      screen.getByText(/No notification providers configured/),
+    ).toBeInTheDocument();
+  });
+
+  it("renders provider list when providers exist", async () => {
+    mockApi.listNotificationProviders.mockResolvedValueOnce([slackProvider]);
+
+    render(<NotificationSettings />);
+
+    expect(await screen.findByText("My Slack")).toBeInTheDocument();
+    expect(screen.getByText("Slack")).toBeInTheDocument();
+    expect(screen.getByText("On")).toBeInTheDocument();
+  });
+
+  it("shows Add Provider button", async () => {
+    render(<NotificationSettings />);
+    await waitFor(() => {
+      expect(mockApi.listNotificationProviders).toHaveBeenCalled();
+    });
+
+    expect(
+      screen.getByRole("button", { name: "Add Provider" }),
+    ).toBeInTheDocument();
+  });
+
+  it("opens form when Add Provider is clicked", async () => {
+    render(<NotificationSettings />);
+    await waitFor(() => {
+      expect(mockApi.listNotificationProviders).toHaveBeenCalled();
+    });
+
+    fireEvent.click(screen.getByRole("button", { name: "Add Provider" }));
+
+    expect(screen.getByText("Provider Type")).toBeInTheDocument();
+    expect(screen.getByText("Name")).toBeInTheDocument();
+  });
+
+  it("toggles enabled/disabled when toggle is clicked", async () => {
+    mockApi.listNotificationProviders.mockResolvedValueOnce([slackProvider]);
+    mockApi.updateNotificationProvider.mockResolvedValueOnce({
+      ...slackProvider,
+      enabled: false,
+    });
+    // After toggle, re-fetch returns updated
+    mockApi.listNotificationProviders.mockResolvedValueOnce([
+      { ...slackProvider, enabled: false },
+    ]);
+
+    render(<NotificationSettings />);
+    await screen.findByText("My Slack");
+
+    fireEvent.click(screen.getByText("On"));
+
+    await waitFor(() => {
+      expect(mockApi.updateNotificationProvider).toHaveBeenCalledWith(
+        "test-slack-1",
+        { enabled: false },
+      );
+    });
+  });
+
+  it("deletes a provider", async () => {
+    mockApi.listNotificationProviders.mockResolvedValueOnce([slackProvider]);
+    mockApi.deleteNotificationProvider.mockResolvedValueOnce({ ok: true });
+    mockApi.listNotificationProviders.mockResolvedValueOnce([]);
+
+    render(<NotificationSettings />);
+    await screen.findByText("My Slack");
+
+    fireEvent.click(screen.getByText("Delete"));
+
+    await waitFor(() => {
+      expect(mockApi.deleteNotificationProvider).toHaveBeenCalledWith(
+        "test-slack-1",
+      );
+    });
+  });
+
+  it("calls test API when Test button is clicked", async () => {
+    mockApi.listNotificationProviders.mockResolvedValueOnce([slackProvider]);
+    mockApi.testNotificationProvider.mockResolvedValueOnce({ success: true });
+
+    render(<NotificationSettings />);
+    await screen.findByText("My Slack");
+
+    fireEvent.click(screen.getByText("Test"));
+
+    await waitFor(() => {
+      expect(mockApi.testNotificationProvider).toHaveBeenCalledWith(
+        "test-slack-1",
+      );
+    });
+
+    expect(
+      await screen.findByText("Test notification sent successfully."),
+    ).toBeInTheDocument();
+  });
+
+  it("shows error when test fails", async () => {
+    mockApi.listNotificationProviders.mockResolvedValueOnce([slackProvider]);
+    mockApi.testNotificationProvider.mockResolvedValueOnce({
+      success: false,
+      error: "Webhook returned 403",
+    });
+
+    render(<NotificationSettings />);
+    await screen.findByText("My Slack");
+
+    fireEvent.click(screen.getByText("Test"));
+
+    expect(
+      await screen.findByText("Test failed: Webhook returned 403"),
+    ).toBeInTheDocument();
+  });
+
+  it("shows trigger badges on provider cards", async () => {
+    mockApi.listNotificationProviders.mockResolvedValueOnce([slackProvider]);
+
+    render(<NotificationSettings />);
+    await screen.findByText("My Slack");
+
+    expect(screen.getByText("Session Complete")).toBeInTheDocument();
+  });
+});

--- a/web/src/components/NotificationSettings.tsx
+++ b/web/src/components/NotificationSettings.tsx
@@ -1,0 +1,633 @@
+import { useState, useEffect } from "react";
+import { api } from "../api.js";
+import type {
+  NotificationProvider,
+  ProviderConfig,
+  ProviderType,
+  NotificationTrigger,
+} from "../../server/notification-types.js";
+
+// ─── Provider metadata ──────────────────────────────────────────────────────
+
+const PROVIDER_LABELS: Record<ProviderType, string> = {
+  slack: "Slack",
+  telegram: "Telegram",
+  discord: "Discord",
+  lark: "Lark",
+  resend: "Resend (Email)",
+  gotify: "Gotify",
+  ntfy: "ntfy",
+  pushover: "Pushover",
+  custom: "Custom Webhook",
+};
+
+const PROVIDER_TYPES = Object.keys(PROVIDER_LABELS) as ProviderType[];
+
+interface FieldDef {
+  label: string;
+  key: string;
+  type: "text" | "password" | "number" | "select";
+  required: boolean;
+  placeholder: string;
+  options?: string[];
+}
+
+const PROVIDER_FIELDS: Record<ProviderType, FieldDef[]> = {
+  slack: [
+    { label: "Webhook URL", key: "webhookUrl", type: "text", required: true, placeholder: "https://hooks.slack.com/services/..." },
+    { label: "Channel", key: "channel", type: "text", required: false, placeholder: "#general (optional)" },
+  ],
+  telegram: [
+    { label: "Bot Token", key: "botToken", type: "password", required: true, placeholder: "123456:ABC-..." },
+    { label: "Chat ID", key: "chatId", type: "text", required: true, placeholder: "-100123456789" },
+  ],
+  discord: [
+    { label: "Webhook URL", key: "webhookUrl", type: "text", required: true, placeholder: "https://discord.com/api/webhooks/..." },
+  ],
+  lark: [
+    { label: "Webhook URL", key: "webhookUrl", type: "text", required: true, placeholder: "https://open.larksuite.com/open-apis/bot/v2/hook/..." },
+  ],
+  resend: [
+    { label: "API Key", key: "apiKey", type: "password", required: true, placeholder: "re_..." },
+    { label: "From Address", key: "fromAddress", type: "text", required: true, placeholder: "notifications@yourdomain.com" },
+    { label: "To Addresses (comma-separated)", key: "toAddresses", type: "text", required: true, placeholder: "user@example.com, other@example.com" },
+  ],
+  gotify: [
+    { label: "Server URL", key: "serverUrl", type: "text", required: true, placeholder: "https://gotify.example.com" },
+    { label: "App Token", key: "appToken", type: "password", required: true, placeholder: "A..." },
+    { label: "Priority", key: "priority", type: "number", required: false, placeholder: "5" },
+  ],
+  ntfy: [
+    { label: "Server URL", key: "serverUrl", type: "text", required: true, placeholder: "https://ntfy.sh" },
+    { label: "Topic", key: "topic", type: "text", required: true, placeholder: "companion-alerts" },
+    { label: "Access Token", key: "accessToken", type: "password", required: false, placeholder: "(optional)" },
+    { label: "Priority", key: "priority", type: "number", required: false, placeholder: "3" },
+  ],
+  pushover: [
+    { label: "User Key", key: "userKey", type: "password", required: true, placeholder: "u..." },
+    { label: "API Token", key: "apiToken", type: "password", required: true, placeholder: "a..." },
+  ],
+  custom: [
+    { label: "Webhook URL", key: "webhookUrl", type: "text", required: true, placeholder: "https://..." },
+    { label: "HTTP Method", key: "method", type: "select", required: true, placeholder: "POST", options: ["GET", "POST", "PUT"] },
+  ],
+};
+
+const TRIGGER_LABELS: Record<NotificationTrigger, string> = {
+  session_complete: "Session Complete",
+  session_error: "Session Error",
+  permission_requested: "Permission Requested",
+};
+
+const ALL_TRIGGERS: NotificationTrigger[] = [
+  "session_complete",
+  "session_error",
+  "permission_requested",
+];
+
+// ─── Helpers ─────────────────────────────────────────────────────────────────
+
+function buildDefaultConfig(type: ProviderType): ProviderConfig {
+  switch (type) {
+    case "slack": return { type: "slack", webhookUrl: "" };
+    case "telegram": return { type: "telegram", botToken: "", chatId: "" };
+    case "discord": return { type: "discord", webhookUrl: "" };
+    case "lark": return { type: "lark", webhookUrl: "" };
+    case "resend": return { type: "resend", apiKey: "", fromAddress: "", toAddresses: [] };
+    case "gotify": return { type: "gotify", serverUrl: "", appToken: "" };
+    case "ntfy": return { type: "ntfy", serverUrl: "https://ntfy.sh", topic: "" };
+    case "pushover": return { type: "pushover", userKey: "", apiToken: "" };
+    case "custom": return { type: "custom", webhookUrl: "", headers: {}, method: "POST" };
+  }
+}
+
+function getConfigValue(config: ProviderConfig, key: string): string {
+  const val = (config as unknown as Record<string, unknown>)[key];
+  if (Array.isArray(val)) return val.join(", ");
+  if (typeof val === "object" && val !== null) {
+    return Object.entries(val).map(([k, v]) => `${k}: ${v}`).join("\n");
+  }
+  return val != null ? String(val) : "";
+}
+
+function setConfigValue(
+  config: ProviderConfig,
+  key: string,
+  value: string,
+  fieldType: string,
+): ProviderConfig {
+  const clone = { ...config } as unknown as Record<string, unknown>;
+  if (key === "toAddresses") {
+    clone[key] = value.split(",").map((s) => s.trim()).filter(Boolean);
+  } else if (fieldType === "number") {
+    clone[key] = value === "" ? undefined : Number(value);
+  } else {
+    clone[key] = value;
+  }
+  return clone as unknown as ProviderConfig;
+}
+
+// ─── Header Editor (for Custom webhook) ──────────────────────────────────────
+
+interface HeaderRow {
+  key: string;
+  value: string;
+}
+
+function HeaderEditor({
+  headers,
+  onChange,
+}: {
+  headers: Record<string, string>;
+  onChange: (h: Record<string, string>) => void;
+}) {
+  const [rows, setRows] = useState<HeaderRow[]>(() => {
+    const entries = Object.entries(headers).map(([key, value]) => ({ key, value }));
+    return entries.length === 0 ? [{ key: "", value: "" }] : entries;
+  });
+
+  function emitHeaders(updated: HeaderRow[]) {
+    const result: Record<string, string> = {};
+    for (const r of updated) {
+      if (r.key.trim()) result[r.key.trim()] = r.value;
+    }
+    onChange(result);
+  }
+
+  function update(idx: number, field: "key" | "value", val: string) {
+    const next = [...rows];
+    next[idx] = { ...next[idx], [field]: val };
+    setRows(next);
+    emitHeaders(next);
+  }
+
+  function addRow() {
+    const next = [...rows, { key: "", value: "" }];
+    setRows(next);
+  }
+
+  function removeRow(idx: number) {
+    const next = rows.filter((_, i) => i !== idx);
+    setRows(next.length === 0 ? [{ key: "", value: "" }] : next);
+    emitHeaders(next);
+  }
+
+  return (
+    <div className="space-y-2">
+      <label className="block text-sm font-medium">Custom Headers</label>
+      {rows.map((row, i) => (
+        <div key={i} className="flex gap-2">
+          <input
+            type="text"
+            value={row.key}
+            onChange={(e) => update(i, "key", e.target.value)}
+            placeholder="Header name"
+            className="flex-1 px-3 py-2 text-sm bg-cc-input-bg border border-cc-border rounded-lg text-cc-fg placeholder:text-cc-muted focus:outline-none focus:border-cc-primary/60"
+          />
+          <input
+            type="text"
+            value={row.value}
+            onChange={(e) => update(i, "value", e.target.value)}
+            placeholder="Value"
+            className="flex-1 px-3 py-2 text-sm bg-cc-input-bg border border-cc-border rounded-lg text-cc-fg placeholder:text-cc-muted focus:outline-none focus:border-cc-primary/60"
+          />
+          <button
+            type="button"
+            onClick={() => removeRow(i)}
+            className="px-2 text-cc-muted hover:text-cc-error text-sm cursor-pointer"
+          >
+            x
+          </button>
+        </div>
+      ))}
+      <button
+        type="button"
+        onClick={addRow}
+        className="text-xs text-cc-primary hover:underline cursor-pointer"
+      >
+        + Add header
+      </button>
+    </div>
+  );
+}
+
+// ─── Provider Form ───────────────────────────────────────────────────────────
+
+interface ProviderFormProps {
+  initialType?: ProviderType;
+  initialName?: string;
+  initialConfig?: ProviderConfig;
+  initialTriggers?: NotificationTrigger[];
+  onSave: (name: string, config: ProviderConfig, triggers: NotificationTrigger[]) => Promise<void>;
+  onCancel: () => void;
+  saving: boolean;
+}
+
+function ProviderForm({
+  initialType = "slack",
+  initialName = "",
+  initialConfig,
+  initialTriggers = ["session_complete", "session_error", "permission_requested"],
+  onSave,
+  onCancel,
+  saving,
+}: ProviderFormProps) {
+  const [providerType, setProviderType] = useState<ProviderType>(initialType);
+  const [name, setName] = useState(initialName);
+  const [config, setConfig] = useState<ProviderConfig>(
+    initialConfig ?? buildDefaultConfig(initialType),
+  );
+  const [triggers, setTriggers] = useState<NotificationTrigger[]>(initialTriggers);
+  const [error, setError] = useState("");
+
+  function handleTypeChange(newType: ProviderType) {
+    setProviderType(newType);
+    setConfig(buildDefaultConfig(newType));
+  }
+
+  function toggleTrigger(t: NotificationTrigger) {
+    setTriggers((prev) =>
+      prev.includes(t) ? prev.filter((x) => x !== t) : [...prev, t],
+    );
+  }
+
+  async function handleSubmit(e: React.FormEvent) {
+    e.preventDefault();
+    setError("");
+    if (!name.trim()) {
+      setError("Name is required");
+      return;
+    }
+    try {
+      await onSave(name.trim(), config, triggers);
+    } catch (err: unknown) {
+      setError(err instanceof Error ? err.message : String(err));
+    }
+  }
+
+  const fields = PROVIDER_FIELDS[providerType];
+
+  return (
+    <form onSubmit={handleSubmit} className="space-y-3">
+      <div>
+        <label className="block text-sm font-medium mb-1">Provider Type</label>
+        <select
+          value={providerType}
+          onChange={(e) => handleTypeChange(e.target.value as ProviderType)}
+          disabled={!!initialConfig}
+          className="w-full px-3 py-2 text-sm bg-cc-input-bg border border-cc-border rounded-lg text-cc-fg focus:outline-none focus:border-cc-primary/60"
+        >
+          {PROVIDER_TYPES.map((t) => (
+            <option key={t} value={t}>
+              {PROVIDER_LABELS[t]}
+            </option>
+          ))}
+        </select>
+      </div>
+
+      <div>
+        <label className="block text-sm font-medium mb-1">Name</label>
+        <input
+          type="text"
+          value={name}
+          onChange={(e) => setName(e.target.value)}
+          placeholder="e.g. My Slack Alert"
+          className="w-full px-3 py-2 text-sm bg-cc-input-bg border border-cc-border rounded-lg text-cc-fg placeholder:text-cc-muted focus:outline-none focus:border-cc-primary/60"
+        />
+      </div>
+
+      {fields.map((field) => (
+        <div key={field.key}>
+          <label className="block text-sm font-medium mb-1">
+            {field.label}
+            {field.required && <span className="text-cc-error ml-0.5">*</span>}
+          </label>
+          {field.type === "select" && field.options ? (
+            <select
+              value={getConfigValue(config, field.key) || field.options[0]}
+              onChange={(e) =>
+                setConfig(setConfigValue(config, field.key, e.target.value, field.type))
+              }
+              className="w-full px-3 py-2 text-sm bg-cc-input-bg border border-cc-border rounded-lg text-cc-fg focus:outline-none focus:border-cc-primary/60"
+            >
+              {field.options.map((opt) => (
+                <option key={opt} value={opt}>{opt}</option>
+              ))}
+            </select>
+          ) : (
+            <input
+              type={field.type}
+              value={getConfigValue(config, field.key)}
+              onChange={(e) =>
+                setConfig(setConfigValue(config, field.key, e.target.value, field.type))
+              }
+              placeholder={field.placeholder}
+              className="w-full px-3 py-2 text-sm bg-cc-input-bg border border-cc-border rounded-lg text-cc-fg placeholder:text-cc-muted focus:outline-none focus:border-cc-primary/60"
+            />
+          )}
+        </div>
+      ))}
+
+      {providerType === "custom" && (
+        <HeaderEditor
+          headers={(config as { headers: Record<string, string> }).headers || {}}
+          onChange={(h) => setConfig({ ...config, headers: h } as ProviderConfig)}
+        />
+      )}
+
+      <div>
+        <label className="block text-sm font-medium mb-1.5">Triggers</label>
+        <div className="flex flex-wrap gap-2">
+          {ALL_TRIGGERS.map((t) => (
+            <label
+              key={t}
+              className="flex items-center gap-1.5 text-sm cursor-pointer"
+            >
+              <input
+                type="checkbox"
+                checked={triggers.includes(t)}
+                onChange={() => toggleTrigger(t)}
+                className="accent-cc-primary"
+              />
+              {TRIGGER_LABELS[t]}
+            </label>
+          ))}
+        </div>
+      </div>
+
+      {error && (
+        <div className="px-3 py-2 rounded-lg bg-cc-error/10 border border-cc-error/20 text-xs text-cc-error">
+          {error}
+        </div>
+      )}
+
+      <div className="flex gap-2 justify-end">
+        <button
+          type="button"
+          onClick={onCancel}
+          className="px-3 py-1.5 rounded-lg text-sm text-cc-muted hover:text-cc-fg hover:bg-cc-hover transition-colors cursor-pointer"
+        >
+          Cancel
+        </button>
+        <button
+          type="submit"
+          disabled={saving}
+          className={`px-3 py-1.5 rounded-lg text-sm font-medium transition-colors ${
+            saving
+              ? "bg-cc-hover text-cc-muted cursor-not-allowed"
+              : "bg-cc-primary hover:bg-cc-primary-hover text-white cursor-pointer"
+          }`}
+        >
+          {saving ? "Saving..." : "Save"}
+        </button>
+      </div>
+    </form>
+  );
+}
+
+// ─── Main Component ──────────────────────────────────────────────────────────
+
+interface NotificationSettingsProps {
+  embedded?: boolean;
+}
+
+export function NotificationSettings({ embedded = false }: NotificationSettingsProps) {
+  const [providers, setProviders] = useState<NotificationProvider[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [adding, setAdding] = useState(false);
+  const [editingId, setEditingId] = useState<string | null>(null);
+  const [saving, setSaving] = useState(false);
+  const [testingId, setTestingId] = useState<string | null>(null);
+  const [testResult, setTestResult] = useState<{ id: string; success: boolean; error?: string } | null>(null);
+
+  function refresh() {
+    api
+      .listNotificationProviders()
+      .then((list) => {
+        setProviders(list);
+      })
+      .catch(() => {})
+      .finally(() => setLoading(false));
+  }
+
+  useEffect(() => {
+    refresh();
+  }, []);
+
+  async function handleCreate(
+    name: string,
+    config: ProviderConfig,
+    triggers: NotificationTrigger[],
+  ) {
+    setSaving(true);
+    try {
+      await api.createNotificationProvider({ name, config, triggers });
+      setAdding(false);
+      refresh();
+    } finally {
+      setSaving(false);
+    }
+  }
+
+  async function handleUpdate(
+    id: string,
+    name: string,
+    config: ProviderConfig,
+    triggers: NotificationTrigger[],
+  ) {
+    setSaving(true);
+    try {
+      await api.updateNotificationProvider(id, { name, config, triggers });
+      setEditingId(null);
+      refresh();
+    } finally {
+      setSaving(false);
+    }
+  }
+
+  async function handleToggle(provider: NotificationProvider) {
+    try {
+      await api.updateNotificationProvider(provider.id, {
+        enabled: !provider.enabled,
+      });
+    } catch {
+      // Silently fail — refresh will restore correct state
+    }
+    refresh();
+  }
+
+  async function handleDelete(id: string) {
+    try {
+      await api.deleteNotificationProvider(id);
+    } catch {
+      // Silently fail — refresh will restore correct state
+    }
+    if (editingId === id) setEditingId(null);
+    refresh();
+  }
+
+  async function handleTest(id: string) {
+    setTestingId(id);
+    setTestResult(null);
+    try {
+      const result = await api.testNotificationProvider(id);
+      setTestResult({ id, ...result });
+    } catch (err: unknown) {
+      setTestResult({
+        id,
+        success: false,
+        error: err instanceof Error ? err.message : String(err),
+      });
+    } finally {
+      setTestingId(null);
+    }
+  }
+
+  if (loading) {
+    if (embedded) {
+      return <p className="text-xs text-cc-muted">Loading providers...</p>;
+    }
+    return (
+      <div className="bg-cc-card border border-cc-border rounded-xl p-4 sm:p-5">
+        <h2 className="text-sm font-semibold mb-3">Notifications</h2>
+        <p className="text-xs text-cc-muted">Loading...</p>
+      </div>
+    );
+  }
+
+  const content = (
+    <>
+      <div className="flex items-center justify-between">
+        {!embedded && <h2 className="text-sm font-semibold">Notifications</h2>}
+        {embedded && <h3 className="text-xs font-medium text-cc-muted uppercase tracking-wide">Providers</h3>}
+        {!adding && (
+          <button
+            onClick={() => { setAdding(true); setEditingId(null); }}
+            className="px-3 py-1.5 rounded-lg text-sm font-medium bg-cc-primary hover:bg-cc-primary-hover text-white transition-colors cursor-pointer"
+          >
+            Add Provider
+          </button>
+        )}
+      </div>
+
+      {providers.length === 0 && !adding && (
+        <p className="text-xs text-cc-muted">
+          No notification providers configured. Add one to receive alerts when
+          sessions complete or need approval.
+        </p>
+      )}
+
+      {/* Provider list */}
+      {providers.map((p) => (
+        <div
+          key={p.id}
+          className="border border-cc-border rounded-lg p-3 space-y-2"
+        >
+          {editingId === p.id ? (
+            <ProviderForm
+              initialType={p.type}
+              initialName={p.name}
+              initialConfig={p.config}
+              initialTriggers={p.triggers}
+              onSave={(name, config, triggers) =>
+                handleUpdate(p.id, name, config, triggers)
+              }
+              onCancel={() => setEditingId(null)}
+              saving={saving}
+            />
+          ) : (
+            <>
+              <div className="flex items-center justify-between gap-2">
+                <div className="flex items-center gap-2 min-w-0">
+                  <span className="text-sm font-medium truncate">
+                    {p.name}
+                  </span>
+                  <span className="px-1.5 py-0.5 rounded text-[10px] font-medium bg-cc-hover text-cc-muted uppercase tracking-wide">
+                    {PROVIDER_LABELS[p.type] || p.type}
+                  </span>
+                </div>
+                <div className="flex items-center gap-1.5 shrink-0">
+                  <button
+                    onClick={() => handleToggle(p)}
+                    className={`px-2 py-1 rounded text-xs font-medium transition-colors cursor-pointer ${
+                      p.enabled
+                        ? "bg-cc-success/15 text-cc-success"
+                        : "bg-cc-hover text-cc-muted"
+                    }`}
+                  >
+                    {p.enabled ? "On" : "Off"}
+                  </button>
+                  <button
+                    onClick={() => handleTest(p.id)}
+                    disabled={testingId === p.id}
+                    className="px-2 py-1 rounded text-xs text-cc-muted hover:text-cc-fg hover:bg-cc-hover transition-colors cursor-pointer disabled:cursor-not-allowed"
+                  >
+                    {testingId === p.id ? "..." : "Test"}
+                  </button>
+                  <button
+                    onClick={() => { setEditingId(p.id); setAdding(false); }}
+                    className="px-2 py-1 rounded text-xs text-cc-muted hover:text-cc-fg hover:bg-cc-hover transition-colors cursor-pointer"
+                  >
+                    Edit
+                  </button>
+                  <button
+                    onClick={() => handleDelete(p.id)}
+                    className="px-2 py-1 rounded text-xs text-cc-muted hover:text-cc-error hover:bg-cc-error/10 transition-colors cursor-pointer"
+                  >
+                    Delete
+                  </button>
+                </div>
+              </div>
+              {p.triggers.length > 0 && (
+                <div className="flex flex-wrap gap-1">
+                  {p.triggers.map((t) => (
+                    <span
+                      key={t}
+                      className="px-1.5 py-0.5 rounded text-[10px] bg-cc-hover text-cc-muted"
+                    >
+                      {TRIGGER_LABELS[t]}
+                    </span>
+                  ))}
+                </div>
+              )}
+              {testResult && testResult.id === p.id && (
+                <div
+                  className={`px-3 py-2 rounded-lg text-xs ${
+                    testResult.success
+                      ? "bg-cc-success/10 border border-cc-success/20 text-cc-success"
+                      : "bg-cc-error/10 border border-cc-error/20 text-cc-error"
+                  }`}
+                >
+                  {testResult.success
+                    ? "Test notification sent successfully."
+                    : `Test failed: ${testResult.error}`}
+                </div>
+              )}
+            </>
+          )}
+        </div>
+      ))}
+
+      {/* Add provider form */}
+      {adding && (
+        <div className="border border-cc-border rounded-lg p-3">
+          <ProviderForm
+            onSave={handleCreate}
+            onCancel={() => setAdding(false)}
+            saving={saving}
+          />
+        </div>
+      )}
+    </>
+  );
+
+  if (embedded) {
+    return <div className="space-y-3 pt-2 mt-2 border-t border-cc-border">{content}</div>;
+  }
+
+  return (
+    <div className="bg-cc-card border border-cc-border rounded-xl p-4 sm:p-5 space-y-4">
+      {content}
+    </div>
+  );
+}

--- a/web/src/components/SettingsPage.test.tsx
+++ b/web/src/components/SettingsPage.test.tsx
@@ -41,6 +41,7 @@ const mockApi = {
   updateSettings: vi.fn(),
   forceCheckForUpdate: vi.fn(),
   triggerUpdate: vi.fn(),
+  listNotificationProviders: vi.fn(),
 };
 
 const mockTelemetry = {
@@ -54,6 +55,7 @@ vi.mock("../api.js", () => ({
     updateSettings: (...args: unknown[]) => mockApi.updateSettings(...args),
     forceCheckForUpdate: (...args: unknown[]) => mockApi.forceCheckForUpdate(...args),
     triggerUpdate: (...args: unknown[]) => mockApi.triggerUpdate(...args),
+    listNotificationProviders: (...args: unknown[]) => mockApi.listNotificationProviders(...args),
   },
 }));
 
@@ -67,6 +69,10 @@ vi.mock("../store.js", () => {
   useStoreFn.getState = () => mockState;
   return { useStore: useStoreFn };
 });
+
+vi.mock("../utils/desktop-notifications.js", () => ({
+  showDesktopNotification: vi.fn(),
+}));
 
 import { SettingsPage } from "./SettingsPage.js";
 
@@ -95,6 +101,7 @@ beforeEach(() => {
     message: "Update started. Server will restart shortly.",
   });
   mockTelemetry.getTelemetryPreferenceEnabled.mockReturnValue(true);
+  mockApi.listNotificationProviders.mockResolvedValue([]);
 });
 
 describe("SettingsPage", () => {

--- a/web/src/components/SettingsPage.tsx
+++ b/web/src/components/SettingsPage.tsx
@@ -3,6 +3,8 @@ import { api } from "../api.js";
 import { useStore } from "../store.js";
 import { getTelemetryPreferenceEnabled, setTelemetryPreferenceEnabled } from "../analytics.js";
 
+import { NotificationSettings } from "./NotificationSettings.js";
+
 interface SettingsPageProps {
   embedded?: boolean;
 }
@@ -21,6 +23,7 @@ export function SettingsPage({ embedded = false }: SettingsPageProps) {
   const toggleNotificationSound = useStore((s) => s.toggleNotificationSound);
   const notificationDesktop = useStore((s) => s.notificationDesktop);
   const setNotificationDesktop = useStore((s) => s.setNotificationDesktop);
+
   const updateInfo = useStore((s) => s.updateInfo);
   const setUpdateInfo = useStore((s) => s.setUpdateInfo);
   const notificationApiAvailable = typeof Notification !== "undefined";
@@ -217,6 +220,7 @@ export function SettingsPage({ embedded = false }: SettingsPageProps) {
               <span className="text-xs text-cc-muted">{notificationDesktop ? "On" : "Off"}</span>
             </button>
           )}
+          <NotificationSettings embedded />
         </div>
 
         <div className="mt-4 bg-cc-card border border-cc-border rounded-xl p-4 sm:p-5 space-y-3">

--- a/web/src/utils/desktop-notifications.ts
+++ b/web/src/utils/desktop-notifications.ts
@@ -1,0 +1,9 @@
+export function showDesktopNotification(title: string, body: string, tag?: string): void {
+  if (!("Notification" in window)) return;
+  if (Notification.permission !== "granted") return;
+  try {
+    new Notification(title, { body, tag });
+  } catch {
+    // Silently fail if Notification API is not available
+  }
+}

--- a/web/src/ws.ts
+++ b/web/src/ws.ts
@@ -2,6 +2,7 @@ import { useStore } from "./store.js";
 import type { BrowserIncomingMessage, BrowserOutgoingMessage, ContentBlock, ChatMessage, TaskItem, SdkSessionInfo, McpServerConfig } from "./types.js";
 import { generateUniqueSessionName } from "./utils/names.js";
 import { playNotificationSound } from "./utils/notification-sound.js";
+import { showDesktopNotification } from "./utils/desktop-notifications.js";
 
 const sockets = new Map<string, WebSocket>();
 const reconnectTimers = new Map<string, ReturnType<typeof setTimeout>>();
@@ -122,12 +123,6 @@ function extractChangedFilesFromBlocks(sessionId: string, blocks: ContentBlock[]
       }
     }
   }
-}
-
-function sendBrowserNotification(title: string, body: string, tag: string) {
-  if (typeof Notification === "undefined") return;
-  if (Notification.permission !== "granted") return;
-  new Notification(title, { body, tag });
 }
 
 let idCounter = 0;
@@ -342,8 +337,14 @@ function handleParsedMessage(
       if (!document.hasFocus() && store.notificationSound) {
         playNotificationSound();
       }
-      if (!document.hasFocus() && store.notificationDesktop) {
-        sendBrowserNotification("Session completed", "Claude finished the task", sessionId);
+      // Desktop notification (browser-side)
+      if (!document.hasFocus() && useStore.getState().notificationDesktop) {
+        const sessionName = store.sessionNames.get(sessionId) || sessionId;
+        showDesktopNotification(
+          "Companion",
+          `${sessionName}: ${r.is_error ? "Session error" : "Session complete"}`,
+          sessionId,
+        );
       }
       if (r.is_error && r.errors?.length) {
         store.appendMessage(sessionId, {
@@ -358,12 +359,13 @@ function handleParsedMessage(
 
     case "permission_request": {
       store.addPermission(sessionId, data.request);
-      if (!document.hasFocus() && store.notificationDesktop) {
-        const req = data.request;
-        sendBrowserNotification(
-          "Permission needed",
-          `${req.tool_name}: approve or deny`,
-          req.request_id,
+      // Desktop notification for permission requests
+      if (!document.hasFocus() && useStore.getState().notificationDesktop) {
+        const sessionName = store.sessionNames.get(sessionId) || sessionId;
+        showDesktopNotification(
+          "Companion",
+          `${sessionName}: Permission requested - ${data.request.tool_name || "unknown"}`,
+          data.request.request_id,
         );
       }
       // Also extract tasks and changed files from permission requests


### PR DESCRIPTION
## Summary

- Add a pluggable server-side notification system supporting 9 providers: Slack, Telegram, Discord, Lark, Resend (email), Gotify, ntfy, Pushover, and Custom Webhook
- Each provider can be independently configured with specific triggers (session complete, session error, permission requested) and toggled on/off
- Provider configuration is persisted to `~/.companion/notifications.json`
- Frontend `NotificationSettings` component embedded in the Settings page with full CRUD, test, and enable/disable controls
- Desktop browser notifications via the Notification API for tab-unfocused alerts

## Architecture

**Server** (`web/server/`):
- `notification-types.ts` — TypeScript types for all provider configs, triggers, and events
- `notification-manager.ts` — CRUD for provider records with JSON file persistence
- `notification-sender.ts` — Dispatch engine that formats and sends to each provider type
- `routes.ts` — REST endpoints for provider management and test sends
- `ws-bridge.ts` — Fires notification events on session result and permission request

**Frontend** (`web/src/`):
- `NotificationSettings.tsx` — Full provider management UI (add/edit/delete/toggle/test)
- `desktop-notifications.ts` — Browser Notification API wrapper
- `SettingsPage.tsx` — Embeds notification settings
- `ws.ts` — Desktop notification triggers on session events

## Test plan

- [ ] Add a notification provider (e.g. ntfy) and verify it saves
- [ ] Toggle provider on/off and verify state persists
- [ ] Use "Test" button to send a test notification
- [ ] Verify notifications fire on session complete and permission request
- [ ] Enable desktop notifications and verify browser prompts for permission
- [ ] Edit and delete providers
- [ ] Verify all triggers are enabled by default for new providers
- [ ] Verify "Add header" works correctly for Custom Webhook provider