### PR TITLE
feat(analytics): add anonymous local interaction events

### DIFF
--- a/web/src/analytics-events.test.ts
+++ b/web/src/analytics-events.test.ts
@@ -1,0 +1,27 @@
+import { describe, it, expect } from "vitest";
+import { getPromptTelemetry } from "./analytics-events.js";
+
+describe("getPromptTelemetry", () => {
+  it("buckets empty messages as zeros and no attachment", () => {
+    const result = getPromptTelemetry("   ", 0);
+    expect(result).toEqual({
+      prompt_length_bucket: "0",
+      prompt_word_count_bucket: "0",
+      attachment_count_bucket: "0",
+      has_attachments: false,
+    });
+  });
+
+  it("produces larger buckets for longer prompts with attachments", () => {
+    const result = getPromptTelemetry(
+      "Refactor the billing module and add error handling around the external client call.",
+      3,
+    );
+    expect(result).toEqual(expect.objectContaining({
+      prompt_length_bucket: "81-200",
+      prompt_word_count_bucket: "11-25",
+      attachment_count_bucket: "3-5",
+      has_attachments: true,
+    }));
+  });
+});

--- a/web/src/analytics-events.ts
+++ b/web/src/analytics-events.ts
@@ -1,0 +1,38 @@
+export interface PromptTelemetry {
+  prompt_length_bucket: string;
+  prompt_word_count_bucket: string;
+  attachment_count_bucket: string;
+  has_attachments: boolean;
+}
+
+function bucketForNumber(value: number, boundaries: number[], labels: string[]): string {
+  for (let i = 0; i < boundaries.length; i++) {
+    if (value <= boundaries[i]) return labels[i];
+  }
+  return labels[labels.length - 1];
+}
+
+export function getPromptTelemetry(message: string, attachmentCount: number): PromptTelemetry {
+  const clean = message.trim();
+  const length = clean.length;
+  const wordCount = clean.length ? clean.split(/\s+/).filter(Boolean).length : 0;
+
+  return {
+    prompt_length_bucket: bucketForNumber(
+      length,
+      [0, 30, 80, 200, 500, 1200],
+      ["0", "1-30", "31-80", "81-200", "201-500", "501-1200", "1201+"],
+    ),
+    prompt_word_count_bucket: bucketForNumber(
+      wordCount,
+      [0, 4, 10, 25, 50, 100],
+      ["0", "1-4", "5-10", "11-25", "26-50", "51-100", "100+"],
+    ),
+    attachment_count_bucket: bucketForNumber(
+      attachmentCount,
+      [0, 1, 2, 5],
+      ["0", "1", "2", "3-5", "6+"],
+    ),
+    has_attachments: attachmentCount > 0,
+  };
+}

--- a/web/src/components/Composer.test.tsx
+++ b/web/src/components/Composer.test.tsx
@@ -8,6 +8,7 @@ import type { SessionState } from "../../server/session-types.js";
 Element.prototype.scrollIntoView = vi.fn();
 
 const mockSendToSession = vi.fn();
+const mockCaptureEvent = vi.fn();
 
 // Build a controllable mock store state
 let mockStoreState: Record<string, unknown> = {};
@@ -20,6 +21,10 @@ vi.mock("../api.js", () => ({
   api: {
     gitPull: vi.fn().mockResolvedValue({ success: true, output: "", git_ahead: 0, git_behind: 0 }),
   },
+}));
+
+vi.mock("../analytics.js", () => ({
+  captureEvent: (...args: unknown[]) => mockCaptureEvent(...args),
 }));
 
 // Mock useStore as a function that takes a selector
@@ -159,6 +164,12 @@ describe("Composer sending messages", () => {
       type: "user_message",
       content: "test message",
       session_id: "s1",
+    }));
+    expect(mockCaptureEvent).toHaveBeenCalledWith("user_prompt_submitted", expect.objectContaining({
+      source: "composer",
+      backend: "claude",
+      permission_mode: "acceptEdits",
+      has_attachments: false,
     }));
   });
 

--- a/web/src/components/Sidebar.test.tsx
+++ b/web/src/components/Sidebar.test.tsx
@@ -8,11 +8,16 @@ import type { SessionState, SdkSessionInfo } from "../types.js";
 const mockConnectSession = vi.fn();
 const mockConnectAllSessions = vi.fn();
 const mockDisconnectSession = vi.fn();
