### PR TITLE
fix(integrations): refine linear settings flow and home card UX

### DIFF
--- a/web/server/routes.test.ts
+++ b/web/server/routes.test.ts
@@ -1376,7 +1376,7 @@ describe("GET /api/linear/issues", () => {
       statusText: "OK",
       json: async () => ({
         data: {
-          issueSearch: {
+          searchIssues: {
             nodes: [{
               id: "issue-id",
               identifier: "ENG-123",
@@ -1417,6 +1417,10 @@ describe("GET /api/linear/issues", () => {
         headers: expect.objectContaining({ Authorization: "lin_api_123" }),
       }),
     );
+    const [, requestInit] = vi.mocked(fetchMock).mock.calls[0];
+    const requestBody = JSON.parse(String(requestInit?.body ?? "{}"));
+    expect(requestBody.query).toContain("searchIssues(term: $term, first: $first)");
+    expect(requestBody.variables).toEqual({ term: "auth", first: 5 });
     vi.unstubAllGlobals();
   });
 });

--- a/web/server/routes.ts
+++ b/web/server/routes.ts
@@ -1362,8 +1362,8 @@ export function createRoutes(
       },
       body: JSON.stringify({
         query: `
-          query CompanionIssueSearch($query: String!, $first: Int!) {
-            issueSearch(query: $query, first: $first) {
+          query CompanionIssueSearch($term: String!, $first: Int!) {
+            searchIssues(term: $term, first: $first) {
               nodes {
                 id
                 identifier
@@ -1377,7 +1377,7 @@ export function createRoutes(
             }
           }
         `,
-        variables: { query, first: limit },
+        variables: { term: query, first: limit },
       }),
     }).catch((e: unknown) => {
       throw new Error(`Failed to connect to Linear: ${e instanceof Error ? e.message : String(e)}`);
@@ -1385,7 +1385,7 @@ export function createRoutes(
 
     const json = await response.json().catch(() => ({})) as {
       data?: {
-        issueSearch?: {
+        searchIssues?: {
           nodes?: Array<{
             id: string;
             identifier: string;
@@ -1406,7 +1406,7 @@ export function createRoutes(
       return c.json({ error: firstError }, 502);
     }
 
-    const issues = (json.data?.issueSearch?.nodes || []).map((issue) => ({
+    const issues = (json.data?.searchIssues?.nodes || []).map((issue) => ({
       id: issue.id,
       identifier: issue.identifier,
       title: issue.title,

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -14,6 +14,7 @@ import { Playground } from "./components/Playground.js";
 import { UpdateBanner } from "./components/UpdateBanner.js";
 import { SettingsPage } from "./components/SettingsPage.js";
 import { IntegrationsPage } from "./components/IntegrationsPage.js";
+import { LinearSettingsPage } from "./components/LinearSettingsPage.js";
 import { PromptsPage } from "./components/PromptsPage.js";
 import { EnvManager } from "./components/EnvManager.js";
 import { CronManager } from "./components/CronManager.js";
@@ -44,6 +45,7 @@ export default function App() {
   const isSettingsPage = route.page === "settings";
   const isPromptsPage = route.page === "prompts";
   const isIntegrationsPage = route.page === "integrations";
+  const isLinearIntegrationPage = route.page === "integration-linear";
   const isTerminalPage = route.page === "terminal";
   const isEnvironmentsPage = route.page === "environments";
   const isScheduledPage = route.page === "scheduled";
@@ -144,6 +146,12 @@ export default function App() {
           {isIntegrationsPage && (
             <div className="absolute inset-0">
               <IntegrationsPage embedded />
+            </div>
+          )}
+
+          {isLinearIntegrationPage && (
+            <div className="absolute inset-0">
+              <LinearSettingsPage embedded />
             </div>
           )}
 

--- a/web/src/api.test.ts
+++ b/web/src/api.test.ts
@@ -287,6 +287,12 @@ describe("settings", () => {
     expect(result).toEqual(data);
   });
 
+  it("surfaces backend error message for Linear issue search", async () => {
+    mockFetch.mockResolvedValueOnce(mockResponse({ error: "Linear token invalid" }, 502));
+
+    await expect(api.searchLinearIssues("auth bug", 5)).rejects.toThrow("Linear token invalid");
+  });
+
   it("gets Linear connection status", async () => {
     const data = {
       connected: true,

--- a/web/src/api.ts
+++ b/web/src/api.ts
@@ -68,7 +68,8 @@ async function get<T = unknown>(path: string): Promise<T> {
   try {
     const res = await fetch(`${BASE}${path}`);
     if (!res.ok) {
-      const apiError = new Error(res.statusText);
+      const err = await res.json().catch(() => ({ error: res.statusText }));
+      const apiError = new Error(err.error || res.statusText);
       trackApiFailure("GET", path, nowMs() - startedAt, apiError, res.status);
       failureTracked = true;
       throw apiError;

--- a/web/src/components/HomePage.tsx
+++ b/web/src/components/HomePage.tsx
@@ -532,12 +532,12 @@ export function HomePage() {
   const canSend = text.trim().length > 0 && !sending;
 
   return (
-    <div className="flex-1 h-full flex items-start justify-center px-3 sm:px-4 pt-[15vh] sm:pt-[20vh] overflow-y-auto">
+    <div className="flex-1 h-full flex items-start justify-center px-3 sm:px-4 pt-6 sm:pt-8 pb-6 overflow-y-auto">
       <div className="w-full max-w-2xl">
         {/* Logo + Title */}
-        <div className="flex flex-col items-center justify-center mb-4 sm:mb-6">
-          <img src={logoSrc} alt="The Companion" className="w-24 h-24 sm:w-32 sm:h-32 mb-3" />
-          <h1 className="text-xl sm:text-2xl font-semibold text-cc-fg">
+        <div className="flex flex-col items-center justify-center mb-3 sm:mb-4">
+          <img src={logoSrc} alt="The Companion" className="w-16 h-16 sm:w-20 sm:h-20 mb-2.5" />
+          <h1 className="text-2xl sm:text-[2rem] font-semibold tracking-tight text-cc-fg">
             The Companion
           </h1>
         </div>
@@ -575,89 +575,113 @@ export function HomePage() {
           className="hidden"
         />
 
-        {/* Input card */}
-        <div className="bg-cc-card border border-cc-border rounded-[14px] shadow-sm overflow-hidden">
-          <textarea
-            ref={textareaRef}
-            value={text}
-            onChange={handleInput}
-            onKeyDown={handleKeyDown}
-            onPaste={handlePaste}
-            placeholder="Fix a bug, build a feature, refactor code..."
-            rows={4}
-            className="w-full px-4 pt-4 pb-2 text-base sm:text-sm bg-transparent resize-none focus:outline-none text-cc-fg font-sans-ui placeholder:text-cc-muted overflow-y-auto"
-            style={{ minHeight: "100px", maxHeight: "200px" }}
-          />
-
-          {/* Bottom toolbar */}
-          <div className="flex items-center justify-between px-3 pb-3">
-            {/* Left: mode dropdown */}
-            <div className="relative" ref={modeDropdownRef}>
-              <button
-                onClick={() => setShowModeDropdown(!showModeDropdown)}
-                className="flex items-center gap-1.5 px-2.5 py-1.5 text-xs font-medium text-cc-muted hover:text-cc-fg rounded-lg hover:bg-cc-hover transition-colors cursor-pointer"
-              >
-                <svg viewBox="0 0 16 16" fill="none" stroke="currentColor" strokeWidth="1.5" className="w-3.5 h-3.5">
-                  <path d="M2 4h12M2 8h8M2 12h10" strokeLinecap="round" />
-                </svg>
-                {selectedMode.label}
-                <svg viewBox="0 0 16 16" fill="currentColor" className="w-3 h-3 opacity-50">
-                  <path d="M4 6l4 4 4-4" />
-                </svg>
-              </button>
-              {showModeDropdown && (
-                <div className="absolute left-0 bottom-full mb-1 w-40 bg-cc-card border border-cc-border rounded-[10px] shadow-lg z-10 py-1 overflow-hidden">
-                  {MODES.map((m) => (
+        <div className="grid grid-cols-1 gap-3 sm:gap-4 items-start">
+          <div>
+            {/* Input card */}
+            <div className="bg-cc-card border border-cc-border rounded-[14px] shadow-sm overflow-hidden">
+              {selectedLinearIssue && (
+                <div className="px-3 pt-3">
+                  <div className="inline-flex max-w-full items-center gap-2 rounded-md border border-cc-border bg-cc-hover/60 px-2.5 py-1.5 text-[11px] text-cc-muted">
+                    <span className="shrink-0">Linear</span>
+                    <span className="font-mono-code shrink-0">{selectedLinearIssue.identifier}</span>
+                    <span className="truncate">{selectedLinearIssue.title}</span>
                     <button
-                      key={m.value}
-                      onClick={() => { setMode(m.value); setShowModeDropdown(false); }}
-                      className={`w-full px-3 py-2 text-xs text-left hover:bg-cc-hover transition-colors cursor-pointer ${
-                        m.value === mode ? "text-cc-primary font-medium" : "text-cc-fg"
-                      }`}
+                      type="button"
+                      onClick={() => {
+                        setSelectedLinearIssue(null);
+                        setLinearQuery("");
+                        setLinearIssues([]);
+                        setLinearSearchError("");
+                      }}
+                      className="shrink-0 rounded px-1 text-cc-muted hover:text-cc-fg hover:bg-cc-active transition-colors cursor-pointer"
+                      title="Remove Linear issue"
                     >
-                      {m.label}
+                      ×
                     </button>
-                  ))}
+                  </div>
                 </div>
               )}
+              <textarea
+                ref={textareaRef}
+                value={text}
+                onChange={handleInput}
+                onKeyDown={handleKeyDown}
+                onPaste={handlePaste}
+                placeholder="Fix a bug, build a feature, refactor code..."
+                rows={4}
+                className="w-full px-4 pt-4 pb-2 text-base sm:text-sm bg-transparent resize-none focus:outline-none text-cc-fg font-sans-ui placeholder:text-cc-muted overflow-y-auto"
+                style={{ minHeight: "100px", maxHeight: "200px" }}
+              />
+
+              {/* Bottom toolbar */}
+              <div className="flex items-center justify-between px-3 pb-3">
+                {/* Left: mode dropdown */}
+                <div className="relative" ref={modeDropdownRef}>
+                  <button
+                    onClick={() => setShowModeDropdown(!showModeDropdown)}
+                    className="flex items-center gap-1.5 px-2.5 py-1.5 text-xs font-medium text-cc-muted hover:text-cc-fg rounded-lg hover:bg-cc-hover transition-colors cursor-pointer"
+                  >
+                    <svg viewBox="0 0 16 16" fill="none" stroke="currentColor" strokeWidth="1.5" className="w-3.5 h-3.5">
+                      <path d="M2 4h12M2 8h8M2 12h10" strokeLinecap="round" />
+                    </svg>
+                    {selectedMode.label}
+                    <svg viewBox="0 0 16 16" fill="currentColor" className="w-3 h-3 opacity-50">
+                      <path d="M4 6l4 4 4-4" />
+                    </svg>
+                  </button>
+                  {showModeDropdown && (
+                    <div className="absolute left-0 bottom-full mb-1 w-40 bg-cc-card border border-cc-border rounded-[10px] shadow-lg z-10 py-1 overflow-hidden">
+                      {MODES.map((m) => (
+                        <button
+                          key={m.value}
+                          onClick={() => { setMode(m.value); setShowModeDropdown(false); }}
+                          className={`w-full px-3 py-2 text-xs text-left hover:bg-cc-hover transition-colors cursor-pointer ${
+                            m.value === mode ? "text-cc-primary font-medium" : "text-cc-fg"
+                          }`}
+                        >
+                          {m.label}
+                        </button>
+                      ))}
+                    </div>
+                  )}
+                </div>
+
+                {/* Right: image placeholder + send */}
+                <div className="flex items-center gap-1.5">
+                  {/* Image upload */}
+                  <button
+                    onClick={() => fileInputRef.current?.click()}
+                    className="flex items-center justify-center w-8 h-8 rounded-lg text-cc-muted hover:text-cc-fg hover:bg-cc-hover transition-colors cursor-pointer"
+                    title="Upload image"
+                  >
+                    <svg viewBox="0 0 16 16" fill="none" stroke="currentColor" strokeWidth="1.5" className="w-4 h-4">
+                      <rect x="2" y="2" width="12" height="12" rx="2" />
+                      <circle cx="5.5" cy="5.5" r="1" fill="currentColor" stroke="none" />
+                      <path d="M2 11l3-3 2 2 3-4 4 5" strokeLinecap="round" strokeLinejoin="round" />
+                    </svg>
+                  </button>
+
+                  {/* Send button */}
+                  <button
+                    onClick={handleSend}
+                    disabled={!canSend}
+                    className={`flex items-center justify-center w-8 h-8 rounded-full transition-colors ${
+                      canSend
+                        ? "bg-cc-primary hover:bg-cc-primary-hover text-white cursor-pointer"
+                        : "bg-cc-hover text-cc-muted cursor-not-allowed"
+                    }`}
+                    title="Send message"
+                  >
+                    <svg viewBox="0 0 16 16" fill="currentColor" className="w-3.5 h-3.5">
+                      <path d="M3 2l11 6-11 6V9.5l7-1.5-7-1.5V2z" />
+                    </svg>
+                  </button>
+                </div>
+              </div>
             </div>
 
-            {/* Right: image placeholder + send */}
-            <div className="flex items-center gap-1.5">
-              {/* Image upload */}
-              <button
-                onClick={() => fileInputRef.current?.click()}
-                className="flex items-center justify-center w-8 h-8 rounded-lg text-cc-muted hover:text-cc-fg hover:bg-cc-hover transition-colors cursor-pointer"
-                title="Upload image"
-              >
-                <svg viewBox="0 0 16 16" fill="none" stroke="currentColor" strokeWidth="1.5" className="w-4 h-4">
-                  <rect x="2" y="2" width="12" height="12" rx="2" />
-                  <circle cx="5.5" cy="5.5" r="1" fill="currentColor" stroke="none" />
-                  <path d="M2 11l3-3 2 2 3-4 4 5" strokeLinecap="round" strokeLinejoin="round" />
-                </svg>
-              </button>
-
-              {/* Send button */}
-              <button
-                onClick={handleSend}
-                disabled={!canSend}
-                className={`flex items-center justify-center w-8 h-8 rounded-full transition-colors ${
-                  canSend
-                    ? "bg-cc-primary hover:bg-cc-primary-hover text-white cursor-pointer"
-                    : "bg-cc-hover text-cc-muted cursor-not-allowed"
-                }`}
-                title="Send message"
-              >
-                <svg viewBox="0 0 16 16" fill="currentColor" className="w-3.5 h-3.5">
-                  <path d="M3 2l11 6-11 6V9.5l7-1.5-7-1.5V2z" />
-                </svg>
-              </button>
-            </div>
-          </div>
-        </div>
-
-        {/* Below-card selectors */}
-        <div className="flex items-center gap-1 sm:gap-2 mt-2 sm:mt-3 px-1 flex-wrap">
+            {/* Below-card selectors */}
+            <div className="flex items-center gap-1 sm:gap-2 mt-2 sm:mt-3 px-1 flex-wrap">
           {/* Backend toggle */}
           {backends.length > 1 && (
             <div className="flex items-center bg-cc-hover/50 rounded-lg p-0.5">
@@ -988,115 +1012,159 @@ export function HomePage() {
               </div>
             )}
           </div>
-        </div>
-
-        {!linearConfigured && (
-          <div className="mt-3 p-3 rounded-[10px] bg-amber-500/10 border border-amber-500/20 text-xs text-amber-700 dark:text-amber-300">
-            Warning: Linear is not configured. Are you sure you want to continue? Problem drift is common without clear issue context.
-          </div>
-        )}
-
-        {showLinearStartWarning && (
-          <div className="mt-3 p-3 rounded-[10px] bg-amber-500/10 border border-amber-500/20">
-            <p className="text-xs text-amber-700 dark:text-amber-300 leading-snug">
-              Warning: Linear is not configured. Are you sure you want to continue? Problem drift is common without clear issue context.
-            </p>
-            <div className="flex gap-2 mt-2.5">
-              <button
-                type="button"
-                onClick={() => {
-                  setShowLinearStartWarning(false);
-                  window.location.hash = "#/integrations";
-                }}
-                className="px-2.5 py-1 text-[11px] font-medium rounded-md bg-cc-hover text-cc-fg hover:bg-cc-active transition-colors cursor-pointer"
-              >
-                Configurer Linear
-              </button>
-              <button
-                type="button"
-                onClick={handleContinueWithoutLinear}
-                className="px-2.5 py-1 text-[11px] font-medium rounded-md bg-amber-500/20 text-amber-700 dark:text-amber-300 hover:bg-amber-500/30 transition-colors cursor-pointer"
-              >
-                Continuer sans Linear
-              </button>
             </div>
           </div>
-        )}
 
-        {linearConfigured && (
-          <div className="mt-3 relative" ref={linearDropdownRef}>
-            <label className="block text-[11px] text-cc-muted mb-1.5">
-              <span className="inline-flex items-center gap-1.5">
-                <LinearLogo className="w-3.5 h-3.5 text-cc-fg" />
-                <span>Linear issue context (optional)</span>
-              </span>
-            </label>
-            <div className="flex items-center gap-2">
-              <input
-                type="text"
-                value={linearQuery}
-                onChange={(e) => {
-                  setLinearQuery(e.target.value);
-                  setShowLinearDropdown(true);
-                }}
-                onFocus={() => setShowLinearDropdown(true)}
-                placeholder="Search by issue title or key (e.g. ENG-123)"
-                className="w-full px-3 py-2 text-sm bg-cc-input-bg border border-cc-border rounded-lg text-cc-fg placeholder:text-cc-muted focus:outline-none focus:border-cc-primary/60"
-              />
-              {selectedLinearIssue && (
+          <aside className="space-y-2 mt-0.5" ref={linearDropdownRef}>
+            <div className="relative rounded-[12px] border border-cc-border bg-cc-card/90 px-2.5 py-2">
+              <div className="flex items-center gap-2 flex-wrap">
+                <span className="text-[11px] uppercase tracking-wide text-cc-muted">Context</span>
                 <button
                   type="button"
                   onClick={() => {
-                    setSelectedLinearIssue(null);
-                    setLinearQuery("");
-                    setLinearIssues([]);
-                    setLinearSearchError("");
+                    if (!linearConfigured) {
+                      window.location.hash = "#/integrations/linear";
+                      return;
+                    }
+                    setShowLinearDropdown(!showLinearDropdown);
                   }}
-                  className="px-2.5 py-2 rounded-lg text-xs bg-cc-hover text-cc-muted hover:text-cc-fg transition-colors cursor-pointer shrink-0"
+                  className={`inline-flex items-center gap-1.5 px-2.5 py-1.5 rounded-lg text-xs border transition-colors cursor-pointer ${
+                    selectedLinearIssue
+                      ? "border-cc-primary/35 bg-cc-primary/10 text-cc-primary"
+                      : linearConfigured
+                        ? "border-cc-border bg-cc-hover/70 text-cc-fg hover:bg-cc-hover"
+                        : "border-amber-500/25 bg-amber-500/10 text-amber-600 dark:text-amber-300"
+                  }`}
                 >
-                  Clear
+                  <LinearLogo className="w-3.5 h-3.5" />
+                  <span>Linear</span>
                 </button>
-              )}
-            </div>
-            {selectedLinearIssue && (
-              <div className="mt-1.5 text-[11px] text-cc-muted">
-                Selected: <span className="font-mono-code">{selectedLinearIssue.identifier}</span> - {selectedLinearIssue.title}
+                {!linearConfigured && (
+                  <span className="text-[11px] text-amber-600 dark:text-amber-300">
+                    Configure Linear to attach an issue.
+                  </span>
+                )}
               </div>
-            )}
-            {showLinearDropdown && linearQuery.trim().length >= 2 && (
-              <div className="absolute left-0 right-0 mt-1 bg-cc-card border border-cc-border rounded-[10px] shadow-lg z-20 overflow-hidden">
-                {linearSearching && (
-                  <div className="px-3 py-2 text-xs text-cc-muted">Searching Linear...</div>
-                )}
-                {!linearSearching && linearSearchError && (
-                  <div className="px-3 py-2 text-xs text-cc-error">{linearSearchError}</div>
-                )}
-                {!linearSearching && !linearSearchError && linearIssues.length === 0 && (
-                  <div className="px-3 py-2 text-xs text-cc-muted">No matching issues</div>
-                )}
-                {!linearSearching && !linearSearchError && linearIssues.map((issue) => (
+
+              {showLinearDropdown && linearConfigured && (
+                <div className="absolute left-2.5 right-2.5 top-[44px] bg-cc-card border border-cc-border rounded-[10px] shadow-lg z-20 overflow-hidden">
+                  <div className="p-2 border-b border-cc-border">
+                    <div className="flex items-center gap-2">
+                      <input
+                        type="text"
+                        value={linearQuery}
+                        onChange={(e) => {
+                          setLinearQuery(e.target.value);
+                        }}
+                        onFocus={() => setShowLinearDropdown(true)}
+                        autoFocus
+                        placeholder="ENG-123 or issue title"
+                        className="w-full px-2.5 py-2 text-sm bg-cc-input-bg border border-cc-border rounded-md text-cc-fg placeholder:text-cc-muted focus:outline-none focus:border-cc-primary/60"
+                      />
+                      <button
+                        type="button"
+                        onClick={() => {
+                          setShowLinearDropdown(false);
+                        }}
+                        className="px-2 py-2 rounded-md text-xs bg-cc-hover text-cc-muted hover:text-cc-fg transition-colors cursor-pointer"
+                      >
+                        Close
+                      </button>
+                    </div>
+                    <div className="mt-1.5 flex items-center justify-between text-[11px] text-cc-muted">
+                      <span>Attach an issue to this draft</span>
+                      <button
+                        type="button"
+                        onClick={() => {
+                          window.location.hash = "#/integrations/linear";
+                        }}
+                        className="hover:text-cc-fg underline underline-offset-2 cursor-pointer"
+                      >
+                        Settings
+                      </button>
+                    </div>
+                  </div>
+
+                  {linearQuery.trim().length < 2 && (
+                    <div className="px-3 py-2 text-xs text-cc-muted">Type at least 2 characters…</div>
+                  )}
+                  {linearQuery.trim().length >= 2 && linearSearching && (
+                    <div className="px-3 py-2 text-xs text-cc-muted">Searching Linear...</div>
+                  )}
+                  {linearQuery.trim().length >= 2 && !linearSearching && linearSearchError && (
+                    <div className="px-3 py-2 text-xs text-cc-error">{linearSearchError}</div>
+                  )}
+                  {linearQuery.trim().length >= 2 && !linearSearching && !linearSearchError && linearIssues.length === 0 && (
+                    <div className="px-3 py-2 text-xs text-cc-muted">No matching issues</div>
+                  )}
+                  {linearQuery.trim().length >= 2 && !linearSearching && !linearSearchError && (
+                    <div className="max-h-56 overflow-y-auto">
+                      {linearIssues.map((issue) => (
+                        <button
+                          key={issue.id}
+                          type="button"
+                          onClick={() => {
+                            setSelectedLinearIssue(issue);
+                            setLinearQuery(`${issue.identifier} - ${issue.title}`);
+                            setShowLinearDropdown(false);
+                          }}
+                          className="w-full px-3 py-2 text-left hover:bg-cc-hover transition-colors cursor-pointer"
+                        >
+                          <div className="text-xs text-cc-fg truncate">
+                            <span className="font-mono-code">{issue.identifier}</span> - {issue.title}
+                          </div>
+                          <div className="text-[10px] text-cc-muted truncate">
+                            {[issue.stateName, issue.teamName].filter(Boolean).join(" • ")}
+                          </div>
+                        </button>
+                      ))}
+                    </div>
+                  )}
+                </div>
+              )}
+
+              <button
+                type="button"
+                onClick={() => {
+                  window.location.hash = "#/integrations/linear";
+                }}
+                className="absolute bottom-2 right-2 inline-flex h-7 w-7 items-center justify-center rounded-md text-cc-muted hover:text-cc-fg hover:bg-cc-hover transition-colors cursor-pointer"
+                title="Linear settings"
+              >
+                <svg viewBox="0 0 20 20" fill="currentColor" className="w-3.5 h-3.5">
+                  <path fillRule="evenodd" d="M11.49 3.17c-.38-1.56-2.6-1.56-2.98 0a1.53 1.53 0 01-2.29.95c-1.35-.8-2.92.77-2.12 2.12.54.9.07 2.04-.95 2.29-1.56.38-1.56 2.6 0 2.98 1.02.25 1.49 1.39.95 2.29-.8 1.35.77 2.92 2.12 2.12.9-.54 2.04-.07 2.29.95.38 1.56 2.6 1.56 2.98 0 .25-1.02 1.39-1.49 2.29-.95 1.35.8 2.92-.77 2.12-2.12-.54-.9-.07-2.04.95-2.29 1.56-.38 1.56-2.6 0-2.98-1.02-.25-1.49-1.39-.95-2.29.8-1.35-.77-2.92-2.12-2.12-.9.54-2.04.07-2.29-.95zM10 13a3 3 0 100-6 3 3 0 000 6z" clipRule="evenodd" />
+                </svg>
+              </button>
+            </div>
+
+            {showLinearStartWarning && (
+              <div className="p-3 rounded-[10px] bg-amber-500/10 border border-amber-500/20">
+                <p className="text-xs text-amber-700 dark:text-amber-300 leading-snug">
+                  Warning: Linear is not configured. Continue anyway?
+                </p>
+                <div className="flex gap-2 mt-2.5">
                   <button
-                    key={issue.id}
                     type="button"
                     onClick={() => {
-                      setSelectedLinearIssue(issue);
-                      setLinearQuery(`${issue.identifier} - ${issue.title}`);
-                      setShowLinearDropdown(false);
+                      setShowLinearStartWarning(false);
+                      window.location.hash = "#/integrations/linear";
                     }}
-                    className="w-full px-3 py-2 text-left hover:bg-cc-hover transition-colors cursor-pointer"
+                    className="px-2.5 py-1 text-[11px] font-medium rounded-md bg-cc-hover text-cc-fg hover:bg-cc-active transition-colors cursor-pointer"
                   >
-                    <div className="text-xs text-cc-fg truncate">
-                      <span className="font-mono-code">{issue.identifier}</span> - {issue.title}
-                    </div>
-                    <div className="text-[10px] text-cc-muted truncate">
-                      {[issue.stateName, issue.teamName].filter(Boolean).join(" • ")}
-                    </div>
+                    Configurer Linear
                   </button>
-                ))}
+                  <button
+                    type="button"
+                    onClick={handleContinueWithoutLinear}
+                    className="px-2.5 py-1 text-[11px] font-medium rounded-md bg-amber-500/20 text-amber-700 dark:text-amber-300 hover:bg-amber-500/30 transition-colors cursor-pointer"
+                  >
+                    Continuer sans Linear
+                  </button>
+                </div>
               </div>
             )}
-          </div>
-        )}
+          </aside>
+        </div>
 
         {/* Branch behind remote warning */}
         {pullPrompt && (

--- a/web/src/components/LinearSettingsPage.test.tsx
+++ b/web/src/components/LinearSettingsPage.test.tsx
@@ -1,0 +1,115 @@
+// @vitest-environment jsdom
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import "@testing-library/jest-dom";
+
+interface MockStoreState {
+  currentSessionId: string | null;
+}
+
+let mockState: MockStoreState;
+
+const mockApi = {
+  getSettings: vi.fn(),
+  updateSettings: vi.fn(),
+  getLinearConnection: vi.fn(),
+};
+
+vi.mock("../api.js", () => ({
+  api: {
+    getSettings: (...args: unknown[]) => mockApi.getSettings(...args),
+    updateSettings: (...args: unknown[]) => mockApi.updateSettings(...args),
+    getLinearConnection: (...args: unknown[]) => mockApi.getLinearConnection(...args),
+  },
+}));
+
+vi.mock("../store.js", () => {
+  const useStoreFn = (selector: (state: MockStoreState) => unknown) => selector(mockState);
+  useStoreFn.getState = () => mockState;
+  return { useStore: useStoreFn };
+});
+
+import { LinearSettingsPage } from "./LinearSettingsPage.js";
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockState = { currentSessionId: null };
+  mockApi.getSettings.mockResolvedValue({
+    openrouterApiKeyConfigured: false,
+    openrouterModel: "openrouter/free",
+    linearApiKeyConfigured: true,
+  });
+  mockApi.updateSettings.mockResolvedValue({
+    openrouterApiKeyConfigured: false,
+    openrouterModel: "openrouter/free",
+    linearApiKeyConfigured: true,
+  });
+  mockApi.getLinearConnection.mockResolvedValue({
+    connected: true,
+    viewerName: "Ada",
+    viewerEmail: "ada@example.com",
+    teamName: "Engineering",
+    teamKey: "ENG",
+  });
+});
+
+describe("LinearSettingsPage", () => {
+  it("loads Linear configuration status", async () => {
+    render(<LinearSettingsPage />);
+    expect(mockApi.getSettings).toHaveBeenCalledTimes(1);
+    expect(await screen.findByText("Linear key configured")).toBeInTheDocument();
+  });
+
+  it("saves trimmed Linear API key", async () => {
+    render(<LinearSettingsPage />);
+    await screen.findByText("Linear key configured");
+
+    fireEvent.change(screen.getByLabelText("Linear API Key"), {
+      target: { value: "  lin_api_123  " },
+    });
+    fireEvent.click(screen.getByRole("button", { name: "Save" }));
+
+    await waitFor(() => {
+      expect(mockApi.updateSettings).toHaveBeenCalledWith({ linearApiKey: "lin_api_123" });
+    });
+    expect(mockApi.getLinearConnection).toHaveBeenCalled();
+    expect(await screen.findByText("Integration saved.")).toBeInTheDocument();
+  });
+
+  it("shows an error when saving empty key", async () => {
+    render(<LinearSettingsPage />);
+    await screen.findByText("Linear key configured");
+    fireEvent.click(screen.getByRole("button", { name: "Save" }));
+    expect(await screen.findByText("Please enter a Linear API key.")).toBeInTheDocument();
+    expect(mockApi.updateSettings).not.toHaveBeenCalled();
+  });
+
+  it("verifies connection when Verify is clicked", async () => {
+    render(<LinearSettingsPage />);
+    await screen.findByText("Linear key configured");
+
+    fireEvent.click(screen.getByRole("button", { name: "Verify" }));
+
+    await waitFor(() => {
+      expect(mockApi.getLinearConnection).toHaveBeenCalled();
+    });
+    expect(await screen.findByText("Linear connection verified.")).toBeInTheDocument();
+  });
+
+  it("disconnects Linear integration", async () => {
+    mockApi.updateSettings.mockResolvedValueOnce({
+      openrouterApiKeyConfigured: false,
+      openrouterModel: "openrouter/free",
+      linearApiKeyConfigured: false,
+    });
+
+    render(<LinearSettingsPage />);
+    await screen.findByText("Linear key configured");
+
+    fireEvent.click(screen.getByRole("button", { name: "Disconnect" }));
+
+    await waitFor(() => {
+      expect(mockApi.updateSettings).toHaveBeenCalledWith({ linearApiKey: "" });
+    });
+    expect(await screen.findByText("Linear disconnected.")).toBeInTheDocument();
+  });
+});

--- a/web/src/components/LinearSettingsPage.tsx
+++ b/web/src/components/LinearSettingsPage.tsx
@@ -1,0 +1,271 @@
+import { useEffect, useState } from "react";
+import { api } from "../api.js";
+import { navigateHome, navigateToSession } from "../utils/routing.js";
+import { useStore } from "../store.js";
+import { LinearLogo } from "./LinearLogo.js";
+
+interface LinearSettingsPageProps {
+  embedded?: boolean;
+}
+
+export function LinearSettingsPage({ embedded = false }: LinearSettingsPageProps) {
+  const [linearApiKey, setLinearApiKey] = useState("");
+  const [configured, setConfigured] = useState(false);
+  const [connected, setConnected] = useState(false);
+  const [viewerLabel, setViewerLabel] = useState("");
+  const [loading, setLoading] = useState(true);
+  const [saving, setSaving] = useState(false);
+  const [checkingConnection, setCheckingConnection] = useState(false);
+  const [error, setError] = useState("");
+  const [saved, setSaved] = useState(false);
+  const [connectionNote, setConnectionNote] = useState("");
+
+  async function refreshConnectionStatus() {
+    setCheckingConnection(true);
+    setError("");
+    setConnectionNote("");
+    try {
+      const info = await api.getLinearConnection();
+      setConnected(info.connected);
+      const label = info.viewerName || info.viewerEmail || "Connected account";
+      const team = info.teamName ? ` • ${info.teamName}` : "";
+      setViewerLabel(`${label}${team}`);
+      setConnectionNote("Linear connection verified.");
+    } catch (e: unknown) {
+      setConnected(false);
+      setViewerLabel("");
+      setConnectionNote("");
+      setError(e instanceof Error ? e.message : String(e));
+    } finally {
+      setCheckingConnection(false);
+    }
+  }
+
+  useEffect(() => {
+    api.getSettings()
+      .then((settings) => {
+        setConfigured(settings.linearApiKeyConfigured);
+        if (settings.linearApiKeyConfigured) {
+          refreshConnectionStatus().catch(() => {});
+        }
+      })
+      .catch((e: unknown) => setError(e instanceof Error ? e.message : String(e)))
+      .finally(() => setLoading(false));
+  }, []);
+
+  async function onSave(e: React.FormEvent) {
+    e.preventDefault();
+    const trimmed = linearApiKey.trim();
+    if (!trimmed) {
+      setError("Please enter a Linear API key.");
+      return;
+    }
+
+    setSaving(true);
+    setError("");
+    setSaved(false);
+    setConnectionNote("");
+    try {
+      const settings = await api.updateSettings({ linearApiKey: trimmed });
+      setConfigured(settings.linearApiKeyConfigured);
+      setLinearApiKey("");
+      setSaved(true);
+      await refreshConnectionStatus();
+      setTimeout(() => setSaved(false), 1800);
+    } catch (e: unknown) {
+      setError(e instanceof Error ? e.message : String(e));
+    } finally {
+      setSaving(false);
+    }
+  }
+
+  async function onDisconnect() {
+    setSaving(true);
+    setError("");
+    setSaved(false);
+    setConnectionNote("");
+    try {
+      const settings = await api.updateSettings({ linearApiKey: "" });
+      setConfigured(settings.linearApiKeyConfigured);
+      setConnected(false);
+      setViewerLabel("");
+      setLinearApiKey("");
+      setConnectionNote("Linear disconnected.");
+    } catch (e: unknown) {
+      setError(e instanceof Error ? e.message : String(e));
+    } finally {
+      setSaving(false);
+    }
+  }
+
+  return (
+    <div className={`${embedded ? "h-full" : "h-[100dvh]"} bg-cc-bg text-cc-fg font-sans-ui antialiased overflow-y-auto`}>
+      <div className="max-w-5xl mx-auto px-4 sm:px-8 py-6 sm:py-10">
+        <div className="flex items-start justify-between gap-3 mb-6">
+          <div>
+            <h1 className="text-xl font-semibold text-cc-fg">Linear Settings</h1>
+            <p className="mt-1 text-sm text-cc-muted">
+              Configure Linear search and issue context injection at session start.
+            </p>
+          </div>
+          <div className="flex items-center gap-2">
+            <button
+              onClick={() => {
+                window.location.hash = "#/integrations";
+              }}
+              className="px-3 py-1.5 rounded-lg text-sm text-cc-muted hover:text-cc-fg hover:bg-cc-hover transition-colors cursor-pointer"
+            >
+              Integrations
+            </button>
+            {!embedded && (
+              <button
+                onClick={() => {
+                  const sessionId = useStore.getState().currentSessionId;
+                  if (sessionId) {
+                    navigateToSession(sessionId);
+                  } else {
+                    navigateHome();
+                  }
+                }}
+                className="px-3 py-1.5 rounded-lg text-sm text-cc-muted hover:text-cc-fg hover:bg-cc-hover transition-colors cursor-pointer"
+              >
+                Back
+              </button>
+            )}
+          </div>
+        </div>
+
+        <section className="relative overflow-hidden bg-cc-card border border-cc-border rounded-xl p-4 sm:p-6 mb-4">
+          <div className="absolute inset-0 pointer-events-none bg-[radial-gradient(circle_at_top_right,rgba(124,58,237,0.1),transparent_45%)]" />
+          <div className="relative flex items-start justify-between gap-4 flex-wrap">
+            <div className="min-w-0">
+              <div className="inline-flex items-center gap-2 px-2.5 py-1 rounded-full border border-cc-border bg-cc-hover/60 text-xs text-cc-muted">
+                <LinearLogo className="w-3.5 h-3.5 text-cc-fg" />
+                <span>Linear Integration</span>
+              </div>
+              <h2 className="mt-3 text-lg sm:text-xl font-semibold text-cc-fg">
+                Turn issues into concrete session context
+              </h2>
+              <p className="mt-1.5 text-sm text-cc-muted max-w-2xl">
+                Search and attach the right Linear issue before the first prompt, so the companion starts with scope, state, and links.
+              </p>
+              <div className="mt-3 flex flex-wrap gap-2 text-[11px]">
+                <span className="px-2 py-1 rounded-md bg-cc-hover text-cc-muted">Issue lookup on Home</span>
+                <span className="px-2 py-1 rounded-md bg-cc-hover text-cc-muted">Context injection on start</span>
+                <span className="px-2 py-1 rounded-md bg-cc-hover text-cc-muted">No key exposure in API responses</span>
+              </div>
+            </div>
+            <div className="shrink-0 rounded-xl border border-cc-border bg-cc-bg px-3 py-2 text-right min-w-[170px]">
+              <p className="text-[11px] text-cc-muted uppercase tracking-wide">Status</p>
+              <p className={`mt-1 text-sm font-medium ${connected ? "text-cc-success" : configured ? "text-amber-500" : "text-cc-muted"}`}>
+                {connected ? "Connected" : configured ? "Needs verification" : "Not connected"}
+              </p>
+              <p className="mt-0.5 text-[11px] text-cc-muted truncate">{viewerLabel || "No workspace linked yet"}</p>
+            </div>
+          </div>
+        </section>
+
+        <form onSubmit={onSave} className="bg-cc-card border border-cc-border rounded-xl p-4 sm:p-5 space-y-4">
+          <h2 className="text-sm font-semibold text-cc-fg flex items-center gap-2">
+            <LinearLogo className="w-4 h-4 text-cc-fg" />
+            <span>Linear Credentials</span>
+          </h2>
+          <div>
+            <label className="block text-sm font-medium mb-1.5" htmlFor="linear-key">
+              Linear API Key
+            </label>
+            <input
+              id="linear-key"
+              type="password"
+              value={linearApiKey}
+              onChange={(e) => setLinearApiKey(e.target.value)}
+              placeholder={configured ? "Configured. Enter a new key to replace." : "lin_api_..."}
+              className="w-full px-3 py-2.5 text-sm bg-cc-input-bg border border-cc-border rounded-lg text-cc-fg placeholder:text-cc-muted focus:outline-none focus:border-cc-primary/60"
+            />
+            <p className="mt-1.5 text-xs text-cc-muted">
+              Used to search Linear issues from the home page and inject issue context at session start.
+            </p>
+          </div>
+
+          {error && (
+            <div className="px-3 py-2 rounded-lg bg-cc-error/10 border border-cc-error/20 text-xs text-cc-error">
+              {error}
+            </div>
+          )}
+
+          {connectionNote && (
+            <div className="px-3 py-2 rounded-lg bg-cc-success/10 border border-cc-success/20 text-xs text-cc-success">
+              {connectionNote}
+            </div>
+          )}
+
+          {saved && (
+            <div className="px-3 py-2 rounded-lg bg-cc-success/10 border border-cc-success/20 text-xs text-cc-success">
+              Integration saved.
+            </div>
+          )}
+
+          <div className="flex items-center justify-between gap-3 flex-wrap">
+            <span className="text-xs text-cc-muted">
+              {loading ? "Loading..." : configured ? "Linear key configured" : "Linear key not configured"}
+            </span>
+            <div className="flex items-center gap-2">
+              <button
+                type="button"
+                onClick={onDisconnect}
+                disabled={saving || loading || !configured}
+                className={`px-3 py-2 rounded-lg text-sm font-medium transition-colors ${
+                  saving || loading || !configured
+                    ? "bg-cc-hover text-cc-muted cursor-not-allowed"
+                    : "bg-cc-error/10 hover:bg-cc-error/20 text-cc-error cursor-pointer"
+                }`}
+              >
+                Disconnect
+              </button>
+              <button
+                type="button"
+                onClick={() => {
+                  refreshConnectionStatus().catch(() => {});
+                }}
+                disabled={checkingConnection || loading || !configured}
+                className={`px-3 py-2 rounded-lg text-sm font-medium transition-colors ${
+                  checkingConnection || loading || !configured
+                    ? "bg-cc-hover text-cc-muted cursor-not-allowed"
+                    : "bg-cc-hover hover:bg-cc-active text-cc-fg cursor-pointer"
+                }`}
+              >
+                {checkingConnection ? "Checking..." : "Verify"}
+              </button>
+              <button
+                type="submit"
+                disabled={saving || loading}
+                className={`px-3 py-2 rounded-lg text-sm font-medium transition-colors ${
+                  saving || loading
+                    ? "bg-cc-hover text-cc-muted cursor-not-allowed"
+                    : "bg-cc-primary hover:bg-cc-primary-hover text-white cursor-pointer"
+                }`}
+              >
+                {saving ? "Saving..." : "Save"}
+              </button>
+            </div>
+          </div>
+        </form>
+
+        <section className="mt-4 grid grid-cols-1 md:grid-cols-3 gap-3">
+          <div className="bg-cc-card border border-cc-border rounded-xl p-4">
+            <p className="text-[11px] uppercase tracking-wide text-cc-muted">1. Configure</p>
+            <p className="mt-1 text-sm text-cc-fg">Add a Linear API key and verify the connection.</p>
+          </div>
+          <div className="bg-cc-card border border-cc-border rounded-xl p-4">
+            <p className="text-[11px] uppercase tracking-wide text-cc-muted">2. Select</p>
+            <p className="mt-1 text-sm text-cc-fg">From Home, search an issue by key or title in one click.</p>
+          </div>
+          <div className="bg-cc-card border border-cc-border rounded-xl p-4">
+            <p className="text-[11px] uppercase tracking-wide text-cc-muted">3. Start</p>
+            <p className="mt-1 text-sm text-cc-fg">The issue details are injected as startup context.</p>
+          </div>
+        </section>
+      </div>
+    </div>
+  );
+}

--- a/web/src/components/Sidebar.tsx
+++ b/web/src/components/Sidebar.tsx
@@ -30,7 +30,7 @@ export function Sidebar() {
   const route = parseHash(hash);
   const isSettingsPage = route.page === "settings";
   const isPromptsPage = route.page === "prompts";
-  const isIntegrationsPage = route.page === "integrations";
+  const isIntegrationsPage = route.page === "integrations" || route.page === "integration-linear";
   const isTerminalPage = route.page === "terminal";
   const isEnvironmentsPage = route.page === "environments";
   const isScheduledPage = route.page === "scheduled";

--- a/web/src/utils/routing.test.ts
+++ b/web/src/utils/routing.test.ts
@@ -23,6 +23,10 @@ describe("parseHash", () => {
     expect(parseHash("#/integrations")).toEqual({ page: "integrations" });
   });
 
+  it("parses linear integration route", () => {
+    expect(parseHash("#/integrations/linear")).toEqual({ page: "integration-linear" });
+  });
+
   it("parses terminal route", () => {
     expect(parseHash("#/terminal")).toEqual({ page: "terminal" });
   });

--- a/web/src/utils/routing.ts
+++ b/web/src/utils/routing.ts
@@ -3,6 +3,7 @@ export type Route =
   | { page: "session"; sessionId: string }
   | { page: "settings" }
   | { page: "integrations" }
+  | { page: "integration-linear" }
   | { page: "prompts" }
   | { page: "terminal" }
   | { page: "environments" }
@@ -17,6 +18,7 @@ const SESSION_PREFIX = "#/session/";
 export function parseHash(hash: string): Route {
   if (hash === "#/settings") return { page: "settings" };
   if (hash === "#/integrations") return { page: "integrations" };
+  if (hash === "#/integrations/linear") return { page: "integration-linear" };
   if (hash === "#/prompts") return { page: "prompts" };
   if (hash === "#/terminal") return { page: "terminal" };
   if (hash === "#/environments") return { page: "environments" };


### PR DESCRIPTION
## Summary
- split Linear into a dedicated settings page and route
- reworked Integrations page to a compact card with status indicator and quick settings access
- improved Home context/integration flow and related API/routing glue
- added/updated tests for routing, API behavior, integrations UI, and Linear settings UI

## Why
- make Linear configuration easier to find and use
- reduce clutter on Integrations while keeping clear status and fast access
- improve first-prompt context UX when using Linear

## Testing
- pre-commit hook ran `tsc --noEmit` and full `vitest --coverage`
- targeted checks:
  - `bun run test src/components/IntegrationsPage.test.tsx src/components/LinearSettingsPage.test.tsx`

## Review provenance
- Implemented by AI agent (Codex)
- Human review: no
