### PR TITLE
fix(codex): use container cwd for docker runtime context

### DIFF
--- a/web/server/cli-launcher.test.ts
+++ b/web/server/cli-launcher.test.ts
@@ -279,6 +279,21 @@ describe("launch", () => {
     expect(info.containerId).toBe("abc123def456");
     expect(info.containerName).toBe("companion-session-1");
     expect(info.containerImage).toBe("ubuntu:22.04");
+    expect(info.containerCwd).toBe("/workspace");
+  });
+
+  it("stores explicit containerCwd when provided", () => {
+    mockSpawn.mockReturnValueOnce(createMockCodexProc());
+    const info = launcher.launch({
+      cwd: "/tmp/project",
+      backendType: "codex",
+      containerId: "abc123def456",
+      containerName: "companion-session-1",
+      containerImage: "ubuntu:22.04",
+      containerCwd: "/workspace/repo",
+    });
+
+    expect(info.containerCwd).toBe("/workspace/repo");
   });
 
   it("uses docker exec -i with bash -lc for containerized Claude sessions", () => {

--- a/web/server/cli-launcher.ts
+++ b/web/server/cli-launcher.ts
@@ -79,6 +79,8 @@ export interface SdkSessionInfo {
   containerName?: string;
   /** Docker image used for the container */
   containerImage?: string;
+  /** Runtime cwd inside container for agent RPC calls (e.g. "/workspace"). */
+  containerCwd?: string;
 }
 
 export interface LaunchOptions {
@@ -102,6 +104,8 @@ export interface LaunchOptions {
   containerName?: string;
   /** Docker image used for the container */
   containerImage?: string;
+  /** Runtime cwd inside the container (typically "/workspace"). */
+  containerCwd?: string;
 }
 
 /**
@@ -215,6 +219,7 @@ export class CliLauncher {
       info.containerId = options.containerId;
       info.containerName = options.containerName;
       info.containerImage = options.containerImage;
+      info.containerCwd = options.containerCwd || "/workspace";
     }
 
     this.sessions.set(sessionId, info);
@@ -314,6 +319,7 @@ export class CliLauncher {
         containerId: info.containerId,
         containerName: info.containerName,
         containerImage: info.containerImage,
+        containerCwd: info.containerCwd,
         env: runtimeEnv,
       });
     } else {
@@ -650,6 +656,7 @@ export class CliLauncher {
     const adapter = new CodexAdapter(proc, sessionId, {
       model: options.model,
       cwd: info.cwd,
+      executionCwd: options.containerId ? (info.containerCwd || "/workspace") : info.cwd,
       approvalMode: options.permissionMode,
       threadId: info.cliSessionId,
       sandbox: options.codexSandbox,

--- a/web/server/routes.test.ts
+++ b/web/server/routes.test.ts
@@ -535,7 +535,11 @@ describe("POST /api/sessions/create", () => {
 
     expect(res.status).toBe(200);
     expect(launcher.launch).toHaveBeenCalledWith(
-      expect.objectContaining({ backendType: "codex", containerId: "cid-codex" }),
+      expect.objectContaining({
+        backendType: "codex",
+        containerId: "cid-codex",
+        containerCwd: "/workspace",
+      }),
     );
   });
 
@@ -2020,6 +2024,12 @@ describe("POST /api/sessions/create-stream", () => {
 
     expect(steps).toContain("creating_container");
     expect(steps).toContain("launching_cli");
+    expect(launcher.launch).toHaveBeenCalledWith(
+      expect.objectContaining({
+        containerId: "cid-stream",
+        containerCwd: "/workspace",
+      }),
+    );
 
     // Done event should include sessionId
     const doneEvent = events.find((e) => e.event === "done");
@@ -2071,6 +2081,12 @@ describe("POST /api/sessions/create-stream", () => {
 
     // Should have pulling_image step
     expect(steps).toContain("pulling_image");
+    expect(launcher.launch).toHaveBeenCalledWith(
+      expect.objectContaining({
+        containerId: "cid-pulled",
+        containerCwd: "/workspace",
+      }),
+    );
     expect(mockImagePullEnsureImage).toHaveBeenCalledWith("the-companion:latest");
     expect(mockImagePullWaitForReady).toHaveBeenCalled();
   });

--- a/web/server/routes.ts
+++ b/web/server/routes.ts
@@ -295,6 +295,7 @@ export function createRoutes(
         containerId,
         containerName,
         containerImage,
+        containerCwd: containerInfo?.containerCwd,
       });
 
       // Re-track container with real session ID and mark session as containerized
@@ -608,6 +609,7 @@ export function createRoutes(
           containerId,
           containerName,
           containerImage,
+          containerCwd: containerInfo?.containerCwd,
         });
 
         // Re-track container and mark session as containerized


### PR DESCRIPTION
## Summary
- fix Codex-in-Docker runtime context by separating host `cwd` (session metadata/UI grouping) from container runtime `cwd`
- pass `containerCwd` from container creation routes into launcher session metadata
- use `executionCwd` in Codex adapter for `thread/start`, `thread/resume`, `turn/start`, and Bash approval fallbacks

## Why
- Codex Docker sessions could infer they were running on host paths (`/Users/...`) instead of container paths (`/workspace`)
- Claude sessions were already behaving correctly; this aligns Codex runtime behavior with Docker isolation

## Testing
- `bun run test server/cli-launcher.test.ts server/codex-adapter.test.ts server/routes.test.ts`
- pre-commit hook also ran:
  - `tsc --noEmit`
  - `vitest run --coverage`

## Added tests
- launcher: container metadata now asserts default `containerCwd` and explicit override
- codex adapter: validates `executionCwd` usage for `thread/start`, `thread/resume`, `turn/start`, and `execCommandApproval` fallback
- routes: validates `containerCwd` propagation in launch payloads for Docker session creation paths

## Review provenance
- Implemented by AI agent
- Human review: no

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/the-vibe-company/companion/pull/313" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
