### PR TITLE
fix(settings): open update overlay on update restart

### DIFF
--- a/web/src/components/SettingsPage.test.tsx
+++ b/web/src/components/SettingsPage.test.tsx
@@ -18,6 +18,7 @@ interface MockStoreState {
   toggleNotificationSound: ReturnType<typeof vi.fn>;
   setNotificationDesktop: ReturnType<typeof vi.fn>;
   setUpdateInfo: ReturnType<typeof vi.fn>;
+  setUpdateOverlayActive: ReturnType<typeof vi.fn>;
 }
 
 let mockState: MockStoreState;
@@ -32,6 +33,7 @@ function createMockState(overrides: Partial<MockStoreState> = {}): MockStoreStat
     toggleNotificationSound: vi.fn(),
     setNotificationDesktop: vi.fn(),
     setUpdateInfo: vi.fn(),
+    setUpdateOverlayActive: vi.fn(),
     ...overrides,
   };
 }
@@ -337,6 +339,7 @@ describe("SettingsPage", () => {
     await waitFor(() => {
       expect(mockApi.triggerUpdate).toHaveBeenCalledTimes(1);
     });
+    expect(mockState.setUpdateOverlayActive).toHaveBeenCalledWith(true);
     expect(await screen.findByText("Update started. Server will restart shortly.")).toBeInTheDocument();
   });
 });

--- a/web/src/components/SettingsPage.tsx
+++ b/web/src/components/SettingsPage.tsx
@@ -26,6 +26,7 @@ export function SettingsPage({ embedded = false }: SettingsPageProps) {
   const setNotificationDesktop = useStore((s) => s.setNotificationDesktop);
   const updateInfo = useStore((s) => s.updateInfo);
   const setUpdateInfo = useStore((s) => s.setUpdateInfo);
+  const setUpdateOverlayActive = useStore((s) => s.setUpdateOverlayActive);
   const notificationApiAvailable = typeof Notification !== "undefined";
   const [checkingUpdates, setCheckingUpdates] = useState(false);
   const [updatingApp, setUpdatingApp] = useState(false);
@@ -96,6 +97,7 @@ export function SettingsPage({ embedded = false }: SettingsPageProps) {
     try {
       const res = await api.triggerUpdate();
       setUpdateStatus(res.message);
+      setUpdateOverlayActive(true);
     } catch (err: unknown) {
       setUpdateError(err instanceof Error ? err.message : String(err));
       setUpdatingApp(false);


### PR DESCRIPTION
## Summary
- fix Settings page `Update & Restart` flow to activate the full-screen update overlay after triggering the server update
- keep behavior aligned with the top update banner flow
- extend `SettingsPage` tests to assert overlay activation

## Why
- the Settings button triggered update but did not open the overlay, creating inconsistent UX and no visual restart state

## Testing
- `cd web && bun run test src/components/SettingsPage.test.tsx`

## Review provenance
- Implemented by AI agent (Codex)
- Human review: no
