### PR TITLE
feat(containers): add Codex CLI support in Docker sessions

### DIFF
--- a/web/docker/Dockerfile.companion-dev
+++ b/web/docker/Dockerfile.companion-dev
@@ -43,6 +43,9 @@ RUN curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg \
 # ── Claude Code CLI ─────────────────────────────────────────────────────────
 RUN npm install -g @anthropic-ai/claude-code
 
+# ── Codex CLI ──────────────────────────────────────────────────────────────
+RUN npm install -g @openai/codex
+
 # ── Workspace ────────────────────────────────────────────────────────────────
 WORKDIR /workspace
 

--- a/web/docker/Dockerfile.the-companion
+++ b/web/docker/Dockerfile.the-companion
@@ -75,7 +75,10 @@ RUN curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg \
 # ── Layer 9: Claude Code CLI ─────────────────────────────────────────────────
 RUN . "$NVM_DIR/nvm.sh" && npm install -g @anthropic-ai/claude-code
 
-# ── Layer 10: Python tooling (poetry, uv) ────────────────────────────────────
+# ── Layer 10: Codex CLI ─────────────────────────────────────────────────────
+RUN . "$NVM_DIR/nvm.sh" && npm install -g @openai/codex
+
+# ── Layer 11: Python tooling (poetry, uv) ────────────────────────────────────
 # --break-system-packages is safe here: this is a disposable container image,
 # not a shared system. No risk of breaking OS-managed Python packages.
 RUN pip install --break-system-packages poetry uv

--- a/web/server/cli-launcher.ts
+++ b/web/server/cli-launcher.ts
@@ -579,6 +579,8 @@ export class CliLauncher {
         }
       }
       dockerArgs.push("-e", "CLAUDECODE=");
+      // Point Codex at /root/.codex where container-manager seeded auth/config
+      dockerArgs.push("-e", "CODEX_HOME=/root/.codex");
       dockerArgs.push(options.containerId!);
       // Use a login shell so ~/.bashrc is sourced and nvm/bun/deno/etc are on PATH
       const innerCmd = [binary, ...args].map(a => `'${a.replace(/'/g, "'\\''")}'`).join(" ");

--- a/web/server/codex-container-auth.test.ts
+++ b/web/server/codex-container-auth.test.ts
@@ -1,0 +1,50 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { hasContainerCodexAuth } from "./codex-container-auth.js";
+
+describe("hasContainerCodexAuth", () => {
+  let tempHome: string;
+  let prevHome: string | undefined;
+
+  beforeEach(() => {
+    tempHome = mkdtempSync(join(tmpdir(), "codex-auth-test-"));
+    prevHome = process.env.HOME;
+    process.env.HOME = tempHome;
+  });
+
+  afterEach(() => {
+    if (prevHome === undefined) {
+      delete process.env.HOME;
+    } else {
+      process.env.HOME = prevHome;
+    }
+    rmSync(tempHome, { recursive: true, force: true });
+  });
+
+  it("returns true when OPENAI_API_KEY env var is provided", () => {
+    expect(hasContainerCodexAuth({ OPENAI_API_KEY: "sk-test" })).toBe(true);
+  });
+
+  it("returns true when CODEX_API_KEY env var is provided", () => {
+    expect(hasContainerCodexAuth({ CODEX_API_KEY: "sk-test" })).toBe(true);
+  });
+
+  it("returns true when ~/.codex/auth.json exists on host", () => {
+    const codexDir = join(tempHome, ".codex");
+    mkdirSync(codexDir, { recursive: true });
+    writeFileSync(join(codexDir, "auth.json"), '{"token":"x"}');
+
+    expect(hasContainerCodexAuth()).toBe(true);
+  });
+
+  it("returns false when neither env vars nor auth files are present", () => {
+    expect(hasContainerCodexAuth()).toBe(false);
+  });
+
+  it("returns false when only unrelated env vars are present", () => {
+    // Claude auth vars should NOT satisfy Codex auth
+    expect(hasContainerCodexAuth({ ANTHROPIC_API_KEY: "sk-ant-test" })).toBe(false);
+  });
+});

--- a/web/server/codex-container-auth.ts
+++ b/web/server/codex-container-auth.ts
@@ -1,0 +1,24 @@
+import { existsSync } from "node:fs";
+import { homedir } from "node:os";
+import { join } from "node:path";
+
+/**
+ * Returns true when Codex running inside a container has a plausible auth source:
+ * - explicit OpenAI auth env vars, or
+ * - known auth files under ~/.codex that can be copied into the container.
+ */
+export function hasContainerCodexAuth(envVars?: Record<string, string>): boolean {
+  if (
+    !!envVars?.OPENAI_API_KEY
+    || !!envVars?.CODEX_API_KEY
+  ) {
+    return true;
+  }
+
+  const home = process.env.HOME || process.env.USERPROFILE || homedir();
+  const candidates = [
+    join(home, ".codex", "auth.json"),
+  ];
+
+  return candidates.some((p) => existsSync(p));
+}

--- a/web/server/container-manager.test.ts
+++ b/web/server/container-manager.test.ts
@@ -1,16 +1,28 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 const mockExecSync = vi.hoisted(() => vi.fn((..._args: unknown[]) => ""));
+const mockExistsSync = vi.hoisted(() => vi.fn((..._args: unknown[]) => false));
 
 vi.mock("node:child_process", () => ({
   execSync: mockExecSync,
 }));