+const mockCaptureEvent = vi.fn();
 
 vi.mock("../ws.js", () => ({
   connectSession: (...args: unknown[]) => mockConnectSession(...args),
   connectAllSessions: (...args: unknown[]) => mockConnectAllSessions(...args),
   disconnectSession: (...args: unknown[]) => mockDisconnectSession(...args),
+}));
+
+vi.mock("../analytics.js", () => ({
+  captureEvent: (...args: unknown[]) => mockCaptureEvent(...args),
 }));
 
 const mockApi = {
@@ -395,6 +400,9 @@ describe("Sidebar", () => {
     render(<Sidebar />);
     fireEvent.click(screen.getByText("Terminal").closest("button")!);
     expect(window.location.hash).toBe("#/terminal");
+    expect(mockCaptureEvent).toHaveBeenCalledWith("terminal_opened", expect.objectContaining({
+      source: "sidebar",
+    }));
   });
 
   it("session name shows animate-name-appear class when recently renamed", () => {

--- a/web/src/components/Sidebar.tsx
+++ b/web/src/components/Sidebar.tsx
@@ -2,6 +2,7 @@ import { useState, useEffect, useCallback, useRef, useMemo } from "react";
 import { useStore } from "../store.js";
 import { api } from "../api.js";
 import { connectSession, connectAllSessions, disconnectSession } from "../ws.js";
+import { captureEvent } from "../analytics.js";
 import { ProjectGroup } from "./ProjectGroup.js";
 import { SessionItem } from "./SessionItem.js";
 import { groupSessionsByProject, type SessionItem as SessionItemType } from "../utils/project-grouping.js";
@@ -355,6 +356,10 @@ export function Sidebar() {
         <button
           onClick={() => {
             window.location.hash = "#/terminal";
+            captureEvent("terminal_opened", {
+              source: "sidebar",
+              has_existing_term_session: useStore.getState().terminalOpen,
+            });
             if (window.innerWidth < 768) {
               useStore.getState().setSidebarOpen(false);
             }

--- a/web/src/components/TerminalPage.tsx
+++ b/web/src/components/TerminalPage.tsx
@@ -2,6 +2,7 @@ import { useState } from "react";
 import { useStore } from "../store.js";
 import { FolderPicker } from "./FolderPicker.js";
 import { TerminalView } from "./TerminalView.js";
+import { captureEvent } from "../analytics.js";
 
 export function TerminalPage() {
   const terminalCwd = useStore((s) => s.terminalCwd);
@@ -19,7 +20,13 @@ export function TerminalPage() {
           </div>
           <button
             type="button"
-            onClick={() => setShowTerminalPicker(true)}
+            onClick={() => {
+              captureEvent("terminal_opened", {
+                source: "terminal_page",
+                has_existing_terminal: Boolean(terminalCwd),
+              });
+              setShowTerminalPicker(true);
+            }}
             className="px-3 py-2 rounded-lg text-sm font-medium bg-cc-primary hover:bg-cc-primary-hover text-white transition-colors cursor-pointer whitespace-nowrap"
           >
             {terminalCwd ? "Change Folder" : "Choose Folder"}
@@ -46,6 +53,10 @@ export function TerminalPage() {
         <FolderPicker
           initialPath={terminalCwd || ""}
           onSelect={(path) => {
+            captureEvent("terminal_folder_selected", {
+              source: "terminal_page",
+              has_active_terminal: Boolean(terminalCwd),
+            });
             useStore.getState().openTerminal(path);
             window.location.hash = "#/terminal";
             setShowTerminalPicker(false);


### PR DESCRIPTION
## Summary
- Add anonymous PostHog events for core local app interactions: session creation, prompt submission, terminal open actions.
- Introduce prompt telemetry bucketing (length/word count/attachment count) in .
- Add tests covering telemetry bucket logic and new capture events in Composer, Sidebar, and TerminalPage.

## Why
- Improve product analytics for The Companion local Bun app while keeping user data anonymous.
- Capture action-level behavior without sending raw prompt text.

## Testing
- Not run in this change set (per request).

## Review provenance
- Implemented by AI agent / Codex
- Human review: pending
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/the-vibe-company/companion/pull/245" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
