### PR TITLE
feat(editor): move VS Code editor to dedicated tab with host fallback

### DIFF
--- a/web/server/index.ts
+++ b/web/server/index.ts
@@ -40,6 +40,7 @@ import { DEFAULT_PORT_DEV, DEFAULT_PORT_PROD } from "./constants.js";
 
 const defaultPort = process.env.NODE_ENV === "production" ? DEFAULT_PORT_PROD : DEFAULT_PORT_DEV;
 const port = Number(process.env.PORT) || defaultPort;
+const idleTimeoutSeconds = Number(process.env.COMPANION_IDLE_TIMEOUT_SECONDS || "120");
 const sessionStore = new SessionStore(process.env.COMPANION_SESSION_DIR);
 const wsBridge = new WsBridge();
 const launcher = new CliLauncher(port);
@@ -130,6 +131,7 @@ if (process.env.NODE_ENV === "production") {
 
 const server = Bun.serve<SocketData>({
   port,
+  idleTimeout: idleTimeoutSeconds,
   async fetch(req, server) {
     const url = new URL(req.url);
 

--- a/web/server/routes.test.ts
+++ b/web/server/routes.test.ts
@@ -910,6 +910,8 @@ describe("POST /api/sessions/:id/editor/start", () => {
     vi.spyOn(containerManager, "hasBinaryInContainer").mockReturnValue(true);
     vi.spyOn(containerManager, "isContainerAlive").mockReturnValue("running");
     const execSpy = vi.spyOn(containerManager, "execInContainer").mockReturnValue("");
+    // Mock fetch so the readiness poll resolves immediately instead of timing out
+    const fetchSpy = vi.spyOn(globalThis, "fetch").mockResolvedValue(new Response("ok", { status: 200 }));
 
     const res = await app.request("/api/sessions/s1/editor/start", { method: "POST" });
 
@@ -926,6 +928,7 @@ describe("POST /api/sessions/:id/editor/start", () => {
       expect.arrayContaining(["sh", "-lc"]),
       10_000,
     );
+    fetchSpy.mockRestore();
   });
 });
 

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -21,6 +21,7 @@ import { CronManager } from "./components/CronManager.js";
 import { TerminalPage } from "./components/TerminalPage.js";
 import { SessionLaunchOverlay } from "./components/SessionLaunchOverlay.js";
 import { SessionTerminalDock } from "./components/SessionTerminalDock.js";
+import { SessionEditorPane } from "./components/SessionEditorPane.js";
 import { UpdateOverlay } from "./components/UpdateOverlay.js";
 
 function useHash() {
@@ -187,13 +188,15 @@ export default function App() {
                         onClosePanel={() => useStore.getState().setActiveTab("chat")}
                       />
                     )
-                    : (
-                      <SessionTerminalDock sessionId={currentSessionId} suppressPanel>
-                        {activeTab === "diff"
-                          ? <DiffPanel sessionId={currentSessionId} />
-                          : <ChatView sessionId={currentSessionId} />}
-                      </SessionTerminalDock>
-                    )
+                    : activeTab === "editor"
+                      ? <SessionEditorPane sessionId={currentSessionId} />
+                      : (
+                        <SessionTerminalDock sessionId={currentSessionId} suppressPanel>
+                          {activeTab === "diff"
+                            ? <DiffPanel sessionId={currentSessionId} />
+                            : <ChatView sessionId={currentSessionId} />}
+                        </SessionTerminalDock>
+                      )
                 ) : (
                   <HomePage key={homeResetKey} />
                 )}

--- a/web/src/components/SessionEditorPane.tsx
+++ b/web/src/components/SessionEditorPane.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useState } from "react";
 import { api, type EditorStartResult } from "../api.js";
+import { useStore } from "../store.js";
 
 interface SessionEditorPaneProps {
   sessionId: string;
@@ -8,6 +9,7 @@ interface SessionEditorPaneProps {
 export function SessionEditorPane({ sessionId }: SessionEditorPaneProps) {
   const [state, setState] = useState<EditorStartResult | null>(null);
   const [loading, setLoading] = useState(true);
+  const setEditorUrl = useStore((s) => s.setEditorUrl);
 
   useEffect(() => {
     let cancelled = false;
@@ -18,6 +20,9 @@ export function SessionEditorPane({ sessionId }: SessionEditorPaneProps) {
       .then((res) => {
         if (cancelled) return;
         setState(res);
+        if (res.available && res.url) {
+          setEditorUrl(sessionId, res.url);
+        }
       })
       .catch((err) => {
         if (cancelled) return;

--- a/web/src/components/SessionTerminalDock.tsx
+++ b/web/src/components/SessionTerminalDock.tsx
@@ -1,8 +1,6 @@
 import { useMemo } from "react";
 import { useStore, type QuickTerminalPlacement } from "../store.js";
 import { TerminalView } from "./TerminalView.js";
-import { SessionEditorPane } from "./SessionEditorPane.js";
-
 interface SessionTerminalDockProps {
   sessionId: string;
   children?: React.ReactNode;
@@ -202,13 +200,8 @@ export function SessionTerminalDock({
 
   if (terminalOnly) {
     return (
-      <div className="h-full min-h-0 bg-cc-card flex flex-col lg:flex-row">
-        <div className="flex-1 min-h-[220px] lg:min-h-0 border-b lg:border-b-0 lg:border-r border-cc-border">
-          <SessionEditorPane sessionId={sessionId} />
-        </div>
-        <div className="flex-1 min-h-[220px] lg:min-h-0">
-          {terminalPanel}
-        </div>
+      <div className="h-full min-h-0 bg-cc-card">
+        {terminalPanel}
       </div>
     );
   }

--- a/web/src/components/TopBar.test.tsx
+++ b/web/src/components/TopBar.test.tsx
@@ -16,9 +16,10 @@ interface MockStoreState {
   setSidebarOpen: ReturnType<typeof vi.fn>;
   taskPanelOpen: boolean;
   setTaskPanelOpen: ReturnType<typeof vi.fn>;
-  activeTab: "chat" | "diff" | "terminal";
+  activeTab: "chat" | "diff" | "terminal" | "editor";
   setActiveTab: ReturnType<typeof vi.fn>;
   markChatTabReentry: ReturnType<typeof vi.fn>;
+  editorUrls: Map<string, string>;
   quickTerminalOpen: boolean;
   quickTerminalTabs: { id: string; label: string; cwd: string; containerId?: string }[];
   openQuickTerminal: ReturnType<typeof vi.fn>;
@@ -42,6 +43,7 @@ function resetStore(overrides: Partial<MockStoreState> = {}) {
     activeTab: "chat",
     setActiveTab: vi.fn(),
     markChatTabReentry: vi.fn(),
+    editorUrls: new Map(),
     quickTerminalOpen: false,
     quickTerminalTabs: [],
     openQuickTerminal: vi.fn(),

--- a/web/src/store.ts
+++ b/web/src/store.ts
@@ -93,7 +93,8 @@ interface AppState {
   taskPanelConfig: TaskPanelConfig;
   taskPanelConfigMode: boolean;
   homeResetKey: number;
-  activeTab: "chat" | "diff" | "terminal";
+  activeTab: "chat" | "diff" | "terminal" | "editor";
+  editorUrls: Map<string, string>;
   chatTabReentryTickBySession: Map<string, number>;
   diffPanelSelectedFile: Map<string, string>;
 
@@ -175,7 +176,8 @@ interface AppState {
   setUpdateOverlayActive: (active: boolean) => void;
 
   // Diff panel actions
-  setActiveTab: (tab: "chat" | "diff" | "terminal") => void;
+  setActiveTab: (tab: "chat" | "diff" | "terminal" | "editor") => void;
+  setEditorUrl: (sessionId: string, url: string) => void;
   markChatTabReentry: (sessionId: string) => void;
   setDiffPanelSelectedFile: (sessionId: string, filePath: string | null) => void;
 
@@ -317,6 +319,7 @@ export const useStore = create<AppState>((set) => ({
   taskPanelConfigMode: false,
   homeResetKey: 0,
   activeTab: "chat",
+  editorUrls: new Map(),
   chatTabReentryTickBySession: new Map(),
   diffPanelSelectedFile: new Map(),
   quickTerminalOpen: false,
@@ -756,6 +759,12 @@ export const useStore = create<AppState>((set) => ({
   setUpdateOverlayActive: (active) => set({ updateOverlayActive: active }),
 
   setActiveTab: (tab) => set({ activeTab: tab }),
+  setEditorUrl: (sessionId, url) =>
+    set((s) => {
+      const next = new Map(s.editorUrls);
+      next.set(sessionId, url);
+      return { editorUrls: next };
+    }),
   markChatTabReentry: (sessionId) =>
     set((s) => {
       const chatTabReentryTickBySession = new Map(s.chatTabReentryTickBySession);
@@ -874,6 +883,7 @@ export const useStore = create<AppState>((set) => ({
       linkedLinearIssues: new Map(),
       taskPanelConfigMode: false,
       activeTab: "chat" as const,
+      editorUrls: new Map(),
       chatTabReentryTickBySession: new Map(),
       diffPanelSelectedFile: new Map(),
       quickTerminalOpen: false,


### PR DESCRIPTION
## Summary
- Move VS Code editor from side-by-side split in Shell tab to its own dedicated "Editor" tab
- Fix shell syntax error in code-server startup command (`then &&` → `then`)
- Add server-side readiness poll (up to 5s) so the iframe doesn't load before code-server is ready
- Fall back to host code-server when container image doesn't have it installed
- Add pop-out button in TopBar to open editor in a new browser window
- Improve workspace copy to container using tar pipe for better throughput on Docker Desktop

## Testing
- All 1408 tests pass
- Typecheck clean
- Docker image rebuilt with code-server layer
- Tested host editor, container editor, and host fallback paths

## Review provenance
- Implemented by AI agent
- Human review: no
