### PR TITLE
feat(sidebar): add collapsible footer links with persisted state

### DIFF
--- a/web/src/components/Sidebar.test.tsx
+++ b/web/src/components/Sidebar.test.tsx
@@ -145,6 +145,7 @@ import { Sidebar } from "./Sidebar.js";
 beforeEach(() => {
   vi.clearAllMocks();
   mockState = createMockState();
+  localStorage.removeItem("cc-sidebar-footer-expanded");
   window.location.hash = "";
 });
 
@@ -443,6 +444,28 @@ describe("Sidebar", () => {
     render(<Sidebar />);
     fireEvent.click(screen.getByText("Terminal").closest("button")!);
     expect(window.location.hash).toBe("#/terminal");
+  });
+
+  it("collapses footer links while keeping settings visible", () => {
+    localStorage.setItem("cc-sidebar-footer-expanded", "false");
+
+    render(<Sidebar />);
+
+    expect(screen.getByText("Settings")).toBeInTheDocument();
+    expect(screen.queryByText("Prompts")).not.toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Expand sidebar links" })).toBeInTheDocument();
+  });
+
+  it("persists footer accordion state when toggled", () => {
+    render(<Sidebar />);
+
+    fireEvent.click(screen.getByRole("button", { name: "Collapse sidebar links" }));
+    expect(localStorage.getItem("cc-sidebar-footer-expanded")).toBe("false");
+    expect(screen.queryByText("Prompts")).not.toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole("button", { name: "Expand sidebar links" }));
+    expect(localStorage.getItem("cc-sidebar-footer-expanded")).toBe("true");
+    expect(screen.getByText("Prompts")).toBeInTheDocument();
   });
 
   it("session name shows animate-name-appear class when recently renamed", () => {

--- a/web/src/components/Sidebar.tsx
+++ b/web/src/components/Sidebar.tsx
@@ -7,11 +7,24 @@ import { ProjectGroup } from "./ProjectGroup.js";
 import { SessionItem } from "./SessionItem.js";
 import { groupSessionsByProject, type SessionItem as SessionItemType } from "../utils/project-grouping.js";
 
+const SIDEBAR_FOOTER_EXPANDED_STORAGE_KEY = "cc-sidebar-footer-expanded";
+
+function getInitialFooterExpandedState(): boolean {
+  if (typeof window === "undefined") return true;
+  try {
+    const stored = window.localStorage.getItem(SIDEBAR_FOOTER_EXPANDED_STORAGE_KEY);
+    return stored !== "false";
+  } catch {
+    return true;
+  }
+}
+
 export function Sidebar() {
   const [editingSessionId, setEditingSessionId] = useState<string | null>(null);
   const [editingName, setEditingName] = useState("");
   const [showArchived, setShowArchived] = useState(false);
   const [confirmArchiveId, setConfirmArchiveId] = useState<string | null>(null);
+  const [footerExpanded, setFooterExpanded] = useState(getInitialFooterExpandedState);
   const [hash, setHash] = useState(() => (typeof window !== "undefined" ? window.location.hash : ""));
   const editInputRef = useRef<HTMLInputElement>(null);
   const sessions = useStore((s) => s.sessions);
@@ -77,6 +90,14 @@ export function Sidebar() {
     window.addEventListener("hashchange", onHashChange);
     return () => window.removeEventListener("hashchange", onHashChange);
   }, []);
+
+  useEffect(() => {
+    try {
+      window.localStorage.setItem(SIDEBAR_FOOTER_EXPANDED_STORAGE_KEY, String(footerExpanded));
+    } catch {
+      // best-effort
+    }
+  }, [footerExpanded]);
 
   function handleSelectSession(sessionId: string) {
     useStore.getState().closeTerminal();
@@ -397,104 +418,121 @@ export function Sidebar() {
 
       {/* Footer */}
       <div className="p-3 border-t border-cc-border space-y-0.5">
-        <button
-          onClick={() => {
-            useStore.getState().closeTerminal();
-            window.location.hash = "#/prompts";
-          }}
-          className={`w-full flex items-center gap-2.5 px-3 py-2 rounded-[10px] text-sm transition-colors cursor-pointer ${
-            isPromptsPage
-              ? "bg-cc-active text-cc-fg"
-              : "text-cc-muted hover:text-cc-fg hover:bg-cc-hover"
-          }`}
-        >
-          <svg viewBox="0 0 16 16" fill="currentColor" className="w-4 h-4">
-            <path d="M3 2.5A1.5 1.5 0 014.5 1h5.879c.398 0 .779.158 1.06.44l1.621 1.62c.281.282.44.663.44 1.061V13.5A1.5 1.5 0 0112 15H4.5A1.5 1.5 0 013 13.5v-11zM4.5 2a.5.5 0 00-.5.5v11a.5.5 0 00.5.5H12a.5.5 0 00.5-.5V4.121a.5.5 0 00-.146-.353l-1.621-1.621A.5.5 0 0010.379 2H4.5zm1.25 4.25a.75.75 0 01.75-.75h3a.75.75 0 010 1.5h-3a.75.75 0 01-.75-.75zm0 3a.75.75 0 01.75-.75h3.5a.75.75 0 010 1.5H6.5a.75.75 0 01-.75-.75z" />
-          </svg>
-          <span>Prompts</span>
-        </button>
-        <button
-          onClick={() => {
-            useStore.getState().closeTerminal();
-            window.location.hash = "#/integrations";
-          }}
-          className={`w-full flex items-center gap-2.5 px-3 py-2 rounded-[10px] text-sm transition-colors cursor-pointer ${
-            isIntegrationsPage
-              ? "bg-cc-active text-cc-fg"
-              : "text-cc-muted hover:text-cc-fg hover:bg-cc-hover"
-          }`}
-        >
-          <svg viewBox="0 0 16 16" fill="currentColor" className="w-4 h-4">
-            <path d="M2.5 3A1.5 1.5 0 001 4.5v2A1.5 1.5 0 002.5 8h2A1.5 1.5 0 006 6.5v-2A1.5 1.5 0 004.5 3h-2zm0 1h2a.5.5 0 01.5.5v2a.5.5 0 01-.5.5h-2a.5.5 0 01-.5-.5v-2a.5.5 0 01.5-.5zm9 0A1.5 1.5 0 0010 5.5v2A1.5 1.5 0 0011.5 9h2A1.5 1.5 0 0015 7.5v-2A1.5 1.5 0 0013.5 4h-2zm0 1h2a.5.5 0 01.5.5v2a.5.5 0 01-.5.5h-2a.5.5 0 01-.5-.5v-2a.5.5 0 01.5-.5zM2.5 10A1.5 1.5 0 001 11.5v2A1.5 1.5 0 002.5 15h2A1.5 1.5 0 006 13.5v-2A1.5 1.5 0 004.5 10h-2zm0 1h2a.5.5 0 01.5.5v2a.5.5 0 01-.5.5h-2a.5.5 0 01-.5-.5v-2a.5.5 0 01.5-.5zM8.5 12a.5.5 0 100 1h5a.5.5 0 100-1h-5zm0-2a.5.5 0 100 1h2a.5.5 0 100-1h-2z" />
-          </svg>
-          <span>Integrations</span>
-        </button>
-        <button
-          onClick={() => {
-            window.location.hash = "#/terminal";
-            if (window.innerWidth < 768) {
-              useStore.getState().setSidebarOpen(false);
-            }
-          }}
-          className={`w-full flex items-center gap-2.5 px-3 py-2 rounded-[10px] text-sm transition-colors cursor-pointer ${
-            isTerminalPage
-              ? "bg-cc-active text-cc-fg"
-              : "text-cc-muted hover:text-cc-fg hover:bg-cc-hover"
-          }`}
-        >
-          <svg viewBox="0 0 16 16" fill="currentColor" className="w-4 h-4">
-            <path d="M2 3a1 1 0 011-1h10a1 1 0 011 1v10a1 1 0 01-1 1H3a1 1 0 01-1-1V3zm2 1.5l3 2.5-3 2.5V4.5zM8.5 10h3v1h-3v-1z" />
-          </svg>
-          <span>Terminal</span>
-        </button>
-        <button
-          onClick={() => {
-            useStore.getState().closeTerminal();
-            window.location.hash = "#/environments";
-          }}
-          className={`w-full flex items-center gap-2.5 px-3 py-2 rounded-[10px] text-sm transition-colors cursor-pointer ${
-            isEnvironmentsPage
-              ? "bg-cc-active text-cc-fg"
-              : "text-cc-muted hover:text-cc-fg hover:bg-cc-hover"
-          }`}
-        >
-          <svg viewBox="0 0 16 16" fill="currentColor" className="w-4 h-4">
-            <path d="M8 1a2 2 0 012 2v1h2a2 2 0 012 2v6a2 2 0 01-2 2H4a2 2 0 01-2-2V6a2 2 0 012-2h2V3a2 2 0 012-2zm0 1.5a.5.5 0 00-.5.5v1h1V3a.5.5 0 00-.5-.5zM4 5.5a.5.5 0 00-.5.5v6a.5.5 0 00.5.5h8a.5.5 0 00.5-.5V6a.5.5 0 00-.5-.5H4z" />
-          </svg>
-          <span>Environments</span>
-        </button>
-        <button
-          onClick={() => {
-            useStore.getState().closeTerminal();
-            window.location.hash = "#/scheduled";
-          }}
-          className={`w-full flex items-center gap-2.5 px-3 py-2 rounded-[10px] text-sm transition-colors cursor-pointer ${
-            isScheduledPage
-              ? "bg-cc-active text-cc-fg"
-              : "text-cc-muted hover:text-cc-fg hover:bg-cc-hover"
-          }`}
-        >
-          <svg viewBox="0 0 16 16" fill="currentColor" className="w-4 h-4">
-            <path d="M8 2a6 6 0 100 12A6 6 0 008 2zM0 8a8 8 0 1116 0A8 8 0 010 8zm9-3a1 1 0 10-2 0v3a1 1 0 00.293.707l2 2a1 1 0 001.414-1.414L9 7.586V5z" />
-          </svg>
-          <span>Scheduled</span>
-        </button>
-        <button
-          onClick={() => {
-            useStore.getState().closeTerminal();
-            window.location.hash = "#/settings";
-          }}
-          className={`w-full flex items-center gap-2.5 px-3 py-2 rounded-[10px] text-sm transition-colors cursor-pointer ${
-            isSettingsPage
-              ? "bg-cc-active text-cc-fg"
-              : "text-cc-muted hover:text-cc-fg hover:bg-cc-hover"
-          }`}
-        >
-          <svg viewBox="0 0 20 20" fill="currentColor" className="w-4 h-4">
-            <path fillRule="evenodd" d="M11.49 3.17c-.38-1.56-2.6-1.56-2.98 0a1.53 1.53 0 01-2.29.95c-1.35-.8-2.92.77-2.12 2.12.54.9.07 2.04-.95 2.29-1.56.38-1.56 2.6 0 2.98 1.02.25 1.49 1.39.95 2.29-.8 1.35.77 2.92 2.12 2.12.9-.54 2.04-.07 2.29.95.38 1.56 2.6 1.56 2.98 0 .25-1.02 1.39-1.49 2.29-.95 1.35.8 2.92-.77 2.12-2.12-.54-.9-.07-2.04.95-2.29 1.56-.38 1.56-2.6 0-2.98-1.02-.25-1.49-1.39-.95-2.29.8-1.35-.77-2.92-2.12-2.12-.9.54-2.04.07-2.29-.95zM10 13a3 3 0 100-6 3 3 0 000 6z" clipRule="evenodd" />
-          </svg>
-          <span>Settings</span>
-        </button>
+        <div className="flex items-center gap-1">
+          <button
+            onClick={() => {
+              useStore.getState().closeTerminal();
+              window.location.hash = "#/settings";
+            }}
+            className={`flex-1 flex items-center gap-2.5 px-3 py-2 rounded-[10px] text-sm transition-colors cursor-pointer ${
+              isSettingsPage
+                ? "bg-cc-active text-cc-fg"
+                : "text-cc-muted hover:text-cc-fg hover:bg-cc-hover"
+            }`}
+          >
+            <svg viewBox="0 0 20 20" fill="currentColor" className="w-4 h-4">
+              <path fillRule="evenodd" d="M11.49 3.17c-.38-1.56-2.6-1.56-2.98 0a1.53 1.53 0 01-2.29.95c-1.35-.8-2.92.77-2.12 2.12.54.9.07 2.04-.95 2.29-1.56.38-1.56 2.6 0 2.98 1.02.25 1.49 1.39.95 2.29-.8 1.35.77 2.92 2.12 2.12.9-.54 2.04-.07 2.29.95.38 1.56 2.6 1.56 2.98 0 .25-1.02 1.39-1.49 2.29-.95 1.35.8 2.92-.77 2.12-2.12-.54-.9-.07-2.04.95-2.29 1.56-.38 1.56-2.6 0-2.98-1.02-.25-1.49-1.39-.95-2.29.8-1.35-.77-2.92-2.12-2.12-.9.54-2.04.07-2.29-.95zM10 13a3 3 0 100-6 3 3 0 000 6z" clipRule="evenodd" />
+            </svg>
+            <span>Settings</span>
+          </button>
+          <button
+            onClick={() => setFooterExpanded((v) => !v)}
+            aria-label={footerExpanded ? "Collapse sidebar links" : "Expand sidebar links"}
+            aria-expanded={footerExpanded}
+            className="shrink-0 flex items-center justify-center w-9 h-9 rounded-[10px] text-cc-muted hover:text-cc-fg hover:bg-cc-hover transition-colors cursor-pointer"
+            title={footerExpanded ? "Collapse links" : "Expand links"}
+          >
+            <svg viewBox="0 0 16 16" fill="currentColor" className={`w-4 h-4 transition-transform ${footerExpanded ? "rotate-180" : ""}`}>
+              <path d="M4.22 6.22a.75.75 0 011.06 0L8 8.94l2.72-2.72a.75.75 0 111.06 1.06l-3.25 3.25a.75.75 0 01-1.06 0L4.22 7.28a.75.75 0 010-1.06z" />
+            </svg>
+          </button>
+        </div>
+        {footerExpanded && (
+          <div className="space-y-0.5">
+            <button
+              onClick={() => {
+                useStore.getState().closeTerminal();
+                window.location.hash = "#/prompts";
+              }}
+              className={`w-full flex items-center gap-2.5 px-3 py-2 rounded-[10px] text-sm transition-colors cursor-pointer ${
+                isPromptsPage
+                  ? "bg-cc-active text-cc-fg"
+                  : "text-cc-muted hover:text-cc-fg hover:bg-cc-hover"
+              }`}
+            >
+              <svg viewBox="0 0 16 16" fill="currentColor" className="w-4 h-4">
+                <path d="M3 2.5A1.5 1.5 0 014.5 1h5.879c.398 0 .779.158 1.06.44l1.621 1.62c.281.282.44.663.44 1.061V13.5A1.5 1.5 0 0112 15H4.5A1.5 1.5 0 013 13.5v-11zM4.5 2a.5.5 0 00-.5.5v11a.5.5 0 00.5.5H12a.5.5 0 00.5-.5V4.121a.5.5 0 00-.146-.353l-1.621-1.621A.5.5 0 0010.379 2H4.5zm1.25 4.25a.75.75 0 01.75-.75h3a.75.75 0 010 1.5h-3a.75.75 0 01-.75-.75zm0 3a.75.75 0 01.75-.75h3.5a.75.75 0 010 1.5H6.5a.75.75 0 01-.75-.75z" />
+              </svg>
+              <span>Prompts</span>
+            </button>
+            <button
+              onClick={() => {
+                useStore.getState().closeTerminal();
+                window.location.hash = "#/integrations";
+              }}
+              className={`w-full flex items-center gap-2.5 px-3 py-2 rounded-[10px] text-sm transition-colors cursor-pointer ${
+                isIntegrationsPage
+                  ? "bg-cc-active text-cc-fg"
+                  : "text-cc-muted hover:text-cc-fg hover:bg-cc-hover"
+              }`}
+            >
+              <svg viewBox="0 0 16 16" fill="currentColor" className="w-4 h-4">
+                <path d="M2.5 3A1.5 1.5 0 001 4.5v2A1.5 1.5 0 002.5 8h2A1.5 1.5 0 006 6.5v-2A1.5 1.5 0 004.5 3h-2zm0 1h2a.5.5 0 01.5.5v2a.5.5 0 01-.5.5h-2a.5.5 0 01-.5-.5v-2a.5.5 0 01.5-.5zm9 0A1.5 1.5 0 0010 5.5v2A1.5 1.5 0 0011.5 9h2A1.5 1.5 0 0015 7.5v-2A1.5 1.5 0 0013.5 4h-2zm0 1h2a.5.5 0 01.5.5v2a.5.5 0 01-.5.5h-2a.5.5 0 01-.5-.5v-2a.5.5 0 01.5-.5zM2.5 10A1.5 1.5 0 001 11.5v2A1.5 1.5 0 002.5 15h2A1.5 1.5 0 006 13.5v-2A1.5 1.5 0 004.5 10h-2zm0 1h2a.5.5 0 01.5.5v2a.5.5 0 01-.5.5h-2a.5.5 0 01-.5-.5v-2a.5.5 0 01.5-.5zM8.5 12a.5.5 0 100 1h5a.5.5 0 100-1h-5zm0-2a.5.5 0 100 1h2a.5.5 0 100-1h-2z" />
+              </svg>
+              <span>Integrations</span>
+            </button>
+            <button
+              onClick={() => {
+                window.location.hash = "#/terminal";
+                if (window.innerWidth < 768) {
+                  useStore.getState().setSidebarOpen(false);
+                }
+              }}
+              className={`w-full flex items-center gap-2.5 px-3 py-2 rounded-[10px] text-sm transition-colors cursor-pointer ${
+                isTerminalPage
+                  ? "bg-cc-active text-cc-fg"
+                  : "text-cc-muted hover:text-cc-fg hover:bg-cc-hover"
+              }`}
+            >
+              <svg viewBox="0 0 16 16" fill="currentColor" className="w-4 h-4">
+                <path d="M2 3a1 1 0 011-1h10a1 1 0 011 1v10a1 1 0 01-1 1H3a1 1 0 01-1-1V3zm2 1.5l3 2.5-3 2.5V4.5zM8.5 10h3v1h-3v-1z" />
+              </svg>
+              <span>Terminal</span>
+            </button>
+            <button
+              onClick={() => {
+                useStore.getState().closeTerminal();
+                window.location.hash = "#/environments";
+              }}
+              className={`w-full flex items-center gap-2.5 px-3 py-2 rounded-[10px] text-sm transition-colors cursor-pointer ${
+                isEnvironmentsPage
+                  ? "bg-cc-active text-cc-fg"
+                  : "text-cc-muted hover:text-cc-fg hover:bg-cc-hover"
+              }`}
+            >
+              <svg viewBox="0 0 16 16" fill="currentColor" className="w-4 h-4">
+                <path d="M8 1a2 2 0 012 2v1h2a2 2 0 012 2v6a2 2 0 01-2 2H4a2 2 0 01-2-2V6a2 2 0 012-2h2V3a2 2 0 012-2zm0 1.5a.5.5 0 00-.5.5v1h1V3a.5.5 0 00-.5-.5zM4 5.5a.5.5 0 00-.5.5v6a.5.5 0 00.5.5h8a.5.5 0 00.5-.5V6a.5.5 0 00-.5-.5H4z" />
+              </svg>
+              <span>Environments</span>
+            </button>
+            <button
+              onClick={() => {
+                useStore.getState().closeTerminal();
+                window.location.hash = "#/scheduled";
+              }}
+              className={`w-full flex items-center gap-2.5 px-3 py-2 rounded-[10px] text-sm transition-colors cursor-pointer ${
+                isScheduledPage
+                  ? "bg-cc-active text-cc-fg"
+                  : "text-cc-muted hover:text-cc-fg hover:bg-cc-hover"
+              }`}
+            >
+              <svg viewBox="0 0 16 16" fill="currentColor" className="w-4 h-4">
+                <path d="M8 2a6 6 0 100 12A6 6 0 008 2zM0 8a8 8 0 1116 0A8 8 0 010 8zm9-3a1 1 0 10-2 0v3a1 1 0 00.293.707l2 2a1 1 0 001.414-1.414L9 7.586V5z" />
+              </svg>
+              <span>Scheduled</span>
+            </button>
+          </div>
+        )}
       </div>
     </aside>
   );


### PR DESCRIPTION
## Summary
- make the sidebar footer links section collapsible to save space on smaller/landscape mobile layouts
- keep `Settings` always visible in collapsed mode and add a chevron toggle to expand/collapse the remaining links
- persist the expanded/collapsed preference in `localStorage` so it is restored when reopening the sidebar
- add sidebar tests for collapsed rendering and persistence behavior

## Why
- the footer links consume too much vertical space, especially on phones in landscape orientation
- this preserves quick access to settings while reducing persistent sidebar clutter

## Visual
- Screenshot: not attached from this CLI environment (UI-only change is in `web/src/components/Sidebar.tsx`)

## Testing
- `cd web && /home/claude/.bun/bin/bun run test src/components/Sidebar.test.tsx`

## Review provenance
- Implemented by AI agent
- Human review: no


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Sidebar footer is now collapsible, keeping Settings visible by default while additional options (Prompts, Integrations, Terminal, Environments, Scheduled) can be toggled. Footer state persists across sessions.

* **Tests**
  * Added test coverage for footer collapse/expand functionality and state persistence.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->