### PR TITLE
fix(server): prevent settings undefined overwrite crash

### DIFF
--- a/web/server/settings-manager.test.ts
+++ b/web/server/settings-manager.test.ts
@@ -117,4 +117,17 @@ describe("settings-manager", () => {
     expect(updated.openrouterModel).toBe("openrouter/free");
     expect(updated.linearApiKey).toBe("lin_api_123");
   });
+
+  it("ignores undefined patch values and preserves existing keys", () => {
+    updateSettings({ openrouterApiKey: "or-key", linearApiKey: "lin_api_123" });
+    const updated = updateSettings({
+      openrouterApiKey: undefined,
+      openrouterModel: "openai/gpt-4o-mini",
+      linearApiKey: undefined,
+    });
+
+    expect(updated.openrouterApiKey).toBe("or-key");
+    expect(updated.openrouterModel).toBe("openai/gpt-4o-mini");
+    expect(updated.linearApiKey).toBe("lin_api_123");
+  });
 });

--- a/web/server/settings-manager.ts
+++ b/web/server/settings-manager.ts
@@ -66,12 +66,12 @@ export function updateSettings(
   patch: Partial<Pick<CompanionSettings, "openrouterApiKey" | "openrouterModel" | "linearApiKey">>,
 ): CompanionSettings {
   ensureLoaded();
-  settings = {
-    ...settings,
-    ...patch,
-    openrouterModel: (patch.openrouterModel && patch.openrouterModel.trim()) || settings.openrouterModel || DEFAULT_OPENROUTER_MODEL,
+  settings = normalize({
+    openrouterApiKey: patch.openrouterApiKey ?? settings.openrouterApiKey,
+    openrouterModel: patch.openrouterModel ?? settings.openrouterModel,
+    linearApiKey: patch.linearApiKey ?? settings.linearApiKey,
     updatedAt: Date.now(),
-  };
+  });
   persist();
   return { ...settings };
 }


### PR DESCRIPTION
## Summary
- fix a server crash when saving settings if partial updates include `undefined` fields
- harden settings merge logic to preserve existing keys and normalize persisted values
- add a regression test for undefined patch values

## Why
- saving/testing API keys could throw `TypeError: undefined is not an object (evaluating 'settings.openrouterApiKey.trim')`
- this blocked valid Linear key save/test flows

## Testing
- `cd web && bun run typecheck`
- `cd web && bun run test server/settings-manager.test.ts`
- `cd web && bun run test server/routes.test.ts -t "PUT /api/settings"`

## Review provenance
- Implemented by AI agent
- Human review: no