+
+vi.mock("node:fs", async (importOriginal) => {
+  const actual = (await importOriginal()) as Record<string, unknown>;
+  return {
+    ...actual,
+    existsSync: mockExistsSync,
+  };
+});
 
 import { ContainerManager } from "./container-manager.js";
 
 describe("ContainerManager git auth seeding", () => {
   beforeEach(() => {
     mockExecSync.mockReset();
+    mockExistsSync.mockReset();
+    // Default: existsSync returns false (no host files)
+    mockExistsSync.mockReturnValue(false);
   });
 
   it("always configures gh as git credential helper when host token lookup fails", () => {
@@ -48,5 +60,64 @@ describe("ContainerManager git auth seeding", () => {
     expect(loginIndex).toBeGreaterThan(-1);
     expect(setupGitIndex).toBeGreaterThan(-1);
     expect(loginIndex).toBeLessThan(setupGitIndex);
+  });
+});
+
+describe("ContainerManager Codex file seeding", () => {
+  beforeEach(() => {
+    mockExecSync.mockReset();
+    mockExistsSync.mockReset();
+    mockExistsSync.mockReturnValue(false);
+  });
+
+  it("seeds Codex auth files when /companion-host-codex is available", () => {
+    // seedCodexFiles is called internally during createContainer and startContainer.
+    // Since we can't call createContainer in a unit test (it needs docker), we
+    // test the seeding indirectly via a restart (startContainer).
+    // However startContainer also calls docker start, so we test via the public
+    // reseedGitAuth path which triggers seedGitAuth but not seedCodexFiles.
+    // Instead, verify the command is issued during a docker exec mock.
+    mockExecSync.mockImplementation((..._args: unknown[]) => "");
+
+    const manager = new ContainerManager();
+    // Access private method via bracket notation for testing
+    (manager as unknown as Record<string, (id: string) => void>)["seedCodexFiles"]("container456");
+
+    const commands = mockExecSync.mock.calls.map((call) => String(call[0] ?? ""));
+    // Should attempt to copy Codex files from bind mount
+    expect(commands.some((cmd) =>
+      cmd.includes("/companion-host-codex") && cmd.includes("/root/.codex"),
+    )).toBe(true);
+  });
+
+  it("copies auth.json, config.toml, and directory seeds for Codex", () => {
+    mockExecSync.mockImplementation((..._args: unknown[]) => "");
+
+    const manager = new ContainerManager();
+    (manager as unknown as Record<string, (id: string) => void>)["seedCodexFiles"]("container789");
+
+    const commands = mockExecSync.mock.calls.map((call) => String(call[0] ?? ""));
+    const seedCmd = commands.find((cmd) => cmd.includes("companion-host-codex"));
+    expect(seedCmd).toBeDefined();
+    // Verify it copies the expected files
+    expect(seedCmd).toContain("auth.json");
+    expect(seedCmd).toContain("config.toml");
+    expect(seedCmd).toContain("models_cache.json");
+    // Verify it copies directories
+    expect(seedCmd).toContain("skills");
+    expect(seedCmd).toContain("prompts");
+    expect(seedCmd).toContain("rules");
+  });
+
+  it("does not fail when seedCodexFiles encounters an error", () => {
+    // seedCodexFiles is best-effort and should not throw
+    mockExecSync.mockImplementation(() => {
+      throw new Error("container not running");
+    });
+
+    const manager = new ContainerManager();
+    expect(() => {
+      (manager as unknown as Record<string, (id: string) => void>)["seedCodexFiles"]("container999");
+    }).not.toThrow();
   });
 });


### PR DESCRIPTION
## Summary
- Install `@openai/codex` CLI in both Docker images (companion-dev and the-companion)
- Seed Codex auth/config files (`~/.codex`) from host into containers via read-only bind mount + tmpfs overlay
- Set `CODEX_HOME=/root/.codex` when running Codex inside Docker via `docker exec -e`
- Validate Codex auth (`OPENAI_API_KEY` / `CODEX_API_KEY` env vars or `~/.codex/auth.json` on host) before creating containerized Codex sessions, matching the existing Claude auth gate pattern

## What changed

### Dockerfiles
- `Dockerfile.companion-dev`: Added `npm install -g @openai/codex`
- `Dockerfile.the-companion`: Added layer 10 for Codex CLI install (with nvm sourcing)

### Container Manager (`container-manager.ts`)
- Mount `~/.codex` as `/companion-host-codex:ro` (if it exists on host)
- Add writable tmpfs at `/root/.codex` for container runtime state
- New `seedCodexFiles()` method copies auth.json, config.toml, models_cache.json, and directory seeds (skills, prompts, rules) from bind mount into tmpfs
- Called during both initial create and container restart

### CLI Launcher (`cli-launcher.ts`)
- Pass `-e CODEX_HOME=/root/.codex` when running Codex via `docker exec`

### Routes (`routes.ts`)
- Import and use `hasContainerCodexAuth()` in both `/sessions/create` and `/sessions/create-stream`
- Return 400 with clear error message when containerized Codex lacks auth

### New file: `codex-container-auth.ts`
- `hasContainerCodexAuth()`: checks for `OPENAI_API_KEY`, `CODEX_API_KEY` env vars, or `~/.codex/auth.json` on host

## Testing
- `codex-container-auth.test.ts`: 5 tests covering env vars, file-based auth, and negative cases
- `container-manager.test.ts`: 3 new tests for Codex file seeding (command content, file list, error resilience)
- `routes.test.ts`: 2 new tests for Codex container auth rejection and successful auth pass-through
- All 1182 tests pass, typecheck clean

## Review provenance
- Implemented by AI agent (Claude Opus 4.6)
- Human review: no

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/the-vibe-company/companion/pull/290" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
