### PR TITLE
fix(ui): address review comments - stray 0 render, concurrent progress clearing

### DIFF
--- a/web/src/components/ToolBlock.tsx
+++ b/web/src/components/ToolBlock.tsx
@@ -182,10 +182,10 @@ function ReadToolDetail({ input }: { input: Record<string, unknown> }) {
   return (
     <div className="space-y-1">
       <div className="text-xs text-cc-muted font-mono-code">{filePath}</div>
-      {(offset || limit) && (
+      {(offset != null || limit != null) && (
         <div className="flex gap-2 text-[10px] text-cc-muted">
-          {offset && <span>offset: {offset}</span>}
-          {limit && <span>limit: {limit}</span>}
+          {offset != null && <span>offset: {offset}</span>}
+          {limit != null && <span>limit: {limit}</span>}
         </div>
       )}
     </div>

--- a/web/src/ws.ts
+++ b/web/src/ws.ts
@@ -264,7 +264,15 @@ function handleParsedMessage(
       };
       store.appendMessage(sessionId, chatMsg);
       store.setStreaming(sessionId, null);
-      store.clearToolProgress(sessionId);
+      // Clear progress only for completed tools (tool_result blocks), not all tools.
+      // Blanket clear would cause flickering during concurrent tool execution.
+      if (msg.content?.length) {
+        for (const block of msg.content) {
+          if (block.type === "tool_result") {
+            store.clearToolProgress(sessionId, block.tool_use_id);
+          }
+        }
+      }
       store.setSessionStatus(sessionId, "running");
 
       // Start timer if not already started (for non-streaming tool calls)


### PR DESCRIPTION
## Summary
- Fix `ReadToolDetail` rendering stray `0` when `offset=0` by using `!= null` guards instead of truthy checks (React renders `{0 && <JSX>}` as literal "0")
- Fix `tool_progress` flickering during concurrent tool execution by clearing progress per-tool (via `tool_result` blocks) instead of blanket `clearToolProgress(sessionId)`
- Add 4 tests for `tool_progress`, `tool_use_summary`, and concurrent progress clearing

## Why
These were unresolved review comments from PR #264 that got merged before the fix was pushed.

## Testing
- All 1051 tests pass
- Typecheck clean

## Review provenance
- Implemented by AI agent
- Human review: no

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/the-vibe-company/companion/pull/265" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
