### PR TITLE
fix(linear): add server-side cache to prevent API rate limiting

### DIFF
--- a/web/server/linear-cache.test.ts
+++ b/web/server/linear-cache.test.ts
@@ -1,0 +1,136 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { LinearCache } from "./linear-cache.js";
+
+describe("LinearCache", () => {
+  let cache: LinearCache;
+
+  beforeEach(() => {
+    cache = new LinearCache();
+  });
+
+  it("returns fetched data and caches it", async () => {
+    const fetcher = vi.fn().mockResolvedValue({ issues: ["a"] });
+    const result = await cache.getOrFetch("key1", 5000, fetcher);
+    expect(result).toEqual({ issues: ["a"] });
+    expect(fetcher).toHaveBeenCalledTimes(1);
+  });
+
+  it("serves from cache within TTL without calling fetcher again", async () => {
+    const fetcher = vi.fn().mockResolvedValue("data");
+    await cache.getOrFetch("k", 5000, fetcher);
+    const result = await cache.getOrFetch("k", 5000, fetcher);
+    expect(result).toBe("data");
+    expect(fetcher).toHaveBeenCalledTimes(1);
+  });
+
+  it("re-fetches after TTL expires", async () => {
+    // Use fake timers to test TTL expiration
+    vi.useFakeTimers();
+    const fetcher = vi.fn()
+      .mockResolvedValueOnce("old")
+      .mockResolvedValueOnce("new");
+
+    await cache.getOrFetch("k", 100, fetcher);
+
+    // Advance past TTL
+    vi.advanceTimersByTime(150);
+
+    const result = await cache.getOrFetch("k", 100, fetcher);
+    expect(result).toBe("new");
+    expect(fetcher).toHaveBeenCalledTimes(2);
+
+    vi.useRealTimers();
+  });
+
+  it("deduplicates concurrent requests — fetcher called only once", async () => {
+    // Fetcher that resolves after a small delay to simulate network latency
+    let resolvePromise: (v: string) => void;
+    const fetcher = vi.fn().mockImplementation(
+      () => new Promise<string>((resolve) => { resolvePromise = resolve; }),
+    );
+
+    const p1 = cache.getOrFetch("k", 5000, fetcher);
+    const p2 = cache.getOrFetch("k", 5000, fetcher);
+
+    // Both should be the same promise, fetcher called only once
+    expect(fetcher).toHaveBeenCalledTimes(1);
+
+    resolvePromise!("shared");
+    const [r1, r2] = await Promise.all([p1, p2]);
+    expect(r1).toBe("shared");
+    expect(r2).toBe("shared");
+  });
+
+  it("invalidates a specific key", async () => {
+    const fetcher = vi.fn()
+      .mockResolvedValueOnce("v1")
+      .mockResolvedValueOnce("v2");
+
+    await cache.getOrFetch("k", 60000, fetcher);
+    cache.invalidate("k");
+
+    const result = await cache.getOrFetch("k", 60000, fetcher);
+    expect(result).toBe("v2");
+    expect(fetcher).toHaveBeenCalledTimes(2);
+  });
+
+  it("invalidates by prefix", async () => {
+    const fetcher1 = vi.fn().mockResolvedValue("a");
+    const fetcher2 = vi.fn().mockResolvedValue("b");
+    const fetcher3 = vi.fn().mockResolvedValue("c");
+
+    await cache.getOrFetch("issue:123", 60000, fetcher1);
+    await cache.getOrFetch("issue:456", 60000, fetcher2);
+    await cache.getOrFetch("search:hello", 60000, fetcher3);
+
+    cache.invalidate("issue:");
+    expect(cache.size).toBe(1); // only "search:hello" remains
+  });
+
+  it("clear() empties the entire cache", async () => {
+    await cache.getOrFetch("a", 60000, () => Promise.resolve(1));
+    await cache.getOrFetch("b", 60000, () => Promise.resolve(2));
+    expect(cache.size).toBe(2);
+
+    cache.clear();
+    expect(cache.size).toBe(0);
+  });
+
+  it("failed fetch does not poison the cache — allows retry", async () => {
+    const fetcher = vi.fn()
+      .mockRejectedValueOnce(new Error("network fail"))
+      .mockResolvedValueOnce("recovered");
+
+    await expect(cache.getOrFetch("k", 5000, fetcher)).rejects.toThrow("network fail");
+
+    // Retry should call fetcher again, not serve the error
+    const result = await cache.getOrFetch("k", 5000, fetcher);
+    expect(result).toBe("recovered");
+    expect(fetcher).toHaveBeenCalledTimes(2);
+  });
+
+  it("failed fetch with existing stale data keeps the stale entry for future retry", async () => {
+    vi.useFakeTimers();
+
+    const fetcher = vi.fn()
+      .mockResolvedValueOnce("stale-data")
+      .mockRejectedValueOnce(new Error("refresh failed"))
+      .mockResolvedValueOnce("fresh-data");
+
+    // Populate cache
+    await cache.getOrFetch("k", 100, fetcher);
+
+    // Expire the entry
+    vi.advanceTimersByTime(150);
+
+    // Attempt refresh — fails
+    await expect(cache.getOrFetch("k", 100, fetcher)).rejects.toThrow("refresh failed");
+
+    // Next attempt should retry the fetcher, not serve stale data
+    const result = await cache.getOrFetch("k", 100, fetcher);
+    expect(result).toBe("fresh-data");
+    expect(fetcher).toHaveBeenCalledTimes(3);
+
+    vi.useRealTimers();
+  });
+});

