### PR TITLE
fix(ui): cap textarea height and add overflow scroll for long prompts

### DIFF
--- a/web/src/components/Composer.tsx
+++ b/web/src/components/Composer.tsx
@@ -337,7 +337,7 @@ export function Composer({ sessionId }: { sessionId: string }) {
               : "Waiting for CLI connection..."}
             disabled={!isConnected}
             rows={1}
-            className="w-full px-4 pt-3 pb-1 text-base sm:text-sm bg-transparent resize-none focus:outline-none text-cc-fg font-sans-ui placeholder:text-cc-muted disabled:opacity-50"
+            className="w-full px-4 pt-3 pb-1 text-base sm:text-sm bg-transparent resize-none focus:outline-none text-cc-fg font-sans-ui placeholder:text-cc-muted disabled:opacity-50 overflow-y-auto"
             style={{ minHeight: "36px", maxHeight: "200px" }}
           />
 

--- a/web/src/components/HomePage.tsx
+++ b/web/src/components/HomePage.tsx
@@ -228,7 +228,7 @@ export function HomePage() {
     setText(e.target.value);
     const ta = e.target;
     ta.style.height = "auto";
-    ta.style.height = Math.min(ta.scrollHeight, 300) + "px";
+    ta.style.height = Math.min(ta.scrollHeight, 200) + "px";
   }
 
   function handleKeyDown(e: React.KeyboardEvent) {
@@ -449,8 +449,8 @@ export function HomePage() {
             onPaste={handlePaste}
             placeholder="Fix a bug, build a feature, refactor code..."
             rows={4}
-            className="w-full px-4 pt-4 pb-2 text-base sm:text-sm bg-transparent resize-none focus:outline-none text-cc-fg font-sans-ui placeholder:text-cc-muted"
-            style={{ minHeight: "100px", maxHeight: "300px" }}
+            className="w-full px-4 pt-4 pb-2 text-base sm:text-sm bg-transparent resize-none focus:outline-none text-cc-fg font-sans-ui placeholder:text-cc-muted overflow-y-auto"
+            style={{ minHeight: "100px", maxHeight: "200px" }}
           />
 
           {/* Bottom toolbar */}


### PR DESCRIPTION
## Summary
- Cap textarea max height to 200px in both HomePage and Composer components
- Add `overflow-y-auto` so textareas scroll internally instead of growing unboundedly
- HomePage textarea reduced from 300px to 200px max height

## Why
When typing long prompts, the textarea would grow excessively and push the entire layout down, making the UI unusable. Now the input box stops growing at 200px and scrolls instead.

## Testing
- Typecheck passes
- All tests pass
- Verified both `handleInput` JS cap and CSS `maxHeight` are in sync at 200px

## Review provenance
- Implemented by AI agent
- Human review: no

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/the-vibe-company/companion/pull/285" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
