### PR TITLE
fix(codex): harden disconnect recovery and reasoning parsing

### DIFF
--- a/web/server/cli-launcher.ts
+++ b/web/server/cli-launcher.ts
@@ -504,6 +504,14 @@ export class CliLauncher {
       if (session) {
         session.state = "exited";
         session.exitCode = exitCode;
+        // If Codex exits shortly after launching a resumed thread, the saved
+        // thread id is often stale/corrupted. Clear it so the next relaunch
+        // starts a fresh thread instead of repeatedly failing on resume.
+        const uptime = Date.now() - spawnedAt;
+        if (uptime < 60_000 && session.cliSessionId) {
+          console.warn(`[cli-launcher] Codex session ${sessionId} exited quickly after resume (${uptime}ms). Clearing cliSessionId for fresh start.`);
+          session.cliSessionId = undefined;
+        }
       }
       this.processes.delete(sessionId);
       this.persistState();

--- a/web/server/ws-bridge.ts
+++ b/web/server/ws-bridge.ts
@@ -368,6 +368,13 @@ export class WsBridge {
     }
   }
 
+  private triggerRelaunchIfSessionActive(session: Session): void {
+    if (!this.onCLIRelaunchNeeded) return;
+    if (session.browserSockets.size === 0) return;
+    if (session.state.is_compacting) return;
+    this.onCLIRelaunchNeeded(session.id);
+  }
+
   private normalizeToolInput(input: Record<string, unknown>): { command?: string; filePath?: string } {
     return {
       command: typeof input.command === "string" ? input.command : undefined,
@@ -768,6 +775,7 @@ export class WsBridge {
           this.broadcastPluginInsights(session, pluginResult.insights);
         }
       });
+      this.triggerRelaunchIfSessionActive(session);
     });
 
     // Flush any messages queued while waiting for the adapter
@@ -868,6 +876,7 @@ export class WsBridge {
         this.broadcastPluginInsights(session, pluginResult.insights);
       }
     });
+    this.triggerRelaunchIfSessionActive(session);
   }
 
   // ── Browser WebSocket handlers ──────────────────────────────────────────


### PR DESCRIPTION
## Summary
- harden Codex disconnect handling by auto-requesting backend relaunch when a session is still active in the browser
- fix Codex reasoning parsing to accept non-string structured payloads without throwing (`trim` crash)
- clear stale `cliSessionId` when a resumed Codex process exits quickly, so the next relaunch starts a fresh thread

## Why
- logs showed repeated Codex disconnections and restarts, plus runtime errors in reasoning handling
- this keeps sessions recoverable and avoids crashy paths from structured reasoning payloads

## Testing
- `cd web && bun run typecheck`
- `cd web && bun run test server/ws-bridge.test.ts`
- `cd web && bun run test server/codex-adapter.test.ts`

## Review provenance
- Implemented by AI agent
- Human review: no

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/the-vibe-company/companion/pull/259" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
