### PR TITLE
fix(web): add Windows support for binary resolution and fix CLAUDECODE nesting

### DIFF
--- a/web/server/routes.ts
+++ b/web/server/routes.ts
@@ -13,6 +13,8 @@ import * as gitUtils from "./git-utils.js";
 import * as sessionNames from "./session-names.js";
 import { getUsageLimits } from "./usage-limits.js";
 
+const whichCmd = process.platform === "win32" ? "where" : "which";
+
 export function createRoutes(
   launcher: CliLauncher,
   wsBridge: WsBridge,
@@ -219,7 +221,7 @@ export function createRoutes(
     // Check Claude Code
     let claudeAvailable = false;
     try {
-      execSync("which claude", { encoding: "utf-8", timeout: 3000 });
+      execSync(`${whichCmd} claude`, { encoding: "utf-8", timeout: 3000 });
       claudeAvailable = true;
     } catch {}
     backends.push({ id: "claude", name: "Claude Code", available: claudeAvailable });
@@ -227,7 +229,7 @@ export function createRoutes(
     // Check Codex
     let codexAvailable = false;
     try {
-      execSync("which codex", { encoding: "utf-8", timeout: 3000 });
+      execSync(`${whichCmd} codex`, { encoding: "utf-8", timeout: 3000 });
       codexAvailable = true;
     } catch {}
     backends.push({ id: "codex", name: "Codex", available: codexAvailable });


### PR DESCRIPTION
## Summary
- Use `where` on Windows and `which` on Unix to resolve claude/codex binaries across cli-launcher, routes, and auto-namer
- Prefer `.exe` over `.cmd` on Windows to avoid `Bun.spawn` ENOENT on extensionless npm shims
- Use `path.isAbsolute()` instead of `startsWith("/")` to handle Windows drive-letter paths
- Unset `CLAUDECODE` env var in spawned CLI processes to prevent nesting detection when the server itself runs under Claude Code
- Add `process.kill(pid, 0)` alive check before SIGTERM to suppress Windows taskkill noise

## Test plan
- [x] `tsc --noEmit` passes
- [x] All 47 cli-launcher tests pass (including new Windows absolute path test)
- [x] All 50 routes tests pass
- [x] All 12 auto-namer tests pass
- [ ] Manual: start dev server on Windows, create Claude Code session — spawns correctly
- [ ] Manual: create Codex session — binary resolves to `.cmd`, no ENOENT
- [ ] Manual: relaunch session — no "ERROR: The process not found" noise

🤖 Generated with [Claude Code](https://claude.com/claude-code)