### PR TITLE
fix(test): stabilize editor start route test timeout

### DIFF
--- a/web/server/routes.test.ts
+++ b/web/server/routes.test.ts
@@ -889,7 +889,7 @@ describe("POST /api/sessions/:id/editor/start", () => {
       expect.stringContaining("--bind-addr 127.0.0.1:13338"),
       expect.objectContaining({ timeout: 10_000 }),
     );
-  });
+  }, 15_000);
 
   it("starts container editor and returns mapped host URL", async () => {
     launcher.getSession.mockReturnValue({


### PR DESCRIPTION
## Summary
- increase timeout for a flaky `server/routes.test.ts` case that starts code-server on host

## Why
- CI repeatedly failed on this test with a 5s timeout despite passing locally and being unrelated to feature logic

## Testing
- `cd web && bun run test server/routes.test.ts`

## Review provenance
- Implemented by AI agent
- Human review: no
