### PR TITLE
test(server): add regression coverage for container gh setup-git

### DIFF
--- a/web/server/container-manager.test.ts
+++ b/web/server/container-manager.test.ts
@@ -1,0 +1,52 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mockExecSync = vi.hoisted(() => vi.fn((..._args: unknown[]) => ""));
+
+vi.mock("node:child_process", () => ({
+  execSync: mockExecSync,
+}));
+
+import { ContainerManager } from "./container-manager.js";
+
+describe("ContainerManager git auth seeding", () => {
+  beforeEach(() => {
+    mockExecSync.mockReset();
+  });
+
+  it("always configures gh as git credential helper when host token lookup fails", () => {
+    // Regression guard: copied gh auth files in the container are still valid even
+    // when `gh auth token` cannot read host keychain state.
+    mockExecSync.mockImplementation((...args: unknown[]) => {
+      const cmd = String(args[0] ?? "");
+      if (cmd.includes("gh auth token")) throw new Error("host token unavailable");
+      return "";
+    });
+
+    const manager = new ContainerManager();
+    manager.reseedGitAuth("container123");
+
+    const commands = mockExecSync.mock.calls.map((call) => String(call[0] ?? ""));
+    expect(commands.some((cmd) => cmd.includes("gh auth setup-git"))).toBe(true);
+    expect(commands.some((cmd) => cmd.includes("gh auth login --with-token"))).toBe(false);
+  });
+
+  it("logs in with host token before running gh auth setup-git when token exists", () => {
+    // Ordering matters: authenticate first, then wire git credential helper.
+    mockExecSync.mockImplementation((...args: unknown[]) => {
+      const cmd = String(args[0] ?? "");
+      if (cmd.includes("gh auth token")) return "ghp_test_token";
+      return "";
+    });
+
+    const manager = new ContainerManager();
+    manager.reseedGitAuth("container123");
+
+    const commands = mockExecSync.mock.calls.map((call) => String(call[0] ?? ""));
+    const loginIndex = commands.findIndex((cmd) => cmd.includes("gh auth login --with-token"));
+    const setupGitIndex = commands.findIndex((cmd) => cmd.includes("gh auth setup-git"));
+
+    expect(loginIndex).toBeGreaterThan(-1);
+    expect(setupGitIndex).toBeGreaterThan(-1);
+    expect(loginIndex).toBeLessThan(setupGitIndex);
+  });
+});


### PR DESCRIPTION
## Summary
- add `web/server/container-manager.test.ts` with regression coverage for container git auth seeding
- verify `gh auth setup-git` is always attempted even when host `gh auth token` lookup fails
- verify ordering when host token exists: `gh auth login --with-token` runs before `gh auth setup-git`

## Why
- Docker sessions can rely on copied gh auth files without host keychain token access
- this test prevents regressions where git push/fetch break with:
  `fatal: could not read Username for 'https://github.com': No such device or address`

## Testing
- `cd web && bun run typecheck`
- `cd web && bun run test server/container-manager.test.ts`
- pre-commit hook also ran full suite (`bun run test --coverage`)

## Review provenance
- Implemented by AI agent
- Human review: no

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/the-vibe-company/companion/pull/288" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
