### PR TITLE
fix(sidebar): separate scheduled runs from regular sessions

### DIFF
--- a/web/src/components/Sidebar.tsx
+++ b/web/src/components/Sidebar.tsx
@@ -382,7 +382,7 @@ export function Sidebar() {
 
       {/* Session list */}
       <div className="flex-1 overflow-y-auto px-2 pb-2">
-        {activeSessions.length === 0 && archivedSessions.length === 0 ? (
+        {activeSessions.length === 0 && cronSessions.length === 0 && archivedSessions.length === 0 ? (
           <p className="px-3 py-8 text-xs text-cc-muted text-center leading-relaxed">
             No sessions yet.
           </p>


### PR DESCRIPTION
## Summary
- Scheduled runs (cron-spawned sessions) are now displayed in their own collapsible "Scheduled Runs" section in the sidebar, separate from regular sessions
- The section uses a violet accent to match the existing "Cron" pill badge style
- Regular sessions in project groups no longer include cron sessions

## Why
- Cron sessions were mixed in with regular sessions, making the sidebar cluttered and hard to parse
- Users need to quickly distinguish between sessions they started manually and those spawned by scheduled jobs

## Testing
- Typecheck passes
- All 1153 tests pass (52 test files)

## Review provenance
- Implemented by AI agent
- Human review: no

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/the-vibe-company/companion/pull/284" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
