### PR TITLE
feat(diff): add diff base setting (last commit vs default branch)

### DIFF
--- a/web/src/api.ts
+++ b/web/src/api.ts
@@ -581,9 +581,9 @@ export const api = {
     ),
   writeFile: (path: string, content: string) =>
     put<{ ok: boolean; path: string }>("/fs/write", { path, content }),
-  getFileDiff: (path: string) =>
+  getFileDiff: (path: string, base?: "last-commit" | "default-branch") =>
     get<{ path: string; diff: string }>(
-      `/fs/diff?path=${encodeURIComponent(path)}`,
+      `/fs/diff?path=${encodeURIComponent(path)}${base ? `&base=${encodeURIComponent(base)}` : ""}`,
     ),
   getClaudeMdFiles: (cwd: string) =>
     get<{ cwd: string; files: { path: string; content: string }[] }>(

--- a/web/src/components/DiffPanel.tsx
+++ b/web/src/components/DiffPanel.tsx
@@ -8,6 +8,8 @@ export function DiffPanel({ sessionId }: { sessionId: string }) {
   const sdkSession = useStore((s) => s.sdkSessions.find((sdk) => sdk.sessionId === sessionId));
   const selectedFile = useStore((s) => s.diffPanelSelectedFile.get(sessionId) ?? null);
   const setSelectedFile = useStore((s) => s.setDiffPanelSelectedFile);
+  const diffBase = useStore((s) => s.diffBase);
+  const setDiffBase = useStore((s) => s.setDiffBase);
   const changedFilesSet = useStore((s) => s.changedFiles.get(sessionId));
 
   const cwd = session?.cwd || sdkSession?.cwd;
@@ -52,7 +54,7 @@ export function DiffPanel({ sessionId }: { sessionId: string }) {
     let cancelled = false;
     setDiffLoading(true);
     api
-      .getFileDiff(selectedFile)
+      .getFileDiff(selectedFile, diffBase)
       .then((res) => {
         if (!cancelled) {
           setDiffContent(res.diff);
@@ -66,7 +68,7 @@ export function DiffPanel({ sessionId }: { sessionId: string }) {
         }
       });
     return () => { cancelled = true; };
-  }, [selectedFile]);
+  }, [selectedFile, diffBase]);
 
   const handleFileSelect = useCallback(
     (path: string) => {
@@ -190,9 +192,13 @@ export function DiffPanel({ sessionId }: { sessionId: string }) {
                 {selectedRelPath}
               </span>
             </div>
-            <span className="text-cc-muted text-[11px] shrink-0 hidden sm:inline">
-              Compared to default branch
-            </span>
+            <button
+              onClick={() => setDiffBase(diffBase === "last-commit" ? "default-branch" : "last-commit")}
+              className="text-cc-muted text-[11px] shrink-0 hidden sm:inline hover:text-cc-fg transition-colors cursor-pointer"
+              title={`Switch to ${diffBase === "last-commit" ? "default branch" : "last commit"} comparison`}
+            >
+              {diffBase === "default-branch" ? "vs default branch" : "vs last commit"}
+            </button>
           </div>
         )}
 

--- a/web/src/components/SettingsPage.tsx
+++ b/web/src/components/SettingsPage.tsx
@@ -18,6 +18,8 @@ export function SettingsPage({ embedded = false }: SettingsPageProps) {
   const [saved, setSaved] = useState(false);
   const darkMode = useStore((s) => s.darkMode);
   const toggleDarkMode = useStore((s) => s.toggleDarkMode);
+  const diffBase = useStore((s) => s.diffBase);
+  const setDiffBase = useStore((s) => s.setDiffBase);
   const notificationSound = useStore((s) => s.notificationSound);
   const toggleNotificationSound = useStore((s) => s.toggleNotificationSound);
   const notificationDesktop = useStore((s) => s.notificationDesktop);
@@ -293,6 +295,23 @@ export function SettingsPage({ embedded = false }: SettingsPageProps) {
             <span>Theme</span>
             <span className="text-xs text-cc-muted">{darkMode ? "Dark" : "Light"}</span>
           </button>
+        </div>
+
+        <div className="mt-4 bg-cc-card border border-cc-border rounded-xl p-4 sm:p-5 space-y-3">
+          <h2 className="text-sm font-semibold text-cc-fg">Diff</h2>
+          <button
+            type="button"
+            onClick={() => setDiffBase(diffBase === "last-commit" ? "default-branch" : "last-commit")}
+            className="w-full flex items-center justify-between px-3 py-2 rounded-lg text-sm bg-cc-hover text-cc-fg hover:bg-cc-active transition-colors cursor-pointer"
+          >
+            <span>Compare against</span>
+            <span className="text-xs text-cc-muted">
+              {diffBase === "last-commit" ? "Last commit (HEAD)" : "Default branch"}
+            </span>
+          </button>
+          <p className="text-xs text-cc-muted">
+            Last commit shows only uncommitted changes. Default branch shows all changes since diverging from main.
+          </p>
         </div>
 
         <div className="mt-4 bg-cc-card border border-cc-border rounded-xl p-4 sm:p-5 space-y-3">

--- a/web/src/store.ts
+++ b/web/src/store.ts
@@ -11,6 +11,8 @@ export interface QuickTerminalTab {
 
 export type QuickTerminalPlacement = "top" | "right" | "bottom" | "left";
 
+export type DiffBase = "last-commit" | "default-branch";
+
 interface AppState {
   // Sessions
   sessions: Map<string, SessionState>;
@@ -169,6 +171,9 @@ interface AppState {
   quickTerminalNextHostIndex: number;
   quickTerminalNextDockerIndex: number;
 
+  // Diff settings
+  diffBase: DiffBase;
+
   // Session quick terminal actions
   setQuickTerminalOpen: (open: boolean) => void;
   openQuickTerminal: (opts: { target: "host" | "docker"; cwd: string; containerId?: string; reuseIfExists?: boolean }) => void;
@@ -176,6 +181,9 @@ interface AppState {
   setActiveQuickTerminalTabId: (tabId: string | null) => void;
   setQuickTerminalPlacement: (placement: QuickTerminalPlacement) => void;
   resetQuickTerminal: () => void;
+
+  // Diff settings actions
+  setDiffBase: (base: DiffBase) => void;
 
   // Terminal state
   terminalOpen: boolean;
@@ -248,6 +256,13 @@ function getInitialQuickTerminalPlacement(): QuickTerminalPlacement {
   return "bottom";
 }
 
+function getInitialDiffBase(): DiffBase {
+  if (typeof window === "undefined") return "last-commit";
+  const stored = window.localStorage.getItem("cc-diff-base");
+  if (stored === "last-commit" || stored === "default-branch") return stored;
+  return "last-commit";
+}
+
 export const useStore = create<AppState>((set) => ({
   sessions: new Map(),
   sdkSessions: [],
@@ -290,6 +305,7 @@ export const useStore = create<AppState>((set) => ({
   quickTerminalPlacement: getInitialQuickTerminalPlacement(),
   quickTerminalNextHostIndex: 1,
   quickTerminalNextDockerIndex: 1,
+  diffBase: getInitialDiffBase(),
   terminalOpen: false,
   terminalCwd: null,
   terminalId: null,
@@ -743,6 +759,12 @@ export const useStore = create<AppState>((set) => ({
     }
     set({ quickTerminalPlacement: placement });
   },
+  setDiffBase: (base) => {
+    if (typeof window !== "undefined") {
+      localStorage.setItem("cc-diff-base", base);
+    }
+    set({ diffBase: base });
+  },
   resetQuickTerminal: () =>
     set({
       quickTerminalOpen: false,
@@ -788,6 +810,7 @@ export const useStore = create<AppState>((set) => ({
       quickTerminalPlacement: getInitialQuickTerminalPlacement(),
       quickTerminalNextHostIndex: 1,
       quickTerminalNextDockerIndex: 1,
+      diffBase: getInitialDiffBase(),
       terminalOpen: false,
       terminalCwd: null,
       terminalId: null,


### PR DESCRIPTION
## Summary
- Add a "diff base" user preference: **last commit (HEAD)** or **default branch** (origin/HEAD, main, master)
- Default is "last commit" — shows only uncommitted changes
- Toggle accessible both inline in the DiffPanel header and in the Settings page

## Changes
- **Store** (`store.ts`): new `DiffBase` type with localStorage persistence (`cc-diff-base`)
- **Backend** (`routes.ts`): `/fs/diff` endpoint accepts optional `base` query param
- **API client** (`api.ts`): `getFileDiff` passes the base param
- **DiffPanel** (`DiffPanel.tsx`): clickable label toggles between modes, re-fetches on change
- **Settings** (`SettingsPage.tsx`): new "Diff" section with "Compare against" toggle

## Testing
- All 1203 tests pass, typecheck passes
- Backend: new test for HEAD default + updated existing tests to use `&base=default-branch`
- DiffPanel: tests for both modes + toggle click behavior

## Review provenance
- Implemented by AI agent
- Human review: no

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/the-vibe-company/companion/pull/308" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
