### PR TITLE
fix(ui): hide Linear context bar when Linear is not configured

### DIFF
--- a/web/src/components/HomePage.tsx
+++ b/web/src/components/HomePage.tsx
@@ -447,9 +447,6 @@ export function HomePage() {
     const msg = text.trim();
     if (!msg || sending) return;
 
-    if (!linearConfigured) {
-      setShowLinearStartWarning(true);
-    }
 
     setSending(true);
     setError("");
@@ -1160,7 +1157,7 @@ export function HomePage() {
             </div>
           </div>
 
-          <aside className="space-y-2 mt-0.5" ref={linearDropdownRef}>
+          {linearConfigured && <aside className="space-y-2 mt-0.5" ref={linearDropdownRef}>
             <div className="relative rounded-[12px] border border-cc-border bg-cc-card/90 px-2.5 py-2">
               <div className="flex items-center gap-2 flex-wrap">
                 <span className="text-[11px] uppercase tracking-wide text-cc-muted">Context</span>
@@ -1489,7 +1486,7 @@ export function HomePage() {
                 </div>
               </div>
             )}
-          </aside>
+          </aside>}
         </div>
 
         {/* Branch behind remote warning */}


### PR DESCRIPTION
## Summary
- Hide the "Context" aside (Linear integration controls) on the homepage when Linear is not configured
- Remove the `showLinearStartWarning` trigger that prompted unconfigured users to set up Linear on send
- Keeps the homepage clean for users who don't use the Linear integration

## Why
The Context bar was always visible even for users without Linear configured, showing a confusing "Configure Linear to attach an issue" message. Users who don't use Linear shouldn't see this section at all.

## Testing
- `bun run typecheck` — passes
- `bun run test` — all 1341 tests pass (63 files)
- Manual verification: context bar hidden when `linearConfigured` is false, visible when true

## Review provenance
- Implemented by AI agent (Claude)
- Human review: no


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Linear integration UI section is now hidden when the feature is not configured.
  * Removed unnecessary warning prompt that appeared when sending messages without Linear integration enabled.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->