--- a/web/server/linear-cache.ts
+++ b/web/server/linear-cache.ts
@@ -1,0 +1,113 @@
+/**
+ * Server-side TTL cache for Linear API responses.
+ *
+ * Prevents hitting Linear's 5000 requests/hour rate limit by caching
+ * read-only GraphQL responses with configurable TTLs. Concurrent identical
+ * requests are deduplicated — only one fetch is made and all callers share
+ * the same promise.
+ */
+
+interface CacheEntry<T = unknown> {
+  data: T;
+  timestamp: number;
+  pending?: Promise<T>;
+}
+
+const MAX_ENTRIES = 500;
+const EVICT_AGE_MS = 5 * 60 * 1000; // 5 minutes — sweep threshold
+
+export class LinearCache {
+  private store = new Map<string, CacheEntry>();
+
+  /**
+   * Return cached data if fresh, otherwise execute `fetcher` and cache the result.
+   * Concurrent calls with the same key share a single in-flight request.
+   */
+  async getOrFetch<T>(key: string, ttlMs: number, fetcher: () => Promise<T>): Promise<T> {
+    const existing = this.store.get(key) as CacheEntry<T> | undefined;
+
+    // Serve from cache if still fresh
+    if (existing && !existing.pending && Date.now() - existing.timestamp < ttlMs) {
+      return existing.data;
+    }
+
+    // Deduplicate: if a fetch is already in flight for this key, piggyback on it
+    if (existing?.pending) {
+      return existing.pending;
+    }
+
+    const pending = fetcher()
+      .then((data) => {
+        this.store.set(key, { data, timestamp: Date.now() });
+        this.maybeEvict();
+        return data;
+      })
+      .catch((err) => {
+        // On failure, remove the pending promise so the next call can retry.
+        // If we have stale data, keep it around (callers won't use it because
+        // timestamp is old, but a future getOrFetch will retry the fetch).
+        const entry = this.store.get(key);
+        if (entry?.pending === pending) {
+          delete entry.pending;
+          // If there was never any cached data, remove the entry entirely
+          if (entry.timestamp === 0) {
+            this.store.delete(key);
+          }
+        }
+        throw err;
+      });
+
+    // Store the in-flight promise
+    if (existing) {
+      existing.pending = pending;
+    } else {
+      this.store.set(key, { data: undefined as T, timestamp: 0, pending });
+    }
+
+    return pending;
+  }
+
+  /** Invalidate a specific key, or all keys that start with `keyOrPrefix`. */
+  invalidate(keyOrPrefix: string): void {
+    // Exact match first
+    if (this.store.has(keyOrPrefix)) {
+      this.store.delete(keyOrPrefix);
+      return;
+    }
+    // Prefix match
+    for (const k of this.store.keys()) {
+      if (k.startsWith(keyOrPrefix)) {
+        this.store.delete(k);
+      }
+    }
+  }
+
+  /** Clear the entire cache (e.g. when the Linear API key changes). */
+  clear(): void {
+    this.store.clear();
+  }
+
+  /** Current number of cached entries. */
+  get size(): number {
+    return this.store.size;
+  }
+
+  /** Sweep stale entries when the store grows too large. */
+  private maybeEvict(): void {
+    if (this.store.size <= MAX_ENTRIES) return;
+    const now = Date.now();
+    for (const [k, entry] of this.store) {
+      if (now - entry.timestamp > EVICT_AGE_MS && !entry.pending) {
+        this.store.delete(k);
+      }
+    }
+  }
+}
+
+/** Singleton cache instance used across all Linear route handlers. */
+export const linearCache = new LinearCache();
+
+/** Reset for test isolation — clears all cached data. */
+export function _resetForTest(): void {
+  linearCache.clear();
+}

--- a/web/src/components/HomePage.tsx
+++ b/web/src/components/HomePage.tsx
@@ -320,7 +320,7 @@ export function HomePage() {
         if (!active) return;
         setLinearSearching(false);
       });
-    }, 220);
+    }, 400);
 
     return () => {
       active = false;
@@ -355,7 +355,7 @@ export function HomePage() {
         if (!active) return;
         setGlobalSearching(false);
       });
-    }, 250);
+    }, 400);
 
     return () => {
       active = false;

--- a/web/src/components/TaskPanel.tsx
+++ b/web/src/components/TaskPanel.tsx
@@ -551,7 +551,7 @@ function LinearIssueSection({ sessionId }: { sessionId: string }) {
       }).finally(() => {
         if (active) setSearching(false);
       });
-    }, 250);
+    }, 400);
     return () => { active = false; clearTimeout(timer); };
   }, [searchQuery, showSearch]);
 


### PR DESCRIPTION
## Summary
- Adds a server-side TTL cache (`linear-cache.ts`) with request deduplication for all Linear GraphQL read endpoints
- Wraps 6 read endpoints in cache with appropriate TTLs (30s for search/issue refresh, 60s for project issues, 5min for connection/states/projects)
- Increases frontend search debounce from 220-250ms to 400ms across HomePage and TaskPanel
- Adds cache invalidation on API key change, after comment creation, and after issue transitions

## Why
The app was hitting Linear's 5000 requests/hour rate limit because every frontend request resulted in a fresh `fetch()` to Linear's GraphQL API with zero caching. This was especially bad with search debounce at 220ms, per-session polling, and multiple components firing simultaneously.

## Testing
- 9 new tests for `LinearCache` (TTL, dedup, invalidation, error recovery)
- All 1343 existing tests pass
- `cli-launcher.test.ts` failure is pre-existing (Bun stub issue)

## Review provenance
- Implemented by AI agent
- Human review: no
