### PR TITLE
feat(context): add context window usage display and compacting indicator

### DIFF
--- a/web/server/session-types.ts
+++ b/web/server/session-types.ts
@@ -133,7 +133,12 @@ export interface CLIAssistantMessage {
 
 export interface CLIResultMessage {
   type: "result";
-  subtype: "success" | "error_during_execution" | "error_max_turns" | "error_max_budget_usd" | "error_max_structured_output_retries";
+  subtype:
+    | "success"
+    | "error_during_execution"
+    | "error_max_turns"
+    | "error_max_budget_usd"
+    | "error_max_structured_output_retries";
   is_error: boolean;
   result?: string;
   errors?: string[];
@@ -148,15 +153,18 @@ export interface CLIResultMessage {
     cache_creation_input_tokens: number;
     cache_read_input_tokens: number;
   };
-  modelUsage?: Record<string, {
-    inputTokens: number;
-    outputTokens: number;
-    cacheReadInputTokens: number;
-    cacheCreationInputTokens: number;
-    contextWindow: number;
-    maxOutputTokens: number;
-    costUSD: number;
-  }>;
+  modelUsage?: Record<
+    string,
+    {
+      inputTokens: number;
+      outputTokens: number;
+      cacheReadInputTokens: number;
+      cacheCreationInputTokens: number;
+      contextWindow: number;
+      maxOutputTokens: number;
+      costUSD: number;
+    }
+  >;
   total_lines_added?: number;
   total_lines_removed?: number;
   uuid: string;
@@ -242,52 +250,163 @@ export type CLIMessage =
 
 export type ContentBlock =
   | { type: "text"; text: string }
-  | { type: "tool_use"; id: string; name: string; input: Record<string, unknown> }
-  | { type: "tool_result"; tool_use_id: string; content: string | ContentBlock[]; is_error?: boolean }
+  | {
+      type: "tool_use";
+      id: string;
+      name: string;
+      input: Record<string, unknown>;
+    }
+  | {
+      type: "tool_result";
+      tool_use_id: string;
+      content: string | ContentBlock[];
+      is_error?: boolean;
+    }
   | { type: "thinking"; thinking: string; budget_tokens?: number };
 
 // ─── Browser Message Types (browser <-> bridge) ──────────────────────────────
 
 /** Messages the browser sends to the bridge */
 export type BrowserOutgoingMessage =
-  | { type: "user_message"; content: string; session_id?: string; images?: { media_type: string; data: string }[]; client_msg_id?: string }
-  | { type: "permission_response"; request_id: string; behavior: "allow" | "deny"; updated_input?: Record<string, unknown>; updated_permissions?: PermissionUpdate[]; message?: string; client_msg_id?: string }
+  | {
+      type: "user_message";
+      content: string;
+      session_id?: string;
+      images?: { media_type: string; data: string }[];
+      client_msg_id?: string;
+    }
+  | {
+      type: "permission_response";
+      request_id: string;
+      behavior: "allow" | "deny";
+      updated_input?: Record<string, unknown>;
+      updated_permissions?: PermissionUpdate[];
+      message?: string;
+      client_msg_id?: string;
+    }
   | { type: "session_subscribe"; last_seq: number }
   | { type: "session_ack"; last_seq: number }
   | { type: "interrupt"; client_msg_id?: string }
   | { type: "set_model"; model: string; client_msg_id?: string }
   | { type: "set_permission_mode"; mode: string; client_msg_id?: string }
   | { type: "mcp_get_status"; client_msg_id?: string }
-  | { type: "mcp_toggle"; serverName: string; enabled: boolean; client_msg_id?: string }
+  | {
+      type: "mcp_toggle";
+      serverName: string;
+      enabled: boolean;
+      client_msg_id?: string;
+    }
   | { type: "mcp_reconnect"; serverName: string; client_msg_id?: string }
-  | { type: "mcp_set_servers"; servers: Record<string, McpServerConfig>; client_msg_id?: string }
-  | { type: "set_ai_validation"; aiValidationEnabled?: boolean | null; aiValidationAutoApprove?: boolean | null; aiValidationAutoDeny?: boolean | null; client_msg_id?: string };
+  | {
+      type: "mcp_set_servers";
+      servers: Record<string, McpServerConfig>;
+      client_msg_id?: string;
+    }
+  | {
+      type: "set_ai_validation";
+      aiValidationEnabled?: boolean | null;
+      aiValidationAutoApprove?: boolean | null;
+      aiValidationAutoDeny?: boolean | null;
+      client_msg_id?: string;
+    };
 
 /** Messages the bridge sends to the browser */
 export type BrowserIncomingMessageBase =
   | { type: "session_init"; session: SessionState }
   | { type: "session_update"; session: Partial<SessionState> }
-  | { type: "assistant"; message: CLIAssistantMessage["message"]; parent_tool_use_id: string | null; timestamp?: number }
+  | {
+      type: "assistant";
+      message: CLIAssistantMessage["message"];
+      parent_tool_use_id: string | null;
+      timestamp?: number;
+    }
   | { type: "stream_event"; event: unknown; parent_tool_use_id: string | null }
   | {
-    type: "system_event";
-    event:
-      | Pick<CLICompactBoundaryMessage, "subtype" | "compact_metadata" | "uuid" | "session_id">
-      | Pick<CLITaskNotificationMessage, "subtype" | "task_id" | "status" | "output_file" | "summary" | "uuid" | "session_id">
-      | Pick<CLIFilesPersistedMessage, "subtype" | "files" | "failed" | "processed_at" | "uuid" | "session_id">
-      | Pick<CLIHookStartedMessage, "subtype" | "hook_id" | "hook_name" | "hook_event" | "uuid" | "session_id">
-      | Pick<CLIHookProgressMessage, "subtype" | "hook_id" | "hook_name" | "hook_event" | "stdout" | "stderr" | "output" | "uuid" | "session_id">
-      | Pick<CLIHookResponseMessage, "subtype" | "hook_id" | "hook_name" | "hook_event" | "output" | "stdout" | "stderr" | "exit_code" | "outcome" | "uuid" | "session_id">;
-    timestamp?: number;
-  }
+      type: "system_event";
+      event:
+        | Pick<
+            CLICompactBoundaryMessage,
+            "subtype" | "compact_metadata" | "uuid" | "session_id"
+          >
+        | Pick<
+            CLITaskNotificationMessage,
+            | "subtype"
+            | "task_id"
+            | "status"
+            | "output_file"
+            | "summary"
+            | "uuid"
+            | "session_id"
+          >
+        | Pick<
+            CLIFilesPersistedMessage,
+            | "subtype"
+            | "files"
+            | "failed"
+            | "processed_at"
+            | "uuid"
+            | "session_id"
+          >
+        | Pick<
+            CLIHookStartedMessage,
+            | "subtype"
+            | "hook_id"
+            | "hook_name"
+            | "hook_event"
+            | "uuid"
+            | "session_id"
+          >
+        | Pick<
+            CLIHookProgressMessage,
+            | "subtype"
+            | "hook_id"
+            | "hook_name"
+            | "hook_event"
+            | "stdout"
+            | "stderr"
+            | "output"
+            | "uuid"
+            | "session_id"
+          >
+        | Pick<
+            CLIHookResponseMessage,
+            | "subtype"
+            | "hook_id"
+            | "hook_name"
+            | "hook_event"
+            | "output"
+            | "stdout"
+            | "stderr"
+            | "exit_code"
+            | "outcome"
+            | "uuid"
+            | "session_id"
+          >;
+      timestamp?: number;
+    }
   | { type: "result"; data: CLIResultMessage }
   | { type: "permission_request"; request: PermissionRequest }
   | { type: "permission_cancelled"; request_id: string }
-  | { type: "permission_auto_resolved"; request: PermissionRequest; behavior: "allow" | "deny"; reason: string }
-  | { type: "tool_progress"; tool_use_id: string; tool_name: string; elapsed_time_seconds: number }
+  | {
+      type: "permission_auto_resolved";
+      request: PermissionRequest;
+      behavior: "allow" | "deny";
+      reason: string;
+    }
+  | {
+      type: "tool_progress";
+      tool_use_id: string;
+      tool_name: string;
+      elapsed_time_seconds: number;
+    }
   | { type: "tool_use_summary"; summary: string; tool_use_ids: string[] }
   | { type: "status_change"; status: "compacting" | "idle" | "running" | null }
-  | { type: "auth_status"; isAuthenticating: boolean; output: string[]; error?: string }
+  | {
+      type: "auth_status";
+      isAuthenticating: boolean;
+      output: string[];
+      error?: string;
+    }
   | { type: "error"; message: string }
   | { type: "cli_disconnected" }
   | { type: "cli_connected" }
@@ -295,12 +414,21 @@ export type BrowserIncomingMessageBase =
   | { type: "message_history"; messages: BrowserIncomingMessage[] }
   | { type: "event_replay"; events: BufferedBrowserEvent[] }
   | { type: "session_name_update"; name: string }
-  | { type: "pr_status_update"; pr: import("./github-pr.js").GitHubPRInfo | null; available: boolean }
+  | {
+      type: "pr_status_update";
+      pr: import("./github-pr.js").GitHubPRInfo | null;
+      available: boolean;
+    }
   | { type: "mcp_status"; servers: McpServerDetail[] };
 
-export type BrowserIncomingMessage = BrowserIncomingMessageBase & { seq?: number };
+export type BrowserIncomingMessage = BrowserIncomingMessageBase & {
+  seq?: number;
+};
 
-export type ReplayableBrowserIncomingMessage = Exclude<BrowserIncomingMessageBase, { type: "event_replay" }>;
+export type ReplayableBrowserIncomingMessage = Exclude<
+  BrowserIncomingMessageBase,
+  { type: "event_replay" }
+>;
 
 export interface BufferedBrowserEvent {
   seq: number;
@@ -335,6 +463,15 @@ export interface SessionState {
   git_behind: number;
   total_lines_added: number;
   total_lines_removed: number;
+  // Claude Code per-turn token details (from assistant message usage)
+  claude_token_details?: {
+    inputTokens: number;
+    outputTokens: number;
+    cacheReadInputTokens: number;
+    cacheCreationInputTokens: number;
+    contextWindow: number;
+    maxOutputTokens: number;
+  };
   // Codex-specific token details (forwarded from thread/tokenUsage/updated)
   codex_token_details?: {
     inputTokens: number;
@@ -345,8 +482,16 @@ export interface SessionState {
   };
   // Codex-specific rate limits (forwarded from account/rateLimits/updated)
   codex_rate_limits?: {
-    primary: { usedPercent: number; windowDurationMins: number; resetsAt: number } | null;
-    secondary: { usedPercent: number; windowDurationMins: number; resetsAt: number } | null;
+    primary: {
+      usedPercent: number;
+      windowDurationMins: number;
+      resetsAt: number;
+    } | null;
+    secondary: {
+      usedPercent: number;
+      windowDurationMins: number;
+      resetsAt: number;
+    } | null;
   };
   /** If this session was spawned by a cron job */
   cronJobId?: string;
@@ -381,22 +526,57 @@ export interface McpServerDetail {
   error?: string;
   config: { type: string; url?: string; command?: string; args?: string[] };
   scope: string;
-  tools?: { name: string; annotations?: { readOnly?: boolean; destructive?: boolean; openWorld?: boolean } }[];
+  tools?: {
+    name: string;
+    annotations?: {
+      readOnly?: boolean;
+      destructive?: boolean;
+      openWorld?: boolean;
+    };
+  }[];
 }
 
 // ─── Permission Request ──────────────────────────────────────────────────────
 
 // ─── Permission Rule Types ───────────────────────────────────────────────────
 
-export type PermissionDestination = "userSettings" | "projectSettings" | "localSettings" | "session" | "cliArg";
+export type PermissionDestination =
+  | "userSettings"
+  | "projectSettings"
+  | "localSettings"
+  | "session"
+  | "cliArg";
 
 export type PermissionUpdate =
-  | { type: "addRules"; rules: { toolName: string; ruleContent?: string }[]; behavior: "allow" | "deny" | "ask"; destination: PermissionDestination }
-  | { type: "replaceRules"; rules: { toolName: string; ruleContent?: string }[]; behavior: "allow" | "deny" | "ask"; destination: PermissionDestination }
-  | { type: "removeRules"; rules: { toolName: string; ruleContent?: string }[]; behavior: "allow" | "deny" | "ask"; destination: PermissionDestination }
+  | {
+      type: "addRules";
+      rules: { toolName: string; ruleContent?: string }[];
+      behavior: "allow" | "deny" | "ask";
+      destination: PermissionDestination;
+    }
+  | {
+      type: "replaceRules";
+      rules: { toolName: string; ruleContent?: string }[];
+      behavior: "allow" | "deny" | "ask";
+      destination: PermissionDestination;
+    }
+  | {
+      type: "removeRules";
+      rules: { toolName: string; ruleContent?: string }[];
+      behavior: "allow" | "deny" | "ask";
+      destination: PermissionDestination;
+    }
   | { type: "setMode"; mode: string; destination: PermissionDestination }
-  | { type: "addDirectories"; directories: string[]; destination: PermissionDestination }
-  | { type: "removeDirectories"; directories: string[]; destination: PermissionDestination };
+  | {
+      type: "addDirectories";
+      directories: string[];
+      destination: PermissionDestination;
+    }
+  | {
+      type: "removeDirectories";
+      directories: string[];
+      destination: PermissionDestination;
+    };
 
 export interface AiValidationInfo {
   verdict: "safe" | "dangerous" | "uncertain";

--- a/web/server/ws-bridge.test.ts
+++ b/web/server/ws-bridge.test.ts
@@ -196,8 +196,12 @@ describe("CLI handlers", () => {
     expect(bridge.isCliConnected("s1")).toBe(true);
 
     // Should have broadcast cli_connected
-    const calls = browser.send.mock.calls.map(([arg]: [string]) => JSON.parse(arg));
-    expect(calls).toContainEqual(expect.objectContaining({ type: "cli_connected" }));
+    const calls = browser.send.mock.calls.map(([arg]: [string]) =>
+      JSON.parse(arg),
+    );
+    expect(calls).toContainEqual(
+      expect.objectContaining({ type: "cli_connected" }),
+    );
   });
 
   it("handleCLIOpen: flushes pending messages immediately", () => {
@@ -208,10 +212,13 @@ describe("CLI handlers", () => {
     const browser = makeBrowserSocket("s1");
     bridge.handleBrowserOpen(browser, "s1");
 
-    bridge.handleBrowserMessage(browser, JSON.stringify({
-      type: "user_message",
-      content: "hello queued",
-    }));
+    bridge.handleBrowserMessage(
+      browser,
+      JSON.stringify({
+        type: "user_message",
+        content: "hello queued",
+      }),
+    );
 
     // CLI not yet connected, message should be queued
     const session = bridge.getSession("s1")!;
@@ -236,15 +243,20 @@ describe("CLI handlers", () => {
   it("handleCLIMessage: system.init does not re-flush already-sent messages", () => {
     // Messages are flushed on CLI connect, so by the time system.init
     // arrives the queue should already be empty.
-    mockExecSync.mockImplementation(() => { throw new Error("not a git repo"); });
+    mockExecSync.mockImplementation(() => {
+      throw new Error("not a git repo");
+    });
 
     const browser = makeBrowserSocket("s1");
     bridge.handleBrowserOpen(browser, "s1");
 
-    bridge.handleBrowserMessage(browser, JSON.stringify({
-      type: "user_message",
-      content: "hello queued",
-    }));
+    bridge.handleBrowserMessage(
+      browser,
+      JSON.stringify({
+        type: "user_message",
+        content: "hello queued",
+      }),
+    );
 
     const session = bridge.getSession("s1")!;
     expect(session.pendingMessages.length).toBe(1);
@@ -260,7 +272,9 @@ describe("CLI handlers", () => {
 
     // Verify no additional user messages were sent after system.init
     const newCalls = cli.send.mock.calls.slice(sendCountAfterOpen);
-    const userMsgAfterInit = newCalls.find(([arg]: [string]) => arg.includes('"type":"user"'));
+    const userMsgAfterInit = newCalls.find(([arg]: [string]) =>
+      arg.includes('"type":"user"'),
+    );
     expect(userMsgAfterInit).toBeUndefined();
   });
 
@@ -282,7 +296,9 @@ describe("CLI handlers", () => {
     expect(session.state.cwd).toBe("/test");
 
     // Should broadcast session_init to browser
-    const calls = browser.send.mock.calls.map(([arg]: [string]) => JSON.parse(arg));
+    const calls = browser.send.mock.calls.map(([arg]: [string]) =>
+      JSON.parse(arg),
+    );
     const initCall = calls.find((c: any) => c.type === "session_init");
     expect(initCall).toBeDefined();
     expect(initCall.session.model).toBe("claude-sonnet-4-6");
@@ -298,7 +314,10 @@ describe("CLI handlers", () => {
 
     const cli = makeCliSocket("s1");
     bridge.handleCLIOpen(cli, "s1");
-    bridge.handleCLIMessage(cli, makeInitMsg({ session_id: "cli-internal-id" }));
+    bridge.handleCLIMessage(
+      cli,
+      makeInitMsg({ session_id: "cli-internal-id" }),
+    );
 
     expect(callback).toHaveBeenCalledWith("s1", "cli-internal-id");
   });
@@ -311,17 +330,20 @@ describe("CLI handlers", () => {
     const cli = makeCliSocket("s1");
     bridge.handleCLIOpen(cli, "s1");
 
-    bridge.handleCLIMessage(cli, makeInitMsg({
-      model: "claude-opus-4-5-20250929",
-      cwd: "/workspace",
-      tools: ["Bash", "Read", "Edit"],
-      permissionMode: "bypassPermissions",
-      claude_code_version: "2.0",
-      mcp_servers: [{ name: "test-mcp", status: "connected" }],
-      agents: ["agent1"],
-      slash_commands: ["/commit"],
-      skills: ["pdf"],
-    }));
+    bridge.handleCLIMessage(
+      cli,
+      makeInitMsg({
+        model: "claude-opus-4-5-20250929",
+        cwd: "/workspace",
+        tools: ["Bash", "Read", "Edit"],
+        permissionMode: "bypassPermissions",
+        claude_code_version: "2.0",
+        mcp_servers: [{ name: "test-mcp", status: "connected" }],
+        agents: ["agent1"],
+        slash_commands: ["/commit"],
+        skills: ["pdf"],
+      }),
+    );
 
     const state = bridge.getSession("s1")!.state;
     expect(state.model).toBe("claude-opus-4-5-20250929");
@@ -329,7 +351,9 @@ describe("CLI handlers", () => {
     expect(state.tools).toEqual(["Bash", "Read", "Edit"]);
     expect(state.permissionMode).toBe("bypassPermissions");
     expect(state.claude_code_version).toBe("2.0");
-    expect(state.mcp_servers).toEqual([{ name: "test-mcp", status: "connected" }]);
+    expect(state.mcp_servers).toEqual([
+      { name: "test-mcp", status: "connected" },
+    ]);
     expect(state.agents).toEqual(["agent1"]);
     expect(state.slash_commands).toEqual(["/commit"]);
     expect(state.skills).toEqual(["pdf"]);
@@ -379,15 +403,17 @@ describe("CLI handlers", () => {
 
   it("handleCLIMessage: resolves git info from container for containerized sessions", () => {
     bridge.markContainerized("s1", "/Users/stan/Dev/myproject");
-    const getContainerSpy = vi.spyOn(containerManager, "getContainer").mockReturnValue({
-      containerId: "abc123def456",
-      name: "companion-test",
-      image: "the-companion:latest",
-      portMappings: [],
-      hostCwd: "/Users/stan/Dev/myproject",
-      containerCwd: "/workspace",
-      state: "running",
-    });
+    const getContainerSpy = vi
+      .spyOn(containerManager, "getContainer")
+      .mockReturnValue({
+        containerId: "abc123def456",
+        name: "companion-test",
+        image: "the-companion:latest",
+        portMappings: [],
+        hostCwd: "/Users/stan/Dev/myproject",
+        containerCwd: "/workspace",
+        state: "running",
+      });
 
     mockExecSync.mockImplementation((cmd: string) => {
       if (!cmd.startsWith("docker exec abc123def456 sh -lc ")) {
@@ -416,15 +442,17 @@ describe("CLI handlers", () => {
 
   it("handleCLIMessage: maps nested container repo_root paths back to host paths", () => {
     bridge.markContainerized("s1", "/Users/stan/Dev/myproject");
-    const getContainerSpy = vi.spyOn(containerManager, "getContainer").mockReturnValue({
-      containerId: "abc123def456",
-      name: "companion-test",
-      image: "the-companion:latest",
-      portMappings: [],
-      hostCwd: "/Users/stan/Dev/myproject",
-      containerCwd: "/workspace",
-      state: "running",
-    });
+    const getContainerSpy = vi
+      .spyOn(containerManager, "getContainer")
+      .mockReturnValue({
+        containerId: "abc123def456",
+        name: "companion-test",
+        image: "the-companion:latest",
+        portMappings: [],
+        hostCwd: "/Users/stan/Dev/myproject",
+        containerCwd: "/workspace",
+        state: "running",
+      });
 
     mockExecSync.mockImplementation((cmd: string) => {
       if (!cmd.startsWith("docker exec abc123def456 sh -lc ")) {
@@ -505,8 +533,12 @@ describe("CLI handlers", () => {
     expect(state.is_compacting).toBe(true);
     expect(state.permissionMode).toBe("plan");
 
-    const calls = browser.send.mock.calls.map(([arg]: [string]) => JSON.parse(arg));
-    expect(calls).toContainEqual(expect.objectContaining({ type: "status_change", status: "compacting" }));
+    const calls = browser.send.mock.calls.map(([arg]: [string]) =>
+      JSON.parse(arg),
+    );
+    expect(calls).toContainEqual(
+      expect.objectContaining({ type: "status_change", status: "compacting" }),
+    );
   });
 
   it("handleCLIMessage: forwards compact_boundary as system_event and persists it", () => {
@@ -516,13 +548,16 @@ describe("CLI handlers", () => {
     bridge.handleBrowserOpen(browser, "s1");
     browser.send.mockClear();
 
-    bridge.handleCLIMessage(cli, JSON.stringify({
-      type: "system",
-      subtype: "compact_boundary",
-      compact_metadata: { trigger: "auto", pre_tokens: 4096 },
-      uuid: "uuid-compact",
-      session_id: "s1",
-    }));
+    bridge.handleCLIMessage(
+      cli,
+      JSON.stringify({
+        type: "system",
+        subtype: "compact_boundary",
+        compact_metadata: { trigger: "auto", pre_tokens: 4096 },
+        uuid: "uuid-compact",
+        session_id: "s1",
+      }),
+    );
 
     const session = bridge.getSession("s1")!;
     expect(session.messageHistory).toHaveLength(1);
@@ -533,7 +568,9 @@ describe("CLI handlers", () => {
       },
     });
 
-    const calls = browser.send.mock.calls.map(([arg]: [string]) => JSON.parse(arg));
+    const calls = browser.send.mock.calls.map(([arg]: [string]) =>
+      JSON.parse(arg),
+    );
     const forwarded = calls.find((c: any) => c.type === "system_event");
     expect(forwarded).toBeDefined();
     expect(forwarded.event.subtype).toBe("compact_boundary");
@@ -546,23 +583,28 @@ describe("CLI handlers", () => {
     bridge.handleBrowserOpen(browser, "s1");
     browser.send.mockClear();
 
-    bridge.handleCLIMessage(cli, JSON.stringify({
-      type: "system",
-      subtype: "hook_progress",
-      hook_id: "hk-1",
-      hook_name: "lint",
-      hook_event: "post_tool_use",
-      stdout: "running",
-      stderr: "",
-      output: "running",
-      uuid: "uuid-hook-progress",
-      session_id: "s1",
-    }));
+    bridge.handleCLIMessage(
+      cli,
+      JSON.stringify({
+        type: "system",
+        subtype: "hook_progress",
+        hook_id: "hk-1",
+        hook_name: "lint",
+        hook_event: "post_tool_use",
+        stdout: "running",
+        stderr: "",
+        output: "running",
+        uuid: "uuid-hook-progress",
+        session_id: "s1",
+      }),
+    );
 
     const session = bridge.getSession("s1")!;
     expect(session.messageHistory).toHaveLength(0);
 
-    const calls = browser.send.mock.calls.map(([arg]: [string]) => JSON.parse(arg));
+    const calls = browser.send.mock.calls.map(([arg]: [string]) =>
+      JSON.parse(arg),
+    );
     const forwarded = calls.find((c: any) => c.type === "system_event");
     expect(forwarded).toBeDefined();
     expect(forwarded.event.subtype).toBe("hook_progress");
@@ -581,8 +623,12 @@ describe("CLI handlers", () => {
     expect(session.cliSocket).toBeNull();
     expect(bridge.isCliConnected("s1")).toBe(false);
 
-    const calls = browser.send.mock.calls.map(([arg]: [string]) => JSON.parse(arg));
-    expect(calls).toContainEqual(expect.objectContaining({ type: "cli_disconnected" }));
+    const calls = browser.send.mock.calls.map(([arg]: [string]) =>
+      JSON.parse(arg),
+    );
+    expect(calls).toContainEqual(
+      expect.objectContaining({ type: "cli_disconnected" }),
+    );
   });
 
   it("handleCLIClose: cancels pending permissions", () => {
@@ -610,7 +656,9 @@ describe("CLI handlers", () => {
     const session = bridge.getSession("s1")!;
     expect(session.pendingPermissions.size).toBe(0);
 
-    const calls = browser.send.mock.calls.map(([arg]: [string]) => JSON.parse(arg));
+    const calls = browser.send.mock.calls.map(([arg]: [string]) =>
+      JSON.parse(arg),
+    );
     const cancelMsg = calls.find((c: any) => c.type === "permission_cancelled");
     expect(cancelMsg).toBeDefined();
     expect(cancelMsg.request_id).toBe("req-1");
@@ -657,7 +705,11 @@ describe("Browser handlers", () => {
     const firstMsg = JSON.parse(browser.send.mock.calls[0][0]);
     expect(firstMsg.type).toBe("session_init");
     expect(firstMsg.session.git_branch).toBe("feat/dynamic-branch");
-    expect(gitInfoCb).toHaveBeenCalledWith("s1", "/repo", "feat/dynamic-branch");
+    expect(gitInfoCb).toHaveBeenCalledWith(
+      "s1",
+      "/repo",
+      "feat/dynamic-branch",
+    );
   });
 
   it("handleBrowserOpen: replays message history", () => {
@@ -678,7 +730,12 @@ describe("Browser handlers", () => {
         model: "claude-sonnet-4-6",
         content: [{ type: "text", text: "Hello!" }],
         stop_reason: null,
-        usage: { input_tokens: 10, output_tokens: 5, cache_creation_input_tokens: 0, cache_read_input_tokens: 0 },
+        usage: {
+          input_tokens: 10,
+          output_tokens: 5,
+          cache_creation_input_tokens: 0,
+          cache_read_input_tokens: 0,
+        },
       },
       parent_tool_use_id: null,
       uuid: "uuid-2",
@@ -690,7 +747,9 @@ describe("Browser handlers", () => {
     const browser = makeBrowserSocket("s1");
     bridge.handleBrowserOpen(browser, "s1");
 
-    const calls = browser.send.mock.calls.map(([arg]: [string]) => JSON.parse(arg));
+    const calls = browser.send.mock.calls.map(([arg]: [string]) =>
+      JSON.parse(arg),
+    );
     const historyMsg = calls.find((c: any) => c.type === "message_history");
     expect(historyMsg).toBeDefined();
     expect(historyMsg.messages).toHaveLength(1);
@@ -718,7 +777,9 @@ describe("Browser handlers", () => {
     const browser = makeBrowserSocket("s1");
     bridge.handleBrowserOpen(browser, "s1");
 
-    const calls = browser.send.mock.calls.map(([arg]: [string]) => JSON.parse(arg));
+    const calls = browser.send.mock.calls.map(([arg]: [string]) =>
+      JSON.parse(arg),
+    );
     const permMsg = calls.find((c: any) => c.type === "permission_request");
     expect(permMsg).toBeDefined();
     expect(permMsg.request.tool_name).toBe("Edit");
@@ -736,8 +797,12 @@ describe("Browser handlers", () => {
     expect(relaunchCb).toHaveBeenCalledWith("s1");
 
     // Also sends cli_disconnected
-    const calls = browser.send.mock.calls.map(([arg]: [string]) => JSON.parse(arg));
-    const disconnectedMsg = calls.find((c: any) => c.type === "cli_disconnected");
+    const calls = browser.send.mock.calls.map(([arg]: [string]) =>
+      JSON.parse(arg),
+    );
+    const disconnectedMsg = calls.find(
+      (c: any) => c.type === "cli_disconnected",
+    );
     expect(disconnectedMsg).toBeDefined();
   });
 
@@ -753,8 +818,12 @@ describe("Browser handlers", () => {
 
     expect(relaunchCb).not.toHaveBeenCalled();
 
-    const calls = browser.send.mock.calls.map(([arg]: [string]) => JSON.parse(arg));
-    const disconnectedMsg = calls.find((c: any) => c.type === "cli_disconnected");
+    const calls = browser.send.mock.calls.map(([arg]: [string]) =>
+      JSON.parse(arg),
+    );
+    const disconnectedMsg = calls.find(
+      (c: any) => c.type === "cli_disconnected",
+    );
     expect(disconnectedMsg).toBeUndefined();
   });
 
@@ -772,32 +841,49 @@ describe("Browser handlers", () => {
     bridge.handleCLIOpen(cli, "s1");
 
     // Generate replayable events while no browser is connected.
-    bridge.handleCLIMessage(cli, JSON.stringify({
-      type: "stream_event",
-      event: { type: "content_block_delta", delta: { type: "text_delta", text: "a" } },
-      parent_tool_use_id: null,
-      uuid: "u1",
-      session_id: "s1",
-    }));
-    bridge.handleCLIMessage(cli, JSON.stringify({
-      type: "stream_event",
-      event: { type: "content_block_delta", delta: { type: "text_delta", text: "b" } },
-      parent_tool_use_id: null,
-      uuid: "u2",
-      session_id: "s1",
-    }));
+    bridge.handleCLIMessage(
+      cli,
+      JSON.stringify({
+        type: "stream_event",
+        event: {
+          type: "content_block_delta",
+          delta: { type: "text_delta", text: "a" },
+        },
+        parent_tool_use_id: null,
+        uuid: "u1",
+        session_id: "s1",
+      }),
+    );
+    bridge.handleCLIMessage(
+      cli,
+      JSON.stringify({
+        type: "stream_event",
+        event: {
+          type: "content_block_delta",
+          delta: { type: "text_delta", text: "b" },
+        },
+        parent_tool_use_id: null,
+        uuid: "u2",
+        session_id: "s1",
+      }),
+    );
 
     const browser = makeBrowserSocket("s1");
     bridge.handleBrowserOpen(browser, "s1");
     browser.send.mockClear();
 
     // Ask for replay after seq=1 (cli_connected). Both stream events should replay.
-    bridge.handleBrowserMessage(browser, JSON.stringify({
-      type: "session_subscribe",
-      last_seq: 1,
-    }));
+    bridge.handleBrowserMessage(
+      browser,
+      JSON.stringify({
+        type: "session_subscribe",
+        last_seq: 1,
+      }),
+    );
 
-    const calls = browser.send.mock.calls.map(([arg]: [string]) => JSON.parse(arg));
+    const calls = browser.send.mock.calls.map(([arg]: [string]) =>
+      JSON.parse(arg),
+    );
     const replay = calls.find((c: any) => c.type === "event_replay");
     expect(replay).toBeDefined();
     expect(replay.events).toHaveLength(2);
@@ -810,37 +896,57 @@ describe("Browser handlers", () => {
     bridge.handleCLIOpen(cli, "s1");
 
     // Populate history so fallback payload has content.
-    bridge.handleCLIMessage(cli, JSON.stringify({
-      type: "assistant",
-      message: {
-        id: "hist-1",
-        type: "message",
-        role: "assistant",
-        model: "claude-sonnet-4-6",
-        content: [{ type: "text", text: "from history" }],
-        stop_reason: "end_turn",
-        usage: { input_tokens: 1, output_tokens: 1, cache_creation_input_tokens: 0, cache_read_input_tokens: 0 },
-      },
-      parent_tool_use_id: null,
-      uuid: "hist-u1",
-      session_id: "s1",
-    }));
+    bridge.handleCLIMessage(
+      cli,
+      JSON.stringify({
+        type: "assistant",
+        message: {
+          id: "hist-1",
+          type: "message",
+          role: "assistant",
+          model: "claude-sonnet-4-6",
+          content: [{ type: "text", text: "from history" }],
+          stop_reason: "end_turn",
+          usage: {
+            input_tokens: 1,
+            output_tokens: 1,
+            cache_creation_input_tokens: 0,
+            cache_read_input_tokens: 0,
+          },
+        },
+        parent_tool_use_id: null,
+        uuid: "hist-u1",
+        session_id: "s1",
+      }),
+    );
 
     // Generate several stream events, then trim the first one from in-memory buffer.
-    bridge.handleCLIMessage(cli, JSON.stringify({
-      type: "stream_event",
-      event: { type: "content_block_delta", delta: { type: "text_delta", text: "1" } },
-      parent_tool_use_id: null,
-      uuid: "se-u1",
-      session_id: "s1",
-    }));
-    bridge.handleCLIMessage(cli, JSON.stringify({
-      type: "stream_event",
-      event: { type: "content_block_delta", delta: { type: "text_delta", text: "2" } },
-      parent_tool_use_id: null,
-      uuid: "se-u2",
-      session_id: "s1",
-    }));
+    bridge.handleCLIMessage(
+      cli,
+      JSON.stringify({
+        type: "stream_event",
+        event: {
+          type: "content_block_delta",
+          delta: { type: "text_delta", text: "1" },
+        },
+        parent_tool_use_id: null,
+        uuid: "se-u1",
+        session_id: "s1",
+      }),
+    );
+    bridge.handleCLIMessage(
+      cli,
+      JSON.stringify({
+        type: "stream_event",
+        event: {
+          type: "content_block_delta",
+          delta: { type: "text_delta", text: "2" },
+        },
+        parent_tool_use_id: null,
+        uuid: "se-u2",
+        session_id: "s1",
+      }),
+    );
     const session = bridge.getSession("s1")!;
     session.eventBuffer.shift();
     session.eventBuffer.shift(); // force earliest seq high enough to create a gap for last_seq=1
@@ -849,18 +955,27 @@ describe("Browser handlers", () => {
     bridge.handleBrowserOpen(browser, "s1");
     browser.send.mockClear();
 
-    bridge.handleBrowserMessage(browser, JSON.stringify({
-      type: "session_subscribe",
-      last_seq: 1,
-    }));
+    bridge.handleBrowserMessage(
+      browser,
+      JSON.stringify({
+        type: "session_subscribe",
+        last_seq: 1,
+      }),
+    );
 
-    const calls = browser.send.mock.calls.map(([arg]: [string]) => JSON.parse(arg));
+    const calls = browser.send.mock.calls.map(([arg]: [string]) =>
+      JSON.parse(arg),
+    );
     const historyMsg = calls.find((c: any) => c.type === "message_history");
     expect(historyMsg).toBeDefined();
-    expect(historyMsg.messages.some((m: any) => m.type === "assistant")).toBe(true);
+    expect(historyMsg.messages.some((m: any) => m.type === "assistant")).toBe(
+      true,
+    );
     const replayMsg = calls.find((c: any) => c.type === "event_replay");
     expect(replayMsg).toBeDefined();
-    expect(replayMsg.events.some((e: any) => e.message.type === "stream_event")).toBe(true);
+    expect(
+      replayMsg.events.some((e: any) => e.message.type === "stream_event"),
+    ).toBe(true);
   });
 
   it("session_subscribe: sends ground-truth status_change=idle after event_replay when last history is result", () => {
@@ -870,39 +985,55 @@ describe("Browser handlers", () => {
     bridge.handleCLIOpen(cli, "s1");
 
     // Simulate a completed turn: assistant → result in history
-    bridge.handleCLIMessage(cli, JSON.stringify({
-      type: "assistant",
-      message: {
-        id: "a1",
-        type: "message",
-        role: "assistant",
-        model: "claude-sonnet-4-6",
-        content: [{ type: "text", text: "hello" }],
-        stop_reason: "end_turn",
-        usage: { input_tokens: 1, output_tokens: 1, cache_creation_input_tokens: 0, cache_read_input_tokens: 0 },
-      },
-      parent_tool_use_id: null,
-      uuid: "u1",
-      session_id: "s1",
-    }));
-    bridge.handleCLIMessage(cli, JSON.stringify({
-      type: "result",
-      is_error: false,
-      total_cost_usd: 0.01,
-      num_turns: 1,
-      session_id: "s1",
-    }));
+    bridge.handleCLIMessage(
+      cli,
+      JSON.stringify({
+        type: "assistant",
+        message: {
+          id: "a1",
+          type: "message",
+          role: "assistant",
+          model: "claude-sonnet-4-6",
+          content: [{ type: "text", text: "hello" }],
+          stop_reason: "end_turn",
+          usage: {
+            input_tokens: 1,
+            output_tokens: 1,
+            cache_creation_input_tokens: 0,
+            cache_read_input_tokens: 0,
+          },
+        },
+        parent_tool_use_id: null,
+        uuid: "u1",
+        session_id: "s1",
+      }),
+    );
+    bridge.handleCLIMessage(
+      cli,
+      JSON.stringify({
+        type: "result",
+        is_error: false,
+        total_cost_usd: 0.01,
+        num_turns: 1,
+        session_id: "s1",
+      }),
+    );
 
     const browser = makeBrowserSocket("s1");
     bridge.handleBrowserOpen(browser, "s1");
     browser.send.mockClear();
 
-    bridge.handleBrowserMessage(browser, JSON.stringify({
-      type: "session_subscribe",
-      last_seq: 0,
-    }));
+    bridge.handleBrowserMessage(
+      browser,
+      JSON.stringify({
+        type: "session_subscribe",
+        last_seq: 0,
+      }),
+    );
 
-    const calls = browser.send.mock.calls.map(([arg]: [string]) => JSON.parse(arg));
+    const calls = browser.send.mock.calls.map(([arg]: [string]) =>
+      JSON.parse(arg),
+    );
     // Last message should be a status_change with idle
     const statusMsg = calls.filter((c: any) => c.type === "status_change");
     expect(statusMsg.length).toBeGreaterThanOrEqual(1);
@@ -916,32 +1047,45 @@ describe("Browser handlers", () => {
     const cli = makeCliSocket("s1");
     bridge.handleCLIOpen(cli, "s1");
 
-    bridge.handleCLIMessage(cli, JSON.stringify({
-      type: "assistant",
-      message: {
-        id: "a1",
-        type: "message",
-        role: "assistant",
-        model: "claude-sonnet-4-6",
-        content: [{ type: "text", text: "working on it" }],
-        stop_reason: "end_turn",
-        usage: { input_tokens: 1, output_tokens: 1, cache_creation_input_tokens: 0, cache_read_input_tokens: 0 },
-      },
-      parent_tool_use_id: null,
-      uuid: "u1",
-      session_id: "s1",
-    }));
+    bridge.handleCLIMessage(
+      cli,
+      JSON.stringify({
+        type: "assistant",
+        message: {
+          id: "a1",
+          type: "message",
+          role: "assistant",
+          model: "claude-sonnet-4-6",
+          content: [{ type: "text", text: "working on it" }],
+          stop_reason: "end_turn",
+          usage: {
+            input_tokens: 1,
+            output_tokens: 1,
+            cache_creation_input_tokens: 0,
+            cache_read_input_tokens: 0,
+          },
+        },
+        parent_tool_use_id: null,
+        uuid: "u1",
+        session_id: "s1",
+      }),
+    );
 
     const browser = makeBrowserSocket("s1");
     bridge.handleBrowserOpen(browser, "s1");
     browser.send.mockClear();
 
-    bridge.handleBrowserMessage(browser, JSON.stringify({
-      type: "session_subscribe",
-      last_seq: 0,
-    }));
+    bridge.handleBrowserMessage(
+      browser,
+      JSON.stringify({
+        type: "session_subscribe",
+        last_seq: 0,
+      }),
+    );
 
-    const calls = browser.send.mock.calls.map(([arg]: [string]) => JSON.parse(arg));
+    const calls = browser.send.mock.calls.map(([arg]: [string]) =>
+      JSON.parse(arg),
+    );
     const statusMsg = calls.filter((c: any) => c.type === "status_change");
     expect(statusMsg.length).toBeGreaterThanOrEqual(1);
     const lastStatus = statusMsg[statusMsg.length - 1];
@@ -954,36 +1098,53 @@ describe("Browser handlers", () => {
     const cli = makeCliSocket("s1");
     bridge.handleCLIOpen(cli, "s1");
 
-    bridge.handleCLIMessage(cli, JSON.stringify({
-      type: "assistant",
-      message: {
-        id: "a1",
-        type: "message",
-        role: "assistant",
-        model: "claude-sonnet-4-6",
-        content: [{ type: "text", text: "done" }],
-        stop_reason: "end_turn",
-        usage: { input_tokens: 1, output_tokens: 1, cache_creation_input_tokens: 0, cache_read_input_tokens: 0 },
-      },
-      parent_tool_use_id: null,
-      uuid: "u1",
-      session_id: "s1",
-    }));
-    bridge.handleCLIMessage(cli, JSON.stringify({
-      type: "result",
-      is_error: false,
-      total_cost_usd: 0.01,
-      num_turns: 1,
-      session_id: "s1",
-    }));
+    bridge.handleCLIMessage(
+      cli,
+      JSON.stringify({
+        type: "assistant",
+        message: {
+          id: "a1",
+          type: "message",
+          role: "assistant",
+          model: "claude-sonnet-4-6",
+          content: [{ type: "text", text: "done" }],
+          stop_reason: "end_turn",
+          usage: {
+            input_tokens: 1,
+            output_tokens: 1,
+            cache_creation_input_tokens: 0,
+            cache_read_input_tokens: 0,
+          },
+        },
+        parent_tool_use_id: null,
+        uuid: "u1",
+        session_id: "s1",
+      }),
+    );
+    bridge.handleCLIMessage(
+      cli,
+      JSON.stringify({
+        type: "result",
+        is_error: false,
+        total_cost_usd: 0.01,
+        num_turns: 1,
+        session_id: "s1",
+      }),
+    );
     // Add a stream event and then force a gap by trimming the buffer
-    bridge.handleCLIMessage(cli, JSON.stringify({
-      type: "stream_event",
-      event: { type: "content_block_delta", delta: { type: "text_delta", text: "x" } },
-      parent_tool_use_id: null,
-      uuid: "se1",
-      session_id: "s1",
-    }));
+    bridge.handleCLIMessage(
+      cli,
+      JSON.stringify({
+        type: "stream_event",
+        event: {
+          type: "content_block_delta",
+          delta: { type: "text_delta", text: "x" },
+        },
+        parent_tool_use_id: null,
+        uuid: "se1",
+        session_id: "s1",
+      }),
+    );
     const session = bridge.getSession("s1")!;
     session.eventBuffer.shift(); // force a gap
 
@@ -991,12 +1152,17 @@ describe("Browser handlers", () => {
     bridge.handleBrowserOpen(browser, "s1");
     browser.send.mockClear();
 
-    bridge.handleBrowserMessage(browser, JSON.stringify({
-      type: "session_subscribe",
-      last_seq: 1,
-    }));
+    bridge.handleBrowserMessage(
+      browser,
+      JSON.stringify({
+        type: "session_subscribe",
+        last_seq: 1,
+      }),
+    );
 
-    const calls = browser.send.mock.calls.map(([arg]: [string]) => JSON.parse(arg));
+    const calls = browser.send.mock.calls.map(([arg]: [string]) =>
+      JSON.parse(arg),
+    );
     const statusMsg = calls.filter((c: any) => c.type === "status_change");
     expect(statusMsg.length).toBeGreaterThanOrEqual(1);
     expect(statusMsg[statusMsg.length - 1].status).toBe("idle");
@@ -1006,10 +1172,13 @@ describe("Browser handlers", () => {
     const browser = makeBrowserSocket("s1");
     bridge.handleBrowserOpen(browser, "s1");
 
-    bridge.handleBrowserMessage(browser, JSON.stringify({
-      type: "session_ack",
-      last_seq: 42,
-    }));
+    bridge.handleBrowserMessage(
+      browser,
+      JSON.stringify({
+        type: "session_ack",
+        last_seq: 42,
+      }),
+    );
 
     const session = bridge.getSession("s1")!;
     expect(session.lastAckSeq).toBe(42);
@@ -1040,7 +1209,12 @@ describe("CLI message routing", () => {
         model: "claude-sonnet-4-6",
         content: [{ type: "text", text: "Hello world!" }],
         stop_reason: "end_turn",
-        usage: { input_tokens: 100, output_tokens: 50, cache_creation_input_tokens: 0, cache_read_input_tokens: 0 },
+        usage: {
+          input_tokens: 100,
+          output_tokens: 50,
+          cache_creation_input_tokens: 0,
+          cache_read_input_tokens: 0,
+        },
       },
       parent_tool_use_id: null,
       uuid: "uuid-3",
@@ -1053,7 +1227,9 @@ describe("CLI message routing", () => {
     expect(session.messageHistory).toHaveLength(1);
     expect(session.messageHistory[0].type).toBe("assistant");
 
-    const calls = browser.send.mock.calls.map(([arg]: [string]) => JSON.parse(arg));
+    const calls = browser.send.mock.calls.map(([arg]: [string]) =>
+      JSON.parse(arg),
+    );
     const assistantBroadcast = calls.find((c: any) => c.type === "assistant");
     expect(assistantBroadcast).toBeDefined();
     expect(assistantBroadcast.message.content[0].text).toBe("Hello world!");
@@ -1071,7 +1247,12 @@ describe("CLI message routing", () => {
       num_turns: 3,
       total_cost_usd: 0.05,
       stop_reason: "end_turn",
-      usage: { input_tokens: 500, output_tokens: 200, cache_creation_input_tokens: 0, cache_read_input_tokens: 0 },
+      usage: {
+        input_tokens: 500,
+        output_tokens: 200,
+        cache_creation_input_tokens: 0,
+        cache_read_input_tokens: 0,
+      },
       total_lines_added: 42,
       total_lines_removed: 10,
       uuid: "uuid-4",
@@ -1090,7 +1271,9 @@ describe("CLI message routing", () => {
     expect(session.messageHistory).toHaveLength(1);
     expect(session.messageHistory[0].type).toBe("result");
 
-    const calls = browser.send.mock.calls.map(([arg]: [string]) => JSON.parse(arg));
+    const calls = browser.send.mock.calls.map(([arg]: [string]) =>
+      JSON.parse(arg),
+    );
     const resultBroadcast = calls.find((c: any) => c.type === "result");
     expect(resultBroadcast).toBeDefined();
     expect(resultBroadcast.data.total_cost_usd).toBe(0.05);
@@ -1119,14 +1302,21 @@ describe("CLI message routing", () => {
       num_turns: 1,
       total_cost_usd: 0.01,
       stop_reason: "end_turn",
-      usage: { input_tokens: 100, output_tokens: 50, cache_creation_input_tokens: 0, cache_read_input_tokens: 0 },
+      usage: {
+        input_tokens: 100,
+        output_tokens: 50,
+        cache_creation_input_tokens: 0,
+        cache_read_input_tokens: 0,
+      },
       uuid: "uuid-refresh-git",
       session_id: "s1",
     });
 
     bridge.handleCLIMessage(cli, msg);
 
-    const calls = browser.send.mock.calls.map(([arg]: [string]) => JSON.parse(arg));
+    const calls = browser.send.mock.calls.map(([arg]: [string]) =>
+      JSON.parse(arg),
+    );
     const updateMsg = calls.find((c: any) => c.type === "session_update");
     expect(updateMsg).toBeDefined();
     expect(updateMsg.session.git_branch).toBe("feat/new-branch");
@@ -1134,7 +1324,7 @@ describe("CLI message routing", () => {
     expect(bridge.getSession("s1")!.state.git_branch).toBe("feat/new-branch");
   });
 
-  it("result: computes context_used_percent from modelUsage", () => {
+  it("result: computes context_used_percent from modelUsage (fallback without prior assistant)", () => {
     const msg = JSON.stringify({
       type: "result",
       subtype: "success",
@@ -1144,7 +1334,12 @@ describe("CLI message routing", () => {
       num_turns: 1,
       total_cost_usd: 0.02,
       stop_reason: "end_turn",
-      usage: { input_tokens: 500, output_tokens: 200, cache_creation_input_tokens: 0, cache_read_input_tokens: 0 },
+      usage: {
+        input_tokens: 500,
+        output_tokens: 200,
+        cache_creation_input_tokens: 0,
+        cache_read_input_tokens: 0,
+      },
       modelUsage: {
         "claude-sonnet-4-6": {
           inputTokens: 8000,
@@ -1163,14 +1358,86 @@ describe("CLI message routing", () => {
     bridge.handleCLIMessage(cli, msg);
 
     const state = bridge.getSession("s1")!.state;
-    // (8000 + 2000) / 200000 * 100 = 5
+    // No prior assistant message → fallback: (8000 + 2000) / 200000 * 100 = 5
     expect(state.context_used_percent).toBe(5);
+  });
+
+  it("result: recomputes context_used_percent using per-turn data from assistant + contextWindow from modelUsage", () => {
+    // First: assistant message provides per-turn token usage
+    const assistantMsg = JSON.stringify({
+      type: "assistant",
+      message: {
+        id: "msg-1",
+        type: "message",
+        role: "assistant",
+        model: "claude-sonnet-4-6",
+        content: [{ type: "text", text: "Hello" }],
+        stop_reason: "end_turn",
+        usage: {
+          input_tokens: 50000,
+          output_tokens: 1000,
+          cache_read_input_tokens: 100000,
+          cache_creation_input_tokens: 10000,
+        },
+      },
+      parent_tool_use_id: null,
+      uuid: "uuid-a1",
+      session_id: "s1",
+    });
+    bridge.handleCLIMessage(cli, assistantMsg);
+
+    // Then: result message provides contextWindow
+    const resultMsg = JSON.stringify({
+      type: "result",
+      subtype: "success",
+      is_error: false,
+      duration_ms: 5000,
+      duration_api_ms: 4000,
+      num_turns: 1,
+      total_cost_usd: 0.05,
+      stop_reason: "end_turn",
+      usage: {
+        input_tokens: 50000,
+        output_tokens: 1000,
+        cache_creation_input_tokens: 10000,
+        cache_read_input_tokens: 100000,
+      },
+      modelUsage: {
+        "claude-sonnet-4-6": {
+          inputTokens: 50000,
+          outputTokens: 1000,
+          cacheReadInputTokens: 100000,
+          cacheCreationInputTokens: 10000,
+          contextWindow: 200000,
+          maxOutputTokens: 16384,
+          costUSD: 0.05,
+        },
+      },
+      uuid: "uuid-r1",
+      session_id: "s1",
+    });
+    bridge.handleCLIMessage(cli, resultMsg);
+
+    const state = bridge.getSession("s1")!.state;
+    // Per-turn formula: (50000 + 100000 + 10000) / 200000 * 100 = 80
+    expect(state.context_used_percent).toBe(80);
+    expect(state.claude_token_details).toEqual({
+      inputTokens: 50000,
+      outputTokens: 1000,
+      cacheReadInputTokens: 100000,
+      cacheCreationInputTokens: 10000,
+      contextWindow: 200000,
+      maxOutputTokens: 16384,
+    });
   });
 
   it("stream_event: broadcasts without storing", () => {
     const msg = JSON.stringify({
       type: "stream_event",
-      event: { type: "content_block_delta", delta: { type: "text_delta", text: "hi" } },
+      event: {
+        type: "content_block_delta",
+        delta: { type: "text_delta", text: "hi" },
+      },
       parent_tool_use_id: null,
       uuid: "uuid-6",
       session_id: "s1",
@@ -1181,7 +1448,9 @@ describe("CLI message routing", () => {
     const session = bridge.getSession("s1")!;
     expect(session.messageHistory).toHaveLength(0);
 
-    const calls = browser.send.mock.calls.map(([arg]: [string]) => JSON.parse(arg));
+    const calls = browser.send.mock.calls.map(([arg]: [string]) =>
+      JSON.parse(arg),
+    );
     const streamEvent = calls.find((c: any) => c.type === "stream_event");
     expect(streamEvent).toBeDefined();
     expect(streamEvent.event.delta.text).toBe("hi");
@@ -1199,7 +1468,14 @@ describe("CLI message routing", () => {
         description: "List files",
         tool_use_id: "tu-42",
         agent_id: "agent-1",
-        permission_suggestions: [{ type: "addRules", rules: [{ toolName: "Bash" }], behavior: "allow", destination: "session" }],
+        permission_suggestions: [
+          {
+            type: "addRules",
+            rules: [{ toolName: "Bash" }],
+            behavior: "allow",
+            destination: "session",
+          },
+        ],
       },
     });
 
@@ -1215,8 +1491,12 @@ describe("CLI message routing", () => {
     expect(perm.agent_id).toBe("agent-1");
     expect(perm.timestamp).toBeGreaterThan(0);
 
-    const calls = browser.send.mock.calls.map(([arg]: [string]) => JSON.parse(arg));
-    const permBroadcast = calls.find((c: any) => c.type === "permission_request");
+    const calls = browser.send.mock.calls.map(([arg]: [string]) =>
+      JSON.parse(arg),
+    );
+    const permBroadcast = calls.find(
+      (c: any) => c.type === "permission_request",
+    );
     expect(permBroadcast).toBeDefined();
     expect(permBroadcast.request.request_id).toBe("req-42");
     expect(permBroadcast.request.tool_name).toBe("Bash");
@@ -1235,7 +1515,9 @@ describe("CLI message routing", () => {
 
     bridge.handleCLIMessage(cli, msg);
 
-    const calls = browser.send.mock.calls.map(([arg]: [string]) => JSON.parse(arg));
+    const calls = browser.send.mock.calls.map(([arg]: [string]) =>
+      JSON.parse(arg),
+    );
     const progressMsg = calls.find((c: any) => c.type === "tool_progress");
     expect(progressMsg).toBeDefined();
     expect(progressMsg.tool_use_id).toBe("tu-10");
@@ -1254,7 +1536,9 @@ describe("CLI message routing", () => {
 
     bridge.handleCLIMessage(cli, msg);
 
-    const calls = browser.send.mock.calls.map(([arg]: [string]) => JSON.parse(arg));
+    const calls = browser.send.mock.calls.map(([arg]: [string]) =>
+      JSON.parse(arg),
+    );
     const summaryMsg = calls.find((c: any) => c.type === "tool_use_summary");
     expect(summaryMsg).toBeDefined();
     expect(summaryMsg.summary).toBe("Ran bash command successfully");
@@ -1291,7 +1575,9 @@ describe("CLI message routing", () => {
 
     bridge.handleCLIMessage(cli, line1 + "\n" + line2);
 
-    const calls = browser.send.mock.calls.map(([arg]: [string]) => JSON.parse(arg));
+    const calls = browser.send.mock.calls.map(([arg]: [string]) =>
+      JSON.parse(arg),
+    );
     const progressMsgs = calls.filter((c: any) => c.type === "tool_progress");
     expect(progressMsgs).toHaveLength(2);
     expect(progressMsgs[0].tool_use_id).toBe("tu-a");
@@ -1325,10 +1611,13 @@ describe("Browser message routing", () => {
   });
 
   it("user_message: sends NDJSON to CLI and stores in history", () => {
-    bridge.handleBrowserMessage(browser, JSON.stringify({
-      type: "user_message",
-      content: "What is 2+2?",
-    }));
+    bridge.handleBrowserMessage(
+      browser,
+      JSON.stringify({
+        type: "user_message",
+        content: "What is 2+2?",
+      }),
+    );
 
     // Should have sent NDJSON to CLI
     expect(cli.send).toHaveBeenCalledTimes(1);
@@ -1352,10 +1641,13 @@ describe("Browser message routing", () => {
     bridge.handleCLIClose(cli);
     browser.send.mockClear();
 
-    bridge.handleBrowserMessage(browser, JSON.stringify({
-      type: "user_message",
-      content: "queued message",
-    }));
+    bridge.handleBrowserMessage(
+      browser,
+      JSON.stringify({
+        type: "user_message",
+        content: "queued message",
+      }),
+    );
 
     const session = bridge.getSession("s1")!;
     expect(session.pendingMessages).toHaveLength(1);
@@ -1376,18 +1668,21 @@ describe("Browser message routing", () => {
 
     expect(cli.send).toHaveBeenCalledTimes(1);
     const session = bridge.getSession("s1")!;
-    const userMessages = session.messageHistory.filter((m) => m.type === "user_message");
+    const userMessages = session.messageHistory.filter(
+      (m) => m.type === "user_message",
+    );
     expect(userMessages).toHaveLength(1);
   });
 
   it("user_message with images: builds content blocks", () => {
-    bridge.handleBrowserMessage(browser, JSON.stringify({
-      type: "user_message",
-      content: "What's in this image?",
-      images: [
-        { media_type: "image/png", data: "base64data==" },
-      ],
-    }));
+    bridge.handleBrowserMessage(
+      browser,
+      JSON.stringify({
+        type: "user_message",
+        content: "What's in this image?",
+        images: [{ media_type: "image/png", data: "base64data==" }],
+      }),
+    );
 
     const sentRaw = cli.send.mock.calls[0][0] as string;
     const sent = JSON.parse(sentRaw.trim());
@@ -1406,23 +1701,29 @@ describe("Browser message routing", () => {
 
   it("permission_response allow: sends control_response to CLI", () => {
     // First create a pending permission
-    bridge.handleCLIMessage(cli, JSON.stringify({
-      type: "control_request",
-      request_id: "req-allow",
-      request: {
-        subtype: "can_use_tool",
-        tool_name: "Bash",
-        input: { command: "echo hi" },
-        tool_use_id: "tu-allow",
-      },
-    }));
+    bridge.handleCLIMessage(
+      cli,
+      JSON.stringify({
+        type: "control_request",
+        request_id: "req-allow",
+        request: {
+          subtype: "can_use_tool",
+          tool_name: "Bash",
+          input: { command: "echo hi" },
+          tool_use_id: "tu-allow",
+        },
+      }),
+    );
     cli.send.mockClear();
 
-    bridge.handleBrowserMessage(browser, JSON.stringify({
-      type: "permission_response",
-      request_id: "req-allow",
-      behavior: "allow",
-    }));
+    bridge.handleBrowserMessage(
+      browser,
+      JSON.stringify({
+        type: "permission_response",
+        request_id: "req-allow",
+        behavior: "allow",
+      }),
+    );
 
     expect(cli.send).toHaveBeenCalledTimes(1);
     const sentRaw = cli.send.mock.calls[0][0] as string;
@@ -1440,24 +1741,30 @@ describe("Browser message routing", () => {
 
   it("permission_response deny: sends deny response to CLI", () => {
     // Create a pending permission
-    bridge.handleCLIMessage(cli, JSON.stringify({
-      type: "control_request",
-      request_id: "req-deny",
-      request: {
-        subtype: "can_use_tool",
-        tool_name: "Bash",
-        input: { command: "rm -rf /" },
-        tool_use_id: "tu-deny",
-      },
-    }));
+    bridge.handleCLIMessage(
+      cli,
+      JSON.stringify({
+        type: "control_request",
+        request_id: "req-deny",
+        request: {
+          subtype: "can_use_tool",
+          tool_name: "Bash",
+          input: { command: "rm -rf /" },
+          tool_use_id: "tu-deny",
+        },
+      }),
+    );
     cli.send.mockClear();
 
-    bridge.handleBrowserMessage(browser, JSON.stringify({
-      type: "permission_response",
-      request_id: "req-deny",
-      behavior: "deny",
-      message: "Too dangerous",
-    }));
+    bridge.handleBrowserMessage(
+      browser,
+      JSON.stringify({
+        type: "permission_response",
+        request_id: "req-deny",
+        behavior: "deny",
+        message: "Too dangerous",
+      }),
+    );
 
     expect(cli.send).toHaveBeenCalledTimes(1);
     const sentRaw = cli.send.mock.calls[0][0] as string;
@@ -1474,16 +1781,19 @@ describe("Browser message routing", () => {
   });
 
   it("permission_response: deduplicates repeated client_msg_id", () => {
-    bridge.handleCLIMessage(cli, JSON.stringify({
-      type: "control_request",
-      request_id: "req-dedupe",
-      request: {
-        subtype: "can_use_tool",
-        tool_name: "Bash",
-        input: { command: "echo hi" },
-        tool_use_id: "tu-dedupe",
-      },
-    }));
+    bridge.handleCLIMessage(
+      cli,
+      JSON.stringify({
+        type: "control_request",
+        request_id: "req-dedupe",
+        request: {
+          subtype: "can_use_tool",
+          tool_name: "Bash",
+          input: { command: "echo hi" },
+          tool_use_id: "tu-dedupe",
+        },
+      }),
+    );
     cli.send.mockClear();
 
     const payload = {
@@ -1501,9 +1811,12 @@ describe("Browser message routing", () => {
   });
 
   it("interrupt: sends control_request with interrupt subtype to CLI", () => {
-    bridge.handleBrowserMessage(browser, JSON.stringify({
-      type: "interrupt",
-    }));
+    bridge.handleBrowserMessage(
+      browser,
+      JSON.stringify({
+        type: "interrupt",
+      }),
+    );
 
     expect(cli.send).toHaveBeenCalledTimes(1);
     const sentRaw = cli.send.mock.calls[0][0] as string;
@@ -1522,10 +1835,13 @@ describe("Browser message routing", () => {
   });
 
   it("set_model: sends control_request with set_model subtype to CLI", () => {
-    bridge.handleBrowserMessage(browser, JSON.stringify({
-      type: "set_model",
-      model: "claude-opus-4-5-20250929",
-    }));
+    bridge.handleBrowserMessage(
+      browser,
+      JSON.stringify({
+        type: "set_model",
+        model: "claude-opus-4-5-20250929",
+      }),
+    );
 
     expect(cli.send).toHaveBeenCalledTimes(1);
     const sentRaw = cli.send.mock.calls[0][0] as string;
@@ -1537,10 +1853,13 @@ describe("Browser message routing", () => {
   });
 
   it("set_permission_mode: sends control_request with set_permission_mode subtype to CLI", () => {
-    bridge.handleBrowserMessage(browser, JSON.stringify({
-      type: "set_permission_mode",
-      mode: "bypassPermissions",
-    }));
+    bridge.handleBrowserMessage(
+      browser,
+      JSON.stringify({
+        type: "set_permission_mode",
+        mode: "bypassPermissions",
+      }),
+    );
 
     expect(cli.send).toHaveBeenCalledTimes(1);
     const sentRaw = cli.send.mock.calls[0][0] as string;
@@ -1676,7 +1995,9 @@ describe("Persistence", () => {
     expect(session!.messageHistory).toHaveLength(1);
     expect(session!.cliSocket).toBeNull();
     expect(session!.browserSockets.size).toBe(0);
-    expect(session!.processedClientMessageIdSet.has("restored-client-1")).toBe(true);
+    expect(session!.processedClientMessageIdSet.has("restored-client-1")).toBe(
+      true,
+    );
   });
 
   it("restoreFromDisk: does not overwrite live sessions", () => {
@@ -1745,54 +2066,73 @@ describe("Persistence", () => {
     saveSpy.mockClear();
 
     // assistant message should trigger persist
-    bridge.handleCLIMessage(cli, JSON.stringify({
-      type: "assistant",
-      message: {
-        id: "msg-1",
-        type: "message",
-        role: "assistant",
-        model: "claude-sonnet-4-6",
-        content: [{ type: "text", text: "Test" }],
-        stop_reason: "end_turn",
-        usage: { input_tokens: 10, output_tokens: 5, cache_creation_input_tokens: 0, cache_read_input_tokens: 0 },
-      },
-      parent_tool_use_id: null,
-      uuid: "uuid-p1",
-      session_id: "s1",
-    }));
+    bridge.handleCLIMessage(
+      cli,
+      JSON.stringify({
+        type: "assistant",
+        message: {
+          id: "msg-1",
+          type: "message",
+          role: "assistant",
+          model: "claude-sonnet-4-6",
+          content: [{ type: "text", text: "Test" }],
+          stop_reason: "end_turn",
+          usage: {
+            input_tokens: 10,
+            output_tokens: 5,
+            cache_creation_input_tokens: 0,
+            cache_read_input_tokens: 0,
+          },
+        },
+        parent_tool_use_id: null,
+        uuid: "uuid-p1",
+        session_id: "s1",
+      }),
+    );
     expect(saveSpy).toHaveBeenCalled();
 
     saveSpy.mockClear();
 
     // result message should trigger persist
-    bridge.handleCLIMessage(cli, JSON.stringify({
-      type: "result",
-      subtype: "success",
-      is_error: false,
-      duration_ms: 1000,
-      duration_api_ms: 800,
-      num_turns: 1,
-      total_cost_usd: 0.01,
-      stop_reason: "end_turn",
-      usage: { input_tokens: 100, output_tokens: 50, cache_creation_input_tokens: 0, cache_read_input_tokens: 0 },
-      uuid: "uuid-p2",
-      session_id: "s1",
-    }));
+    bridge.handleCLIMessage(
+      cli,
+      JSON.stringify({
+        type: "result",
+        subtype: "success",
+        is_error: false,
+        duration_ms: 1000,
+        duration_api_ms: 800,
+        num_turns: 1,
+        total_cost_usd: 0.01,
+        stop_reason: "end_turn",
+        usage: {
+          input_tokens: 100,
+          output_tokens: 50,
+          cache_creation_input_tokens: 0,
+          cache_read_input_tokens: 0,
+        },
+        uuid: "uuid-p2",
+        session_id: "s1",
+      }),
+    );
     expect(saveSpy).toHaveBeenCalled();
 
     saveSpy.mockClear();
 
     // control_request (can_use_tool) should trigger persist
-    bridge.handleCLIMessage(cli, JSON.stringify({
-      type: "control_request",
-      request_id: "req-persist",
-      request: {
-        subtype: "can_use_tool",
-        tool_name: "Bash",
-        input: { command: "echo test" },
-        tool_use_id: "tu-persist",
-      },
-    }));
+    bridge.handleCLIMessage(
+      cli,
+      JSON.stringify({
+        type: "control_request",
+        request_id: "req-persist",
+        request: {
+          subtype: "can_use_tool",
+          tool_name: "Bash",
+          input: { command: "echo test" },
+          tool_use_id: "tu-persist",
+        },
+      }),
+    );
     expect(saveSpy).toHaveBeenCalled();
 
     saveSpy.mockClear();
@@ -1800,10 +2140,13 @@ describe("Persistence", () => {
     // user message from browser should trigger persist
     const browserWs = makeBrowserSocket("s1");
     bridge.handleBrowserOpen(browserWs, "s1");
-    bridge.handleBrowserMessage(browserWs, JSON.stringify({
-      type: "user_message",
-      content: "test persist",
-    }));
+    bridge.handleBrowserMessage(
+      browserWs,
+      JSON.stringify({
+        type: "user_message",
+        content: "test persist",
+      }),
+    );
     expect(saveSpy).toHaveBeenCalled();
   });
 });
@@ -1833,7 +2176,9 @@ describe("auth_status message routing", () => {
 
     bridge.handleCLIMessage(cli, msg);
 
-    const calls = browser.send.mock.calls.map(([arg]: [string]) => JSON.parse(arg));
+    const calls = browser.send.mock.calls.map(([arg]: [string]) =>
+      JSON.parse(arg),
+    );
     const authMsg = calls.find((c: any) => c.type === "auth_status");
     expect(authMsg).toBeDefined();
     expect(authMsg.isAuthenticating).toBe(true);
@@ -1852,7 +2197,9 @@ describe("auth_status message routing", () => {
 
     bridge.handleCLIMessage(cli, msg);
 
-    const calls = browser.send.mock.calls.map(([arg]: [string]) => JSON.parse(arg));
+    const calls = browser.send.mock.calls.map(([arg]: [string]) =>
+      JSON.parse(arg),
+    );
     const authMsg = calls.find((c: any) => c.type === "auth_status");
     expect(authMsg).toBeDefined();
     expect(authMsg.isAuthenticating).toBe(false);
@@ -1871,7 +2218,9 @@ describe("auth_status message routing", () => {
 
     bridge.handleCLIMessage(cli, msg);
 
-    const calls = browser.send.mock.calls.map(([arg]: [string]) => JSON.parse(arg));
+    const calls = browser.send.mock.calls.map(([arg]: [string]) =>
+      JSON.parse(arg),
+    );
     const authMsg = calls.find((c: any) => c.type === "auth_status");
     expect(authMsg).toBeDefined();
     expect(authMsg.isAuthenticating).toBe(false);
@@ -1897,56 +2246,75 @@ describe("permission_response with updated_permissions", () => {
 
   it("allow with updated_permissions forwards updatedPermissions in control_response", () => {
     // Create pending permission
-    bridge.handleCLIMessage(cli, JSON.stringify({
-      type: "control_request",
-      request_id: "req-perm-update",
-      request: {
-        subtype: "can_use_tool",
-        tool_name: "Bash",
-        input: { command: "echo hello" },
-        tool_use_id: "tu-perm-update",
-      },
-    }));
+    bridge.handleCLIMessage(
+      cli,
+      JSON.stringify({
+        type: "control_request",
+        request_id: "req-perm-update",
+        request: {
+          subtype: "can_use_tool",
+          tool_name: "Bash",
+          input: { command: "echo hello" },
+          tool_use_id: "tu-perm-update",
+        },
+      }),
+    );
     cli.send.mockClear();
 
     const updatedPermissions = [
-      { type: "addRules", rules: [{ toolName: "Bash", ruleContent: "echo *" }], behavior: "allow", destination: "session" },
+      {
+        type: "addRules",
+        rules: [{ toolName: "Bash", ruleContent: "echo *" }],
+        behavior: "allow",
+        destination: "session",
+      },
     ];
 
-    bridge.handleBrowserMessage(browser, JSON.stringify({
-      type: "permission_response",
-      request_id: "req-perm-update",
-      behavior: "allow",
-      updated_permissions: updatedPermissions,
-    }));
+    bridge.handleBrowserMessage(
+      browser,
+      JSON.stringify({
+        type: "permission_response",
+        request_id: "req-perm-update",
+        behavior: "allow",
+        updated_permissions: updatedPermissions,
+      }),
+    );
 
     expect(cli.send).toHaveBeenCalledTimes(1);
     const sentRaw = cli.send.mock.calls[0][0] as string;
     const sent = JSON.parse(sentRaw.trim());
     expect(sent.type).toBe("control_response");
     expect(sent.response.response.behavior).toBe("allow");
-    expect(sent.response.response.updatedPermissions).toEqual(updatedPermissions);
+    expect(sent.response.response.updatedPermissions).toEqual(
+      updatedPermissions,
+    );
   });
 
   it("allow without updated_permissions does not include updatedPermissions key", () => {
     // Create pending permission
-    bridge.handleCLIMessage(cli, JSON.stringify({
-      type: "control_request",
-      request_id: "req-no-perm",
-      request: {
-        subtype: "can_use_tool",
-        tool_name: "Read",
-        input: { file_path: "/test.ts" },
-        tool_use_id: "tu-no-perm",
-      },
-    }));
+    bridge.handleCLIMessage(
+      cli,
+      JSON.stringify({
+        type: "control_request",
+        request_id: "req-no-perm",
+        request: {
+          subtype: "can_use_tool",
+          tool_name: "Read",
+          input: { file_path: "/test.ts" },
+          tool_use_id: "tu-no-perm",
+        },
+      }),
+    );
     cli.send.mockClear();
 
-    bridge.handleBrowserMessage(browser, JSON.stringify({
-      type: "permission_response",
-      request_id: "req-no-perm",
-      behavior: "allow",
-    }));
+    bridge.handleBrowserMessage(
+      browser,
+      JSON.stringify({
+        type: "permission_response",
+        request_id: "req-no-perm",
+        behavior: "allow",
+      }),
+    );
 
     const sentRaw = cli.send.mock.calls[0][0] as string;
     const sent = JSON.parse(sentRaw.trim());
@@ -1954,24 +2322,30 @@ describe("permission_response with updated_permissions", () => {
   });
 
   it("allow with empty updated_permissions does not include updatedPermissions key", () => {
-    bridge.handleCLIMessage(cli, JSON.stringify({
-      type: "control_request",
-      request_id: "req-empty-perm",
-      request: {
-        subtype: "can_use_tool",
-        tool_name: "Read",
-        input: { file_path: "/test.ts" },
-        tool_use_id: "tu-empty-perm",
-      },
-    }));
+    bridge.handleCLIMessage(
+      cli,
+      JSON.stringify({
+        type: "control_request",
+        request_id: "req-empty-perm",
+        request: {
+          subtype: "can_use_tool",
+          tool_name: "Read",
+          input: { file_path: "/test.ts" },
+          tool_use_id: "tu-empty-perm",
+        },
+      }),
+    );
     cli.send.mockClear();
 
-    bridge.handleBrowserMessage(browser, JSON.stringify({
-      type: "permission_response",
-      request_id: "req-empty-perm",
-      behavior: "allow",
-      updated_permissions: [],
-    }));
+    bridge.handleBrowserMessage(
+      browser,
+      JSON.stringify({
+        type: "permission_response",
+        request_id: "req-empty-perm",
+        behavior: "allow",
+        updated_permissions: [],
+      }),
+    );
 
     const sentRaw = cli.send.mock.calls[0][0] as string;
     const sent = JSON.parse(sentRaw.trim());
@@ -2082,7 +2456,9 @@ describe("handleCLIMessage with Buffer", () => {
     // Pass as Buffer instead of string
     bridge.handleCLIMessage(cli, Buffer.from(jsonStr, "utf-8"));
 
-    const calls = browser.send.mock.calls.map(([arg]: [string]) => JSON.parse(arg));
+    const calls = browser.send.mock.calls.map(([arg]: [string]) =>
+      JSON.parse(arg),
+    );
     const progressMsg = calls.find((c: any) => c.type === "tool_progress");
     expect(progressMsg).toBeDefined();
     expect(progressMsg.tool_use_id).toBe("tu-buf");
@@ -2111,7 +2487,9 @@ describe("handleCLIMessage with Buffer", () => {
     bridge.handleCLIMessage(cli, Buffer.from(ndjson, "utf-8"));
 
     // keep_alive is silently consumed, only tool_progress should be broadcast
-    const calls = browser.send.mock.calls.map(([arg]: [string]) => JSON.parse(arg));
+    const calls = browser.send.mock.calls.map(([arg]: [string]) =>
+      JSON.parse(arg),
+    );
     expect(calls).toHaveLength(1);
     expect(calls[0].type).toBe("tool_progress");
     expect(calls[0].tool_use_id).toBe("tu-buf2");
@@ -2236,7 +2614,9 @@ describe("Empty NDJSON lines", () => {
     const raw = "\n\n" + validMsg + "\n\n   \n\t\n";
     bridge.handleCLIMessage(cli, raw);
 
-    const calls = browser.send.mock.calls.map(([arg]: [string]) => JSON.parse(arg));
+    const calls = browser.send.mock.calls.map(([arg]: [string]) =>
+      JSON.parse(arg),
+    );
     expect(calls).toHaveLength(1);
     expect(calls[0].type).toBe("tool_progress");
     expect(calls[0].tool_use_id).toBe("tu-empty-lines");
@@ -2272,7 +2652,9 @@ describe("Empty NDJSON lines", () => {
     const raw = line1 + "\n   \n\n" + line2 + "\n";
     bridge.handleCLIMessage(cli, raw);
 
-    const calls = browser.send.mock.calls.map(([arg]: [string]) => JSON.parse(arg));
+    const calls = browser.send.mock.calls.map(([arg]: [string]) =>
+      JSON.parse(arg),
+    );
     const progressMsgs = calls.filter((c: any) => c.type === "tool_progress");
     expect(progressMsgs).toHaveLength(2);
     expect(progressMsgs[0].tool_use_id).toBe("tu-ws-1");
@@ -2288,15 +2670,18 @@ describe("Session not found scenarios", () => {
     // Do NOT call handleCLIOpen — session does not exist in the bridge
 
     expect(() => {
-      bridge.handleCLIMessage(cli, JSON.stringify({
-        type: "tool_progress",
-        tool_use_id: "tu-unknown",
-        tool_name: "Bash",
-        parent_tool_use_id: null,
-        elapsed_time_seconds: 1,
-        uuid: "uuid-unknown",
-        session_id: "unknown-session",
-      }));
+      bridge.handleCLIMessage(
+        cli,
+        JSON.stringify({
+          type: "tool_progress",
+          tool_use_id: "tu-unknown",
+          tool_name: "Bash",
+          parent_tool_use_id: null,
+          elapsed_time_seconds: 1,
+          uuid: "uuid-unknown",
+          session_id: "unknown-session",
+        }),
+      );
     }).not.toThrow();
 
     // Session should not have been created
@@ -2327,10 +2712,13 @@ describe("Session not found scenarios", () => {
     const browser = makeBrowserSocket("nonexistent");
 
     expect(() => {
-      bridge.handleBrowserMessage(browser, JSON.stringify({
-        type: "user_message",
-        content: "hello",
-      }));
+      bridge.handleBrowserMessage(
+        browser,
+        JSON.stringify({
+          type: "user_message",
+          content: "hello",
+        }),
+      );
     }).not.toThrow();
 
     expect(bridge.getSession("nonexistent")).toBeUndefined();
@@ -2342,22 +2730,28 @@ describe("Session not found scenarios", () => {
 describe("Restore from disk with pendingPermissions", () => {
   it("restores sessions with pending permissions as a Map", () => {
     const pendingPerms: [string, any][] = [
-      ["req-restored-1", {
-        request_id: "req-restored-1",
-        tool_name: "Bash",
-        input: { command: "rm -rf /tmp/test" },
-        tool_use_id: "tu-restored-1",
-        timestamp: 1700000000000,
-      }],
-      ["req-restored-2", {
-        request_id: "req-restored-2",
-        tool_name: "Edit",
-        input: { file_path: "/test.ts" },
-        description: "Edit file",
-        tool_use_id: "tu-restored-2",
-        agent_id: "agent-1",
-        timestamp: 1700000001000,
-      }],
+      [
+        "req-restored-1",
+        {
+          request_id: "req-restored-1",
+          tool_name: "Bash",
+          input: { command: "rm -rf /tmp/test" },
+          tool_use_id: "tu-restored-1",
+          timestamp: 1700000000000,
+        },
+      ],
+      [
+        "req-restored-2",
+        {
+          request_id: "req-restored-2",
+          tool_name: "Edit",
+          input: { file_path: "/test.ts" },
+          description: "Edit file",
+          tool_use_id: "tu-restored-2",
+          agent_id: "agent-1",
+          timestamp: 1700000001000,
+        },
+      ],
     ];
 
     store.saveSync({
@@ -2440,13 +2834,16 @@ describe("Restore from disk with pendingPermissions", () => {
       messageHistory: [],
       pendingMessages: [],
       pendingPermissions: [
-        ["req-replay", {
-          request_id: "req-replay",
-          tool_name: "Bash",
-          input: { command: "echo test" },
-          tool_use_id: "tu-replay",
-          timestamp: 1700000000000,
-        }],
+        [
+          "req-replay",
+          {
+            request_id: "req-replay",
+            tool_name: "Bash",
+            input: { command: "echo test" },
+            tool_use_id: "tu-replay",
+            timestamp: 1700000000000,
+          },
+        ],
       ],
     });
 
@@ -2460,7 +2857,9 @@ describe("Restore from disk with pendingPermissions", () => {
     const browser = makeBrowserSocket("perm-replay");
     bridge.handleBrowserOpen(browser, "perm-replay");
 
-    const calls = browser.send.mock.calls.map(([arg]: [string]) => JSON.parse(arg));
+    const calls = browser.send.mock.calls.map(([arg]: [string]) =>
+      JSON.parse(arg),
+    );
     const permMsg = calls.find((c: any) => c.type === "permission_request");
     expect(permMsg).toBeDefined();
     expect(permMsg.request.request_id).toBe("req-replay");
@@ -2565,26 +2964,37 @@ describe("onFirstTurnCompletedCallback", () => {
     // Simulate a browser sending a user message
     const browser = makeBrowserSocket("s1");
     bridge.handleBrowserOpen(browser, "s1");
-    bridge.handleBrowserMessage(browser, JSON.stringify({
-      type: "user_message",
-      content: "Fix the login bug",
-    }));
+    bridge.handleBrowserMessage(
+      browser,
+      JSON.stringify({
+        type: "user_message",
+        content: "Fix the login bug",
+      }),
+    );
 
     // Simulate the result — num_turns is 5 because CLI auto-approved tool calls
-    bridge.handleCLIMessage(cli, JSON.stringify({
-      type: "result",
-      subtype: "success",
-      is_error: false,
-      result: "Done",
-      duration_ms: 1000,
-      duration_api_ms: 800,
-      num_turns: 5,
-      total_cost_usd: 0.01,
-      stop_reason: "end_turn",
-      usage: { input_tokens: 100, output_tokens: 50, cache_creation_input_tokens: 0, cache_read_input_tokens: 0 },
-      uuid: "uuid-first",
-      session_id: "s1",
-    }));
+    bridge.handleCLIMessage(
+      cli,
+      JSON.stringify({
+        type: "result",
+        subtype: "success",
+        is_error: false,
+        result: "Done",
+        duration_ms: 1000,
+        duration_api_ms: 800,
+        num_turns: 5,
+        total_cost_usd: 0.01,
+        stop_reason: "end_turn",
+        usage: {
+          input_tokens: 100,
+          output_tokens: 50,
+          cache_creation_input_tokens: 0,
+          cache_read_input_tokens: 0,
+        },
+        uuid: "uuid-first",
+        session_id: "s1",
+      }),
+    );
 
     expect(callback).toHaveBeenCalledWith("s1", "Fix the login bug");
   });
@@ -2599,46 +3009,68 @@ describe("onFirstTurnCompletedCallback", () => {
 
     const browser = makeBrowserSocket("s1");
     bridge.handleBrowserOpen(browser, "s1");
-    bridge.handleBrowserMessage(browser, JSON.stringify({
-      type: "user_message",
-      content: "First message",
-    }));
+    bridge.handleBrowserMessage(
+      browser,
+      JSON.stringify({
+        type: "user_message",
+        content: "First message",
+      }),
+    );
 
     // First result — triggers callback
-    bridge.handleCLIMessage(cli, JSON.stringify({
-      type: "result",
-      subtype: "success",
-      is_error: false,
-      duration_ms: 1000,
-      duration_api_ms: 800,
-      num_turns: 3,
-      total_cost_usd: 0.05,
-      stop_reason: "end_turn",
-      usage: { input_tokens: 500, output_tokens: 200, cache_creation_input_tokens: 0, cache_read_input_tokens: 0 },
-      uuid: "uuid-first",
-      session_id: "s1",
-    }));
+    bridge.handleCLIMessage(
+      cli,
+      JSON.stringify({
+        type: "result",
+        subtype: "success",
+        is_error: false,
+        duration_ms: 1000,
+        duration_api_ms: 800,
+        num_turns: 3,
+        total_cost_usd: 0.05,
+        stop_reason: "end_turn",
+        usage: {
+          input_tokens: 500,
+          output_tokens: 200,
+          cache_creation_input_tokens: 0,
+          cache_read_input_tokens: 0,
+        },
+        uuid: "uuid-first",
+        session_id: "s1",
+      }),
+    );
 
     expect(callback).toHaveBeenCalledTimes(1);
 
     // Second user message + result — should NOT trigger callback again
-    bridge.handleBrowserMessage(browser, JSON.stringify({
-      type: "user_message",
-      content: "Second message",
-    }));
-    bridge.handleCLIMessage(cli, JSON.stringify({
-      type: "result",
-      subtype: "success",
-      is_error: false,
-      duration_ms: 1000,
-      duration_api_ms: 800,
-      num_turns: 6,
-      total_cost_usd: 0.10,
-      stop_reason: "end_turn",
-      usage: { input_tokens: 800, output_tokens: 300, cache_creation_input_tokens: 0, cache_read_input_tokens: 0 },
-      uuid: "uuid-second",
-      session_id: "s1",
-    }));
+    bridge.handleBrowserMessage(
+      browser,
+      JSON.stringify({
+        type: "user_message",
+        content: "Second message",
+      }),
+    );
+    bridge.handleCLIMessage(
+      cli,
+      JSON.stringify({
+        type: "result",
+        subtype: "success",
+        is_error: false,
+        duration_ms: 1000,
+        duration_api_ms: 800,
+        num_turns: 6,
+        total_cost_usd: 0.1,
+        stop_reason: "end_turn",
+        usage: {
+          input_tokens: 800,
+          output_tokens: 300,
+          cache_creation_input_tokens: 0,
+          cache_read_input_tokens: 0,
+        },
+        uuid: "uuid-second",
+        session_id: "s1",
+      }),
+    );
 
     expect(callback).toHaveBeenCalledTimes(1);
   });
@@ -2653,25 +3085,36 @@ describe("onFirstTurnCompletedCallback", () => {
 
     const browser = makeBrowserSocket("s1");
     bridge.handleBrowserOpen(browser, "s1");
-    bridge.handleBrowserMessage(browser, JSON.stringify({
-      type: "user_message",
-      content: "Some request",
-    }));
+    bridge.handleBrowserMessage(
+      browser,
+      JSON.stringify({
+        type: "user_message",
+        content: "Some request",
+      }),
+    );
 
-    bridge.handleCLIMessage(cli, JSON.stringify({
-      type: "result",
-      subtype: "error_during_execution",
-      is_error: true,
-      errors: ["Something went wrong"],
-      duration_ms: 500,
-      duration_api_ms: 400,
-      num_turns: 1,
-      total_cost_usd: 0.005,
-      stop_reason: null,
-      usage: { input_tokens: 50, output_tokens: 10, cache_creation_input_tokens: 0, cache_read_input_tokens: 0 },
-      uuid: "uuid-err",
-      session_id: "s1",
-    }));
+    bridge.handleCLIMessage(
+      cli,
+      JSON.stringify({
+        type: "result",
+        subtype: "error_during_execution",
+        is_error: true,
+        errors: ["Something went wrong"],
+        duration_ms: 500,
+        duration_api_ms: 400,
+        num_turns: 1,
+        total_cost_usd: 0.005,
+        stop_reason: null,
+        usage: {
+          input_tokens: 50,
+          output_tokens: 10,
+          cache_creation_input_tokens: 0,
+          cache_read_input_tokens: 0,
+        },
+        uuid: "uuid-err",
+        session_id: "s1",
+      }),
+    );
 
     expect(callback).not.toHaveBeenCalled();
   });
@@ -2686,43 +3129,62 @@ describe("onFirstTurnCompletedCallback", () => {
 
     const browser = makeBrowserSocket("s1");
     bridge.handleBrowserOpen(browser, "s1");
-    bridge.handleBrowserMessage(browser, JSON.stringify({
-      type: "user_message",
-      content: "Fix the bug",
-    }));
+    bridge.handleBrowserMessage(
+      browser,
+      JSON.stringify({
+        type: "user_message",
+        content: "Fix the bug",
+      }),
+    );
 
     // First result is an error — should NOT trigger
-    bridge.handleCLIMessage(cli, JSON.stringify({
-      type: "result",
-      subtype: "error_during_execution",
-      is_error: true,
-      errors: ["Oops"],
-      duration_ms: 100,
-      duration_api_ms: 50,
-      num_turns: 1,
-      total_cost_usd: 0.001,
-      stop_reason: null,
-      usage: { input_tokens: 10, output_tokens: 5, cache_creation_input_tokens: 0, cache_read_input_tokens: 0 },
-      uuid: "uuid-err",
-      session_id: "s1",
-    }));
+    bridge.handleCLIMessage(
+      cli,
+      JSON.stringify({
+        type: "result",
+        subtype: "error_during_execution",
+        is_error: true,
+        errors: ["Oops"],
+        duration_ms: 100,
+        duration_api_ms: 50,
+        num_turns: 1,
+        total_cost_usd: 0.001,
+        stop_reason: null,
+        usage: {
+          input_tokens: 10,
+          output_tokens: 5,
+          cache_creation_input_tokens: 0,
+          cache_read_input_tokens: 0,
+        },
+        uuid: "uuid-err",
+        session_id: "s1",
+      }),
+    );
     expect(callback).not.toHaveBeenCalled();
 
     // Second result is success — should trigger since no successful result yet
-    bridge.handleCLIMessage(cli, JSON.stringify({
-      type: "result",
-      subtype: "success",
-      is_error: false,
-      result: "Done",
-      duration_ms: 500,
-      duration_api_ms: 400,
-      num_turns: 3,
-      total_cost_usd: 0.01,
-      stop_reason: "end_turn",
-      usage: { input_tokens: 100, output_tokens: 50, cache_creation_input_tokens: 0, cache_read_input_tokens: 0 },
-      uuid: "uuid-ok",
-      session_id: "s1",
-    }));
+    bridge.handleCLIMessage(
+      cli,
+      JSON.stringify({
+        type: "result",
+        subtype: "success",
+        is_error: false,
+        result: "Done",
+        duration_ms: 500,
+        duration_api_ms: 400,
+        num_turns: 3,
+        total_cost_usd: 0.01,
+        stop_reason: "end_turn",
+        usage: {
+          input_tokens: 100,
+          output_tokens: 50,
+          cache_creation_input_tokens: 0,
+          cache_read_input_tokens: 0,
+        },
+        uuid: "uuid-ok",
+        session_id: "s1",
+      }),
+    );
     expect(callback).toHaveBeenCalledWith("s1", "Fix the bug");
     expect(callback).toHaveBeenCalledTimes(1);
   });
@@ -2736,20 +3198,28 @@ describe("onFirstTurnCompletedCallback", () => {
     bridge.handleCLIMessage(cli, makeInitMsg());
 
     // Send result without any user message first
-    bridge.handleCLIMessage(cli, JSON.stringify({
-      type: "result",
-      subtype: "success",
-      is_error: false,
-      result: "Done",
-      duration_ms: 100,
-      duration_api_ms: 50,
-      num_turns: 1,
-      total_cost_usd: 0.001,
-      stop_reason: "end_turn",
-      usage: { input_tokens: 10, output_tokens: 5, cache_creation_input_tokens: 0, cache_read_input_tokens: 0 },
-      uuid: "uuid-1",
-      session_id: "s1",
-    }));
+    bridge.handleCLIMessage(
+      cli,
+      JSON.stringify({
+        type: "result",
+        subtype: "success",
+        is_error: false,
+        result: "Done",
+        duration_ms: 100,
+        duration_api_ms: 50,
+        num_turns: 1,
+        total_cost_usd: 0.001,
+        stop_reason: "end_turn",
+        usage: {
+          input_tokens: 10,
+          output_tokens: 5,
+          cache_creation_input_tokens: 0,
+          cache_read_input_tokens: 0,
+        },
+        uuid: "uuid-1",
+        session_id: "s1",
+      }),
+    );
 
     expect(callback).not.toHaveBeenCalled();
   });
@@ -2764,10 +3234,13 @@ describe("onFirstTurnCompletedCallback", () => {
     bridge.handleCLIMessage(cli1, makeInitMsg());
     const browser1 = makeBrowserSocket("s1");
     bridge.handleBrowserOpen(browser1, "s1");
-    bridge.handleBrowserMessage(browser1, JSON.stringify({
-      type: "user_message",
-      content: "Message for s1",
-    }));
+    bridge.handleBrowserMessage(
+      browser1,
+      JSON.stringify({
+        type: "user_message",
+        content: "Message for s1",
+      }),
+    );
 
     // Setup session 2
     const cli2 = makeCliSocket("s2");
@@ -2775,43 +3248,62 @@ describe("onFirstTurnCompletedCallback", () => {
     bridge.handleCLIMessage(cli2, makeInitMsg());
     const browser2 = makeBrowserSocket("s2");
     bridge.handleBrowserOpen(browser2, "s2");
-    bridge.handleBrowserMessage(browser2, JSON.stringify({
-      type: "user_message",
-      content: "Message for s2",
-    }));
+    bridge.handleBrowserMessage(
+      browser2,
+      JSON.stringify({
+        type: "user_message",
+        content: "Message for s2",
+      }),
+    );
 
     // Result for s1
-    bridge.handleCLIMessage(cli1, JSON.stringify({
-      type: "result",
-      subtype: "success",
-      is_error: false,
-      duration_ms: 100,
-      duration_api_ms: 50,
-      num_turns: 2,
-      total_cost_usd: 0.01,
-      stop_reason: "end_turn",
-      usage: { input_tokens: 50, output_tokens: 25, cache_creation_input_tokens: 0, cache_read_input_tokens: 0 },
-      uuid: "uuid-s1",
-      session_id: "s1",
-    }));
+    bridge.handleCLIMessage(
+      cli1,
+      JSON.stringify({
+        type: "result",
+        subtype: "success",
+        is_error: false,
+        duration_ms: 100,
+        duration_api_ms: 50,
+        num_turns: 2,
+        total_cost_usd: 0.01,
+        stop_reason: "end_turn",
+        usage: {
+          input_tokens: 50,
+          output_tokens: 25,
+          cache_creation_input_tokens: 0,
+          cache_read_input_tokens: 0,
+        },
+        uuid: "uuid-s1",
+        session_id: "s1",
+      }),
+    );
 
     expect(callback).toHaveBeenCalledTimes(1);
     expect(callback).toHaveBeenCalledWith("s1", "Message for s1");
 
     // Result for s2 — should also fire (independent session)
-    bridge.handleCLIMessage(cli2, JSON.stringify({
-      type: "result",
-      subtype: "success",
-      is_error: false,
-      duration_ms: 100,
-      duration_api_ms: 50,
-      num_turns: 4,
-      total_cost_usd: 0.02,
-      stop_reason: "end_turn",
-      usage: { input_tokens: 80, output_tokens: 40, cache_creation_input_tokens: 0, cache_read_input_tokens: 0 },
-      uuid: "uuid-s2",
-      session_id: "s2",
-    }));
+    bridge.handleCLIMessage(
+      cli2,
+      JSON.stringify({
+        type: "result",
+        subtype: "success",
+        is_error: false,
+        duration_ms: 100,
+        duration_api_ms: 50,
+        num_turns: 4,
+        total_cost_usd: 0.02,
+        stop_reason: "end_turn",
+        usage: {
+          input_tokens: 80,
+          output_tokens: 40,
+          cache_creation_input_tokens: 0,
+          cache_read_input_tokens: 0,
+        },
+        uuid: "uuid-s2",
+        session_id: "s2",
+      }),
+    );
 
     expect(callback).toHaveBeenCalledTimes(2);
     expect(callback).toHaveBeenCalledWith("s2", "Message for s2");
@@ -2826,25 +3318,36 @@ describe("onFirstTurnCompletedCallback", () => {
     bridge.handleCLIMessage(cli, makeInitMsg());
     const browser = makeBrowserSocket("s1");
     bridge.handleBrowserOpen(browser, "s1");
-    bridge.handleBrowserMessage(browser, JSON.stringify({
-      type: "user_message",
-      content: "Hello",
-    }));
+    bridge.handleBrowserMessage(
+      browser,
+      JSON.stringify({
+        type: "user_message",
+        content: "Hello",
+      }),
+    );
 
     // First result triggers callback
-    bridge.handleCLIMessage(cli, JSON.stringify({
-      type: "result",
-      subtype: "success",
-      is_error: false,
-      duration_ms: 100,
-      duration_api_ms: 50,
-      num_turns: 1,
-      total_cost_usd: 0.01,
-      stop_reason: "end_turn",
-      usage: { input_tokens: 10, output_tokens: 5, cache_creation_input_tokens: 0, cache_read_input_tokens: 0 },
-      uuid: "uuid-1",
-      session_id: "s1",
-    }));
+    bridge.handleCLIMessage(
+      cli,
+      JSON.stringify({
+        type: "result",
+        subtype: "success",
+        is_error: false,
+        duration_ms: 100,
+        duration_api_ms: 50,
+        num_turns: 1,
+        total_cost_usd: 0.01,
+        stop_reason: "end_turn",
+        usage: {
+          input_tokens: 10,
+          output_tokens: 5,
+          cache_creation_input_tokens: 0,
+          cache_read_input_tokens: 0,
+        },
+        uuid: "uuid-1",
+        session_id: "s1",
+      }),
+    );
     expect(callback).toHaveBeenCalledTimes(1);
 
     // Remove and recreate the session
@@ -2854,25 +3357,36 @@ describe("onFirstTurnCompletedCallback", () => {
     bridge.handleCLIMessage(cli2, makeInitMsg());
     const browser2 = makeBrowserSocket("s1");
     bridge.handleBrowserOpen(browser2, "s1");
-    bridge.handleBrowserMessage(browser2, JSON.stringify({
-      type: "user_message",
-      content: "Hello again",
-    }));
+    bridge.handleBrowserMessage(
+      browser2,
+      JSON.stringify({
+        type: "user_message",
+        content: "Hello again",
+      }),
+    );
 
     // Should fire again for the recreated session
-    bridge.handleCLIMessage(cli2, JSON.stringify({
-      type: "result",
-      subtype: "success",
-      is_error: false,
-      duration_ms: 100,
-      duration_api_ms: 50,
-      num_turns: 2,
-      total_cost_usd: 0.01,
-      stop_reason: "end_turn",
-      usage: { input_tokens: 10, output_tokens: 5, cache_creation_input_tokens: 0, cache_read_input_tokens: 0 },
-      uuid: "uuid-2",
-      session_id: "s1",
-    }));
+    bridge.handleCLIMessage(
+      cli2,
+      JSON.stringify({
+        type: "result",
+        subtype: "success",
+        is_error: false,
+        duration_ms: 100,
+        duration_api_ms: 50,
+        num_turns: 2,
+        total_cost_usd: 0.01,
+        stop_reason: "end_turn",
+        usage: {
+          input_tokens: 10,
+          output_tokens: 5,
+          cache_creation_input_tokens: 0,
+          cache_read_input_tokens: 0,
+        },
+        uuid: "uuid-2",
+        session_id: "s1",
+      }),
+    );
     expect(callback).toHaveBeenCalledTimes(2);
     expect(callback).toHaveBeenLastCalledWith("s1", "Hello again");
   });
@@ -2886,25 +3400,36 @@ describe("onFirstTurnCompletedCallback", () => {
     bridge.handleCLIMessage(cli, makeInitMsg());
     const browser = makeBrowserSocket("s1");
     bridge.handleBrowserOpen(browser, "s1");
-    bridge.handleBrowserMessage(browser, JSON.stringify({
-      type: "user_message",
-      content: "First session",
-    }));
+    bridge.handleBrowserMessage(
+      browser,
+      JSON.stringify({
+        type: "user_message",
+        content: "First session",
+      }),
+    );
 
     // Trigger callback
-    bridge.handleCLIMessage(cli, JSON.stringify({
-      type: "result",
-      subtype: "success",
-      is_error: false,
-      duration_ms: 100,
-      duration_api_ms: 50,
-      num_turns: 1,
-      total_cost_usd: 0.01,
-      stop_reason: "end_turn",
-      usage: { input_tokens: 10, output_tokens: 5, cache_creation_input_tokens: 0, cache_read_input_tokens: 0 },
-      uuid: "uuid-1",
-      session_id: "s1",
-    }));
+    bridge.handleCLIMessage(
+      cli,
+      JSON.stringify({
+        type: "result",
+        subtype: "success",
+        is_error: false,
+        duration_ms: 100,
+        duration_api_ms: 50,
+        num_turns: 1,
+        total_cost_usd: 0.01,
+        stop_reason: "end_turn",
+        usage: {
+          input_tokens: 10,
+          output_tokens: 5,
+          cache_creation_input_tokens: 0,
+          cache_read_input_tokens: 0,
+        },
+        uuid: "uuid-1",
+        session_id: "s1",
+      }),
+    );
     expect(callback).toHaveBeenCalledTimes(1);
 
     // Close session (should clean up tracking)
@@ -2916,23 +3441,34 @@ describe("onFirstTurnCompletedCallback", () => {
     bridge.handleCLIMessage(cli2, makeInitMsg());
     const browser2 = makeBrowserSocket("s1");
     bridge.handleBrowserOpen(browser2, "s1");
-    bridge.handleBrowserMessage(browser2, JSON.stringify({
-      type: "user_message",
-      content: "Second session",
-    }));
-    bridge.handleCLIMessage(cli2, JSON.stringify({
-      type: "result",
-      subtype: "success",
-      is_error: false,
-      duration_ms: 100,
-      duration_api_ms: 50,
-      num_turns: 1,
-      total_cost_usd: 0.01,
-      stop_reason: "end_turn",
-      usage: { input_tokens: 10, output_tokens: 5, cache_creation_input_tokens: 0, cache_read_input_tokens: 0 },
-      uuid: "uuid-2",
-      session_id: "s1",
-    }));
+    bridge.handleBrowserMessage(
+      browser2,
+      JSON.stringify({
+        type: "user_message",
+        content: "Second session",
+      }),
+    );
+    bridge.handleCLIMessage(
+      cli2,
+      JSON.stringify({
+        type: "result",
+        subtype: "success",
+        is_error: false,
+        duration_ms: 100,
+        duration_api_ms: 50,
+        num_turns: 1,
+        total_cost_usd: 0.01,
+        stop_reason: "end_turn",
+        usage: {
+          input_tokens: 10,
+          output_tokens: 5,
+          cache_creation_input_tokens: 0,
+          cache_read_input_tokens: 0,
+        },
+        uuid: "uuid-2",
+        session_id: "s1",
+      }),
+    );
     expect(callback).toHaveBeenCalledTimes(2);
   });
 
@@ -2968,7 +3504,11 @@ describe("onFirstTurnCompletedCallback", () => {
         total_lines_removed: 0,
       },
       messageHistory: [
-        { type: "user_message" as const, content: "Build the app", timestamp: Date.now() },
+        {
+          type: "user_message" as const,
+          content: "Build the app",
+          timestamp: Date.now(),
+        },
       ],
       pendingMessages: [],
       pendingPermissions: [],
@@ -2982,19 +3522,27 @@ describe("onFirstTurnCompletedCallback", () => {
     bridge.handleCLIOpen(cli, "restored-1");
 
     // Another result comes in — should NOT trigger callback
-    bridge.handleCLIMessage(cli, JSON.stringify({
-      type: "result",
-      subtype: "success",
-      is_error: false,
-      duration_ms: 200,
-      duration_api_ms: 150,
-      num_turns: 5,
-      total_cost_usd: 0.02,
-      stop_reason: "end_turn",
-      usage: { input_tokens: 200, output_tokens: 100, cache_creation_input_tokens: 0, cache_read_input_tokens: 0 },
-      uuid: "uuid-restored",
-      session_id: "restored-1",
-    }));
+    bridge.handleCLIMessage(
+      cli,
+      JSON.stringify({
+        type: "result",
+        subtype: "success",
+        is_error: false,
+        duration_ms: 200,
+        duration_api_ms: 150,
+        num_turns: 5,
+        total_cost_usd: 0.02,
+        stop_reason: "end_turn",
+        usage: {
+          input_tokens: 200,
+          output_tokens: 100,
+          cache_creation_input_tokens: 0,
+          cache_read_input_tokens: 0,
+        },
+        uuid: "uuid-restored",
+        session_id: "restored-1",
+      }),
+    );
 
     expect(callback).not.toHaveBeenCalled();
   });
@@ -3043,24 +3591,35 @@ describe("onFirstTurnCompletedCallback", () => {
     bridge.handleCLIMessage(cli, makeInitMsg());
     const browser = makeBrowserSocket("fresh-restored");
     bridge.handleBrowserOpen(browser, "fresh-restored");
-    bridge.handleBrowserMessage(browser, JSON.stringify({
-      type: "user_message",
-      content: "Hello world",
-    }));
+    bridge.handleBrowserMessage(
+      browser,
+      JSON.stringify({
+        type: "user_message",
+        content: "Hello world",
+      }),
+    );
 
-    bridge.handleCLIMessage(cli, JSON.stringify({
-      type: "result",
-      subtype: "success",
-      is_error: false,
-      duration_ms: 100,
-      duration_api_ms: 50,
-      num_turns: 2,
-      total_cost_usd: 0.01,
-      stop_reason: "end_turn",
-      usage: { input_tokens: 50, output_tokens: 25, cache_creation_input_tokens: 0, cache_read_input_tokens: 0 },
-      uuid: "uuid-fresh",
-      session_id: "fresh-restored",
-    }));
+    bridge.handleCLIMessage(
+      cli,
+      JSON.stringify({
+        type: "result",
+        subtype: "success",
+        is_error: false,
+        duration_ms: 100,
+        duration_api_ms: 50,
+        num_turns: 2,
+        total_cost_usd: 0.01,
+        stop_reason: "end_turn",
+        usage: {
+          input_tokens: 50,
+          output_tokens: 25,
+          cache_creation_input_tokens: 0,
+          cache_read_input_tokens: 0,
+        },
+        uuid: "uuid-fresh",
+        session_id: "fresh-restored",
+      }),
+    );
 
     expect(callback).toHaveBeenCalledWith("fresh-restored", "Hello world");
   });
@@ -3080,10 +3639,24 @@ describe("broadcastNameUpdate", () => {
 
     bridge.broadcastNameUpdate("s1", "Fix Auth Bug");
 
-    const calls1 = browser1.send.mock.calls.map(([arg]: [string]) => JSON.parse(arg));
-    const calls2 = browser2.send.mock.calls.map(([arg]: [string]) => JSON.parse(arg));
-    expect(calls1).toContainEqual(expect.objectContaining({ type: "session_name_update", name: "Fix Auth Bug" }));
-    expect(calls2).toContainEqual(expect.objectContaining({ type: "session_name_update", name: "Fix Auth Bug" }));
+    const calls1 = browser1.send.mock.calls.map(([arg]: [string]) =>
+      JSON.parse(arg),
+    );
+    const calls2 = browser2.send.mock.calls.map(([arg]: [string]) =>
+      JSON.parse(arg),
+    );
+    expect(calls1).toContainEqual(
+      expect.objectContaining({
+        type: "session_name_update",
+        name: "Fix Auth Bug",
+      }),
+    );
+    expect(calls2).toContainEqual(
+      expect.objectContaining({
+        type: "session_name_update",
+        name: "Fix Auth Bug",
+      }),
+    );
   });
 
   it("does nothing for unknown sessions", () => {
@@ -3109,9 +3682,12 @@ describe("MCP control messages", () => {
   });
 
   it("mcp_get_status: sends mcp_status control_request to CLI", () => {
-    bridge.handleBrowserMessage(browser, JSON.stringify({
-      type: "mcp_get_status",
-    }));
+    bridge.handleBrowserMessage(
+      browser,
+      JSON.stringify({
+        type: "mcp_get_status",
+      }),
+    );
 
     expect(cli.send).toHaveBeenCalledTimes(1);
     const sentRaw = cli.send.mock.calls[0][0] as string;
@@ -3124,11 +3700,14 @@ describe("MCP control messages", () => {
   it("mcp_toggle: sends mcp_toggle control_request to CLI", () => {
     // Use vi.useFakeTimers to prevent the delayed mcp_get_status
     vi.useFakeTimers();
-    bridge.handleBrowserMessage(browser, JSON.stringify({
-      type: "mcp_toggle",
-      serverName: "my-server",
-      enabled: false,
-    }));
+    bridge.handleBrowserMessage(
+      browser,
+      JSON.stringify({
+        type: "mcp_toggle",
+        serverName: "my-server",
+        enabled: false,
+      }),
+    );
 
     expect(cli.send).toHaveBeenCalledTimes(1);
     const sentRaw = cli.send.mock.calls[0][0] as string;
@@ -3142,10 +3721,13 @@ describe("MCP control messages", () => {
 
   it("mcp_reconnect: sends mcp_reconnect control_request to CLI", () => {
     vi.useFakeTimers();
-    bridge.handleBrowserMessage(browser, JSON.stringify({
-      type: "mcp_reconnect",
-      serverName: "failing-server",
-    }));
+    bridge.handleBrowserMessage(
+      browser,
+      JSON.stringify({
+        type: "mcp_reconnect",
+        serverName: "failing-server",
+      }),
+    );
 
     expect(cli.send).toHaveBeenCalledTimes(1);
     const sentRaw = cli.send.mock.calls[0][0] as string;
@@ -3158,9 +3740,12 @@ describe("MCP control messages", () => {
 
   it("control_response for mcp_status: broadcasts mcp_status to browsers", () => {
     // Send mcp_get_status to create the pending request
-    bridge.handleBrowserMessage(browser, JSON.stringify({
-      type: "mcp_get_status",
-    }));
+    bridge.handleBrowserMessage(
+      browser,
+      JSON.stringify({
+        type: "mcp_get_status",
+      }),
+    );
     browser.send.mockClear();
 
     // Simulate CLI responding with control_response
@@ -3174,14 +3759,17 @@ describe("MCP control messages", () => {
       },
     ];
 
-    bridge.handleCLIMessage(cli, JSON.stringify({
-      type: "control_response",
-      response: {
-        subtype: "success",
-        request_id: "test-uuid",
-        response: { mcpServers: mockServers },
-      },
-    }));
+    bridge.handleCLIMessage(
+      cli,
+      JSON.stringify({
+        type: "control_response",
+        response: {
+          subtype: "success",
+          request_id: "test-uuid",
+          response: { mcpServers: mockServers },
+        },
+      }),
+    );
 
     expect(browser.send).toHaveBeenCalledTimes(1);
     const browserMsg = JSON.parse(browser.send.mock.calls[0][0] as string);
@@ -3193,33 +3781,42 @@ describe("MCP control messages", () => {
   });
 
   it("control_response with error: does not broadcast to browsers", () => {
-    bridge.handleBrowserMessage(browser, JSON.stringify({
-      type: "mcp_get_status",
-    }));
+    bridge.handleBrowserMessage(
+      browser,
+      JSON.stringify({
+        type: "mcp_get_status",
+      }),
+    );
     browser.send.mockClear();
 
-    bridge.handleCLIMessage(cli, JSON.stringify({
-      type: "control_response",
-      response: {
-        subtype: "error",
-        request_id: "test-uuid",
-        error: "MCP not available",
-      },
-    }));
+    bridge.handleCLIMessage(
+      cli,
+      JSON.stringify({
+        type: "control_response",
+        response: {
+          subtype: "error",
+          request_id: "test-uuid",
+          error: "MCP not available",
+        },
+      }),
+    );
 
     // Should not broadcast anything
     expect(browser.send).not.toHaveBeenCalled();
   });
 
   it("control_response for unknown request_id: ignored silently", () => {
-    bridge.handleCLIMessage(cli, JSON.stringify({
-      type: "control_response",
-      response: {
-        subtype: "success",
-        request_id: "unknown-id",
-        response: { mcpServers: [] },
-      },
-    }));
+    bridge.handleCLIMessage(
+      cli,
+      JSON.stringify({
+        type: "control_response",
+        response: {
+          subtype: "success",
+          request_id: "unknown-id",
+          response: { mcpServers: [] },
+        },
+      }),
+    );
 
     // Should not throw and not send anything
     expect(browser.send).not.toHaveBeenCalled();
@@ -3234,10 +3831,13 @@ describe("MCP control messages", () => {
         args: ["-y", "@modelcontextprotocol/server-memory"],
       },
     };
-    bridge.handleBrowserMessage(browser, JSON.stringify({
-      type: "mcp_set_servers",
-      servers,
-    }));
+    bridge.handleBrowserMessage(
+      browser,
+      JSON.stringify({
+        type: "mcp_set_servers",
+        servers,
+      }),
+    );
 
     expect(cli.send).toHaveBeenCalledTimes(1);
     const sentRaw = cli.send.mock.calls[0][0] as string;

--- a/web/server/ws-bridge.ts
+++ b/web/server/ws-bridge.ts
@@ -77,12 +77,18 @@ export class WsBridge {
   private sessions = new Map<string, Session>();
   private store: SessionStore | null = null;
   private recorder: RecorderManager | null = null;
-  private onCLISessionId: ((sessionId: string, cliSessionId: string) => void) | null = null;
+  private onCLISessionId:
+    | ((sessionId: string, cliSessionId: string) => void)
+    | null = null;
   private onCLIRelaunchNeeded: ((sessionId: string) => void) | null = null;
-  private onFirstTurnCompleted: ((sessionId: string, firstUserMessage: string) => void) | null = null;
+  private onFirstTurnCompleted:
+    | ((sessionId: string, firstUserMessage: string) => void)
+    | null = null;
   private autoNamingAttempted = new Set<string>();
   private userMsgCounter = 0;
-  private onGitInfoReady: ((sessionId: string, cwd: string, branch: string) => void) | null = null;
+  private onGitInfoReady:
+    | ((sessionId: string, cwd: string, branch: string) => void)
+    | null = null;
   private static readonly GIT_SESSION_KEYS: GitSessionKey[] = [
     "git_branch",
     "is_worktree",
@@ -93,7 +99,9 @@ export class WsBridge {
   ];
 
   /** Register a callback for when we learn the CLI's internal session ID. */
-  onCLISessionIdReceived(cb: (sessionId: string, cliSessionId: string) => void): void {
+  onCLISessionIdReceived(
+    cb: (sessionId: string, cliSessionId: string) => void,
+  ): void {
     this.onCLISessionId = cb;
   }
 
@@ -103,12 +111,16 @@ export class WsBridge {
   }
 
   /** Register a callback for when a session completes its first turn. */
-  onFirstTurnCompletedCallback(cb: (sessionId: string, firstUserMessage: string) => void): void {
+  onFirstTurnCompletedCallback(
+    cb: (sessionId: string, firstUserMessage: string) => void,
+  ): void {
     this.onFirstTurnCompleted = cb;
   }
 
   /** Register a callback for when git info is resolved and branch is known. */
-  onSessionGitInfoReadyCallback(cb: (sessionId: string, cwd: string, branch: string) => void): void {
+  onSessionGitInfoReadyCallback(
+    cb: (sessionId: string, cwd: string, branch: string) => void,
+  ): void {
     this.onGitInfoReady = cb;
   }
 
@@ -161,9 +173,13 @@ export class WsBridge {
         nextEventSeq: p.nextEventSeq && p.nextEventSeq > 0 ? p.nextEventSeq : 1,
         eventBuffer: Array.isArray(p.eventBuffer) ? p.eventBuffer : [],
         lastAckSeq: typeof p.lastAckSeq === "number" ? p.lastAckSeq : 0,
-        processedClientMessageIds: Array.isArray(p.processedClientMessageIds) ? p.processedClientMessageIds : [],
+        processedClientMessageIds: Array.isArray(p.processedClientMessageIds)
+          ? p.processedClientMessageIds
+          : [],
         processedClientMessageIdSet: new Set(
-          Array.isArray(p.processedClientMessageIds) ? p.processedClientMessageIds : [],
+          Array.isArray(p.processedClientMessageIds)
+            ? p.processedClientMessageIds
+            : [],
         ),
       };
       session.state.backend_type = session.backendType;
@@ -238,8 +254,17 @@ export class WsBridge {
       this.persistSession(session);
     }
 
-    if (options.notifyPoller && session.state.git_branch && session.state.cwd && this.onGitInfoReady) {
-      this.onGitInfoReady(session.id, session.state.cwd, session.state.git_branch);
+    if (
+      options.notifyPoller &&
+      session.state.git_branch &&
+      session.state.cwd &&
+      this.onGitInfoReady
+    ) {
+      this.onGitInfoReady(
+        session.id,
+        session.state.cwd,
+        session.state.git_branch,
+      );
     }
   }
 
@@ -313,7 +338,9 @@ export class WsBridge {
 
     // Close CLI socket (Claude)
     if (session.cliSocket) {
-      try { session.cliSocket.close(); } catch {}
+      try {
+        session.cliSocket.close();
+      } catch {}
       session.cliSocket = null;
     }
 
@@ -325,7 +352,9 @@ export class WsBridge {
 
     // Close all browser sockets
     for (const ws of session.browserSockets) {
-      try { ws.close(); } catch {}
+      try {
+        ws.close();
+      } catch {}
     }
     session.browserSockets.clear();
 
@@ -370,7 +399,9 @@ export class WsBridge {
     // system.init (which would create a deadlock for slow-starting sessions
     // like Docker containers where the user message arrives before CLI connects).
     if (session.pendingMessages.length > 0) {
-      console.log(`[ws-bridge] Flushing ${session.pendingMessages.length} queued message(s) on CLI connect for session ${sessionId}`);
+      console.log(
+        `[ws-bridge] Flushing ${session.pendingMessages.length} queued message(s) on CLI connect for session ${sessionId}`,
+      );
       const queued = session.pendingMessages.splice(0);
       for (const ndjson of queued) {
         this.sendToCLI(session, ndjson);
@@ -385,7 +416,14 @@ export class WsBridge {
     if (!session) return;
 
     // Record raw incoming CLI message before any parsing
-    this.recorder?.record(sessionId, "in", data, "cli", session.backendType, session.state.cwd);
+    this.recorder?.record(
+      sessionId,
+      "in",
+      data,
+      "cli",
+      session.backendType,
+      session.state.cwd,
+    );
 
     // NDJSON: split on newlines, parse each line
     const lines = data.split("\n").filter((l) => l.trim());
@@ -394,7 +432,9 @@ export class WsBridge {
       try {
         msg = JSON.parse(line);
       } catch {
-        console.warn(`[ws-bridge] Failed to parse CLI message: ${line.substring(0, 200)}`);
+        console.warn(
+          `[ws-bridge] Failed to parse CLI message: ${line.substring(0, 200)}`,
+        );
         continue;
       }
       this.routeCLIMessage(session, msg);
@@ -412,7 +452,10 @@ export class WsBridge {
 
     // Cancel any pending permission requests
     for (const [reqId] of session.pendingPermissions) {
-      this.broadcastToBrowsers(session, { type: "permission_cancelled", request_id: reqId });
+      this.broadcastToBrowsers(session, {
+        type: "permission_cancelled",
+        request_id: reqId,
+      });
     }
     session.pendingPermissions.clear();
   }
@@ -425,7 +468,9 @@ export class WsBridge {
     browserData.subscribed = false;
     browserData.lastAckSeq = 0;
     session.browserSockets.add(ws);
-    console.log(`[ws-bridge] Browser connected for session ${sessionId} (${session.browserSockets.size} browsers)`);
+    console.log(
+      `[ws-bridge] Browser connected for session ${sessionId} (${session.browserSockets.size} browsers)`,
+    );
 
     // Refresh git state on browser connect so branch changes made mid-session are reflected.
     this.refreshGitInfo(session, { notifyPoller: true });
@@ -451,17 +496,20 @@ export class WsBridge {
     }
 
     // Notify if backend is not connected and request relaunch
-    const backendConnected = session.backendType === "codex"
-      // Treat an attached adapter as "alive" during init.
-      // `isConnected()` flips true only after initialize/thread start, and
-      // relaunching during that window can kill a healthy startup.
-      ? !!session.codexAdapter
-      : !!session.cliSocket;
+    const backendConnected =
+      session.backendType === "codex"
+        ? // Treat an attached adapter as "alive" during init.
+          // `isConnected()` flips true only after initialize/thread start, and
+          // relaunching during that window can kill a healthy startup.
+          !!session.codexAdapter
+        : !!session.cliSocket;
 
     if (!backendConnected) {
       this.sendToBrowser(ws, { type: "cli_disconnected" });
       if (this.onCLIRelaunchNeeded) {
-        console.log(`[ws-bridge] Browser connected but backend is dead for session ${sessionId}, requesting relaunch`);
+        console.log(
+          `[ws-bridge] Browser connected but backend is dead for session ${sessionId}, requesting relaunch`,
+        );
         this.onCLIRelaunchNeeded(sessionId);
       }
     }
@@ -474,13 +522,22 @@ export class WsBridge {
     if (!session) return;
 
     // Record raw incoming browser message
-    this.recorder?.record(sessionId, "in", data, "browser", session.backendType, session.state.cwd);
+    this.recorder?.record(
+      sessionId,
+      "in",
+      data,
+      "browser",
+      session.backendType,
+      session.state.cwd,
+    );
 
     let msg: BrowserOutgoingMessage;
     try {
       msg = JSON.parse(data);
     } catch {
-      console.warn(`[ws-bridge] Failed to parse browser message: ${data.substring(0, 200)}`);
+      console.warn(
+        `[ws-bridge] Failed to parse browser message: ${data.substring(0, 200)}`,
+      );
       return;
     }
 
@@ -492,7 +549,9 @@ export class WsBridge {
   injectUserMessage(sessionId: string, content: string): void {
     const session = this.sessions.get(sessionId);
     if (!session) {
-      console.error(`[ws-bridge] Cannot inject message: session ${sessionId} not found`);
+      console.error(
+        `[ws-bridge] Cannot inject message: session ${sessionId} not found`,
+      );
       return;
     }
     this.routeBrowserMessage(session, { type: "user_message", content });
@@ -500,10 +559,15 @@ export class WsBridge {
 
   /** Configure MCP servers on a session programmatically (no browser required).
    *  Used by the agent executor to set up MCP servers after CLI connects. */
-  injectMcpSetServers(sessionId: string, servers: Record<string, McpServerConfig>): void {
+  injectMcpSetServers(
+    sessionId: string,
+    servers: Record<string, McpServerConfig>,
+  ): void {
     const session = this.sessions.get(sessionId);
     if (!session) {
-      console.error(`[ws-bridge] Cannot inject MCP servers: session ${sessionId} not found`);
+      console.error(
+        `[ws-bridge] Cannot inject MCP servers: session ${sessionId} not found`,
+      );
       return;
     }
     this.routeBrowserMessage(session, { type: "mcp_set_servers", servers });
@@ -515,7 +579,9 @@ export class WsBridge {
     if (!session) return;
 
     session.browserSockets.delete(ws);
-    console.log(`[ws-bridge] Browser disconnected for session ${sessionId} (${session.browserSockets.size} browsers)`);
+    console.log(
+      `[ws-bridge] Browser disconnected for session ${sessionId} (${session.browserSockets.size} browsers)`,
+    );
   }
 
   // ── CLI message routing ─────────────────────────────────────────────────
@@ -605,7 +671,9 @@ export class WsBridge {
       // Flush any messages queued before CLI was initialized (e.g. user sent
       // a message while the container was still starting up).
       if (session.pendingMessages.length > 0) {
-        console.log(`[ws-bridge] Flushing ${session.pendingMessages.length} queued message(s) after init for session ${session.id}`);
+        console.log(
+          `[ws-bridge] Flushing ${session.pendingMessages.length} queued message(s) after init for session ${session.id}`,
+        );
         const queued = session.pendingMessages.splice(0);
         for (const ndjson of queued) {
           this.sendToCLI(session, ndjson);
@@ -676,17 +744,21 @@ export class WsBridge {
     }
 
     if (msg.subtype === "hook_progress") {
-      this.forwardSystemEvent(session, {
-        subtype: "hook_progress",
-        hook_id: msg.hook_id,
-        hook_name: msg.hook_name,
-        hook_event: msg.hook_event,
-        stdout: msg.stdout,
-        stderr: msg.stderr,
-        output: msg.output,
-        uuid: msg.uuid,
-        session_id: msg.session_id,
-      }, { persistInHistory: false });
+      this.forwardSystemEvent(
+        session,
+        {
+          subtype: "hook_progress",
+          hook_id: msg.hook_id,
+          hook_name: msg.hook_name,
+          hook_event: msg.hook_event,
+          stdout: msg.stdout,
+          stderr: msg.stderr,
+          output: msg.output,
+          uuid: msg.uuid,
+          session_id: msg.session_id,
+        },
+        { persistInHistory: false },
+      );
       return;
     }
 
@@ -730,6 +802,32 @@ export class WsBridge {
   }
 
   private handleAssistantMessage(session: Session, msg: CLIAssistantMessage) {
+    // Track per-turn token usage from assistant message for accurate context %
+    const usage = msg.message?.usage;
+    if (usage) {
+      const inputTokens = usage.input_tokens ?? 0;
+      const cacheRead = usage.cache_read_input_tokens ?? 0;
+      const cacheCreation = usage.cache_creation_input_tokens ?? 0;
+      const outputTokens = usage.output_tokens ?? 0;
+      const prev = session.state.claude_token_details;
+      session.state.claude_token_details = {
+        inputTokens,
+        outputTokens,
+        cacheReadInputTokens: cacheRead,
+        cacheCreationInputTokens: cacheCreation,
+        contextWindow: prev?.contextWindow ?? 0,
+        maxOutputTokens: prev?.maxOutputTokens ?? 0,
+      };
+      // Recompute context % if we already know contextWindow
+      const ctxWindow = session.state.claude_token_details.contextWindow;
+      if (ctxWindow > 0) {
+        const pct = Math.round(
+          ((inputTokens + cacheRead + cacheCreation) / ctxWindow) * 100,
+        );
+        session.state.context_used_percent = Math.max(0, Math.min(pct, 100));
+      }
+    }
+
     const browserMsg: BrowserIncomingMessage = {
       type: "assistant",
       message: msg.message,
@@ -754,14 +852,38 @@ export class WsBridge {
       session.state.total_lines_removed = msg.total_lines_removed;
     }
 
-    // Compute context usage from modelUsage
+    // Store contextWindow/maxOutputTokens from modelUsage, then recompute
+    // context % using per-turn data from the assistant message (more accurate).
     if (msg.modelUsage) {
       for (const usage of Object.values(msg.modelUsage)) {
         if (usage.contextWindow > 0) {
-          const pct = Math.round(
-            ((usage.inputTokens + usage.outputTokens) / usage.contextWindow) * 100
-          );
-          session.state.context_used_percent = Math.max(0, Math.min(pct, 100));
+          const prev = session.state.claude_token_details;
+          if (prev) {
+            prev.contextWindow = usage.contextWindow;
+            prev.maxOutputTokens = usage.maxOutputTokens;
+            // Recompute using per-turn tokens (input + cache_read + cache_creation)
+            const pct = Math.round(
+              ((prev.inputTokens +
+                prev.cacheReadInputTokens +
+                prev.cacheCreationInputTokens) /
+                usage.contextWindow) *
+                100,
+            );
+            session.state.context_used_percent = Math.max(
+              0,
+              Math.min(pct, 100),
+            );
+          } else {
+            // No per-turn data yet — fall back to cumulative formula
+            const pct = Math.round(
+              ((usage.inputTokens + usage.outputTokens) / usage.contextWindow) *
+                100,
+            );
+            session.state.context_used_percent = Math.max(
+              0,
+              Math.min(pct, 100),
+            );
+          }
         }
       }
     }
@@ -803,7 +925,10 @@ export class WsBridge {
     });
   }
 
-  private async handleControlRequest(session: Session, msg: CLIControlRequestMessage) {
+  private async handleControlRequest(
+    session: Session,
+    msg: CLIControlRequestMessage,
+  ) {
     if (msg.request.subtype === "can_use_tool") {
       const perm: PermissionRequest = {
         request_id: msg.request_id,
@@ -819,10 +944,10 @@ export class WsBridge {
       // AI Validation Mode: evaluate the tool call before showing to user
       const aiSettings = getEffectiveAiValidation(session.state);
       if (
-        aiSettings.enabled
-        && aiSettings.anthropicApiKey
-        && msg.request.tool_name !== "AskUserQuestion"
-        && msg.request.tool_name !== "ExitPlanMode"
+        aiSettings.enabled &&
+        aiSettings.anthropicApiKey &&
+        msg.request.tool_name !== "AskUserQuestion" &&
+        msg.request.tool_name !== "ExitPlanMode"
       ) {
         try {
           const result = await validatePermission(
@@ -838,17 +963,32 @@ export class WsBridge {
 
           // Auto-approve safe tools
           if (result.verdict === "safe" && aiSettings.autoApprove) {
-            this.autoRespondPermission(session, msg.request_id, perm, "allow", result.reason);
+            this.autoRespondPermission(
+              session,
+              msg.request_id,
+              perm,
+              "allow",
+              result.reason,
+            );
             return;
           }
 
           // Auto-deny dangerous tools
           if (result.verdict === "dangerous" && aiSettings.autoDeny) {
-            this.autoRespondPermission(session, msg.request_id, perm, "deny", result.reason);
+            this.autoRespondPermission(
+              session,
+              msg.request_id,
+              perm,
+              "deny",
+              result.reason,
+            );
             return;
           }
         } catch (err) {
-          console.warn(`[ws-bridge] AI validation error for tool=${msg.request.tool_name} request_id=${msg.request_id} session=${session.id}, falling through to manual:`, err);
+          console.warn(
+            `[ws-bridge] AI validation error for tool=${msg.request.tool_name} request_id=${msg.request_id} session=${session.id}, falling through to manual:`,
+            err,
+          );
         }
       }
 
@@ -899,7 +1039,10 @@ export class WsBridge {
     });
   }
 
-  private handleToolUseSummary(session: Session, msg: CLIToolUseSummaryMessage) {
+  private handleToolUseSummary(
+    session: Session,
+    msg: CLIToolUseSummaryMessage,
+  ) {
     this.broadcastToBrowsers(session, {
       type: "tool_use_summary",
       summary: msg.summary,
@@ -935,14 +1078,19 @@ export class WsBridge {
     }
 
     if (msg.type === "session_ack") {
-      handleSessionAck(session, ws, msg.last_seq, this.persistSession.bind(this));
+      handleSessionAck(
+        session,
+        ws,
+        msg.last_seq,
+        this.persistSession.bind(this),
+      );
       return;
     }
 
     if (
-      WsBridge.IDEMPOTENT_BROWSER_MESSAGE_TYPES.has(msg.type)
-      && "client_msg_id" in msg
-      && msg.client_msg_id
+      WsBridge.IDEMPOTENT_BROWSER_MESSAGE_TYPES.has(msg.type) &&
+      "client_msg_id" in msg &&
+      msg.client_msg_id
     ) {
       if (isDuplicateClientMessage(session, msg.client_msg_id)) {
         return;
@@ -979,7 +1127,9 @@ export class WsBridge {
         // Adapter not yet attached — queue for when it's ready.
         // The adapter itself also queues during init, but this covers
         // the window between session creation and adapter attachment.
-        console.log(`[ws-bridge] Codex adapter not yet attached for session ${session.id}, queuing ${msg.type}`);
+        console.log(
+          `[ws-bridge] Codex adapter not yet attached for session ${session.id}, queuing ${msg.type}`,
+        );
         session.pendingMessages.push(JSON.stringify(msg));
       }
       return;
@@ -1023,20 +1173,33 @@ export class WsBridge {
       case "mcp_get_status":
         handleMcpGetStatus(
           session,
-          (request, onResponse) => sendControlRequest(session, request, this.sendToCLI.bind(this), onResponse),
+          (request, onResponse) =>
+            sendControlRequest(
+              session,
+              request,
+              this.sendToCLI.bind(this),
+              onResponse,
+            ),
           this.broadcastToBrowsers.bind(this),
         );
         break;
 
       case "mcp_toggle":
         handleMcpToggle(
-          (request) => sendControlRequest(session, request, this.sendToCLI.bind(this)),
+          (request) =>
+            sendControlRequest(session, request, this.sendToCLI.bind(this)),
           msg.serverName,
           msg.enabled,
           () =>
             handleMcpGetStatus(
               session,
-              (request, onResponse) => sendControlRequest(session, request, this.sendToCLI.bind(this), onResponse),
+              (request, onResponse) =>
+                sendControlRequest(
+                  session,
+                  request,
+                  this.sendToCLI.bind(this),
+                  onResponse,
+                ),
               this.broadcastToBrowsers.bind(this),
             ),
         );
@@ -1044,12 +1207,19 @@ export class WsBridge {
 
       case "mcp_reconnect":
         handleMcpReconnect(
-          (request) => sendControlRequest(session, request, this.sendToCLI.bind(this)),
+          (request) =>
+            sendControlRequest(session, request, this.sendToCLI.bind(this)),
           msg.serverName,
           () =>
             handleMcpGetStatus(
               session,
-              (request, onResponse) => sendControlRequest(session, request, this.sendToCLI.bind(this), onResponse),
+              (request, onResponse) =>
+                sendControlRequest(
+                  session,
+                  request,
+                  this.sendToCLI.bind(this),
+                  onResponse,
+                ),
               this.broadcastToBrowsers.bind(this),
             ),
         );
@@ -1057,12 +1227,19 @@ export class WsBridge {
 
       case "mcp_set_servers":
         handleMcpSetServers(
-          (request) => sendControlRequest(session, request, this.sendToCLI.bind(this)),
+          (request) =>
+            sendControlRequest(session, request, this.sendToCLI.bind(this)),
           msg.servers,
           () =>
             handleMcpGetStatus(
               session,
-              (request, onResponse) => sendControlRequest(session, request, this.sendToCLI.bind(this), onResponse),
+              (request, onResponse) =>
+                sendControlRequest(
+                  session,
+                  request,
+                  this.sendToCLI.bind(this),
+                  onResponse,
+                ),
               this.broadcastToBrowsers.bind(this),
             ),
         );
@@ -1072,7 +1249,12 @@ export class WsBridge {
 
   private handleUserMessage(
     session: Session,
-    msg: { type: "user_message"; content: string; session_id?: string; images?: { media_type: string; data: string }[] }
+    msg: {
+      type: "user_message";
+      content: string;
+      session_id?: string;
+      images?: { media_type: string; data: string }[];
+    },
   ) {
     // Store user message in history for replay with stable ID for dedup on reconnect
     const ts = Date.now();
@@ -1090,7 +1272,11 @@ export class WsBridge {
       for (const img of msg.images) {
         blocks.push({
           type: "image",
-          source: { type: "base64", media_type: img.media_type, data: img.data },
+          source: {
+            type: "base64",
+            media_type: img.media_type,
+            data: img.data,
+          },
         });
       }
       blocks.push({ type: "text", text: msg.content });
@@ -1115,17 +1301,29 @@ export class WsBridge {
     if (!session.cliSocket) {
       // Queue the message — CLI might still be starting up.
       // Don't record here; the message will be recorded when flushed.
-      console.log(`[ws-bridge] CLI not yet connected for session ${session.id}, queuing message`);
+      console.log(
+        `[ws-bridge] CLI not yet connected for session ${session.id}, queuing message`,
+      );
       session.pendingMessages.push(ndjson);
       return;
     }
     // Record raw outgoing CLI message (only when actually sending, not when queuing)
-    this.recorder?.record(session.id, "out", ndjson, "cli", session.backendType, session.state.cwd);
+    this.recorder?.record(
+      session.id,
+      "out",
+      ndjson,
+      "cli",
+      session.backendType,
+      session.state.cwd,
+    );
     try {
       // NDJSON requires a newline delimiter
       session.cliSocket.send(ndjson + "\n");
     } catch (err) {
-      console.error(`[ws-bridge] Failed to send to CLI for session ${session.id}:`, err);
+      console.error(
+        `[ws-bridge] Failed to send to CLI for session ${session.id}:`,
+        err,
+      );
     }
   }
 
@@ -1138,8 +1336,15 @@ export class WsBridge {
 
   private broadcastToBrowsers(session: Session, msg: BrowserIncomingMessage) {
     // Debug: warn when assistant messages are broadcast to 0 browsers (they may be lost)
-    if (session.browserSockets.size === 0 && (msg.type === "assistant" || msg.type === "stream_event" || msg.type === "result")) {
-      console.log(`[ws-bridge] ⚠ Broadcasting ${msg.type} to 0 browsers for session ${session.id} (stored in history: ${msg.type === "assistant" || msg.type === "result"})`);
+    if (
+      session.browserSockets.size === 0 &&
+      (msg.type === "assistant" ||
+        msg.type === "stream_event" ||
+        msg.type === "result")
+    ) {
+      console.log(
+        `[ws-bridge] ⚠ Broadcasting ${msg.type} to 0 browsers for session ${session.id} (stored in history: ${msg.type === "assistant" || msg.type === "result"})`,
+      );
     }
     const json = JSON.stringify(
       sequenceEvent(
@@ -1151,7 +1356,14 @@ export class WsBridge {
     );
 
     // Record raw outgoing browser message
-    this.recorder?.record(session.id, "out", json, "browser", session.backendType, session.state.cwd);
+    this.recorder?.record(
+      session.id,
+      "out",
+      json,
+      "browser",
+      session.backendType,
+      session.state.cwd,
+    );
 
     for (const ws of session.browserSockets) {
       try {
@@ -1162,7 +1374,10 @@ export class WsBridge {
     }
   }
 
-  private sendToBrowser(ws: ServerWebSocket<SocketData>, msg: BrowserIncomingMessage) {
+  private sendToBrowser(
+    ws: ServerWebSocket<SocketData>,
+    msg: BrowserIncomingMessage,
+  ) {
     try {
       ws.send(JSON.stringify(msg));
     } catch {

--- a/web/src/components/Playground.tsx
+++ b/web/src/components/Playground.tsx
@@ -1,7 +1,13 @@
 import { useState, useEffect, useMemo } from "react";
 import { PermissionBanner } from "./PermissionBanner.js";
 import { MessageBubble } from "./MessageBubble.js";
-import { ToolBlock, getToolIcon, getToolLabel, getPreview, ToolIcon } from "./ToolBlock.js";
+import {
+  ToolBlock,
+  getToolIcon,
+  getToolLabel,
+  getPreview,
+  ToolIcon,
+} from "./ToolBlock.js";
 import { DiffViewer } from "./DiffViewer.js";
 import { useStore } from "../store.js";
 import { navigateToSession, navigateHome } from "../utils/routing.js";
@@ -9,12 +15,28 @@ import { UpdateBanner } from "./UpdateBanner.js";
 import { ClaudeMdEditor } from "./ClaudeMdEditor.js";
 import { ChatView } from "./ChatView.js";
 import { api } from "../api.js";
-import type { PermissionRequest, ChatMessage, ContentBlock, SessionState, McpServerDetail } from "../types.js";
+import type {
+  PermissionRequest,
+  ChatMessage,
+  ContentBlock,
+  SessionState,
+  McpServerDetail,
+} from "../types.js";
 import { AiValidationBadge } from "./AiValidationBadge.js";
 import { AiValidationToggle } from "./AiValidationToggle.js";
 import type { TaskItem } from "../types.js";
-import type { UpdateInfo, GitHubPRInfo, LinearIssue, LinearComment } from "../api.js";
-import { GitHubPRDisplay, CodexRateLimitsSection, CodexTokenDetailsSection } from "./TaskPanel.js";
+import type {
+  UpdateInfo,
+  GitHubPRInfo,
+  LinearIssue,
+  LinearComment,
+} from "../api.js";
+import {
+  GitHubPRDisplay,
+  ClaudeContextSection,
+  CodexRateLimitsSection,
+  CodexTokenDetailsSection,
+} from "./TaskPanel.js";
 import { LinearLogo } from "./LinearLogo.js";
 import { SessionCreationProgress } from "./SessionCreationProgress.js";
 import { SessionLaunchOverlay } from "./SessionLaunchOverlay.js";
@@ -27,7 +49,12 @@ import type { SessionItem as SessionItemType } from "../utils/project-grouping.j
 
 const MOCK_SESSION_ID = "playground-session";
 
-function mockPermission(overrides: Partial<PermissionRequest> & { tool_name: string; input: Record<string, unknown> }): PermissionRequest {
+function mockPermission(
+  overrides: Partial<PermissionRequest> & {
+    tool_name: string;
+    input: Record<string, unknown>;
+  },
+): PermissionRequest {
   return {
     request_id: `perm-${Math.random().toString(36).slice(2, 8)}`,
     tool_use_id: `tu-${Math.random().toString(36).slice(2, 8)}`,
@@ -45,13 +72,23 @@ const PERM_BASH = mockPermission({
   permission_suggestions: [
     {
       type: "addRules" as const,
-      rules: [{ toolName: "Bash", ruleContent: "git log --oneline -20 && npm run build" }],
+      rules: [
+        {
+          toolName: "Bash",
+          ruleContent: "git log --oneline -20 && npm run build",
+        },
+      ],
       behavior: "allow" as const,
       destination: "session" as const,
     },
     {
       type: "addRules" as const,
-      rules: [{ toolName: "Bash", ruleContent: "git log --oneline -20 && npm run build" }],
+      rules: [
+        {
+          toolName: "Bash",
+          ruleContent: "git log --oneline -20 && npm run build",
+        },
+      ],
       behavior: "allow" as const,
       destination: "projectSettings" as const,
     },
@@ -62,8 +99,10 @@ const PERM_EDIT = mockPermission({
   tool_name: "Edit",
   input: {
     file_path: "/Users/stan/Dev/project/src/utils/format.ts",
-    old_string: 'export function formatDate(d: Date) {\n  return d.toISOString();\n}',
-    new_string: 'export function formatDate(d: Date, locale = "en-US") {\n  return d.toLocaleDateString(locale, {\n    year: "numeric",\n    month: "short",\n    day: "numeric",\n  });\n}',
+    old_string:
+      "export function formatDate(d: Date) {\n  return d.toISOString();\n}",
+    new_string:
+      'export function formatDate(d: Date, locale = "en-US") {\n  return d.toLocaleDateString(locale, {\n    year: "numeric",\n    month: "short",\n    day: "numeric",\n  });\n}',
   },
   permission_suggestions: [
     {
@@ -79,7 +118,8 @@ const PERM_WRITE = mockPermission({
   tool_name: "Write",
   input: {
     file_path: "/Users/stan/Dev/project/src/config.ts",
-    content: 'export const config = {\n  apiUrl: "https://api.example.com",\n  timeout: 5000,\n  retries: 3,\n  debug: process.env.NODE_ENV !== "production",\n};\n',
+    content:
+      'export const config = {\n  apiUrl: "https://api.example.com",\n  timeout: 5000,\n  retries: 3,\n  debug: process.env.NODE_ENV !== "production",\n};\n',
   },
 });
 
@@ -109,7 +149,11 @@ const PERM_GLOB = mockPermission({
 
 const PERM_GREP = mockPermission({
   tool_name: "Grep",
-  input: { pattern: "TODO|FIXME|HACK", path: "/Users/stan/Dev/project/src", glob: "*.ts" },
+  input: {
+    pattern: "TODO|FIXME|HACK",
+    path: "/Users/stan/Dev/project/src",
+    glob: "*.ts",
+  },
 });
 
 const PERM_EXIT_PLAN = mockPermission({
@@ -125,7 +169,10 @@ const PERM_EXIT_PLAN = mockPermission({
 
 const PERM_GENERIC = mockPermission({
   tool_name: "WebSearch",
-  input: { query: "TypeScript 5.5 new features", allowed_domains: ["typescriptlang.org", "github.com"] },
+  input: {
+    query: "TypeScript 5.5 new features",
+    allowed_domains: ["typescriptlang.org", "github.com"],
+  },
   description: "Search the web for TypeScript 5.5 features",
 });
 
@@ -139,21 +186,33 @@ const PERM_DYNAMIC = mockPermission({
 const PERM_AI_UNCERTAIN = mockPermission({
   tool_name: "Bash",
   input: { command: "npm install --save-dev @types/react" },
-  ai_validation: { verdict: "uncertain", reason: "Package installation modifies node_modules", ruleBasedOnly: false },
+  ai_validation: {
+    verdict: "uncertain",
+    reason: "Package installation modifies node_modules",
+    ruleBasedOnly: false,
+  },
 });
 
 // AI Validation mock: safe recommendation (shown when auto-approve is off)
 const PERM_AI_SAFE = mockPermission({
   tool_name: "Bash",
   input: { command: "git status" },
-  ai_validation: { verdict: "safe", reason: "Read-only git command", ruleBasedOnly: false },
+  ai_validation: {
+    verdict: "safe",
+    reason: "Read-only git command",
+    ruleBasedOnly: false,
+  },
 });
 
 // AI Validation mock: dangerous recommendation (shown when auto-deny is off)
 const PERM_AI_DANGEROUS = mockPermission({
   tool_name: "Bash",
   input: { command: "rm -rf node_modules && rm -rf .git" },
-  ai_validation: { verdict: "dangerous", reason: "Recursive delete of project files", ruleBasedOnly: false },
+  ai_validation: {
+    verdict: "dangerous",
+    reason: "Recursive delete of project files",
+    ruleBasedOnly: false,
+  },
 });
 
 const PERM_ASK_SINGLE = mockPermission({
@@ -164,9 +223,19 @@ const PERM_ASK_SINGLE = mockPermission({
         header: "Auth method",
         question: "Which authentication method should we use for the API?",
         options: [
-          { label: "JWT tokens (Recommended)", description: "Stateless, scalable, works well with microservices" },
-          { label: "Session cookies", description: "Traditional approach, simpler but requires session storage" },
-          { label: "OAuth 2.0", description: "Delegated auth, best for third-party integrations" },
+          {
+            label: "JWT tokens (Recommended)",
+            description: "Stateless, scalable, works well with microservices",
+          },
+          {
+            label: "Session cookies",
+            description:
+              "Traditional approach, simpler but requires session storage",
+          },
+          {
+            label: "OAuth 2.0",
+            description: "Delegated auth, best for third-party integrations",
+          },
         ],
         multiSelect: false,
       },
@@ -182,7 +251,10 @@ const PERM_ASK_MULTI = mockPermission({
         header: "Database",
         question: "Which database should we use?",
         options: [
-          { label: "PostgreSQL", description: "Relational, strong consistency" },
+          {
+            label: "PostgreSQL",
+            description: "Relational, strong consistency",
+          },
           { label: "MongoDB", description: "Document store, flexible schema" },
         ],
         multiSelect: false,
@@ -204,7 +276,8 @@ const PERM_ASK_MULTI = mockPermission({
 const MSG_USER: ChatMessage = {
   id: "msg-1",
   role: "user",
-  content: "Can you help me refactor the authentication module to use JWT tokens?",
+  content:
+    "Can you help me refactor the authentication module to use JWT tokens?",
   timestamp: Date.now() - 60000,
 };
 
@@ -260,9 +333,13 @@ const MSG_ASSISTANT_TOOLS: ChatMessage = {
     {
       type: "tool_result",
       tool_use_id: "tu-2",
-      content: 'export function authMiddleware(req, res, next) {\n  if (!req.session.userId) {\n    return res.status(401).json({ error: "Unauthorized" });\n  }\n  next();\n}',
+      content:
+        'export function authMiddleware(req, res, next) {\n  if (!req.session.userId) {\n    return res.status(401).json({ error: "Unauthorized" });\n  }\n  next();\n}',
     },
-    { type: "text", text: "Now I understand the current structure. Let me create the JWT utility." },
+    {
+      type: "text",
+      text: "Now I understand the current structure. Let me create the JWT utility.",
+    },
   ],
   timestamp: Date.now() - 45000,
 };
@@ -274,9 +351,13 @@ const MSG_ASSISTANT_THINKING: ChatMessage = {
   contentBlocks: [
     {
       type: "thinking",
-      thinking: "Let me think about the best approach here. The user wants to migrate from session cookies to JWT. I need to:\n1. Create a JWT sign/verify utility\n2. Update the middleware to read Authorization header\n3. Change the login endpoint to return a token\n4. Update all tests\n\nI should use jsonwebtoken package for signing and jose for verification in edge environments. But since this is a Node.js server, jsonwebtoken is fine.\n\nThe token should contain: userId, role, iat, exp. Expiry should be configurable. I'll also add a refresh token mechanism.",
+      thinking:
+        "Let me think about the best approach here. The user wants to migrate from session cookies to JWT. I need to:\n1. Create a JWT sign/verify utility\n2. Update the middleware to read Authorization header\n3. Change the login endpoint to return a token\n4. Update all tests\n\nI should use jsonwebtoken package for signing and jose for verification in edge environments. But since this is a Node.js server, jsonwebtoken is fine.\n\nThe token should contain: userId, role, iat, exp. Expiry should be configurable. I'll also add a refresh token mechanism.",
     },
-    { type: "text", text: "I've analyzed the codebase and have a clear plan. Let me start implementing." },
+    {
+      type: "text",
+      text: "I've analyzed the codebase and have a clear plan. Let me start implementing.",
+    },
   ],
   timestamp: Date.now() - 40000,
 };
@@ -312,7 +393,8 @@ const MSG_TOOL_ERROR: ChatMessage = {
     {
       type: "tool_result",
       tool_use_id: "tu-3",
-      content: "FAIL src/auth/__tests__/middleware.test.ts\n  ● Auth Middleware › should reject expired tokens\n    Expected: 401\n    Received: 500\n\n    TypeError: Cannot read property 'verify' of undefined",
+      content:
+        "FAIL src/auth/__tests__/middleware.test.ts\n  ● Auth Middleware › should reject expired tokens\n    Expected: 401\n    Received: 500\n\n    TypeError: Cannot read property 'verify' of undefined",
       is_error: true,
     },
     { type: "text", text: "There's a test failure. Let me fix the issue." },
@@ -322,12 +404,46 @@ const MSG_TOOL_ERROR: ChatMessage = {
 
 // Tasks
 const MOCK_TASKS: TaskItem[] = [
-  { id: "1", subject: "Create JWT utility module", description: "", status: "completed" },
-  { id: "2", subject: "Update auth middleware", description: "", status: "completed", activeForm: "Updating auth middleware" },
-  { id: "3", subject: "Migrate login endpoint", description: "", status: "in_progress", activeForm: "Refactoring login to return JWT" },
-  { id: "4", subject: "Add refresh token support", description: "", status: "pending" },
-  { id: "5", subject: "Update all auth tests", description: "", status: "pending", blockedBy: ["3"] },
-  { id: "6", subject: "Run full test suite and fix failures", description: "", status: "pending", blockedBy: ["5"] },
+  {
+    id: "1",
+    subject: "Create JWT utility module",
+    description: "",
+    status: "completed",
+  },
+  {
+    id: "2",
+    subject: "Update auth middleware",
+    description: "",
+    status: "completed",
+    activeForm: "Updating auth middleware",
+  },
+  {
+    id: "3",
+    subject: "Migrate login endpoint",
+    description: "",
+    status: "in_progress",
+    activeForm: "Refactoring login to return JWT",
+  },
+  {
+    id: "4",
+    subject: "Add refresh token support",
+    description: "",
+    status: "pending",
+  },
+  {
+    id: "5",
+    subject: "Update all auth tests",
+    description: "",
+    status: "pending",
+    blockedBy: ["3"],
+  },
+  {
+    id: "6",
+    subject: "Run full test suite and fix failures",
+    description: "",
+    status: "pending",
+    blockedBy: ["5"],
+  },
 ];
 
 // Tool group items (for ToolMessageGroup mock)
@@ -340,7 +456,11 @@ const MOCK_TOOL_GROUP_ITEMS = [
 
 const MOCK_SUBAGENT_TOOL_ITEMS = [
   { id: "sa-1", name: "Grep", input: { pattern: "useAuth", path: "src/" } },
-  { id: "sa-2", name: "Grep", input: { pattern: "session.userId", path: "src/" } },
+  {
+    id: "sa-2",
+    name: "Grep",
+    input: { pattern: "session.userId", path: "src/" },
+  },
 ];
 
 // GitHub PR mock data
@@ -423,7 +543,11 @@ const MOCK_MCP_SERVERS: McpServerDetail[] = [
   {
     name: "filesystem",
     status: "connected",
-    config: { type: "stdio", command: "npx", args: ["-y", "@anthropic/mcp-fs"] },
+    config: {
+      type: "stdio",
+      command: "npx",
+      args: ["-y", "@anthropic/mcp-fs"],
+    },
     scope: "project",
     tools: [
       { name: "read_file", annotations: { readOnly: true } },
@@ -434,7 +558,11 @@ const MOCK_MCP_SERVERS: McpServerDetail[] = [
   {
     name: "github",
     status: "connected",
-    config: { type: "stdio", command: "npx", args: ["-y", "@anthropic/mcp-github"] },
+    config: {
+      type: "stdio",
+      command: "npx",
+      args: ["-y", "@anthropic/mcp-github"],
+    },
     scope: "user",
     tools: [
       { name: "create_issue" },
@@ -446,7 +574,11 @@ const MOCK_MCP_SERVERS: McpServerDetail[] = [
     name: "postgres",
     status: "failed",
     error: "Connection refused: ECONNREFUSED 127.0.0.1:5432",
-    config: { type: "stdio", command: "npx", args: ["-y", "@anthropic/mcp-postgres"] },
+    config: {
+      type: "stdio",
+      command: "npx",
+      args: ["-y", "@anthropic/mcp-postgres"],
+    },
     scope: "project",
     tools: [],
   },
@@ -455,7 +587,9 @@ const MOCK_MCP_SERVERS: McpServerDetail[] = [
     status: "disabled",
     config: { type: "sse", url: "http://localhost:8080/sse" },
     scope: "user",
-    tools: [{ name: "search", annotations: { readOnly: true, openWorld: true } }],
+    tools: [
+      { name: "search", annotations: { readOnly: true, openWorld: true } },
+    ],
   },
   {
     name: "docker",
@@ -470,7 +604,8 @@ const MOCK_MCP_SERVERS: McpServerDetail[] = [
 const MOCK_LINEAR_ISSUE_ACTIVE: LinearIssue = {
   id: "issue-1",
   identifier: "THE-147",
-  title: "Associer un ticket Linear a une session dans le panneau lateral droit",
+  title:
+    "Associer un ticket Linear a une session dans le panneau lateral droit",
   description: "Pouvoir associer un ticket Linear a une session.",
   url: "https://linear.app/thevibecompany/issue/THE-147",
   branchName: "the-147-associer-un-ticket-linear",
@@ -498,16 +633,31 @@ const MOCK_LINEAR_ISSUE_DONE: LinearIssue = {
 };
 
 const MOCK_LINEAR_COMMENTS: LinearComment[] = [
-  { id: "c1", body: "Started working on the sidebar integration", createdAt: new Date(Date.now() - 3600_000).toISOString(), userName: "Alice" },
-  { id: "c2", body: "Added the search component, LGTM", createdAt: new Date(Date.now() - 1800_000).toISOString(), userName: "Bob" },
-  { id: "c3", body: "Testing the polling flow now", createdAt: new Date(Date.now() - 300_000).toISOString(), userName: "Alice" },
+  {
+    id: "c1",
+    body: "Started working on the sidebar integration",
+    createdAt: new Date(Date.now() - 3600_000).toISOString(),
+    userName: "Alice",
+  },
+  {
+    id: "c2",
+    body: "Added the search component, LGTM",
+    createdAt: new Date(Date.now() - 1800_000).toISOString(),
+    userName: "Bob",
+  },
+  {
+    id: "c3",
+    body: "Testing the polling flow now",
+    createdAt: new Date(Date.now() - 300_000).toISOString(),
+    userName: "Alice",
+  },
 ];
 
 // ─── Playground Component ───────────────────────────────────────────────────
 
 export function Playground() {
-  const [darkMode, setDarkMode] = useState(
-    () => document.documentElement.classList.contains("dark")
+  const [darkMode, setDarkMode] = useState(() =>
+    document.documentElement.classList.contains("dark"),
   );
 
   useEffect(() => {
@@ -527,7 +677,8 @@ export function Playground() {
     const prevStatus = snapshot.sessionStatus.get(sessionId);
     const prevStreaming = snapshot.streaming.get(sessionId);
     const prevStreamingStartedAt = snapshot.streamingStartedAt.get(sessionId);
-    const prevStreamingOutputTokens = snapshot.streamingOutputTokens.get(sessionId);
+    const prevStreamingOutputTokens =
+      snapshot.streamingOutputTokens.get(sessionId);
 
     const session: SessionState = {
       session_id: sessionId,
@@ -559,16 +710,26 @@ export function Playground() {
     store.setConnectionStatus(sessionId, "connected");
     store.setCliConnected(sessionId, true);
     store.setSessionStatus(sessionId, "running");
-    const streamingText = "I'm updating tests and then I'll run the full suite.";
+    const streamingText =
+      "I'm updating tests and then I'll run the full suite.";
     store.setMessages(sessionId, [
       MSG_USER,
       MSG_ASSISTANT,
       MSG_ASSISTANT_TOOLS,
       MSG_TOOL_ERROR,
-      { id: "stream-draft", role: "assistant", content: streamingText, timestamp: Date.now(), isStreaming: true },
+      {
+        id: "stream-draft",
+        role: "assistant",
+        content: streamingText,
+        timestamp: Date.now(),
+        isStreaming: true,
+      },
     ]);
     store.setStreaming(sessionId, streamingText);
-    store.setStreamingStats(sessionId, { startedAt: Date.now() - 12000, outputTokens: 1200 });
+    store.setStreamingStats(sessionId, {
+      startedAt: Date.now() - 12000,
+      outputTokens: 1200,
+    });
     store.addPermission(sessionId, PERM_BASH);
     store.addPermission(sessionId, PERM_DYNAMIC);
 
@@ -584,15 +745,27 @@ export function Playground() {
         const streamingStartedAt = new Map(s.streamingStartedAt);
         const streamingOutputTokens = new Map(s.streamingOutputTokens);
 
-        if (prevSession) sessions.set(sessionId, prevSession); else sessions.delete(sessionId);
-        if (prevMessages) messages.set(sessionId, prevMessages); else messages.delete(sessionId);
-        if (prevPerms) pendingPermissions.set(sessionId, prevPerms); else pendingPermissions.delete(sessionId);
-        if (prevConn) connectionStatus.set(sessionId, prevConn); else connectionStatus.delete(sessionId);
-        if (typeof prevCli === "boolean") cliConnected.set(sessionId, prevCli); else cliConnected.delete(sessionId);
-        if (prevStatus) sessionStatus.set(sessionId, prevStatus); else sessionStatus.delete(sessionId);
-        if (typeof prevStreaming === "string") streaming.set(sessionId, prevStreaming); else streaming.delete(sessionId);
-        if (typeof prevStreamingStartedAt === "number") streamingStartedAt.set(sessionId, prevStreamingStartedAt); else streamingStartedAt.delete(sessionId);
-        if (typeof prevStreamingOutputTokens === "number") streamingOutputTokens.set(sessionId, prevStreamingOutputTokens); else streamingOutputTokens.delete(sessionId);
+        if (prevSession) sessions.set(sessionId, prevSession);
+        else sessions.delete(sessionId);
+        if (prevMessages) messages.set(sessionId, prevMessages);
+        else messages.delete(sessionId);
+        if (prevPerms) pendingPermissions.set(sessionId, prevPerms);
+        else pendingPermissions.delete(sessionId);
+        if (prevConn) connectionStatus.set(sessionId, prevConn);
+        else connectionStatus.delete(sessionId);
+        if (typeof prevCli === "boolean") cliConnected.set(sessionId, prevCli);
+        else cliConnected.delete(sessionId);
+        if (prevStatus) sessionStatus.set(sessionId, prevStatus);
+        else sessionStatus.delete(sessionId);
+        if (typeof prevStreaming === "string")
+          streaming.set(sessionId, prevStreaming);
+        else streaming.delete(sessionId);
+        if (typeof prevStreamingStartedAt === "number")
+          streamingStartedAt.set(sessionId, prevStreamingStartedAt);
+        else streamingStartedAt.delete(sessionId);
+        if (typeof prevStreamingOutputTokens === "number")
+          streamingOutputTokens.set(sessionId, prevStreamingOutputTokens);
+        else streamingOutputTokens.delete(sessionId);
 
         return {
           sessions,
@@ -615,8 +788,12 @@ export function Playground() {
       <header className="sticky top-0 z-50 bg-cc-sidebar border-b border-cc-border">
         <div className="max-w-5xl mx-auto px-6 py-4 flex items-center justify-between">
           <div>
-            <h1 className="text-lg font-semibold text-cc-fg tracking-tight">Component Playground</h1>
-            <p className="text-xs text-cc-muted mt-0.5">Visual catalog of all UI components</p>
+            <h1 className="text-lg font-semibold text-cc-fg tracking-tight">
+              Component Playground
+            </h1>
+            <p className="text-xs text-cc-muted mt-0.5">
+              Visual catalog of all UI components
+            </p>
           </div>
           <div className="flex items-center gap-3">
             <button
@@ -644,56 +821,116 @@ export function Playground() {
 
       <div className="max-w-5xl mx-auto px-6 py-8 space-y-12">
         {/* ─── Permission Banners ──────────────────────────────── */}
-        <Section title="Permission Banners" description="Tool approval requests shown above the composer">
+        <Section
+          title="Permission Banners"
+          description="Tool approval requests shown above the composer"
+        >
           <div className="border border-cc-border rounded-xl overflow-hidden bg-cc-card divide-y divide-cc-border">
-            <PermissionBanner permission={PERM_BASH} sessionId={MOCK_SESSION_ID} />
-            <PermissionBanner permission={PERM_EDIT} sessionId={MOCK_SESSION_ID} />
-            <PermissionBanner permission={PERM_WRITE} sessionId={MOCK_SESSION_ID} />
-            <PermissionBanner permission={PERM_READ} sessionId={MOCK_SESSION_ID} />
-            <PermissionBanner permission={PERM_GLOB} sessionId={MOCK_SESSION_ID} />
-            <PermissionBanner permission={PERM_GREP} sessionId={MOCK_SESSION_ID} />
-            <PermissionBanner permission={PERM_GENERIC} sessionId={MOCK_SESSION_ID} />
-            <PermissionBanner permission={PERM_DYNAMIC} sessionId={MOCK_SESSION_ID} />
+            <PermissionBanner
+              permission={PERM_BASH}
+              sessionId={MOCK_SESSION_ID}
+            />
+            <PermissionBanner
+              permission={PERM_EDIT}
+              sessionId={MOCK_SESSION_ID}
+            />
+            <PermissionBanner
+              permission={PERM_WRITE}
+              sessionId={MOCK_SESSION_ID}
+            />
+            <PermissionBanner
+              permission={PERM_READ}
+              sessionId={MOCK_SESSION_ID}
+            />
+            <PermissionBanner
+              permission={PERM_GLOB}
+              sessionId={MOCK_SESSION_ID}
+            />
+            <PermissionBanner
+              permission={PERM_GREP}
+              sessionId={MOCK_SESSION_ID}
+            />
+            <PermissionBanner
+              permission={PERM_GENERIC}
+              sessionId={MOCK_SESSION_ID}
+            />
+            <PermissionBanner
+              permission={PERM_DYNAMIC}
+              sessionId={MOCK_SESSION_ID}
+            />
           </div>
         </Section>
 
         {/* ─── Real Chat Stack ──────────────────────────────── */}
-        <Section title="Real Chat Stack" description="Integrated ChatView using real MessageFeed + PermissionBanner + Composer components">
-          <div data-testid="playground-real-chat-stack" className="max-w-3xl border border-cc-border rounded-xl overflow-hidden bg-cc-card h-[620px]">
+        <Section
+          title="Real Chat Stack"
+          description="Integrated ChatView using real MessageFeed + PermissionBanner + Composer components"
+        >
+          <div
+            data-testid="playground-real-chat-stack"
+            className="max-w-3xl border border-cc-border rounded-xl overflow-hidden bg-cc-card h-[620px]"
+          >
             <ChatView sessionId={MOCK_SESSION_ID} />
           </div>
         </Section>
 
         {/* ─── ExitPlanMode (the fix) ──────────────────────────── */}
-        <Section title="ExitPlanMode" description="Plan approval request — previously rendered as raw JSON, now shows formatted markdown">
+        <Section
+          title="ExitPlanMode"
+          description="Plan approval request — previously rendered as raw JSON, now shows formatted markdown"
+        >
           <div className="border border-cc-border rounded-xl overflow-hidden bg-cc-card">
-            <PermissionBanner permission={PERM_EXIT_PLAN} sessionId={MOCK_SESSION_ID} />
+            <PermissionBanner
+              permission={PERM_EXIT_PLAN}
+              sessionId={MOCK_SESSION_ID}
+            />
           </div>
         </Section>
 
         {/* ─── AskUserQuestion ──────────────────────────────── */}
-        <Section title="AskUserQuestion" description="Interactive questions with selectable options">
+        <Section
+          title="AskUserQuestion"
+          description="Interactive questions with selectable options"
+        >
           <div className="space-y-4">
             <Card label="Single question">
-              <PermissionBanner permission={PERM_ASK_SINGLE} sessionId={MOCK_SESSION_ID} />
+              <PermissionBanner
+                permission={PERM_ASK_SINGLE}
+                sessionId={MOCK_SESSION_ID}
+              />
             </Card>
             <Card label="Multi-question">
-              <PermissionBanner permission={PERM_ASK_MULTI} sessionId={MOCK_SESSION_ID} />
+              <PermissionBanner
+                permission={PERM_ASK_MULTI}
+                sessionId={MOCK_SESSION_ID}
+              />
             </Card>
           </div>
         </Section>
 
         {/* ─── AI Validation ──────────────────────────────── */}
-        <Section title="AI Validation" description="AI-powered permission validation badges and recommendations">
+        <Section
+          title="AI Validation"
+          description="AI-powered permission validation badges and recommendations"
+        >
           <div className="space-y-4">
             <Card label="Permission with AI recommendation (uncertain)">
-              <PermissionBanner permission={PERM_AI_UNCERTAIN} sessionId={MOCK_SESSION_ID} />
+              <PermissionBanner
+                permission={PERM_AI_UNCERTAIN}
+                sessionId={MOCK_SESSION_ID}
+              />
             </Card>
             <Card label="Permission with AI recommendation (safe)">
-              <PermissionBanner permission={PERM_AI_SAFE} sessionId={MOCK_SESSION_ID} />
+              <PermissionBanner
+                permission={PERM_AI_SAFE}
+                sessionId={MOCK_SESSION_ID}
+              />
             </Card>
             <Card label="Permission with AI recommendation (dangerous)">
-              <PermissionBanner permission={PERM_AI_DANGEROUS} sessionId={MOCK_SESSION_ID} />
+              <PermissionBanner
+                permission={PERM_AI_DANGEROUS}
+                sessionId={MOCK_SESSION_ID}
+              />
             </Card>
             <Card label="Per-session toggle (disabled)">
               <PlaygroundAiValidationToggle enabled={false} />
@@ -703,31 +940,49 @@ export function Playground() {
             </Card>
             <Card label="Auto-resolved badges">
               <div className="border border-cc-border rounded-xl overflow-hidden bg-cc-card divide-y divide-cc-border">
-                <AiValidationBadge entry={{
-                  request: mockPermission({ tool_name: "Read", input: { file_path: "/src/index.ts" } }),
-                  behavior: "allow",
-                  reason: "Read is a read-only tool",
-                  timestamp: Date.now(),
-                }} />
-                <AiValidationBadge entry={{
-                  request: mockPermission({ tool_name: "Bash", input: { command: "rm -rf /" } }),
-                  behavior: "deny",
-                  reason: "Recursive delete of root directory",
-                  timestamp: Date.now(),
-                }} />
-                <AiValidationBadge entry={{
-                  request: mockPermission({ tool_name: "Grep", input: { pattern: "TODO", path: "/src" } }),
-                  behavior: "allow",
-                  reason: "Grep is a read-only tool",
-                  timestamp: Date.now(),
-                }} />
+                <AiValidationBadge
+                  entry={{
+                    request: mockPermission({
+                      tool_name: "Read",
+                      input: { file_path: "/src/index.ts" },
+                    }),
+                    behavior: "allow",
+                    reason: "Read is a read-only tool",
+                    timestamp: Date.now(),
+                  }}
+                />
+                <AiValidationBadge
+                  entry={{
+                    request: mockPermission({
+                      tool_name: "Bash",
+                      input: { command: "rm -rf /" },
+                    }),
+                    behavior: "deny",
+                    reason: "Recursive delete of root directory",
+                    timestamp: Date.now(),
+                  }}
+                />
+                <AiValidationBadge
+                  entry={{
+                    request: mockPermission({
+                      tool_name: "Grep",
+                      input: { pattern: "TODO", path: "/src" },
+                    }),
+                    behavior: "allow",
+                    reason: "Grep is a read-only tool",
+                    timestamp: Date.now(),
+                  }}
+                />
               </div>
             </Card>
           </div>
         </Section>
 
         {/* ─── Messages ──────────────────────────────── */}
-        <Section title="Messages" description="Chat message bubbles for all roles">
+        <Section
+          title="Messages"
+          description="Chat message bubbles for all roles"
+        >
           <div className="space-y-4 max-w-3xl">
             <Card label="User message">
               <MessageBubble message={MSG_USER} />
@@ -757,41 +1012,165 @@ export function Playground() {
         </Section>
 
         {/* ─── Tool Blocks (standalone) ──────────────────────── */}
-        <Section title="Tool Blocks" description="Expandable tool call visualization">
+        <Section
+          title="Tool Blocks"
+          description="Expandable tool call visualization"
+        >
           <div className="space-y-2 max-w-3xl">
-            <ToolBlock name="Bash" input={{ command: "git status && npm run lint", description: "Check git status and lint" }} toolUseId="tb-1" />
-            <ToolBlock name="Read" input={{ file_path: "/Users/stan/Dev/project/src/index.ts", offset: 10, limit: 50 }} toolUseId="tb-2" />
-            <ToolBlock name="Edit" input={{ file_path: "src/utils.ts", old_string: "const x = 1;", new_string: "const x = 2;", replace_all: true }} toolUseId="tb-3" />
+            <ToolBlock
+              name="Bash"
+              input={{
+                command: "git status && npm run lint",
+                description: "Check git status and lint",
+              }}
+              toolUseId="tb-1"
+            />
+            <ToolBlock
+              name="Read"
+              input={{
+                file_path: "/Users/stan/Dev/project/src/index.ts",
+                offset: 10,
+                limit: 50,
+              }}
+              toolUseId="tb-2"
+            />
+            <ToolBlock
+              name="Edit"
+              input={{
+                file_path: "src/utils.ts",
+                old_string: "const x = 1;",
+                new_string: "const x = 2;",
+                replace_all: true,
+              }}
+              toolUseId="tb-3"
+            />
             <ToolBlock
               name="Edit"
               input={{
                 file_path: "/Users/stan/Dev/project/src/store.ts",
                 changes: [
-                  { path: "/Users/stan/Dev/project/src/store.ts", kind: "update" },
+                  {
+                    path: "/Users/stan/Dev/project/src/store.ts",
+                    kind: "update",
+                  },
                   { path: "/Users/stan/Dev/project/src/ws.ts", kind: "update" },
                 ],
               }}
               toolUseId="tb-3b"
             />
-            <ToolBlock name="Write" input={{ file_path: "src/new-file.ts", content: 'export const hello = "world";\n' }} toolUseId="tb-4" />
-            <ToolBlock name="Glob" input={{ pattern: "**/*.tsx", path: "/Users/stan/Dev/project/src" }} toolUseId="tb-5" />
-            <ToolBlock name="Grep" input={{ pattern: "useEffect", path: "src/", glob: "*.tsx", output_mode: "content", context: 3, head_limit: 20 }} toolUseId="tb-6" />
-            <ToolBlock name="WebSearch" input={{ query: "React 19 new features", allowed_domains: ["react.dev", "github.com"] }} toolUseId="tb-7" />
-            <ToolBlock name="WebFetch" input={{ url: "https://react.dev/blog/2024/12/05/react-19", prompt: "Summarize the key changes in React 19" }} toolUseId="tb-8" />
-            <ToolBlock name="Task" input={{ description: "Search for auth patterns", subagent_type: "Explore", prompt: "Find all files related to authentication and authorization in the codebase. Look for middleware, guards, and token handling." }} toolUseId="tb-9" />
-            <ToolBlock name="TodoWrite" input={{ todos: [
-              { content: "Create JWT utility module", status: "completed", activeForm: "Creating JWT module" },
-              { content: "Update auth middleware", status: "in_progress", activeForm: "Updating middleware" },
-              { content: "Migrate login endpoint", status: "pending", activeForm: "Migrating login" },
-              { content: "Run full test suite", status: "pending", activeForm: "Running tests" },
-            ]}} toolUseId="tb-10" />
-            <ToolBlock name="NotebookEdit" input={{ notebook_path: "/Users/stan/Dev/project/analysis.ipynb", cell_type: "code", edit_mode: "replace", cell_number: 3, new_source: "import pandas as pd\ndf = pd.read_csv('data.csv')\ndf.describe()" }} toolUseId="tb-11" />
-            <ToolBlock name="SendMessage" input={{ type: "message", recipient: "researcher", content: "Please investigate the auth module structure and report back.", summary: "Requesting auth module investigation" }} toolUseId="tb-12" />
+            <ToolBlock
+              name="Write"
+              input={{
+                file_path: "src/new-file.ts",
+                content: 'export const hello = "world";\n',
+              }}
+              toolUseId="tb-4"
+            />
+            <ToolBlock
+              name="Glob"
+              input={{
+                pattern: "**/*.tsx",
+                path: "/Users/stan/Dev/project/src",
+              }}
+              toolUseId="tb-5"
+            />
+            <ToolBlock
+              name="Grep"
+              input={{
+                pattern: "useEffect",
+                path: "src/",
+                glob: "*.tsx",
+                output_mode: "content",
+                context: 3,
+                head_limit: 20,
+              }}
+              toolUseId="tb-6"
+            />
+            <ToolBlock
+              name="WebSearch"
+              input={{
+                query: "React 19 new features",
+                allowed_domains: ["react.dev", "github.com"],
+              }}
+              toolUseId="tb-7"
+            />
+            <ToolBlock
+              name="WebFetch"
+              input={{
+                url: "https://react.dev/blog/2024/12/05/react-19",
+                prompt: "Summarize the key changes in React 19",
+              }}
+              toolUseId="tb-8"
+            />
+            <ToolBlock
+              name="Task"
+              input={{
+                description: "Search for auth patterns",
+                subagent_type: "Explore",
+                prompt:
+                  "Find all files related to authentication and authorization in the codebase. Look for middleware, guards, and token handling.",
+              }}
+              toolUseId="tb-9"
+            />
+            <ToolBlock
+              name="TodoWrite"
+              input={{
+                todos: [
+                  {
+                    content: "Create JWT utility module",
+                    status: "completed",
+                    activeForm: "Creating JWT module",
+                  },
+                  {
+                    content: "Update auth middleware",
+                    status: "in_progress",
+                    activeForm: "Updating middleware",
+                  },
+                  {
+                    content: "Migrate login endpoint",
+                    status: "pending",
+                    activeForm: "Migrating login",
+                  },
+                  {
+                    content: "Run full test suite",
+                    status: "pending",
+                    activeForm: "Running tests",
+                  },
+                ],
+              }}
+              toolUseId="tb-10"
+            />
+            <ToolBlock
+              name="NotebookEdit"
+              input={{
+                notebook_path: "/Users/stan/Dev/project/analysis.ipynb",
+                cell_type: "code",
+                edit_mode: "replace",
+                cell_number: 3,
+                new_source:
+                  "import pandas as pd\ndf = pd.read_csv('data.csv')\ndf.describe()",
+              }}
+              toolUseId="tb-11"
+            />
+            <ToolBlock
+              name="SendMessage"
+              input={{
+                type: "message",
+                recipient: "researcher",
+                content:
+                  "Please investigate the auth module structure and report back.",
+                summary: "Requesting auth module investigation",
+              }}
+              toolUseId="tb-12"
+            />
           </div>
         </Section>
 
         {/* ─── Tool Progress Indicator ──────────────────────── */}
-        <Section title="Tool Progress" description="Real-time progress indicator shown while tools are running">
+        <Section
+          title="Tool Progress"
+          description="Real-time progress indicator shown while tools are running"
+        >
           <div className="space-y-4 max-w-3xl">
             <Card label="Single tool running">
               <div className="flex items-center gap-1.5 text-[11px] text-cc-muted font-mono-code pl-9">
@@ -814,46 +1193,74 @@ export function Playground() {
         </Section>
 
         {/* ─── Tool Use Summary ──────────────────────────────── */}
-        <Section title="Tool Use Summary" description="System message summarizing batch tool execution">
+        <Section
+          title="Tool Use Summary"
+          description="System message summarizing batch tool execution"
+        >
           <div className="space-y-4 max-w-3xl">
             <Card label="Summary as system message">
-              <MessageBubble message={{
-                id: "summary-1",
-                role: "system",
-                content: "Read 4 files, searched 12 matches across 3 directories",
-                timestamp: Date.now(),
-              }} />
+              <MessageBubble
+                message={{
+                  id: "summary-1",
+                  role: "system",
+                  content:
+                    "Read 4 files, searched 12 matches across 3 directories",
+                  timestamp: Date.now(),
+                }}
+              />
             </Card>
           </div>
         </Section>
 
         {/* ─── Task Panel ──────────────────────────────── */}
-        <Section title="Tasks" description="Task list states: pending, in progress, completed, blocked">
+        <Section
+          title="Tasks"
+          description="Task list states: pending, in progress, completed, blocked"
+        >
           <div className="w-[280px] border border-cc-border rounded-xl overflow-hidden bg-cc-card">
             {/* Session stats mock */}
             <div className="px-4 py-3 border-b border-cc-border space-y-2.5">
               <div className="flex items-center justify-between">
-                <span className="text-[11px] text-cc-muted uppercase tracking-wider">Cost</span>
-                <span className="text-[13px] font-medium text-cc-fg tabular-nums">$0.1847</span>
+                <span className="text-[11px] text-cc-muted uppercase tracking-wider">
+                  Cost
+                </span>
+                <span className="text-[13px] font-medium text-cc-fg tabular-nums">
+                  $0.1847
+                </span>
               </div>
               <div className="space-y-1">
                 <div className="flex items-center justify-between">
-                  <span className="text-[11px] text-cc-muted uppercase tracking-wider">Context</span>
-                  <span className="text-[11px] text-cc-muted tabular-nums">62%</span>
+                  <span className="text-[11px] text-cc-muted uppercase tracking-wider">
+                    Context
+                  </span>
+                  <span className="text-[11px] text-cc-muted tabular-nums">
+                    62%
+                  </span>
                 </div>
                 <div className="w-full h-1.5 rounded-full bg-cc-hover overflow-hidden">
-                  <div className="h-full rounded-full bg-cc-warning transition-all duration-500" style={{ width: "62%" }} />
+                  <div
+                    className="h-full rounded-full bg-cc-warning transition-all duration-500"
+                    style={{ width: "62%" }}
+                  />
                 </div>
               </div>
               <div className="flex items-center justify-between">
-                <span className="text-[11px] text-cc-muted uppercase tracking-wider">Turns</span>
-                <span className="text-[13px] font-medium text-cc-fg tabular-nums">14</span>
+                <span className="text-[11px] text-cc-muted uppercase tracking-wider">
+                  Turns
+                </span>
+                <span className="text-[13px] font-medium text-cc-fg tabular-nums">
+                  14
+                </span>
               </div>
             </div>
             {/* Task header */}
             <div className="px-4 py-2.5 border-b border-cc-border flex items-center justify-between">
-              <span className="text-[12px] font-semibold text-cc-fg">Tasks</span>
-              <span className="text-[11px] text-cc-muted tabular-nums">2/{MOCK_TASKS.length}</span>
+              <span className="text-[12px] font-semibold text-cc-fg">
+                Tasks
+              </span>
+              <span className="text-[11px] text-cc-muted tabular-nums">
+                2/{MOCK_TASKS.length}
+              </span>
             </div>
             {/* Task list */}
             <div className="px-3 py-2 space-y-0.5">
@@ -865,7 +1272,10 @@ export function Playground() {
         </Section>
 
         {/* ─── GitHub PR Status ──────────────────────────────── */}
-        <Section title="GitHub PR Status" description="PR health shown in the TaskPanel — checks, reviews, unresolved comments">
+        <Section
+          title="GitHub PR Status"
+          description="PR health shown in the TaskPanel — checks, reviews, unresolved comments"
+        >
           <div className="space-y-4">
             <Card label="Open PR — failing checks + changes requested">
               <div className="w-[280px] border border-cc-border rounded-xl overflow-hidden bg-cc-card">
@@ -891,22 +1301,40 @@ export function Playground() {
         </Section>
 
         {/* ─── Linear Issue (TaskPanel) ────────────────── */}
-        <Section title="Linear Issue (TaskPanel)" description="Linear issue linked to a session — displayed in TaskPanel with status, comments, and actions">
+        <Section
+          title="Linear Issue (TaskPanel)"
+          description="Linear issue linked to a session — displayed in TaskPanel with status, comments, and actions"
+        >
           <div className="space-y-4">
             <Card label="Active issue — In Progress with comments">
               <div className="w-[280px] border border-cc-border rounded-xl overflow-hidden bg-cc-card">
                 <div className="px-4 py-3 space-y-2">
                   <div className="flex items-center gap-1.5">
                     <LinearLogo className="w-3.5 h-3.5 text-cc-muted shrink-0" />
-                    <span className="text-[12px] font-semibold text-cc-fg font-mono-code">{MOCK_LINEAR_ISSUE_ACTIVE.identifier}</span>
+                    <span className="text-[12px] font-semibold text-cc-fg font-mono-code">
+                      {MOCK_LINEAR_ISSUE_ACTIVE.identifier}
+                    </span>
                     <span className="text-[9px] font-medium px-1.5 rounded-full leading-[16px] text-blue-400 bg-blue-400/10">
                       {MOCK_LINEAR_ISSUE_ACTIVE.stateName}
                     </span>
-                    <button className="ml-auto flex items-center justify-center w-5 h-5 rounded text-cc-muted hover:text-cc-fg hover:bg-cc-hover transition-colors cursor-pointer" title="Unlink">
-                      <svg viewBox="0 0 16 16" fill="none" stroke="currentColor" strokeWidth="1.5" className="w-3 h-3"><path d="M4 4l8 8M12 4l-8 8" /></svg>
+                    <button
+                      className="ml-auto flex items-center justify-center w-5 h-5 rounded text-cc-muted hover:text-cc-fg hover:bg-cc-hover transition-colors cursor-pointer"
+                      title="Unlink"
+                    >
+                      <svg
+                        viewBox="0 0 16 16"
+                        fill="none"
+                        stroke="currentColor"
+                        strokeWidth="1.5"
+                        className="w-3 h-3"
+                      >
+                        <path d="M4 4l8 8M12 4l-8 8" />
+                      </svg>
                     </button>
                   </div>
-                  <p className="text-[11px] text-cc-muted truncate">{MOCK_LINEAR_ISSUE_ACTIVE.title}</p>
+                  <p className="text-[11px] text-cc-muted truncate">
+                    {MOCK_LINEAR_ISSUE_ACTIVE.title}
+                  </p>
                   <div className="flex items-center gap-2 text-[10px] text-cc-muted">
                     <span>{MOCK_LINEAR_ISSUE_ACTIVE.priorityLabel}</span>
                     <span>&middot;</span>
@@ -915,18 +1343,34 @@ export function Playground() {
                     <span>@ Alice</span>
                   </div>
                   <div className="flex flex-wrap gap-1">
-                    <span className="text-[9px] px-1.5 py-0.5 rounded-full" style={{ backgroundColor: "#bb87fc20", color: "#bb87fc" }}>feature</span>
-                    <span className="text-[9px] px-1.5 py-0.5 rounded-full" style={{ backgroundColor: "#f2994a20", color: "#f2994a" }}>frontend</span>
+                    <span
+                      className="text-[9px] px-1.5 py-0.5 rounded-full"
+                      style={{ backgroundColor: "#bb87fc20", color: "#bb87fc" }}
+                    >
+                      feature
+                    </span>
+                    <span
+                      className="text-[9px] px-1.5 py-0.5 rounded-full"
+                      style={{ backgroundColor: "#f2994a20", color: "#f2994a" }}
+                    >
+                      frontend
+                    </span>
                   </div>
                 </div>
                 {/* Comments */}
                 <div className="px-4 py-2 border-t border-cc-border space-y-1.5 max-h-36 overflow-y-auto">
-                  <span className="text-[10px] text-cc-muted uppercase tracking-wider">Comments</span>
+                  <span className="text-[10px] text-cc-muted uppercase tracking-wider">
+                    Comments
+                  </span>
                   {MOCK_LINEAR_COMMENTS.map((c) => (
                     <div key={c.id} className="text-[11px]">
                       <div className="flex items-center gap-1">
-                        <span className="font-medium text-cc-fg">{c.userName}</span>
-                        <span className="text-[9px] text-cc-muted">just now</span>
+                        <span className="font-medium text-cc-fg">
+                          {c.userName}
+                        </span>
+                        <span className="text-[9px] text-cc-muted">
+                          just now
+                        </span>
                       </div>
                       <p className="text-cc-muted line-clamp-2">{c.body}</p>
                     </div>
@@ -934,9 +1378,19 @@ export function Playground() {
                 </div>
                 {/* Comment input */}
                 <div className="px-4 py-2 border-t border-cc-border flex items-center gap-1.5">
-                  <input type="text" placeholder="Add a comment..." className="flex-1 text-[11px] bg-transparent border border-cc-border rounded-md px-2 py-1.5 text-cc-fg placeholder:text-cc-muted focus:outline-none focus:border-cc-primary/50" />
+                  <input
+                    type="text"
+                    placeholder="Add a comment..."
+                    className="flex-1 text-[11px] bg-transparent border border-cc-border rounded-md px-2 py-1.5 text-cc-fg placeholder:text-cc-muted focus:outline-none focus:border-cc-primary/50"
+                  />
                   <button className="flex items-center justify-center w-6 h-6 rounded text-cc-primary cursor-pointer">
-                    <svg viewBox="0 0 16 16" fill="currentColor" className="w-3.5 h-3.5"><path d="M1.724 1.053a.5.5 0 0 0-.714.545l1.403 4.85a.5.5 0 0 0 .397.354l5.19.736-5.19.737a.5.5 0 0 0-.397.353L1.01 13.48a.5.5 0 0 0 .714.545l13-6.5a.5.5 0 0 0 0-.894l-13-6.5z" /></svg>
+                    <svg
+                      viewBox="0 0 16 16"
+                      fill="currentColor"
+                      className="w-3.5 h-3.5"
+                    >
+                      <path d="M1.724 1.053a.5.5 0 0 0-.714.545l1.403 4.85a.5.5 0 0 0 .397.354l5.19.736-5.19.737a.5.5 0 0 0-.397.353L1.01 13.48a.5.5 0 0 0 .714.545l13-6.5a.5.5 0 0 0 0-.894l-13-6.5z" />
+                    </svg>
                   </button>
                 </div>
               </div>
@@ -947,12 +1401,16 @@ export function Playground() {
                 <div className="px-4 py-3 space-y-2">
                   <div className="flex items-center gap-1.5">
                     <LinearLogo className="w-3.5 h-3.5 text-cc-muted shrink-0" />
-                    <span className="text-[12px] font-semibold text-cc-fg font-mono-code">{MOCK_LINEAR_ISSUE_DONE.identifier}</span>
+                    <span className="text-[12px] font-semibold text-cc-fg font-mono-code">
+                      {MOCK_LINEAR_ISSUE_DONE.identifier}
+                    </span>
                     <span className="text-[9px] font-medium px-1.5 rounded-full leading-[16px] text-cc-success bg-cc-success/10">
                       {MOCK_LINEAR_ISSUE_DONE.stateName}
                     </span>
                   </div>
-                  <p className="text-[11px] text-cc-muted truncate">{MOCK_LINEAR_ISSUE_DONE.title}</p>
+                  <p className="text-[11px] text-cc-muted truncate">
+                    {MOCK_LINEAR_ISSUE_DONE.title}
+                  </p>
                   <div className="flex items-center gap-2 text-[10px] text-cc-muted">
                     <span>{MOCK_LINEAR_ISSUE_DONE.priorityLabel}</span>
                     <span>&middot;</span>
@@ -962,12 +1420,20 @@ export function Playground() {
                 {/* Done warning */}
                 <div className="px-4 py-2 bg-cc-success/10 border-t border-cc-success/20 flex items-center justify-between gap-2">
                   <div className="min-w-0">
-                    <p className="text-[11px] text-cc-success font-medium">Issue completed</p>
-                    <p className="text-[10px] text-cc-success/80">Ticket moved to done.</p>
+                    <p className="text-[11px] text-cc-success font-medium">
+                      Issue completed
+                    </p>
+                    <p className="text-[10px] text-cc-success/80">
+                      Ticket moved to done.
+                    </p>
                   </div>
                   <div className="flex items-center gap-1.5 shrink-0">
-                    <button className="text-[10px] text-cc-muted hover:text-cc-fg px-1.5 py-0.5 rounded cursor-pointer">Dismiss</button>
-                    <button className="text-[10px] text-cc-success font-medium px-2 py-0.5 rounded bg-cc-success/20 hover:bg-cc-success/30 cursor-pointer">Close session</button>
+                    <button className="text-[10px] text-cc-muted hover:text-cc-fg px-1.5 py-0.5 rounded cursor-pointer">
+                      Dismiss
+                    </button>
+                    <button className="text-[10px] text-cc-success font-medium px-2 py-0.5 rounded bg-cc-success/20 hover:bg-cc-success/30 cursor-pointer">
+                      Close session
+                    </button>
                   </div>
                 </div>
               </div>
@@ -987,22 +1453,42 @@ export function Playground() {
         </Section>
 
         {/* ─── MCP Servers ──────────────────────────────── */}
-        <Section title="MCP Servers" description="MCP server status display with toggle, reconnect, and tool listing">
+        <Section
+          title="MCP Servers"
+          description="MCP server status display with toggle, reconnect, and tool listing"
+        >
           <div className="space-y-4">
             <Card label="All server states (connected, failed, disabled, connecting)">
               <div className="w-[280px] border border-cc-border rounded-xl overflow-hidden bg-cc-card">
                 {/* MCP section header */}
                 <div className="shrink-0 px-4 py-2.5 border-b border-cc-border flex items-center justify-between">
                   <span className="text-[12px] font-semibold text-cc-fg flex items-center gap-1.5">
-                    <svg viewBox="0 0 16 16" fill="currentColor" className="w-3.5 h-3.5 text-cc-muted">
+                    <svg
+                      viewBox="0 0 16 16"
+                      fill="currentColor"
+                      className="w-3.5 h-3.5 text-cc-muted"
+                    >
                       <path d="M1.5 3A1.5 1.5 0 013 1.5h10A1.5 1.5 0 0114.5 3v1A1.5 1.5 0 0113 5.5H3A1.5 1.5 0 011.5 4V3zm0 5A1.5 1.5 0 013 6.5h10A1.5 1.5 0 0114.5 8v1A1.5 1.5 0 0113 10.5H3A1.5 1.5 0 011.5 9V8zm0 5A1.5 1.5 0 013 11.5h10a1.5 1.5 0 011.5 1.5v1a1.5 1.5 0 01-1.5 1.5H3A1.5 1.5 0 011.5 14v-1z" />
                     </svg>
                     MCP Servers
                   </span>
                   <span className="text-[11px] text-cc-muted">
-                    <svg viewBox="0 0 16 16" fill="none" stroke="currentColor" strokeWidth="1.5" className="w-3.5 h-3.5">
-                      <path d="M2.5 8a5.5 5.5 0 019.78-3.5M13.5 8a5.5 5.5 0 01-9.78 3.5" strokeLinecap="round" />
-                      <path d="M12.5 2v3h-3M3.5 14v-3h3" strokeLinecap="round" strokeLinejoin="round" />
+                    <svg
+                      viewBox="0 0 16 16"
+                      fill="none"
+                      stroke="currentColor"
+                      strokeWidth="1.5"
+                      className="w-3.5 h-3.5"
+                    >
+                      <path
+                        d="M2.5 8a5.5 5.5 0 019.78-3.5M13.5 8a5.5 5.5 0 01-9.78 3.5"
+                        strokeLinecap="round"
+                      />
+                      <path
+                        d="M12.5 2v3h-3M3.5 14v-3h3"
+                        strokeLinecap="round"
+                        strokeLinejoin="round"
+                      />
                     </svg>
                   </span>
                 </div>
@@ -1018,15 +1504,26 @@ export function Playground() {
         </Section>
 
         {/* ─── Panel Config View ──────────────────────────── */}
-        <Section title="Panel Config View" description="Inline configuration for the right sidebar — toggle sections on/off and reorder them">
+        <Section
+          title="Panel Config View"
+          description="Inline configuration for the right sidebar — toggle sections on/off and reorder them"
+        >
           <div className="space-y-4">
             <Card label="Config mode with mixed enabled/disabled sections">
               <div className="w-[320px] border border-cc-border rounded-xl overflow-hidden bg-cc-card">
                 {/* Header */}
                 <div className="shrink-0 flex items-center justify-between px-4 py-3 border-b border-cc-border">
-                  <span className="text-sm font-semibold text-cc-fg tracking-tight">Panel Settings</span>
+                  <span className="text-sm font-semibold text-cc-fg tracking-tight">
+                    Panel Settings
+                  </span>
                   <button className="flex items-center justify-center w-6 h-6 rounded-lg text-cc-muted hover:text-cc-fg hover:bg-cc-hover transition-colors cursor-pointer">
-                    <svg viewBox="0 0 16 16" fill="none" stroke="currentColor" strokeWidth="1.5" className="w-3.5 h-3.5">
+                    <svg
+                      viewBox="0 0 16 16"
+                      fill="none"
+                      stroke="currentColor"
+                      strokeWidth="1.5"
+                      className="w-3.5 h-3.5"
+                    >
                       <path d="M4 4l8 8M12 4l-8 8" />
                     </svg>
                   </button>
@@ -1034,12 +1531,42 @@ export function Playground() {
                 {/* Section rows */}
                 <div className="px-3 py-3 space-y-1">
                   {[
-                    { id: "git-branch", label: "Git Branch", desc: "Current branch, ahead/behind, and line changes", enabled: true },
-                    { id: "usage-limits", label: "Usage Limits", desc: "API usage and rate limit meters", enabled: true },
-                    { id: "github-pr", label: "GitHub PR", desc: "Pull request status, CI checks, and reviews", enabled: false },
-                    { id: "linear-issue", label: "Linear Issue", desc: "Linked Linear ticket and comments", enabled: true },
-                    { id: "mcp-servers", label: "MCP Servers", desc: "Model Context Protocol server connections", enabled: false },
-                    { id: "tasks", label: "Tasks", desc: "Agent task list and progress", enabled: true },
+                    {
+                      id: "git-branch",
+                      label: "Git Branch",
+                      desc: "Current branch, ahead/behind, and line changes",
+                      enabled: true,
+                    },
+                    {
+                      id: "usage-limits",
+                      label: "Usage Limits",
+                      desc: "API usage and rate limit meters",
+                      enabled: true,
+                    },
+                    {
+                      id: "github-pr",
+                      label: "GitHub PR",
+                      desc: "Pull request status, CI checks, and reviews",
+                      enabled: false,
+                    },
+                    {
+                      id: "linear-issue",
+                      label: "Linear Issue",
+                      desc: "Linked Linear ticket and comments",
+                      enabled: true,
+                    },
+                    {
+                      id: "mcp-servers",
+                      label: "MCP Servers",
+                      desc: "Model Context Protocol server connections",
+                      enabled: false,
+                    },
+                    {
+                      id: "tasks",
+                      label: "Tasks",
+                      desc: "Agent task list and progress",
+                      enabled: true,
+                    },
                   ].map((s, i, arr) => (
                     <div
                       key={s.id}
@@ -1048,16 +1575,38 @@ export function Playground() {
                       }`}
                     >
                       <div className="flex flex-col gap-0.5 shrink-0">
-                        <button disabled={i === 0} className="w-5 h-4 flex items-center justify-center text-cc-muted hover:text-cc-fg disabled:opacity-20 disabled:cursor-not-allowed cursor-pointer transition-colors">
-                          <svg viewBox="0 0 16 16" fill="currentColor" className="w-3 h-3"><path d="M8 4l4 4H4l4-4z" /></svg>
+                        <button
+                          disabled={i === 0}
+                          className="w-5 h-4 flex items-center justify-center text-cc-muted hover:text-cc-fg disabled:opacity-20 disabled:cursor-not-allowed cursor-pointer transition-colors"
+                        >
+                          <svg
+                            viewBox="0 0 16 16"
+                            fill="currentColor"
+                            className="w-3 h-3"
+                          >
+                            <path d="M8 4l4 4H4l4-4z" />
+                          </svg>
                         </button>
-                        <button disabled={i === arr.length - 1} className="w-5 h-4 flex items-center justify-center text-cc-muted hover:text-cc-fg disabled:opacity-20 disabled:cursor-not-allowed cursor-pointer transition-colors">
-                          <svg viewBox="0 0 16 16" fill="currentColor" className="w-3 h-3"><path d="M8 12l4-4H4l4 4z" /></svg>
+                        <button
+                          disabled={i === arr.length - 1}
+                          className="w-5 h-4 flex items-center justify-center text-cc-muted hover:text-cc-fg disabled:opacity-20 disabled:cursor-not-allowed cursor-pointer transition-colors"
+                        >
+                          <svg
+                            viewBox="0 0 16 16"
+                            fill="currentColor"
+                            className="w-3 h-3"
+                          >
+                            <path d="M8 12l4-4H4l4 4z" />
+                          </svg>
                         </button>
                       </div>
                       <div className="flex-1 min-w-0">
-                        <span className="text-[12px] font-medium text-cc-fg block">{s.label}</span>
-                        <span className="text-[10px] text-cc-muted block truncate">{s.desc}</span>
+                        <span className="text-[12px] font-medium text-cc-fg block">
+                          {s.label}
+                        </span>
+                        <span className="text-[10px] text-cc-muted block truncate">
+                          {s.desc}
+                        </span>
                       </div>
                       <button
                         className={`shrink-0 w-8 h-[18px] rounded-full transition-colors cursor-pointer relative ${
@@ -1066,25 +1615,48 @@ export function Playground() {
                         role="switch"
                         aria-checked={s.enabled}
                       >
-                        <span className={`absolute top-[2px] w-[14px] h-[14px] rounded-full bg-white shadow transition-transform ${
-                          s.enabled ? "translate-x-[16px]" : "translate-x-[2px]"
-                        }`} />
+                        <span
+                          className={`absolute top-[2px] w-[14px] h-[14px] rounded-full bg-white shadow transition-transform ${
+                            s.enabled
+                              ? "translate-x-[16px]"
+                              : "translate-x-[2px]"
+                          }`}
+                        />
                       </button>
                     </div>
                   ))}
                 </div>
                 {/* Footer */}
                 <div className="shrink-0 border-t border-cc-border px-3 py-2.5 flex items-center justify-between">
-                  <button className="text-[11px] text-cc-muted hover:text-cc-fg transition-colors cursor-pointer">Reset to defaults</button>
-                  <button className="text-[11px] font-medium text-cc-primary hover:text-cc-primary-hover transition-colors cursor-pointer">Done</button>
+                  <button className="text-[11px] text-cc-muted hover:text-cc-fg transition-colors cursor-pointer">
+                    Reset to defaults
+                  </button>
+                  <button className="text-[11px] font-medium text-cc-primary hover:text-cc-primary-hover transition-colors cursor-pointer">
+                    Done
+                  </button>
                 </div>
               </div>
             </Card>
           </div>
         </Section>
 
+        {/* ─── Claude Context Window ──────────────────────── */}
+        <Section
+          title="Claude Context Window"
+          description="Context window usage display for Claude Code sessions — uses per-turn token data from assistant messages"
+        >
+          <div className="space-y-4">
+            <Card label="Context usage with cost and turns">
+              <ClaudeContextPlaygroundDemo />
+            </Card>
+          </div>
+        </Section>
+
         {/* ─── Codex Session Details ──────────────────────── */}
-        <Section title="Codex Session Details" description="Rate limits and token details for Codex (OpenAI) sessions — streamed via session_update">
+        <Section
+          title="Codex Session Details"
+          description="Rate limits and token details for Codex (OpenAI) sessions — streamed via session_update"
+        >
           <div className="space-y-4">
             <Card label="Rate limits with token breakdown">
               <CodexPlaygroundDemo />
@@ -1093,7 +1665,10 @@ export function Playground() {
         </Section>
 
         {/* ─── Update Banner ──────────────────────────────── */}
-        <Section title="Update Banner" description="Notification banner for available updates">
+        <Section
+          title="Update Banner"
+          description="Notification banner for available updates"
+        >
           <div className="space-y-4 max-w-3xl">
             <Card label="Service mode (auto-update)">
               <PlaygroundUpdateBanner
@@ -1151,18 +1726,27 @@ export function Playground() {
         </Section>
 
         {/* ─── Status Indicators ──────────────────────────────── */}
-        <Section title="Status Indicators" description="Connection and session status banners">
+        <Section
+          title="Status Indicators"
+          description="Connection and session status banners"
+        >
           <div className="space-y-3 max-w-3xl">
             <Card label="Disconnected warning">
               <div className="px-4 py-2 bg-cc-warning/10 border border-cc-warning/20 rounded-lg text-center">
-                <span className="text-xs text-cc-warning font-medium">Reconnecting to session...</span>
+                <span className="text-xs text-cc-warning font-medium">
+                  Reconnecting to session...
+                </span>
               </div>
             </Card>
             <Card label="Connected">
               <div className="flex items-center gap-2 px-3 py-2 bg-cc-card border border-cc-border rounded-lg">
                 <span className="w-2 h-2 rounded-full bg-cc-success" />
-                <span className="text-xs text-cc-fg font-medium">Connected</span>
-                <span className="text-[11px] text-cc-muted ml-auto">claude-opus-4-6</span>
+                <span className="text-xs text-cc-fg font-medium">
+                  Connected
+                </span>
+                <span className="text-[11px] text-cc-muted ml-auto">
+                  claude-opus-4-6
+                </span>
               </div>
             </Card>
             <Card label="Running / Thinking">
@@ -1173,26 +1757,62 @@ export function Playground() {
             </Card>
             <Card label="Compacting">
               <div className="flex items-center gap-2 px-3 py-2 bg-cc-card border border-cc-border rounded-lg">
-                <svg className="w-3.5 h-3.5 text-cc-muted animate-spin" viewBox="0 0 16 16" fill="none">
-                  <circle cx="8" cy="8" r="6" stroke="currentColor" strokeWidth="1.5" strokeDasharray="28" strokeDashoffset="8" strokeLinecap="round" />
+                <svg
+                  className="w-3.5 h-3.5 text-cc-muted animate-spin"
+                  viewBox="0 0 16 16"
+                  fill="none"
+                >
+                  <circle
+                    cx="8"
+                    cy="8"
+                    r="6"
+                    stroke="currentColor"
+                    strokeWidth="1.5"
+                    strokeDasharray="28"
+                    strokeDashoffset="8"
+                    strokeLinecap="round"
+                  />
                 </svg>
-                <span className="text-xs text-cc-muted font-medium">Compacting context...</span>
+                <span className="text-xs text-cc-muted font-medium">
+                  Compacting context...
+                </span>
               </div>
             </Card>
           </div>
         </Section>
 
         {/* ─── Composer ──────────────────────────────── */}
-        <Section title="Composer" description="Message input bar with mode toggle, image upload, saved prompts (@), and send/stop buttons">
+        <Section
+          title="Composer"
+          description="Message input bar with mode toggle, image upload, saved prompts (@), and send/stop buttons"
+        >
           <div className="max-w-3xl">
             <Card label="Connected — code mode">
               <div className="border-t border-cc-border bg-cc-card px-4 py-3">
                 <div className="relative bg-cc-input-bg/95 border border-cc-border rounded-[14px] shadow-[0_10px_30px_rgba(0,0,0,0.10)] overflow-visible">
                   <div className="flex items-end gap-2 px-2.5 py-2">
                     <div className="mb-0.5 flex items-center gap-1.5 px-2.5 py-1.5 rounded-md border border-cc-border text-[12px] font-semibold text-cc-muted">
-                      <svg viewBox="0 0 16 16" fill="currentColor" className="w-3.5 h-3.5">
-                        <path d="M2.5 4l4 4-4 4" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" fill="none" />
-                        <path d="M8.5 4l4 4-4 4" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" fill="none" />
+                      <svg
+                        viewBox="0 0 16 16"
+                        fill="currentColor"
+                        className="w-3.5 h-3.5"
+                      >
+                        <path
+                          d="M2.5 4l4 4-4 4"
+                          stroke="currentColor"
+                          strokeWidth="2"
+                          strokeLinecap="round"
+                          strokeLinejoin="round"
+                          fill="none"
+                        />
+                        <path
+                          d="M8.5 4l4 4-4 4"
+                          stroke="currentColor"
+                          strokeWidth="2"
+                          strokeLinecap="round"
+                          strokeLinejoin="round"
+                          fill="none"
+                        />
                       </svg>
                       <span>code</span>
                     </div>
@@ -1205,14 +1825,34 @@ export function Playground() {
                     />
                     <div className="mb-0.5 flex items-center gap-1.5">
                       <div className="flex items-center justify-center w-9 h-9 rounded-lg border border-cc-border text-cc-muted">
-                        <svg viewBox="0 0 16 16" fill="none" stroke="currentColor" strokeWidth="1.5" className="w-4 h-4">
+                        <svg
+                          viewBox="0 0 16 16"
+                          fill="none"
+                          stroke="currentColor"
+                          strokeWidth="1.5"
+                          className="w-4 h-4"
+                        >
                           <rect x="2" y="2" width="12" height="12" rx="2" />
-                          <circle cx="5.5" cy="5.5" r="1" fill="currentColor" stroke="none" />
-                          <path d="M2 11l3-3 2 2 3-4 4 5" strokeLinecap="round" strokeLinejoin="round" />
+                          <circle
+                            cx="5.5"
+                            cy="5.5"
+                            r="1"
+                            fill="currentColor"
+                            stroke="none"
+                          />
+                          <path
+                            d="M2 11l3-3 2 2 3-4 4 5"
+                            strokeLinecap="round"
+                            strokeLinejoin="round"
+                          />
                         </svg>
                       </div>
                       <div className="flex items-center justify-center w-9 h-9 rounded-full bg-cc-primary text-white shadow-[0_6px_20px_rgba(0,0,0,0.18)]">
-                        <svg viewBox="0 0 16 16" fill="currentColor" className="w-3.5 h-3.5">
+                        <svg
+                          viewBox="0 0 16 16"
+                          fill="currentColor"
+                          className="w-3.5 h-3.5"
+                        >
                           <path d="M3 2l11 6-11 6V9.5l7-1.5-7-1.5V2z" />
                         </svg>
                       </div>
@@ -1227,12 +1867,21 @@ export function Playground() {
                 <div className="relative bg-cc-input-bg/95 border border-cc-border rounded-[14px] shadow-[0_10px_30px_rgba(0,0,0,0.10)] overflow-visible">
                   <div className="absolute left-2 right-2 bottom-full mb-1 max-h-[180px] overflow-y-auto bg-cc-card border border-cc-border rounded-[10px] shadow-lg z-20 py-1">
                     <div className="px-3 py-2 flex items-center gap-2.5 bg-cc-hover">
-                      <span className="flex items-center justify-center w-6 h-6 rounded-md bg-cc-hover text-cc-muted shrink-0">@</span>
+                      <span className="flex items-center justify-center w-6 h-6 rounded-md bg-cc-hover text-cc-muted shrink-0">
+                        @
+                      </span>
                       <div className="flex-1 min-w-0">
-                        <div className="text-[13px] font-medium text-cc-fg truncate">@review-pr</div>
-                        <div className="text-[11px] text-cc-muted truncate">Review this PR and list risks, regressions, and missing tests.</div>
+                        <div className="text-[13px] font-medium text-cc-fg truncate">
+                          @review-pr
+                        </div>
+                        <div className="text-[11px] text-cc-muted truncate">
+                          Review this PR and list risks, regressions, and
+                          missing tests.
+                        </div>
                       </div>
-                      <span className="text-[10px] text-cc-muted shrink-0">project</span>
+                      <span className="text-[10px] text-cc-muted shrink-0">
+                        project
+                      </span>
                     </div>
                   </div>
                   <div className="flex items-end gap-2 px-2.5 py-2">
@@ -1245,7 +1894,13 @@ export function Playground() {
                     />
                     <div className="mb-0.5 flex items-center gap-1.5">
                       <div className="flex items-center justify-center w-9 h-9 rounded-lg border border-cc-border text-cc-muted">
-                        <svg viewBox="0 0 16 16" fill="none" stroke="currentColor" strokeWidth="1.5" className="w-4 h-4">
+                        <svg
+                          viewBox="0 0 16 16"
+                          fill="none"
+                          stroke="currentColor"
+                          strokeWidth="1.5"
+                          className="w-4 h-4"
+                        >
                           <path d="M4 2.75h8A1.25 1.25 0 0113.25 4v9.25L8 10.5l-5.25 2.75V4A1.25 1.25 0 014 2.75z" />
                         </svg>
                       </div>
@@ -1260,7 +1915,11 @@ export function Playground() {
                 <div className="relative bg-cc-input-bg/95 border border-cc-primary/40 rounded-[14px] shadow-[0_10px_30px_rgba(0,0,0,0.10)] overflow-visible">
                   <div className="flex items-end gap-2 px-2.5 py-2">
                     <div className="mb-0.5 flex items-center gap-1.5 px-2.5 py-1.5 rounded-md border border-cc-primary/40 text-[12px] font-semibold text-cc-primary bg-cc-primary/8">
-                      <svg viewBox="0 0 16 16" fill="currentColor" className="w-3.5 h-3.5">
+                      <svg
+                        viewBox="0 0 16 16"
+                        fill="currentColor"
+                        className="w-3.5 h-3.5"
+                      >
                         <rect x="3" y="3" width="3.5" height="10" rx="0.75" />
                         <rect x="9.5" y="3" width="3.5" height="10" rx="0.75" />
                       </svg>
@@ -1276,14 +1935,34 @@ export function Playground() {
                     />
                     <div className="mb-0.5 flex items-center gap-1.5">
                       <div className="flex items-center justify-center w-9 h-9 rounded-lg border border-cc-border text-cc-muted">
-                        <svg viewBox="0 0 16 16" fill="none" stroke="currentColor" strokeWidth="1.5" className="w-4 h-4">
+                        <svg
+                          viewBox="0 0 16 16"
+                          fill="none"
+                          stroke="currentColor"
+                          strokeWidth="1.5"
+                          className="w-4 h-4"
+                        >
                           <rect x="2" y="2" width="12" height="12" rx="2" />
-                          <circle cx="5.5" cy="5.5" r="1" fill="currentColor" stroke="none" />
-                          <path d="M2 11l3-3 2 2 3-4 4 5" strokeLinecap="round" strokeLinejoin="round" />
+                          <circle
+                            cx="5.5"
+                            cy="5.5"
+                            r="1"
+                            fill="currentColor"
+                            stroke="none"
+                          />
+                          <path
+                            d="M2 11l3-3 2 2 3-4 4 5"
+                            strokeLinecap="round"
+                            strokeLinejoin="round"
+                          />
                         </svg>
                       </div>
                       <div className="flex items-center justify-center w-9 h-9 rounded-full bg-cc-hover text-cc-muted">
-                        <svg viewBox="0 0 16 16" fill="currentColor" className="w-3.5 h-3.5">
+                        <svg
+                          viewBox="0 0 16 16"
+                          fill="currentColor"
+                          className="w-3.5 h-3.5"
+                        >
                           <path d="M3 2l11 6-11 6V9.5l7-1.5-7-1.5V2z" />
                         </svg>
                       </div>
@@ -1298,9 +1977,27 @@ export function Playground() {
                 <div className="relative bg-cc-input-bg/95 border border-cc-border rounded-[14px] shadow-[0_10px_30px_rgba(0,0,0,0.10)] overflow-visible">
                   <div className="flex items-end gap-2 px-2.5 py-2">
                     <div className="mb-0.5 flex items-center gap-1.5 px-2.5 py-1.5 rounded-md border border-cc-border text-[12px] font-semibold text-cc-muted">
-                      <svg viewBox="0 0 16 16" fill="currentColor" className="w-3.5 h-3.5">
-                        <path d="M2.5 4l4 4-4 4" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" fill="none" />
-                        <path d="M8.5 4l4 4-4 4" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" fill="none" />
+                      <svg
+                        viewBox="0 0 16 16"
+                        fill="currentColor"
+                        className="w-3.5 h-3.5"
+                      >
+                        <path
+                          d="M2.5 4l4 4-4 4"
+                          stroke="currentColor"
+                          strokeWidth="2"
+                          strokeLinecap="round"
+                          strokeLinejoin="round"
+                          fill="none"
+                        />
+                        <path
+                          d="M8.5 4l4 4-4 4"
+                          stroke="currentColor"
+                          strokeWidth="2"
+                          strokeLinecap="round"
+                          strokeLinejoin="round"
+                          fill="none"
+                        />
                       </svg>
                       <span>code</span>
                     </div>
@@ -1314,14 +2011,34 @@ export function Playground() {
                     />
                     <div className="mb-0.5 flex items-center gap-1.5">
                       <div className="flex items-center justify-center w-9 h-9 rounded-lg border border-cc-border text-cc-muted">
-                        <svg viewBox="0 0 16 16" fill="none" stroke="currentColor" strokeWidth="1.5" className="w-4 h-4">
+                        <svg
+                          viewBox="0 0 16 16"
+                          fill="none"
+                          stroke="currentColor"
+                          strokeWidth="1.5"
+                          className="w-4 h-4"
+                        >
                           <rect x="2" y="2" width="12" height="12" rx="2" />
-                          <circle cx="5.5" cy="5.5" r="1" fill="currentColor" stroke="none" />
-                          <path d="M2 11l3-3 2 2 3-4 4 5" strokeLinecap="round" strokeLinejoin="round" />
+                          <circle
+                            cx="5.5"
+                            cy="5.5"
+                            r="1"
+                            fill="currentColor"
+                            stroke="none"
+                          />
+                          <path
+                            d="M2 11l3-3 2 2 3-4 4 5"
+                            strokeLinecap="round"
+                            strokeLinejoin="round"
+                          />
                         </svg>
                       </div>
                       <div className="flex items-center justify-center w-9 h-9 rounded-lg bg-cc-error/10 text-cc-error">
-                        <svg viewBox="0 0 16 16" fill="currentColor" className="w-3.5 h-3.5">
+                        <svg
+                          viewBox="0 0 16 16"
+                          fill="currentColor"
+                          className="w-3.5 h-3.5"
+                        >
                           <rect x="3" y="3" width="10" height="10" rx="1" />
                         </svg>
                       </div>
@@ -1334,18 +2051,32 @@ export function Playground() {
         </Section>
 
         {/* ─── Streaming Indicator ──────────────────────────────── */}
-        <Section title="Streaming Indicator" description="Live typing animation shown while the assistant is generating">
+        <Section
+          title="Streaming Indicator"
+          description="Live typing animation shown while the assistant is generating"
+        >
           <div className="space-y-4 max-w-3xl">
             <Card label="Streaming with cursor">
               <div className="flex items-start gap-3">
                 <div className="w-6 h-6 rounded-full bg-cc-primary/10 flex items-center justify-center shrink-0 mt-0.5">
-                  <svg viewBox="0 0 16 16" fill="none" className="w-3.5 h-3.5 text-cc-primary">
-                    <path d="M8 1v14M1 8h14" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" />
+                  <svg
+                    viewBox="0 0 16 16"
+                    fill="none"
+                    className="w-3.5 h-3.5 text-cc-primary"
+                  >
+                    <path
+                      d="M8 1v14M1 8h14"
+                      stroke="currentColor"
+                      strokeWidth="1.5"
+                      strokeLinecap="round"
+                    />
                   </svg>
                 </div>
                 <div className="flex-1 min-w-0">
                   <pre className="font-serif-assistant text-[15px] text-cc-fg whitespace-pre-wrap break-words leading-relaxed">
-                    I'll start by creating the JWT utility module with sign and verify helpers. Let me first check what dependencies are already installed...
+                    I'll start by creating the JWT utility module with sign and
+                    verify helpers. Let me first check what dependencies are
+                    already installed...
                     <span className="inline-block w-0.5 h-4 bg-cc-primary ml-0.5 align-middle animate-[pulse-dot_0.8s_ease-in-out_infinite]" />
                   </pre>
                 </div>
@@ -1366,19 +2097,37 @@ export function Playground() {
         </Section>
 
         {/* ─── Tool Message Groups ──────────────────────────────── */}
-        <Section title="Tool Message Groups" description="Consecutive same-tool calls collapsed into a single expandable row">
+        <Section
+          title="Tool Message Groups"
+          description="Consecutive same-tool calls collapsed into a single expandable row"
+        >
           <div className="space-y-4 max-w-3xl">
             <Card label="Multi-item group (4 Reads)">
-              <PlaygroundToolGroup toolName="Read" items={MOCK_TOOL_GROUP_ITEMS} />
+              <PlaygroundToolGroup
+                toolName="Read"
+                items={MOCK_TOOL_GROUP_ITEMS}
+              />
             </Card>
             <Card label="Single-item group">
-              <PlaygroundToolGroup toolName="Glob" items={[{ id: "sg-1", name: "Glob", input: { pattern: "src/auth/**/*.ts" } }]} />
+              <PlaygroundToolGroup
+                toolName="Glob"
+                items={[
+                  {
+                    id: "sg-1",
+                    name: "Glob",
+                    input: { pattern: "src/auth/**/*.ts" },
+                  },
+                ]}
+              />
             </Card>
           </div>
         </Section>
 
         {/* ─── Subagent Groups ──────────────────────────────── */}
-        <Section title="Subagent Groups" description="Nested messages from Task tool subagents shown in a collapsible indent">
+        <Section
+          title="Subagent Groups"
+          description="Nested messages from Task tool subagents shown in a collapsible indent"
+        >
           <div className="space-y-4 max-w-3xl">
             <Card label="Subagent with nested tool calls">
               <PlaygroundSubagentGroup
@@ -1395,19 +2144,28 @@ export function Playground() {
         </Section>
 
         {/* ─── Diff Viewer ──────────────────────────────── */}
-        <Section title="Diff Viewer" description="Unified diff rendering with word-level highlighting — used in ToolBlock, PermissionBanner, and DiffPanel">
+        <Section
+          title="Diff Viewer"
+          description="Unified diff rendering with word-level highlighting — used in ToolBlock, PermissionBanner, and DiffPanel"
+        >
           <div className="space-y-4 max-w-3xl">
             <Card label="Edit diff (compact mode)">
               <DiffViewer
-                oldText={'export function formatDate(d: Date) {\n  return d.toISOString();\n}'}
-                newText={'export function formatDate(d: Date, locale = "en-US") {\n  return d.toLocaleDateString(locale, {\n    year: "numeric",\n    month: "short",\n    day: "numeric",\n  });\n}'}
+                oldText={
+                  "export function formatDate(d: Date) {\n  return d.toISOString();\n}"
+                }
+                newText={
+                  'export function formatDate(d: Date, locale = "en-US") {\n  return d.toLocaleDateString(locale, {\n    year: "numeric",\n    month: "short",\n    day: "numeric",\n  });\n}'
+                }
                 fileName="src/utils/format.ts"
                 mode="compact"
               />
             </Card>
             <Card label="New file diff (compact mode)">
               <DiffViewer
-                newText={'export const config = {\n  apiUrl: "https://api.example.com",\n  timeout: 5000,\n  retries: 3,\n  debug: process.env.NODE_ENV !== "production",\n};\n'}
+                newText={
+                  'export const config = {\n  apiUrl: "https://api.example.com",\n  timeout: 5000,\n  retries: 3,\n  debug: process.env.NODE_ENV !== "production",\n};\n'
+                }
                 fileName="src/config.ts"
                 mode="compact"
               />
@@ -1446,81 +2204,205 @@ export function Playground() {
           </div>
         </Section>
         {/* ─── Session Creation Progress ─────────────────────── */}
-        <Section title="Session Creation Progress" description="Step-by-step progress indicator shown during session creation (SSE streaming)">
+        <Section
+          title="Session Creation Progress"
+          description="Step-by-step progress indicator shown during session creation (SSE streaming)"
+        >
           <div className="space-y-4 max-w-md">
             <Card label="In progress (container session)">
               <SessionCreationProgress
-                steps={[
-                  { step: "resolving_env", label: "Resolving environment...", status: "done" },
-                  { step: "pulling_image", label: "Pulling Docker image...", status: "done" },
-                  { step: "creating_container", label: "Starting container...", status: "in_progress" },
-                  { step: "launching_cli", label: "Launching Claude Code...", status: "in_progress" },
-                ] satisfies CreationProgressEvent[]}
+                steps={
+                  [
+                    {
+                      step: "resolving_env",
+                      label: "Resolving environment...",
+                      status: "done",
+                    },
+                    {
+                      step: "pulling_image",
+                      label: "Pulling Docker image...",
+                      status: "done",
+                    },
+                    {
+                      step: "creating_container",
+                      label: "Starting container...",
+                      status: "in_progress",
+                    },
+                    {
+                      step: "launching_cli",
+                      label: "Launching Claude Code...",
+                      status: "in_progress",
+                    },
+                  ] satisfies CreationProgressEvent[]
+                }
               />
             </Card>
             <Card label="Completed (worktree session)">
               <SessionCreationProgress
-                steps={[
-                  { step: "resolving_env", label: "Resolving environment...", status: "done" },
-                  { step: "fetching_git", label: "Fetching from remote...", status: "done" },
-                  { step: "checkout_branch", label: "Checking out feat/auth...", status: "done" },
-                  { step: "creating_worktree", label: "Creating worktree...", status: "done" },
-                  { step: "launching_cli", label: "Launching Claude Code...", status: "done" },
-                ] satisfies CreationProgressEvent[]}
+                steps={
+                  [
+                    {
+                      step: "resolving_env",
+                      label: "Resolving environment...",
+                      status: "done",
+                    },
+                    {
+                      step: "fetching_git",
+                      label: "Fetching from remote...",
+                      status: "done",
+                    },
+                    {
+                      step: "checkout_branch",
+                      label: "Checking out feat/auth...",
+                      status: "done",
+                    },
+                    {
+                      step: "creating_worktree",
+                      label: "Creating worktree...",
+                      status: "done",
+                    },
+                    {
+                      step: "launching_cli",
+                      label: "Launching Claude Code...",
+                      status: "done",
+                    },
+                  ] satisfies CreationProgressEvent[]
+                }
               />
             </Card>
             <Card label="Error during image pull">
               <SessionCreationProgress
-                steps={[
-                  { step: "resolving_env", label: "Resolving environment...", status: "done" },
-                  { step: "pulling_image", label: "Pulling Docker image...", status: "error" },
-                ] satisfies CreationProgressEvent[]}
+                steps={
+                  [
+                    {
+                      step: "resolving_env",
+                      label: "Resolving environment...",
+                      status: "done",
+                    },
+                    {
+                      step: "pulling_image",
+                      label: "Pulling Docker image...",
+                      status: "error",
+                    },
+                  ] satisfies CreationProgressEvent[]
+                }
                 error="Failed to pull docker.io/stangirard/the-companion:latest — connection timed out after 30s"
               />
             </Card>
             <Card label="With streaming init script logs">
               <SessionCreationProgress
-                steps={[
-                  { step: "resolving_env", label: "Resolving environment...", status: "done" },
-                  { step: "pulling_image", label: "Image ready", status: "done" },
-                  { step: "creating_container", label: "Container running", status: "done" },
-                  { step: "running_init_script", label: "Running init script...", status: "in_progress", detail: "Installing dependencies..." },
-                ] satisfies CreationProgressEvent[]}
+                steps={
+                  [
+                    {
+                      step: "resolving_env",
+                      label: "Resolving environment...",
+                      status: "done",
+                    },
+                    {
+                      step: "pulling_image",
+                      label: "Image ready",
+                      status: "done",
+                    },
+                    {
+                      step: "creating_container",
+                      label: "Container running",
+                      status: "done",
+                    },
+                    {
+                      step: "running_init_script",
+                      label: "Running init script...",
+                      status: "in_progress",
+                      detail: "Installing dependencies...",
+                    },
+                  ] satisfies CreationProgressEvent[]
+                }
               />
             </Card>
             <Card label="With streaming image pull logs">
               <SessionCreationProgress
-                steps={[
-                  { step: "resolving_env", label: "Resolving environment...", status: "done" },
-                  { step: "pulling_image", label: "Pulling Docker image...", status: "in_progress", detail: "Downloading layer 3/7 [=====>    ] 45%" },
-                ] satisfies CreationProgressEvent[]}
+                steps={
+                  [
+                    {
+                      step: "resolving_env",
+                      label: "Resolving environment...",
+                      status: "done",
+                    },
+                    {
+                      step: "pulling_image",
+                      label: "Pulling Docker image...",
+                      status: "in_progress",
+                      detail: "Downloading layer 3/7 [=====>    ] 45%",
+                    },
+                  ] satisfies CreationProgressEvent[]
+                }
               />
             </Card>
             <Card label="Error during init script">
               <SessionCreationProgress
-                steps={[
-                  { step: "resolving_env", label: "Resolving environment...", status: "done" },
-                  { step: "pulling_image", label: "Pulling Docker image...", status: "done" },
-                  { step: "creating_container", label: "Starting container...", status: "done" },
-                  { step: "running_init_script", label: "Running init script...", status: "error" },
-                ] satisfies CreationProgressEvent[]}
-                error={"npm ERR! code ENOENT\nnpm ERR! syscall open\nnpm ERR! path /app/package.json"}
+                steps={
+                  [
+                    {
+                      step: "resolving_env",
+                      label: "Resolving environment...",
+                      status: "done",
+                    },
+                    {
+                      step: "pulling_image",
+                      label: "Pulling Docker image...",
+                      status: "done",
+                    },
+                    {
+                      step: "creating_container",
+                      label: "Starting container...",
+                      status: "done",
+                    },
+                    {
+                      step: "running_init_script",
+                      label: "Running init script...",
+                      status: "error",
+                    },
+                  ] satisfies CreationProgressEvent[]
+                }
+                error={
+                  "npm ERR! code ENOENT\nnpm ERR! syscall open\nnpm ERR! path /app/package.json"
+                }
               />
             </Card>
           </div>
         </Section>
         {/* ─── Session Launch Overlay ──────────────────────────── */}
-        <Section title="Session Launch Overlay" description="Full-screen overlay shown during session creation, replacing the inline progress list">
+        <Section
+          title="Session Launch Overlay"
+          description="Full-screen overlay shown during session creation, replacing the inline progress list"
+        >
           <div className="space-y-4">
             <Card label="In progress (container session)">
               <div className="relative h-[360px] bg-cc-bg rounded-lg overflow-hidden border border-cc-border">
                 <SessionLaunchOverlay
-                  steps={[
-                    { step: "resolving_env", label: "Environment resolved", status: "done" },
-                    { step: "pulling_image", label: "Pulling Docker image...", status: "done" },
-                    { step: "creating_container", label: "Starting container...", status: "in_progress" },
-                    { step: "launching_cli", label: "Launching Claude Code...", status: "in_progress" },
-                  ] satisfies CreationProgressEvent[]}
+                  steps={
+                    [
+                      {
+                        step: "resolving_env",
+                        label: "Environment resolved",
+                        status: "done",
+                      },
+                      {
+                        step: "pulling_image",
+                        label: "Pulling Docker image...",
+                        status: "done",
+                      },
+                      {
+                        step: "creating_container",
+                        label: "Starting container...",
+                        status: "in_progress",
+                      },
+                      {
+                        step: "launching_cli",
+                        label: "Launching Claude Code...",
+                        status: "in_progress",
+                      },
+                    ] satisfies CreationProgressEvent[]
+                  }
                   backend="claude"
                   onCancel={() => {}}
                 />
@@ -1529,12 +2411,30 @@ export function Playground() {
             <Card label="All steps done (launching)">
               <div className="relative h-[360px] bg-cc-bg rounded-lg overflow-hidden border border-cc-border">
                 <SessionLaunchOverlay
-                  steps={[
-                    { step: "resolving_env", label: "Environment resolved", status: "done" },
-                    { step: "fetching_git", label: "Fetch complete", status: "done" },
-                    { step: "creating_worktree", label: "Worktree created", status: "done" },
-                    { step: "launching_cli", label: "CLI launched", status: "done" },
-                  ] satisfies CreationProgressEvent[]}
+                  steps={
+                    [
+                      {
+                        step: "resolving_env",
+                        label: "Environment resolved",
+                        status: "done",
+                      },
+                      {
+                        step: "fetching_git",
+                        label: "Fetch complete",
+                        status: "done",
+                      },
+                      {
+                        step: "creating_worktree",
+                        label: "Worktree created",
+                        status: "done",
+                      },
+                      {
+                        step: "launching_cli",
+                        label: "CLI launched",
+                        status: "done",
+                      },
+                    ] satisfies CreationProgressEvent[]
+                  }
                   backend="claude"
                 />
               </div>
@@ -1542,10 +2442,20 @@ export function Playground() {
             <Card label="Error state">
               <div className="relative h-[400px] bg-cc-bg rounded-lg overflow-hidden border border-cc-border">
                 <SessionLaunchOverlay
-                  steps={[
-                    { step: "resolving_env", label: "Environment resolved", status: "done" },
-                    { step: "pulling_image", label: "Pulling Docker image...", status: "error" },
-                  ] satisfies CreationProgressEvent[]}
+                  steps={
+                    [
+                      {
+                        step: "resolving_env",
+                        label: "Environment resolved",
+                        status: "done",
+                      },
+                      {
+                        step: "pulling_image",
+                        label: "Pulling Docker image...",
+                        status: "error",
+                      },
+                    ] satisfies CreationProgressEvent[]
+                  }
                   error="Failed to pull docker.io/stangirard/the-companion:latest — connection timed out after 30s"
                   backend="claude"
                   onCancel={() => {}}
@@ -1555,10 +2465,20 @@ export function Playground() {
             <Card label="Codex backend">
               <div className="relative h-[320px] bg-cc-bg rounded-lg overflow-hidden border border-cc-border">
                 <SessionLaunchOverlay
-                  steps={[
-                    { step: "resolving_env", label: "Environment resolved", status: "done" },
-                    { step: "launching_cli", label: "Launching Codex...", status: "in_progress" },
-                  ] satisfies CreationProgressEvent[]}
+                  steps={
+                    [
+                      {
+                        step: "resolving_env",
+                        label: "Environment resolved",
+                        status: "done",
+                      },
+                      {
+                        step: "launching_cli",
+                        label: "Launching Codex...",
+                        status: "in_progress",
+                      },
+                    ] satisfies CreationProgressEvent[]
+                  }
                   backend="codex"
                   onCancel={() => {}}
                 />
@@ -1567,7 +2487,10 @@ export function Playground() {
           </div>
         </Section>
         {/* ─── Update Overlay ──────────────────────────── */}
-        <Section title="Update Overlay" description="Full-screen overlay shown when auto-update is in progress, polls server and reloads when ready">
+        <Section
+          title="Update Overlay"
+          description="Full-screen overlay shown when auto-update is in progress, polls server and reloads when ready"
+        >
           <div className="space-y-4">
             <Card label="Installing phase">
               <div className="relative h-[360px] bg-cc-bg rounded-lg overflow-hidden border border-cc-border">
@@ -1592,7 +2515,10 @@ export function Playground() {
           </div>
         </Section>
         {/* ─── CLAUDE.md Editor ──────────────────────────────── */}
-        <Section title="CLAUDE.md Editor" description="Modal for viewing and editing project CLAUDE.md instructions">
+        <Section
+          title="CLAUDE.md Editor"
+          description="Modal for viewing and editing project CLAUDE.md instructions"
+        >
           <div className="space-y-4 max-w-3xl">
             <Card label="Open editor button (from TopBar)">
               <PlaygroundClaudeMdButton />
@@ -1603,7 +2529,10 @@ export function Playground() {
           </div>
         </Section>
         {/* ─── Session Items ──────────────────────────────────── */}
-        <Section title="Session Items" description="Sidebar session rows — status dot, backend badge, Docker indicator, archive on hover">
+        <Section
+          title="Session Items"
+          description="Sidebar session rows — status dot, backend badge, Docker indicator, archive on hover"
+        >
           <PlaygroundSessionItems />
         </Section>
       </div>
@@ -1659,7 +2588,11 @@ function PlaygroundSessionItems() {
       <Card label="Running — Claude Code">
         <div className="bg-cc-sidebar rounded-lg p-1">
           <SessionItem
-            session={mockSession({ isConnected: true, status: "running", backendType: "claude" })}
+            session={mockSession({
+              isConnected: true,
+              status: "running",
+              backendType: "claude",
+            })}
             isActive={false}
             sessionName="Refactor auth module"
             permCount={0}
@@ -1673,7 +2606,12 @@ function PlaygroundSessionItems() {
       <Card label="Running — Codex + Docker">
         <div className="bg-cc-sidebar rounded-lg p-1">
           <SessionItem
-            session={mockSession({ isConnected: true, status: "running", backendType: "codex", isContainerized: true })}
+            session={mockSession({
+              isConnected: true,
+              status: "running",
+              backendType: "codex",
+              isContainerized: true,
+            })}
             isActive={false}
             sessionName="Add payment flow"
             permCount={0}
@@ -1687,7 +2625,12 @@ function PlaygroundSessionItems() {
       <Card label="Awaiting Input — 2 permissions pending">
         <div className="bg-cc-sidebar rounded-lg p-1">
           <SessionItem
-            session={mockSession({ isConnected: true, status: "running", backendType: "claude", permCount: 2 })}
+            session={mockSession({
+              isConnected: true,
+              status: "running",
+              backendType: "claude",
+              permCount: 2,
+            })}
             isActive={false}
             sessionName="Fix login bug"
             permCount={2}
@@ -1701,7 +2644,11 @@ function PlaygroundSessionItems() {
       <Card label="Idle — connected, not running">
         <div className="bg-cc-sidebar rounded-lg p-1">
           <SessionItem
-            session={mockSession({ isConnected: true, status: "idle", backendType: "claude" })}
+            session={mockSession({
+              isConnected: true,
+              status: "idle",
+              backendType: "claude",
+            })}
             isActive={false}
             sessionName="Review PR #42"
             permCount={0}
@@ -1729,7 +2676,12 @@ function PlaygroundSessionItems() {
       <Card label="Active (selected session)">
         <div className="bg-cc-sidebar rounded-lg p-1">
           <SessionItem
-            session={mockSession({ isConnected: true, status: "running", backendType: "claude", isContainerized: true })}
+            session={mockSession({
+              isConnected: true,
+              status: "running",
+              backendType: "claude",
+              isContainerized: true,
+            })}
             isActive={true}
             sessionName="Build new dashboard"
             permCount={0}
@@ -1759,7 +2711,15 @@ function PlaygroundSessionItems() {
 
 // ─── Shared Layout Helpers ──────────────────────────────────────────────────
 
-function Section({ title, description, children }: { title: string; description: string; children: React.ReactNode }) {
+function Section({
+  title,
+  description,
+  children,
+}: {
+  title: string;
+  description: string;
+  children: React.ReactNode;
+}) {
   return (
     <section>
       <div className="mb-4">
@@ -1771,11 +2731,19 @@ function Section({ title, description, children }: { title: string; description:
   );
 }
 
-function Card({ label, children }: { label: string; children: React.ReactNode }) {
+function Card({
+  label,
+  children,
+}: {
+  label: string;
+  children: React.ReactNode;
+}) {
   return (
     <div className="border border-cc-border rounded-xl overflow-hidden bg-cc-card">
       <div className="px-3 py-1.5 bg-cc-hover/50 border-b border-cc-border">
-        <span className="text-[10px] text-cc-muted font-mono-code uppercase tracking-wider">{label}</span>
+        <span className="text-[10px] text-cc-muted font-mono-code uppercase tracking-wider">
+          {label}
+        </span>
       </div>
       <div className="p-4">{children}</div>
     </div>
@@ -1788,7 +2756,9 @@ function PlaygroundTerminalTabsMock() {
     { id: "docker", label: "Docker", cwd: "/workspace" },
   ];
   const [active, setActive] = useState("host");
-  const [placement, setPlacement] = useState<"top" | "right" | "bottom" | "left">("bottom");
+  const [placement, setPlacement] = useState<
+    "top" | "right" | "bottom" | "left"
+  >("bottom");
 
   return (
     <div className="rounded-xl border border-cc-border bg-cc-card overflow-hidden">
@@ -1802,7 +2772,8 @@ function PlaygroundTerminalTabsMock() {
                 placement === p ? "bg-cc-card text-cc-fg" : "text-cc-muted"
               }`}
             >
-              {p[0]?.toUpperCase()}{p.slice(1)}
+              {p[0]?.toUpperCase()}
+              {p.slice(1)}
             </button>
           ))}
         </div>
@@ -1824,9 +2795,13 @@ function PlaygroundTerminalTabsMock() {
         </span>
       </div>
       <div className="h-32 p-3 bg-cc-bg">
-        <div className={`h-full min-h-0 rounded-lg border border-cc-border bg-cc-card flex ${placement === "left" || placement === "right" ? "flex-row" : "flex-col"}`}>
+        <div
+          className={`h-full min-h-0 rounded-lg border border-cc-border bg-cc-card flex ${placement === "left" || placement === "right" ? "flex-row" : "flex-col"}`}
+        >
           {(placement === "top" || placement === "left") && (
-            <div className={`${placement === "left" ? "w-2/5 border-r" : "h-2/5 border-b"} border-cc-border bg-cc-sidebar/40 flex items-center justify-center text-[10px] text-cc-muted font-mono-code`}>
+            <div
+              className={`${placement === "left" ? "w-2/5 border-r" : "h-2/5 border-b"} border-cc-border bg-cc-sidebar/40 flex items-center justify-center text-[10px] text-cc-muted font-mono-code`}
+            >
               Terminal docked
             </div>
           )}
@@ -1834,7 +2809,9 @@ function PlaygroundTerminalTabsMock() {
             Session content
           </div>
           {(placement === "right" || placement === "bottom") && (
-            <div className={`${placement === "right" ? "w-2/5 border-l" : "h-2/5 border-t"} border-cc-border bg-cc-sidebar/40 flex items-center justify-center text-[10px] text-cc-muted font-mono-code`}>
+            <div
+              className={`${placement === "right" ? "w-2/5 border-l" : "h-2/5 border-t"} border-cc-border bg-cc-sidebar/40 flex items-center justify-center text-[10px] text-cc-muted font-mono-code`}
+            >
               Terminal docked
             </div>
           )}
@@ -1846,9 +2823,19 @@ function PlaygroundTerminalTabsMock() {
 
 // ─── Inline Tool Group (mirrors MessageFeed's ToolMessageGroup) ─────────────
 
-interface ToolItem { id: string; name: string; input: Record<string, unknown> }
+interface ToolItem {
+  id: string;
+  name: string;
+  input: Record<string, unknown>;
+}
 
-function PlaygroundToolGroup({ toolName, items }: { toolName: string; items: ToolItem[] }) {
+function PlaygroundToolGroup({
+  toolName,
+  items,
+}: {
+  toolName: string;
+  items: ToolItem[];
+}) {
   const [open, setOpen] = useState(false);
   const iconType = getToolIcon(toolName);
   const label = getToolLabel(toolName);
@@ -1859,7 +2846,13 @@ function PlaygroundToolGroup({ toolName, items }: { toolName: string; items: Too
     return (
       <div className="flex items-start gap-3">
         <div className="w-6 h-6 rounded-full bg-cc-primary/10 flex items-center justify-center shrink-0 mt-0.5">
-          <svg viewBox="0 0 16 16" fill="currentColor" className="w-3 h-3 text-cc-primary"><circle cx="8" cy="8" r="3" /></svg>
+          <svg
+            viewBox="0 0 16 16"
+            fill="currentColor"
+            className="w-3 h-3 text-cc-primary"
+          >
+            <circle cx="8" cy="8" r="3" />
+          </svg>
         </div>
         <div className="flex-1 min-w-0">
           <div className="border border-cc-border rounded-[10px] overflow-hidden bg-cc-card">
@@ -1867,7 +2860,11 @@ function PlaygroundToolGroup({ toolName, items }: { toolName: string; items: Too
               onClick={() => setOpen(!open)}
               className="w-full flex items-center gap-2.5 px-3 py-2 text-left hover:bg-cc-hover transition-colors cursor-pointer"
             >
-              <svg viewBox="0 0 16 16" fill="currentColor" className={`w-3 h-3 text-cc-muted transition-transform shrink-0 ${open ? "rotate-90" : ""}`}>
+              <svg
+                viewBox="0 0 16 16"
+                fill="currentColor"
+                className={`w-3 h-3 text-cc-muted transition-transform shrink-0 ${open ? "rotate-90" : ""}`}
+              >
                 <path d="M6 4l4 4-4 4" />
               </svg>
               <ToolIcon type={iconType} />
@@ -1892,7 +2889,13 @@ function PlaygroundToolGroup({ toolName, items }: { toolName: string; items: Too
   return (
     <div className="flex items-start gap-3">
       <div className="w-6 h-6 rounded-full bg-cc-primary/10 flex items-center justify-center shrink-0 mt-0.5">
-        <svg viewBox="0 0 16 16" fill="currentColor" className="w-3 h-3 text-cc-primary"><circle cx="8" cy="8" r="3" /></svg>
+        <svg
+          viewBox="0 0 16 16"
+          fill="currentColor"
+          className="w-3 h-3 text-cc-primary"
+        >
+          <circle cx="8" cy="8" r="3" />
+        </svg>
       </div>
       <div className="flex-1 min-w-0">
         <div className="border border-cc-border rounded-[10px] overflow-hidden bg-cc-card">
@@ -1900,7 +2903,11 @@ function PlaygroundToolGroup({ toolName, items }: { toolName: string; items: Too
             onClick={() => setOpen(!open)}
             className="w-full flex items-center gap-2.5 px-3 py-2 text-left hover:bg-cc-hover transition-colors cursor-pointer"
           >
-            <svg viewBox="0 0 16 16" fill="currentColor" className={`w-3 h-3 text-cc-muted transition-transform shrink-0 ${open ? "rotate-90" : ""}`}>
+            <svg
+              viewBox="0 0 16 16"
+              fill="currentColor"
+              className={`w-3 h-3 text-cc-muted transition-transform shrink-0 ${open ? "rotate-90" : ""}`}
+            >
               <path d="M6 4l4 4-4 4" />
             </svg>
             <ToolIcon type={iconType} />
@@ -1914,9 +2921,14 @@ function PlaygroundToolGroup({ toolName, items }: { toolName: string; items: Too
               {items.map((item, i) => {
                 const preview = getPreview(item.name, item.input);
                 return (
-                  <div key={item.id || i} className="flex items-center gap-2 py-1 text-xs text-cc-muted font-mono-code truncate">
+                  <div
+                    key={item.id || i}
+                    className="flex items-center gap-2 py-1 text-xs text-cc-muted font-mono-code truncate"
+                  >
                     <span className="w-1 h-1 rounded-full bg-cc-muted/40 shrink-0" />
-                    <span className="truncate">{preview || JSON.stringify(item.input).slice(0, 80)}</span>
+                    <span className="truncate">
+                      {preview || JSON.stringify(item.input).slice(0, 80)}
+                    </span>
                   </div>
                 );
               })}
@@ -1954,13 +2966,43 @@ function PlaygroundSubagentGroup({
     if (!status) return null;
     const raw = status.trim().toLowerCase();
     if (!raw) return null;
-    if (raw === "completed") return { label: "completed", className: "text-green-600 bg-green-500/15", summary: "completed" };
-    if (raw === "failed" || raw === "error" || raw === "errored") return { label: "failed", className: "text-cc-error bg-cc-error/10", summary: "failed" };
-    if (raw === "pending" || raw === "pendinginit" || raw === "pending_init") return { label: "pending", className: "text-amber-700 bg-amber-500/15", summary: "pending" };
-    if (raw === "running" || raw === "inprogress" || raw === "in_progress" || raw === "started") return { label: "running", className: "text-blue-600 bg-blue-500/15", summary: "running" };
-    return { label: status, className: "text-amber-700 bg-amber-500/15", summary: "running" };
+    if (raw === "completed")
+      return {
+        label: "completed",
+        className: "text-green-600 bg-green-500/15",
+        summary: "completed",
+      };
+    if (raw === "failed" || raw === "error" || raw === "errored")
+      return {
+        label: "failed",
+        className: "text-cc-error bg-cc-error/10",
+        summary: "failed",
+      };
+    if (raw === "pending" || raw === "pendinginit" || raw === "pending_init")
+      return {
+        label: "pending",
+        className: "text-amber-700 bg-amber-500/15",
+        summary: "pending",
+      };
+    if (
+      raw === "running" ||
+      raw === "inprogress" ||
+      raw === "in_progress" ||
+      raw === "started"
+    )
+      return {
+        label: "running",
+        className: "text-blue-600 bg-blue-500/15",
+        summary: "running",
+      };
+    return {
+      label: status,
+      className: "text-amber-700 bg-amber-500/15",
+      summary: "running",
+    };
   }, [status]);
-  const statusSummaryCount = receiverCount !== undefined ? receiverCount : items.length;
+  const statusSummaryCount =
+    receiverCount !== undefined ? receiverCount : items.length;
 
   return (
     <div className="ml-9 border-l-2 border-cc-primary/20 pl-4">
@@ -1968,14 +3010,26 @@ function PlaygroundSubagentGroup({
         onClick={() => setOpen(!open)}
         className="w-full flex items-center gap-2 py-1.5 text-left cursor-pointer mb-1"
       >
-        <svg viewBox="0 0 16 16" fill="currentColor" className={`w-3 h-3 text-cc-muted transition-transform shrink-0 ${open ? "rotate-90" : ""}`}>
+        <svg
+          viewBox="0 0 16 16"
+          fill="currentColor"
+          className={`w-3 h-3 text-cc-muted transition-transform shrink-0 ${open ? "rotate-90" : ""}`}
+        >
           <path d="M6 4l4 4-4 4" />
         </svg>
-        <svg viewBox="0 0 16 16" fill="none" stroke="currentColor" strokeWidth="1.5" className="w-3.5 h-3.5 text-cc-primary shrink-0">
+        <svg
+          viewBox="0 0 16 16"
+          fill="none"
+          stroke="currentColor"
+          strokeWidth="1.5"
+          className="w-3.5 h-3.5 text-cc-primary shrink-0"
+        >
           <circle cx="8" cy="8" r="5" />
           <path d="M8 5v3l2 1" strokeLinecap="round" />
         </svg>
-        <span className="text-xs font-medium text-cc-fg truncate">{description}</span>
+        <span className="text-xs font-medium text-cc-fg truncate">
+          {description}
+        </span>
         {agentType && (
           <span className="text-[10px] text-cc-muted bg-cc-hover rounded-full px-1.5 py-0.5 shrink-0">
             {agentType}
@@ -1985,7 +3039,9 @@ function PlaygroundSubagentGroup({
           {backend === "codex" ? "Codex" : "Claude"}
         </span>
         {normalizedStatus && (
-          <span className={`text-[10px] rounded-full px-1.5 py-0.5 shrink-0 ${normalizedStatus.className}`}>
+          <span
+            className={`text-[10px] rounded-full px-1.5 py-0.5 shrink-0 ${normalizedStatus.className}`}
+          >
             {normalizedStatus.label}
           </span>
         )}
@@ -2000,11 +3056,15 @@ function PlaygroundSubagentGroup({
       </button>
       {open && (
         <div className="space-y-3 pb-2">
-          {(normalizedStatus || senderThreadId || receiverThreadIds.length > 0) && (
+          {(normalizedStatus ||
+            senderThreadId ||
+            receiverThreadIds.length > 0) && (
             <div className="rounded-lg border border-cc-border bg-cc-card px-2.5 py-2 space-y-1.5">
               <div className="flex flex-wrap items-center gap-1.5 text-[10px]">
                 {normalizedStatus && (
-                  <span className={`rounded-full px-1.5 py-0.5 ${normalizedStatus.className}`}>
+                  <span
+                    className={`rounded-full px-1.5 py-0.5 ${normalizedStatus.className}`}
+                  >
                     {statusSummaryCount} {normalizedStatus.summary}
                   </span>
                 )}
@@ -2033,9 +3093,72 @@ function PlaygroundSubagentGroup({
               )}
             </div>
           )}
-          <PlaygroundToolGroup toolName={items[0]?.name || "Grep"} items={items} />
+          <PlaygroundToolGroup
+            toolName={items[0]?.name || "Grep"}
+            items={items}
+          />
         </div>
       )}
+    </div>
+  );
+}
+
+// ─── Claude Context Demo (injects mock Claude data into a temp session) ──────
+
+const CLAUDE_DEMO_SESSION = "claude-playground-demo";
+
+function ClaudeContextPlaygroundDemo() {
+  useEffect(() => {
+    const store = useStore.getState();
+    const prev = store.sessions.get(CLAUDE_DEMO_SESSION);
+
+    store.addSession({
+      session_id: CLAUDE_DEMO_SESSION,
+      backend_type: "claude",
+      model: "claude-sonnet-4-6",
+      cwd: "/Users/demo/project",
+      tools: ["Bash", "Read", "Edit"],
+      permissionMode: "default",
+      claude_code_version: "1.2.0",
+      mcp_servers: [],
+      agents: [],
+      slash_commands: [],
+      skills: [],
+      total_cost_usd: 0.1842,
+      num_turns: 12,
+      context_used_percent: 73,
+      is_compacting: false,
+      git_branch: "feat/new-feature",
+      is_worktree: false,
+      is_containerized: false,
+      repo_root: "/Users/demo/project",
+      git_ahead: 0,
+      git_behind: 0,
+      total_lines_added: 0,
+      total_lines_removed: 0,
+      claude_token_details: {
+        inputTokens: 120_000,
+        outputTokens: 8_500,
+        cacheReadInputTokens: 25_000,
+        cacheCreationInputTokens: 1_200,
+        contextWindow: 200_000,
+        maxOutputTokens: 16384,
+      },
+    });
+
+    return () => {
+      useStore.setState((s) => {
+        const sessions = new Map(s.sessions);
+        if (prev) sessions.set(CLAUDE_DEMO_SESSION, prev);
+        else sessions.delete(CLAUDE_DEMO_SESSION);
+        return { sessions };
+      });
+    };
+  }, []);
+
+  return (
+    <div className="w-[280px] border border-cc-border rounded-xl overflow-hidden bg-cc-card">
+      <ClaudeContextSection sessionId={CLAUDE_DEMO_SESSION} />
     </div>
   );
 }
@@ -2075,8 +3198,16 @@ function CodexPlaygroundDemo() {
       total_lines_added: 0,
       total_lines_removed: 0,
       codex_rate_limits: {
-        primary: { usedPercent: 62, windowDurationMins: 300, resetsAt: Date.now() + 2 * 3_600_000 },
-        secondary: { usedPercent: 18, windowDurationMins: 10080, resetsAt: Date.now() + 5 * 86_400_000 },
+        primary: {
+          usedPercent: 62,
+          windowDurationMins: 300,
+          resetsAt: Date.now() + 2 * 3_600_000,
+        },
+        secondary: {
+          usedPercent: 18,
+          windowDurationMins: 10080,
+          resetsAt: Date.now() + 5 * 86_400_000,
+        },
       },
       codex_token_details: {
         inputTokens: 84_230,
@@ -2134,7 +3265,10 @@ function PlaygroundClaudeMdButton() {
   const [cwd, setCwd] = useState("/tmp");
 
   useEffect(() => {
-    api.getHome().then((res) => setCwd(res.cwd)).catch(() => {});
+    api
+      .getHome()
+      .then((res) => setCwd(res.cwd))
+      .catch(() => {});
   }, []);
 
   return (
@@ -2143,7 +3277,11 @@ function PlaygroundClaudeMdButton() {
         onClick={() => setOpen(true)}
         className="flex items-center gap-2 px-3 py-2 rounded-lg bg-cc-hover border border-cc-border hover:bg-cc-active transition-colors cursor-pointer"
       >
-        <svg viewBox="0 0 16 16" fill="currentColor" className="w-4 h-4 text-cc-primary">
+        <svg
+          viewBox="0 0 16 16"
+          fill="currentColor"
+          className="w-4 h-4 text-cc-primary"
+        >
           <path d="M4 1.5a.5.5 0 01.5-.5h7a.5.5 0 01.354.146l2 2A.5.5 0 0114 3.5v11a.5.5 0 01-.5.5h-11a.5.5 0 01-.5-.5v-13zm1 .5v12h8V4h-1.5a.5.5 0 01-.5-.5V2H5zm6 0v1h1l-1-1zM6.5 7a.5.5 0 000 1h5a.5.5 0 000-1h-5zm0 2a.5.5 0 000 1h5a.5.5 0 000-1h-5zm0 2a.5.5 0 000 1h3a.5.5 0 000-1h-3z" />
         </svg>
         <span className="text-xs font-medium text-cc-fg">Edit CLAUDE.md</span>
@@ -2151,11 +3289,7 @@ function PlaygroundClaudeMdButton() {
       <span className="text-[11px] text-cc-muted">
         Click to open the editor modal (uses server working directory)
       </span>
-      <ClaudeMdEditor
-        cwd={cwd}
-        open={open}
-        onClose={() => setOpen(false)}
-      />
+      <ClaudeMdEditor cwd={cwd} open={open} onClose={() => setOpen(false)} />
     </div>
   );
 }
@@ -2164,22 +3298,46 @@ function PlaygroundClaudeMdButton() {
 
 function PlaygroundMcpRow({ server }: { server: McpServerDetail }) {
   const [expanded, setExpanded] = useState(false);
-  const statusMap: Record<string, { label: string; cls: string; dot: string }> = {
-    connected: { label: "Connected", cls: "text-cc-success bg-cc-success/10", dot: "bg-cc-success" },
-    connecting: { label: "Connecting", cls: "text-cc-warning bg-cc-warning/10", dot: "bg-cc-warning animate-pulse" },
-    failed: { label: "Failed", cls: "text-cc-error bg-cc-error/10", dot: "bg-cc-error" },
-    disabled: { label: "Disabled", cls: "text-cc-muted bg-cc-hover", dot: "bg-cc-muted opacity-40" },
-  };
+  const statusMap: Record<string, { label: string; cls: string; dot: string }> =
+    {
+      connected: {
+        label: "Connected",
+        cls: "text-cc-success bg-cc-success/10",
+        dot: "bg-cc-success",
+      },
+      connecting: {
+        label: "Connecting",
+        cls: "text-cc-warning bg-cc-warning/10",
+        dot: "bg-cc-warning animate-pulse",
+      },
+      failed: {
+        label: "Failed",
+        cls: "text-cc-error bg-cc-error/10",
+        dot: "bg-cc-error",
+      },
+      disabled: {
+        label: "Disabled",
+        cls: "text-cc-muted bg-cc-hover",
+        dot: "bg-cc-muted opacity-40",
+      },
+    };
   const badge = statusMap[server.status] || statusMap.disabled;
 
   return (
     <div className="rounded-lg border border-cc-border bg-cc-bg">
       <div className="flex items-center gap-2 px-2.5 py-2">
         <span className={`w-1.5 h-1.5 rounded-full shrink-0 ${badge.dot}`} />
-        <button onClick={() => setExpanded(!expanded)} className="flex-1 min-w-0 text-left cursor-pointer">
-          <span className="text-[12px] font-medium text-cc-fg truncate block">{server.name}</span>
+        <button
+          onClick={() => setExpanded(!expanded)}
+          className="flex-1 min-w-0 text-left cursor-pointer"
+        >
+          <span className="text-[12px] font-medium text-cc-fg truncate block">
+            {server.name}
+          </span>
         </button>
-        <span className={`text-[9px] font-medium px-1.5 rounded-full leading-[16px] shrink-0 ${badge.cls}`}>
+        <span
+          className={`text-[9px] font-medium px-1.5 rounded-full leading-[16px] shrink-0 ${badge.cls}`}
+        >
           {badge.label}
         </span>
       </div>
@@ -2194,14 +3352,19 @@ function PlaygroundMcpRow({ server }: { server: McpServerDetail }) {
               <div className="flex items-start gap-1">
                 <span className="text-cc-muted/60 shrink-0">Cmd:</span>
                 <span className="font-mono text-[10px] break-all">
-                  {server.config.command}{server.config.args?.length ? ` ${server.config.args.join(" ")}` : ""}
+                  {server.config.command}
+                  {server.config.args?.length
+                    ? ` ${server.config.args.join(" ")}`
+                    : ""}
                 </span>
               </div>
             )}
             {server.config.url && (
               <div className="flex items-start gap-1">
                 <span className="text-cc-muted/60 shrink-0">URL:</span>
-                <span className="font-mono text-[10px] break-all">{server.config.url}</span>
+                <span className="font-mono text-[10px] break-all">
+                  {server.config.url}
+                </span>
               </div>
             )}
             <div className="flex items-center gap-1">
@@ -2210,14 +3373,21 @@ function PlaygroundMcpRow({ server }: { server: McpServerDetail }) {
             </div>
           </div>
           {server.error && (
-            <div className="text-[11px] text-cc-error bg-cc-error/5 rounded px-2 py-1">{server.error}</div>
+            <div className="text-[11px] text-cc-error bg-cc-error/5 rounded px-2 py-1">
+              {server.error}
+            </div>
           )}
           {server.tools && server.tools.length > 0 && (
             <div className="space-y-1">
-              <span className="text-[10px] text-cc-muted uppercase tracking-wider">Tools ({server.tools.length})</span>
+              <span className="text-[10px] text-cc-muted uppercase tracking-wider">
+                Tools ({server.tools.length})
+              </span>
               <div className="flex flex-wrap gap-1">
                 {server.tools.map((tool) => (
-                  <span key={tool.name} className="text-[10px] font-mono px-1.5 py-0.5 rounded bg-cc-hover text-cc-fg">
+                  <span
+                    key={tool.name}
+                    className="text-[10px] font-mono px-1.5 py-0.5 rounded bg-cc-hover text-cc-fg"
+                  >
                     {tool.name}
                   </span>
                 ))}
@@ -2237,37 +3407,87 @@ function TaskRow({ task }: { task: TaskItem }) {
   const isInProgress = task.status === "in_progress";
 
   return (
-    <div className={`px-2.5 py-2 rounded-lg ${isCompleted ? "opacity-50" : ""}`}>
+    <div
+      className={`px-2.5 py-2 rounded-lg ${isCompleted ? "opacity-50" : ""}`}
+    >
       <div className="flex items-start gap-2">
         <span className="shrink-0 flex items-center justify-center w-4 h-4 mt-px">
           {isInProgress ? (
-            <svg className="w-4 h-4 text-cc-primary animate-spin" viewBox="0 0 16 16" fill="none">
-              <circle cx="8" cy="8" r="6" stroke="currentColor" strokeWidth="1.5" strokeDasharray="28" strokeDashoffset="8" strokeLinecap="round" />
+            <svg
+              className="w-4 h-4 text-cc-primary animate-spin"
+              viewBox="0 0 16 16"
+              fill="none"
+            >
+              <circle
+                cx="8"
+                cy="8"
+                r="6"
+                stroke="currentColor"
+                strokeWidth="1.5"
+                strokeDasharray="28"
+                strokeDashoffset="8"
+                strokeLinecap="round"
+              />
             </svg>
           ) : isCompleted ? (
-            <svg viewBox="0 0 16 16" fill="currentColor" className="w-4 h-4 text-cc-success">
-              <path fillRule="evenodd" d="M8 15A7 7 0 108 1a7 7 0 000 14zm3.354-9.354a.5.5 0 00-.708-.708L7 8.586 5.354 6.94a.5.5 0 10-.708.708l2 2a.5.5 0 00.708 0l4-4z" clipRule="evenodd" />
+            <svg
+              viewBox="0 0 16 16"
+              fill="currentColor"
+              className="w-4 h-4 text-cc-success"
+            >
+              <path
+                fillRule="evenodd"
+                d="M8 15A7 7 0 108 1a7 7 0 000 14zm3.354-9.354a.5.5 0 00-.708-.708L7 8.586 5.354 6.94a.5.5 0 10-.708.708l2 2a.5.5 0 00.708 0l4-4z"
+                clipRule="evenodd"
+              />
             </svg>
           ) : (
-            <svg viewBox="0 0 16 16" fill="none" className="w-4 h-4 text-cc-muted">
-              <circle cx="8" cy="8" r="6" stroke="currentColor" strokeWidth="1.5" />
+            <svg
+              viewBox="0 0 16 16"
+              fill="none"
+              className="w-4 h-4 text-cc-muted"
+            >
+              <circle
+                cx="8"
+                cy="8"
+                r="6"
+                stroke="currentColor"
+                strokeWidth="1.5"
+              />
             </svg>
           )}
         </span>
-        <span className={`text-[13px] leading-snug flex-1 ${isCompleted ? "text-cc-muted line-through" : "text-cc-fg"}`}>
+        <span
+          className={`text-[13px] leading-snug flex-1 ${isCompleted ? "text-cc-muted line-through" : "text-cc-fg"}`}
+        >
           {task.subject}
         </span>
       </div>
       {isInProgress && task.activeForm && (
-        <p className="mt-1 ml-6 text-[11px] text-cc-muted italic truncate">{task.activeForm}</p>
+        <p className="mt-1 ml-6 text-[11px] text-cc-muted italic truncate">
+          {task.activeForm}
+        </p>
       )}
       {task.blockedBy && task.blockedBy.length > 0 && (
         <p className="mt-1 ml-6 text-[11px] text-cc-muted flex items-center gap-1">
           <svg viewBox="0 0 16 16" fill="none" className="w-3 h-3 shrink-0">
-            <circle cx="8" cy="8" r="6" stroke="currentColor" strokeWidth="1.5" />
-            <path d="M5 8h6" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" />
+            <circle
+              cx="8"
+              cy="8"
+              r="6"
+              stroke="currentColor"
+              strokeWidth="1.5"
+            />
+            <path
+              d="M5 8h6"
+              stroke="currentColor"
+              strokeWidth="1.5"
+              strokeLinecap="round"
+            />
           </svg>
-          <span>blocked by {task.blockedBy.map((b) => `#${b}`).join(", ")}</span>
+          <span>
+            blocked by {task.blockedBy.map((b) => `#${b}`).join(", ")}
+          </span>
         </p>
       )}
     </div>
@@ -2312,16 +3532,20 @@ function PlaygroundAiValidationToggle({ enabled }: { enabled: boolean }) {
     });
     return () => {
       if (prev) {
-        useStore.getState().updateSession(PLAYGROUND_AI_VALIDATION_SESSION, prev);
+        useStore
+          .getState()
+          .updateSession(PLAYGROUND_AI_VALIDATION_SESSION, prev);
       }
     };
   }, [enabled]);
 
   // Force the enabled state each render to match the prop
   useEffect(() => {
-    useStore.getState().setSessionAiValidation(PLAYGROUND_AI_VALIDATION_SESSION, {
-      aiValidationEnabled: enabled,
-    });
+    useStore
+      .getState()
+      .setSessionAiValidation(PLAYGROUND_AI_VALIDATION_SESSION, {
+        aiValidationEnabled: enabled,
+      });
   }, [enabled]);
 
   return (

--- a/web/src/components/TaskPanel.tsx
+++ b/web/src/components/TaskPanel.tsx
@@ -1,12 +1,29 @@
-import { useEffect, useState, useCallback, useRef, type ComponentType } from "react";
+import {
+  useEffect,
+  useState,
+  useCallback,
+  useRef,
+  type ComponentType,
+} from "react";
 import { useStore } from "../store.js";
-import { api, type UsageLimits, type GitHubPRInfo, type LinearIssue, type LinearComment } from "../api.js";
+import {
+  api,
+  type UsageLimits,
+  type GitHubPRInfo,
+  type LinearIssue,
+  type LinearComment,
+} from "../api.js";
 import type { TaskItem } from "../types.js";
 import { McpSection } from "./McpPanel.js";
 import { LinearLogo } from "./LinearLogo.js";
 import { ClaudeConfigBrowser } from "./ClaudeConfigBrowser.js";
 import { SECTION_DEFINITIONS } from "./task-panel-sections.js";
-import { formatResetTime, formatCodexResetTime, formatWindowDuration, formatTokenCount } from "../utils/format.js";
+import {
+  formatResetTime,
+  formatCodexResetTime,
+  formatWindowDuration,
+  formatTokenCount,
+} from "../utils/format.js";
 import { timeAgo } from "../utils/time-ago.js";
 import { captureException } from "../analytics.js";
 import { SectionErrorBoundary } from "./SectionErrorBoundary.js";
@@ -143,7 +160,9 @@ function UsageLimitsSection({ sessionId }: { sessionId: string }) {
 // ─── Codex Rate Limits ───────────────────────────────────────────────────────
 
 function CodexRateLimitsSection({ sessionId }: { sessionId: string }) {
-  const rateLimits = useStore((s) => s.sessions.get(sessionId)?.codex_rate_limits);
+  const rateLimits = useStore(
+    (s) => s.sessions.get(sessionId)?.codex_rate_limits,
+  );
 
   // Tick for countdown refresh
   const [, setTick] = useState(0);
@@ -209,37 +228,118 @@ function CodexRateLimitsSection({ sessionId }: { sessionId: string }) {
   );
 }
 
+// ─── Claude Code Context Section ─────────────────────────────────────────────
+
+function ClaudeContextSection({ sessionId }: { sessionId: string }) {
+  const details = useStore(
+    (s) => s.sessions.get(sessionId)?.claude_token_details,
+  );
+  const contextPct = useStore(
+    (s) => s.sessions.get(sessionId)?.context_used_percent ?? 0,
+  );
+  const totalCost = useStore(
+    (s) => s.sessions.get(sessionId)?.total_cost_usd ?? 0,
+  );
+  const numTurns = useStore((s) => s.sessions.get(sessionId)?.num_turns ?? 0);
+
+  if (!details) return null;
+
+  const contextWindow = details.contextWindow;
+  const usedTokens =
+    details.inputTokens +
+    details.cacheReadInputTokens +
+    details.cacheCreationInputTokens;
+
+  return (
+    <div className="shrink-0 px-4 py-3 space-y-2">
+      <span className="text-[11px] text-cc-muted uppercase tracking-wider">
+        Context
+      </span>
+      {contextWindow > 0 && (
+        <div className="space-y-1">
+          <div className="flex items-center justify-between">
+            <span className="text-[11px] text-cc-muted">
+              {formatTokenCount(usedTokens)} / {formatTokenCount(contextWindow)}
+            </span>
+            <span className="text-[11px] text-cc-muted tabular-nums">
+              {contextPct}%
+            </span>
+          </div>
+          <div className="w-full h-1.5 rounded-full bg-cc-hover overflow-hidden">
+            <div
+              className={`h-full rounded-full transition-all duration-500 ${barColor(contextPct)}`}
+              style={{ width: `${Math.min(contextPct, 100)}%` }}
+            />
+          </div>
+        </div>
+      )}
+      <div className="grid grid-cols-2 gap-x-3 gap-y-1.5">
+        {totalCost > 0 && (
+          <div className="flex items-center justify-between">
+            <span className="text-[11px] text-cc-muted">Cost</span>
+            <span className="text-[11px] text-cc-fg tabular-nums font-medium">
+              ${totalCost.toFixed(4)}
+            </span>
+          </div>
+        )}
+        {numTurns > 0 && (
+          <div className="flex items-center justify-between">
+            <span className="text-[11px] text-cc-muted">Turns</span>
+            <span className="text-[11px] text-cc-fg tabular-nums font-medium">
+              {numTurns}
+            </span>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}
+
 // ─── Codex Token Details ─────────────────────────────────────────────────────
 
 function CodexTokenDetailsSection({ sessionId }: { sessionId: string }) {
-  const details = useStore((s) => s.sessions.get(sessionId)?.codex_token_details);
+  const details = useStore(
+    (s) => s.sessions.get(sessionId)?.codex_token_details,
+  );
   // Use the server-computed context percentage (input+output / contextWindow, capped 0-100)
-  const contextPct = useStore((s) => s.sessions.get(sessionId)?.context_used_percent ?? 0);
+  const contextPct = useStore(
+    (s) => s.sessions.get(sessionId)?.context_used_percent ?? 0,
+  );
 
   if (!details) return null;
 
   return (
     <div className="shrink-0 px-4 py-3 space-y-2">
-      <span className="text-[11px] text-cc-muted uppercase tracking-wider">Tokens</span>
+      <span className="text-[11px] text-cc-muted uppercase tracking-wider">
+        Tokens
+      </span>
       <div className="grid grid-cols-2 gap-x-3 gap-y-1.5">
         <div className="flex items-center justify-between">
           <span className="text-[11px] text-cc-muted">Input</span>
-          <span className="text-[11px] text-cc-fg tabular-nums font-medium">{formatTokenCount(details.inputTokens)}</span>
+          <span className="text-[11px] text-cc-fg tabular-nums font-medium">
+            {formatTokenCount(details.inputTokens)}
+          </span>
         </div>
         <div className="flex items-center justify-between">
           <span className="text-[11px] text-cc-muted">Output</span>
-          <span className="text-[11px] text-cc-fg tabular-nums font-medium">{formatTokenCount(details.outputTokens)}</span>
+          <span className="text-[11px] text-cc-fg tabular-nums font-medium">
+            {formatTokenCount(details.outputTokens)}
+          </span>
         </div>
         {details.cachedInputTokens > 0 && (
           <div className="flex items-center justify-between">
             <span className="text-[11px] text-cc-muted">Cached</span>
-            <span className="text-[11px] text-cc-fg tabular-nums font-medium">{formatTokenCount(details.cachedInputTokens)}</span>
+            <span className="text-[11px] text-cc-fg tabular-nums font-medium">
+              {formatTokenCount(details.cachedInputTokens)}
+            </span>
           </div>
         )}
         {details.reasoningOutputTokens > 0 && (
           <div className="flex items-center justify-between">
             <span className="text-[11px] text-cc-muted">Reasoning</span>
-            <span className="text-[11px] text-cc-fg tabular-nums font-medium">{formatTokenCount(details.reasoningOutputTokens)}</span>
+            <span className="text-[11px] text-cc-fg tabular-nums font-medium">
+              {formatTokenCount(details.reasoningOutputTokens)}
+            </span>
           </div>
         )}
       </div>
@@ -247,7 +347,9 @@ function CodexTokenDetailsSection({ sessionId }: { sessionId: string }) {
         <div className="space-y-1">
           <div className="flex items-center justify-between">
             <span className="text-[11px] text-cc-muted">Context</span>
-            <span className="text-[11px] text-cc-muted tabular-nums">{contextPct}%</span>
+            <span className="text-[11px] text-cc-muted tabular-nums">
+              {contextPct}%
+            </span>
           </div>
           <div className="w-full h-1.5 rounded-full bg-cc-hover overflow-hidden">
             <div
@@ -266,9 +368,12 @@ function CodexTokenDetailsSection({ sessionId }: { sessionId: string }) {
 function prStatePill(state: GitHubPRInfo["state"], isDraft: boolean) {
   if (isDraft) return { label: "Draft", cls: "text-cc-muted bg-cc-hover" };
   switch (state) {
-    case "OPEN": return { label: "Open", cls: "text-cc-success bg-cc-success/10" };
-    case "MERGED": return { label: "Merged", cls: "text-purple-400 bg-purple-400/10" };
-    case "CLOSED": return { label: "Closed", cls: "text-cc-error bg-cc-error/10" };
+    case "OPEN":
+      return { label: "Open", cls: "text-cc-success bg-cc-success/10" };
+    case "MERGED":
+      return { label: "Merged", cls: "text-purple-400 bg-purple-400/10" };
+    case "CLOSED":
+      return { label: "Closed", cls: "text-cc-error bg-cc-error/10" };
   }
 }
 
@@ -288,7 +393,9 @@ export function GitHubPRDisplay({ pr }: { pr: GitHubPRInfo }) {
         >
           PR #{pr.number}
         </a>
-        <span className={`text-[9px] font-medium px-1.5 rounded-full leading-[16px] ${pill.cls}`}>
+        <span
+          className={`text-[9px] font-medium px-1.5 rounded-full leading-[16px] ${pill.cls}`}
+        >
           {pill.label}
         </span>
       </div>
@@ -304,15 +411,27 @@ export function GitHubPRDisplay({ pr }: { pr: GitHubPRInfo }) {
           {cs.failure > 0 ? (
             <>
               <span className="flex items-center gap-1 text-cc-error">
-                <svg viewBox="0 0 16 16" fill="currentColor" className="w-3 h-3">
+                <svg
+                  viewBox="0 0 16 16"
+                  fill="currentColor"
+                  className="w-3 h-3"
+                >
                   <path d="M3.72 3.72a.75.75 0 011.06 0L8 6.94l3.22-3.22a.75.75 0 111.06 1.06L9.06 8l3.22 3.22a.75.75 0 11-1.06 1.06L8 9.06l-3.22 3.22a.75.75 0 01-1.06-1.06L6.94 8 3.72 4.78a.75.75 0 010-1.06z" />
                 </svg>
                 {cs.failure} failing
               </span>
               {cs.success > 0 && (
                 <span className="flex items-center gap-1 text-cc-success">
-                  <svg viewBox="0 0 16 16" fill="currentColor" className="w-3 h-3">
-                    <path fillRule="evenodd" d="M13.78 4.22a.75.75 0 010 1.06l-7.25 7.25a.75.75 0 01-1.06 0L2.22 9.28a.75.75 0 011.06-1.06L6 10.94l6.72-6.72a.75.75 0 011.06 0z" clipRule="evenodd" />
+                  <svg
+                    viewBox="0 0 16 16"
+                    fill="currentColor"
+                    className="w-3 h-3"
+                  >
+                    <path
+                      fillRule="evenodd"
+                      d="M13.78 4.22a.75.75 0 010 1.06l-7.25 7.25a.75.75 0 01-1.06 0L2.22 9.28a.75.75 0 011.06-1.06L6 10.94l6.72-6.72a.75.75 0 011.06 0z"
+                      clipRule="evenodd"
+                    />
                   </svg>
                   {cs.success} passed
                 </span>
@@ -320,19 +439,32 @@ export function GitHubPRDisplay({ pr }: { pr: GitHubPRInfo }) {
             </>
           ) : cs.pending > 0 ? (
             <span className="flex items-center gap-1 text-cc-warning">
-              <svg viewBox="0 0 16 16" fill="currentColor" className="w-3 h-3 animate-spin">
-                <path d="M8 2a6 6 0 100 12A6 6 0 008 2zM0 8a8 8 0 1116 0A8 8 0 010 8z" opacity=".2" />
+              <svg
+                viewBox="0 0 16 16"
+                fill="currentColor"
+                className="w-3 h-3 animate-spin"
+              >
+                <path
+                  d="M8 2a6 6 0 100 12A6 6 0 008 2zM0 8a8 8 0 1116 0A8 8 0 010 8z"
+                  opacity=".2"
+                />
                 <path d="M8 0a8 8 0 018 8h-2A6 6 0 008 2V0z" />
               </svg>
               {cs.pending} pending
               {cs.success > 0 && (
-                <span className="text-cc-success ml-1">{cs.success} passed</span>
+                <span className="text-cc-success ml-1">
+                  {cs.success} passed
+                </span>
               )}
             </span>
           ) : (
             <span className="flex items-center gap-1 text-cc-success">
               <svg viewBox="0 0 16 16" fill="currentColor" className="w-3 h-3">
-                <path fillRule="evenodd" d="M13.78 4.22a.75.75 0 010 1.06l-7.25 7.25a.75.75 0 01-1.06 0L2.22 9.28a.75.75 0 011.06-1.06L6 10.94l6.72-6.72a.75.75 0 011.06 0z" clipRule="evenodd" />
+                <path
+                  fillRule="evenodd"
+                  d="M13.78 4.22a.75.75 0 010 1.06l-7.25 7.25a.75.75 0 01-1.06 0L2.22 9.28a.75.75 0 011.06-1.06L6 10.94l6.72-6.72a.75.75 0 011.06 0z"
+                  clipRule="evenodd"
+                />
               </svg>
               {cs.total}/{cs.total} checks passed
             </span>
@@ -345,7 +477,11 @@ export function GitHubPRDisplay({ pr }: { pr: GitHubPRInfo }) {
         {pr.reviewDecision === "APPROVED" && (
           <span className="flex items-center gap-1 text-cc-success">
             <svg viewBox="0 0 16 16" fill="currentColor" className="w-3 h-3">
-              <path fillRule="evenodd" d="M13.78 4.22a.75.75 0 010 1.06l-7.25 7.25a.75.75 0 01-1.06 0L2.22 9.28a.75.75 0 011.06-1.06L6 10.94l6.72-6.72a.75.75 0 011.06 0z" clipRule="evenodd" />
+              <path
+                fillRule="evenodd"
+                d="M13.78 4.22a.75.75 0 010 1.06l-7.25 7.25a.75.75 0 01-1.06 0L2.22 9.28a.75.75 0 011.06-1.06L6 10.94l6.72-6.72a.75.75 0 011.06 0z"
+                clipRule="evenodd"
+              />
             </svg>
             Approved
           </span>
@@ -353,19 +489,29 @@ export function GitHubPRDisplay({ pr }: { pr: GitHubPRInfo }) {
         {pr.reviewDecision === "CHANGES_REQUESTED" && (
           <span className="flex items-center gap-1 text-cc-error">
             <svg viewBox="0 0 16 16" fill="currentColor" className="w-3 h-3">
-              <path fillRule="evenodd" d="M8 1.5a6.5 6.5 0 100 13 6.5 6.5 0 000-13zM0 8a8 8 0 1116 0A8 8 0 010 8zm9-3a1 1 0 11-2 0 1 1 0 012 0zM8 7a.75.75 0 01.75.75v3.5a.75.75 0 01-1.5 0v-3.5A.75.75 0 018 7z" clipRule="evenodd" />
+              <path
+                fillRule="evenodd"
+                d="M8 1.5a6.5 6.5 0 100 13 6.5 6.5 0 000-13zM0 8a8 8 0 1116 0A8 8 0 010 8zm9-3a1 1 0 11-2 0 1 1 0 012 0zM8 7a.75.75 0 01.75.75v3.5a.75.75 0 01-1.5 0v-3.5A.75.75 0 018 7z"
+                clipRule="evenodd"
+              />
             </svg>
             Changes requested
           </span>
         )}
-        {(pr.reviewDecision === "REVIEW_REQUIRED" || pr.reviewDecision === null) && pr.state === "OPEN" && (
-          <span className="flex items-center gap-1 text-cc-muted">
-            <svg viewBox="0 0 16 16" fill="currentColor" className="w-3 h-3 opacity-50">
-              <circle cx="8" cy="8" r="6" />
-            </svg>
-            Review pending
-          </span>
-        )}
+        {(pr.reviewDecision === "REVIEW_REQUIRED" ||
+          pr.reviewDecision === null) &&
+          pr.state === "OPEN" && (
+            <span className="flex items-center gap-1 text-cc-muted">
+              <svg
+                viewBox="0 0 16 16"
+                fill="currentColor"
+                className="w-3 h-3 opacity-50"
+              >
+                <circle cx="8" cy="8" r="6" />
+              </svg>
+              Review pending
+            </span>
+          )}
         {rt.unresolved > 0 && (
           <span className="flex items-center gap-1 text-cc-warning">
             <svg viewBox="0 0 16 16" fill="currentColor" className="w-3 h-3">
@@ -388,7 +534,9 @@ export function GitHubPRDisplay({ pr }: { pr: GitHubPRInfo }) {
 
 function GitHubPRSection({ sessionId }: { sessionId: string }) {
   const session = useStore((s) => s.sessions.get(sessionId));
-  const sdk = useStore((s) => s.sdkSessions.find((x) => x.sessionId === sessionId));
+  const sdk = useStore((s) =>
+    s.sdkSessions.find((x) => x.sessionId === sessionId),
+  );
   const prStatus = useStore((s) => s.prStatus.get(sessionId));
 
   const cwd = session?.cwd || sdk?.cwd;
@@ -397,9 +545,12 @@ function GitHubPRSection({ sessionId }: { sessionId: string }) {
   // One-time REST fallback on mount if no pushed data yet
   useEffect(() => {
     if (prStatus || !cwd || !branch) return;
-    api.getPRStatus(cwd, branch).then((data) => {
-      useStore.getState().setPRStatus(sessionId, data);
-    }).catch(() => {});
+    api
+      .getPRStatus(cwd, branch)
+      .then((data) => {
+        useStore.getState().setPRStatus(sessionId, data);
+      })
+      .catch(() => {});
   }, [sessionId, cwd, branch, prStatus]);
 
   if (!prStatus?.available || !prStatus.pr) return null;
@@ -414,25 +565,45 @@ const LINEAR_POLL_INTERVAL = 60_000;
 function linearStatePill(stateType: string, stateName: string) {
   switch (stateType) {
     case "completed":
-      return { label: stateName || "Done", cls: "text-cc-success bg-cc-success/10" };
+      return {
+        label: stateName || "Done",
+        cls: "text-cc-success bg-cc-success/10",
+      };
     case "cancelled":
-      return { label: stateName || "Cancelled", cls: "text-cc-muted bg-cc-hover" };
+      return {
+        label: stateName || "Cancelled",
+        cls: "text-cc-muted bg-cc-hover",
+      };
     case "started":
-      return { label: stateName || "In Progress", cls: "text-blue-400 bg-blue-400/10" };
+      return {
+        label: stateName || "In Progress",
+        cls: "text-blue-400 bg-blue-400/10",
+      };
     case "unstarted":
       return { label: stateName || "Todo", cls: "text-cc-muted bg-cc-hover" };
     case "backlog":
-      return { label: stateName || "Backlog", cls: "text-cc-muted bg-cc-hover" };
+      return {
+        label: stateName || "Backlog",
+        cls: "text-cc-muted bg-cc-hover",
+      };
     default:
-      return { label: stateName || stateType || "Unknown", cls: "text-cc-muted bg-cc-hover" };
+      return {
+        label: stateName || stateType || "Unknown",
+        cls: "text-cc-muted bg-cc-hover",
+      };
   }
 }
 
 function LinearIssueSection({ sessionId }: { sessionId: string }) {
   const linkedIssue = useStore((s) => s.linkedLinearIssues.get(sessionId));
   const [comments, setComments] = useState<LinearComment[]>([]);
-  const [assignee, setAssignee] = useState<{ name: string; avatarUrl?: string | null } | null>(null);
-  const [labels, setLabels] = useState<{ id: string; name: string; color: string }[]>([]);
+  const [assignee, setAssignee] = useState<{
+    name: string;
+    avatarUrl?: string | null;
+  } | null>(null);
+  const [labels, setLabels] = useState<
+    { id: string; name: string; color: string }[]
+  >([]);
   const [commentText, setCommentText] = useState("");
   const [sendingComment, setSendingComment] = useState(false);
   const [showDoneWarning, setShowDoneWarning] = useState(false);
@@ -444,11 +615,14 @@ function LinearIssueSection({ sessionId }: { sessionId: string }) {
 
   // Load stored linked issue from server on mount
   useEffect(() => {
-    api.getLinkedLinearIssue(sessionId).then((data) => {
-      if (data.issue) {
-        useStore.getState().setLinkedLinearIssue(sessionId, data.issue);
-      }
-    }).catch(() => {});
+    api
+      .getLinkedLinearIssue(sessionId)
+      .then((data) => {
+        if (data.issue) {
+          useStore.getState().setLinkedLinearIssue(sessionId, data.issue);
+        }
+      })
+      .catch(() => {});
   }, [sessionId]);
 
   // Fetch fresh data from Linear periodically
@@ -481,19 +655,29 @@ function LinearIssueSection({ sessionId }: { sessionId: string }) {
   useEffect(() => {
     if (!showSearch) return;
     const q = searchQuery.trim();
-    if (q.length < 2) { setSearchResults([]); return; }
+    if (q.length < 2) {
+      setSearchResults([]);
+      return;
+    }
     let active = true;
     setSearching(true);
     const timer = setTimeout(() => {
-      api.searchLinearIssues(q, 6).then((res) => {
-        if (active) setSearchResults(res.issues);
-      }).catch(() => {
-        if (active) setSearchResults([]);
-      }).finally(() => {
-        if (active) setSearching(false);
-      });
+      api
+        .searchLinearIssues(q, 6)
+        .then((res) => {
+          if (active) setSearchResults(res.issues);
+        })
+        .catch(() => {
+          if (active) setSearchResults([]);
+        })
+        .finally(() => {
+          if (active) setSearching(false);
+        });
     }, 400);
-    return () => { active = false; clearTimeout(timer); };
+    return () => {
+      active = false;
+      clearTimeout(timer);
+    };
   }, [searchQuery, showSearch]);
 
   // Focus search input when search opens
@@ -507,7 +691,10 @@ function LinearIssueSection({ sessionId }: { sessionId: string }) {
     if (!linkedIssue || !commentText.trim() || sendingComment) return;
     setSendingComment(true);
     try {
-      const result = await api.addLinearComment(linkedIssue.id, commentText.trim());
+      const result = await api.addLinearComment(
+        linkedIssue.id,
+        commentText.trim(),
+      );
       setComments((prev) => [...prev, result.comment]);
       setCommentText("");
     } catch {
@@ -568,10 +755,20 @@ function LinearIssueSection({ sessionId }: { sessionId: string }) {
                 className="flex-1 text-[11px] bg-transparent border border-cc-border rounded-md px-2 py-1.5 text-cc-fg placeholder:text-cc-muted focus:outline-none focus:border-cc-primary/50"
               />
               <button
-                onClick={() => { setShowSearch(false); setSearchQuery(""); setSearchResults([]); }}
+                onClick={() => {
+                  setShowSearch(false);
+                  setSearchQuery("");
+                  setSearchResults([]);
+                }}
                 className="text-cc-muted hover:text-cc-fg transition-colors cursor-pointer"
               >
-                <svg viewBox="0 0 16 16" fill="none" stroke="currentColor" strokeWidth="1.5" className="w-3.5 h-3.5">
+                <svg
+                  viewBox="0 0 16 16"
+                  fill="none"
+                  stroke="currentColor"
+                  strokeWidth="1.5"
+                  className="w-3.5 h-3.5"
+                >
                   <path d="M4 4l8 8M12 4l-8 8" />
                 </svg>
               </button>
@@ -588,19 +785,32 @@ function LinearIssueSection({ sessionId }: { sessionId: string }) {
                     className="w-full text-left px-2 py-1.5 rounded-md hover:bg-cc-hover transition-colors cursor-pointer"
                   >
                     <div className="flex items-center gap-1.5">
-                      <span className="text-[11px] font-mono-code text-cc-primary shrink-0">{issue.identifier}</span>
-                      <span className={`text-[9px] font-medium px-1 rounded-full leading-[14px] ${linearStatePill(issue.stateType, issue.stateName).cls}`}>
-                        {linearStatePill(issue.stateType, issue.stateName).label}
+                      <span className="text-[11px] font-mono-code text-cc-primary shrink-0">
+                        {issue.identifier}
+                      </span>
+                      <span
+                        className={`text-[9px] font-medium px-1 rounded-full leading-[14px] ${linearStatePill(issue.stateType, issue.stateName).cls}`}
+                      >
+                        {
+                          linearStatePill(issue.stateType, issue.stateName)
+                            .label
+                        }
                       </span>
                     </div>
-                    <p className="text-[11px] text-cc-muted truncate mt-0.5">{issue.title}</p>
+                    <p className="text-[11px] text-cc-muted truncate mt-0.5">
+                      {issue.title}
+                    </p>
                   </button>
                 ))}
               </div>
             )}
-            {searchQuery.trim().length >= 2 && !searching && searchResults.length === 0 && (
-              <p className="text-[10px] text-cc-muted text-center py-2">No issues found</p>
-            )}
+            {searchQuery.trim().length >= 2 &&
+              !searching &&
+              searchResults.length === 0 && (
+                <p className="text-[10px] text-cc-muted text-center py-2">
+                  No issues found
+                </p>
+              )}
           </div>
         )}
       </div>
@@ -624,7 +834,9 @@ function LinearIssueSection({ sessionId }: { sessionId: string }) {
           >
             {linkedIssue.identifier}
           </a>
-          <span className={`text-[9px] font-medium px-1.5 rounded-full leading-[16px] ${pill.cls}`}>
+          <span
+            className={`text-[9px] font-medium px-1.5 rounded-full leading-[16px] ${pill.cls}`}
+          >
             {pill.label}
           </span>
           <button
@@ -632,14 +844,23 @@ function LinearIssueSection({ sessionId }: { sessionId: string }) {
             className="ml-auto flex items-center justify-center w-5 h-5 rounded text-cc-muted hover:text-cc-fg hover:bg-cc-hover transition-colors cursor-pointer"
             title="Unlink issue"
           >
-            <svg viewBox="0 0 16 16" fill="none" stroke="currentColor" strokeWidth="1.5" className="w-3 h-3">
+            <svg
+              viewBox="0 0 16 16"
+              fill="none"
+              stroke="currentColor"
+              strokeWidth="1.5"
+              className="w-3 h-3"
+            >
               <path d="M4 4l8 8M12 4l-8 8" />
             </svg>
           </button>
         </div>
 
         {/* Title */}
-        <p className="text-[11px] text-cc-muted truncate" title={linkedIssue.title}>
+        <p
+          className="text-[11px] text-cc-muted truncate"
+          title={linkedIssue.title}
+        >
           {linkedIssue.title}
         </p>
 
@@ -682,8 +903,12 @@ function LinearIssueSection({ sessionId }: { sessionId: string }) {
       {showDoneWarning && linkedIssue.stateType === "completed" && (
         <div className="px-4 py-2 bg-cc-success/10 border-t border-cc-success/20 flex items-center justify-between gap-2">
           <div className="min-w-0">
-            <p className="text-[11px] text-cc-success font-medium">Issue completed</p>
-            <p className="text-[10px] text-cc-success/80">Ticket moved to done.</p>
+            <p className="text-[11px] text-cc-success font-medium">
+              Issue completed
+            </p>
+            <p className="text-[10px] text-cc-success/80">
+              Ticket moved to done.
+            </p>
           </div>
           <div className="flex items-center gap-1.5 shrink-0">
             <button
@@ -712,12 +937,18 @@ function LinearIssueSection({ sessionId }: { sessionId: string }) {
       {/* Recent comments */}
       {comments.length > 0 && (
         <div className="px-4 py-2 space-y-1.5 max-h-36 overflow-y-auto">
-          <span className="text-[10px] text-cc-muted uppercase tracking-wider">Comments</span>
+          <span className="text-[10px] text-cc-muted uppercase tracking-wider">
+            Comments
+          </span>
           {comments.slice(-3).map((comment) => (
             <div key={comment.id} className="text-[11px]">
               <div className="flex items-center gap-1">
-                <span className="font-medium text-cc-fg">{comment.userName}</span>
-                <span className="text-[9px] text-cc-muted">{timeAgo(new Date(comment.createdAt).getTime())}</span>
+                <span className="font-medium text-cc-fg">
+                  {comment.userName}
+                </span>
+                <span className="text-[9px] text-cc-muted">
+                  {timeAgo(new Date(comment.createdAt).getTime())}
+                </span>
               </div>
               <p className="text-cc-muted line-clamp-2">{comment.body}</p>
             </div>
@@ -731,7 +962,12 @@ function LinearIssueSection({ sessionId }: { sessionId: string }) {
           type="text"
           value={commentText}
           onChange={(e) => setCommentText(e.target.value)}
-          onKeyDown={(e) => { if (e.key === "Enter" && !e.shiftKey) { e.preventDefault(); handleSendComment(); } }}
+          onKeyDown={(e) => {
+            if (e.key === "Enter" && !e.shiftKey) {
+              e.preventDefault();
+              handleSendComment();
+            }
+          }}
           placeholder="Add a comment..."
           aria-label="Add a comment"
           className="flex-1 text-[11px] bg-transparent border border-cc-border rounded-md px-2 py-1.5 text-cc-fg placeholder:text-cc-muted focus:outline-none focus:border-cc-primary/50"
@@ -756,7 +992,9 @@ function LinearIssueSection({ sessionId }: { sessionId: string }) {
 /** Wrapper that renders the correct usage/rate-limit component based on backend type */
 function UsageLimitsRenderer({ sessionId }: { sessionId: string }) {
   const session = useStore((s) => s.sessions.get(sessionId));
-  const sdk = useStore((s) => s.sdkSessions.find((x) => x.sessionId === sessionId));
+  const sdk = useStore((s) =>
+    s.sdkSessions.find((x) => x.sessionId === sessionId),
+  );
   const isCodex = (session?.backend_type || sdk?.backendType) === "codex";
 
   if (isCodex) {
@@ -767,13 +1005,20 @@ function UsageLimitsRenderer({ sessionId }: { sessionId: string }) {
       </>
     );
   }
-  return <UsageLimitsSection sessionId={sessionId} />;
+  return (
+    <>
+      <ClaudeContextSection sessionId={sessionId} />
+      <UsageLimitsSection sessionId={sessionId} />
+    </>
+  );
 }
 
 /** Git branch info — extracted from inline JSX in TaskPanel */
 function GitBranchSection({ sessionId }: { sessionId: string }) {
   const session = useStore((s) => s.sessions.get(sessionId));
-  const sdk = useStore((s) => s.sdkSessions.find((x) => x.sessionId === sessionId));
+  const sdk = useStore((s) =>
+    s.sdkSessions.find((x) => x.sessionId === sessionId),
+  );
 
   const branch = session?.git_branch || sdk?.gitBranch;
   const branchAhead = session?.git_ahead || 0;
@@ -791,32 +1036,51 @@ function GitBranchSection({ sessionId }: { sessionId: string }) {
           Branch
         </span>
         {session?.is_containerized && (
-          <span className="text-[10px] px-1.5 py-0.5 rounded bg-blue-500/10 text-blue-400">container</span>
+          <span className="text-[10px] px-1.5 py-0.5 rounded bg-blue-500/10 text-blue-400">
+            container
+          </span>
         )}
       </div>
       <p className="text-xs font-mono-code text-cc-fg truncate" title={branch}>
         {branch}
       </p>
-      {(branchAhead > 0 || branchBehind > 0 || lineAdds > 0 || lineRemoves > 0) && (
+      {(branchAhead > 0 ||
+        branchBehind > 0 ||
+        lineAdds > 0 ||
+        lineRemoves > 0) && (
         <div className="flex items-center justify-between gap-2">
           <div className="flex items-center gap-1.5 text-[11px]">
-            {branchAhead > 0 && <span className="text-green-500">{branchAhead}&#8593;</span>}
-            {branchBehind > 0 && <span className="text-cc-warning">{branchBehind}&#8595;</span>}
-            {lineAdds > 0 && <span className="text-green-500">+{lineAdds}</span>}
-            {lineRemoves > 0 && <span className="text-red-400">-{lineRemoves}</span>}
+            {branchAhead > 0 && (
+              <span className="text-green-500">{branchAhead}&#8593;</span>
+            )}
+            {branchBehind > 0 && (
+              <span className="text-cc-warning">{branchBehind}&#8595;</span>
+            )}
+            {lineAdds > 0 && (
+              <span className="text-green-500">+{lineAdds}</span>
+            )}
+            {lineRemoves > 0 && (
+              <span className="text-red-400">-{lineRemoves}</span>
+            )}
           </div>
           {branchBehind > 0 && branchCwd && (
             <button
               type="button"
               className="text-[11px] font-medium text-cc-warning hover:text-amber-400 transition-colors cursor-pointer"
               onClick={() => {
-                api.gitPull(branchCwd).then((r) => {
-                  useStore.getState().updateSession(sessionId, {
-                    git_ahead: r.git_ahead,
-                    git_behind: r.git_behind,
-                  });
-                  if (!r.success) captureException(new Error(`git pull failed: ${r.output}`));
-                }).catch((e) => captureException(e));
+                api
+                  .gitPull(branchCwd)
+                  .then((r) => {
+                    useStore.getState().updateSession(sessionId, {
+                      git_ahead: r.git_ahead,
+                      git_behind: r.git_behind,
+                    });
+                    if (!r.success)
+                      captureException(
+                        new Error(`git pull failed: ${r.output}`),
+                      );
+                  })
+                  .catch((e) => captureException(e));
               }}
               title="Pull latest changes"
             >
@@ -833,7 +1097,9 @@ function GitBranchSection({ sessionId }: { sessionId: string }) {
 function TasksSection({ sessionId }: { sessionId: string }) {
   const tasks = useStore((s) => s.sessionTasks.get(sessionId) || EMPTY_TASKS);
   const session = useStore((s) => s.sessions.get(sessionId));
-  const sdk = useStore((s) => s.sdkSessions.find((x) => x.sessionId === sessionId));
+  const sdk = useStore((s) =>
+    s.sdkSessions.find((x) => x.sessionId === sessionId),
+  );
   const isCodex = (session?.backend_type || sdk?.backendType) === "codex";
 
   if (!session || isCodex) return null;
@@ -870,13 +1136,16 @@ function TasksSection({ sessionId }: { sessionId: string }) {
 
 // ─── Section Component Map ───────────────────────────────────────────────────
 
-const SECTION_COMPONENTS: Record<string, ComponentType<{ sessionId: string }>> = {
+const SECTION_COMPONENTS: Record<
+  string,
+  ComponentType<{ sessionId: string }>
+> = {
   "usage-limits": UsageLimitsRenderer,
   "git-branch": GitBranchSection,
   "github-pr": GitHubPRSection,
   "linear-issue": LinearIssueSection,
   "mcp-servers": McpSection,
-  "tasks": TasksSection,
+  tasks: TasksSection,
 };
 
 // ─── Panel Config View ───────────────────────────────────────────────────────
@@ -925,7 +1194,11 @@ function TaskPanelConfigView({ isCodex }: { isCodex: boolean }) {
                   title="Move up"
                   data-testid={`move-up-${sectionId}`}
                 >
-                  <svg viewBox="0 0 16 16" fill="currentColor" className="w-3 h-3">
+                  <svg
+                    viewBox="0 0 16 16"
+                    fill="currentColor"
+                    className="w-3 h-3"
+                  >
                     <path d="M8 4l4 4H4l4-4z" />
                   </svg>
                 </button>
@@ -936,7 +1209,11 @@ function TaskPanelConfigView({ isCodex }: { isCodex: boolean }) {
                   title="Move down"
                   data-testid={`move-down-${sectionId}`}
                 >
-                  <svg viewBox="0 0 16 16" fill="currentColor" className="w-3 h-3">
+                  <svg
+                    viewBox="0 0 16 16"
+                    fill="currentColor"
+                    className="w-3 h-3"
+                  >
                     <path d="M8 12l4-4H4l4 4z" />
                   </svg>
                 </button>
@@ -997,11 +1274,17 @@ function TaskPanelConfigView({ isCodex }: { isCodex: boolean }) {
 
 // ─── Task Panel ──────────────────────────────────────────────────────────────
 
-export { CodexRateLimitsSection, CodexTokenDetailsSection };
+export {
+  ClaudeContextSection,
+  CodexRateLimitsSection,
+  CodexTokenDetailsSection,
+};
 
 export function TaskPanel({ sessionId }: { sessionId: string }) {
   const session = useStore((s) => s.sessions.get(sessionId));
-  const sdk = useStore((s) => s.sdkSessions.find((x) => x.sessionId === sessionId));
+  const sdk = useStore((s) =>
+    s.sdkSessions.find((x) => x.sessionId === sessionId),
+  );
   const taskPanelOpen = useStore((s) => s.taskPanelOpen);
   const setTaskPanelOpen = useStore((s) => s.setTaskPanelOpen);
   const configMode = useStore((s) => s.taskPanelConfigMode);
@@ -1054,14 +1337,19 @@ export function TaskPanel({ sessionId }: { sessionId: string }) {
         <TaskPanelConfigView isCodex={isCodex} />
       ) : (
         <>
-          <div data-testid="task-panel-content" className="min-h-0 flex-1 overflow-y-auto">
+          <div
+            data-testid="task-panel-content"
+            className="min-h-0 flex-1 overflow-y-auto"
+          >
             <ClaudeConfigBrowser sessionId={sessionId} />
             {applicableSections
               .filter((id) => config.enabled[id] !== false)
               .map((sectionId) => {
                 const Component = SECTION_COMPONENTS[sectionId];
                 if (!Component) return null;
-                const label = SECTION_DEFINITIONS.find((d) => d.id === sectionId)?.label;
+                const label = SECTION_DEFINITIONS.find(
+                  (d) => d.id === sectionId,
+                )?.label;
                 return (
                   <SectionErrorBoundary key={sectionId} label={label}>
                     <Component sessionId={sessionId} />
@@ -1078,8 +1366,16 @@ export function TaskPanel({ sessionId }: { sessionId: string }) {
               title="Configure panel sections"
               data-testid="customize-panel-btn"
             >
-              <svg viewBox="0 0 16 16" fill="currentColor" className="w-3.5 h-3.5">
-                <path fillRule="evenodd" d="M7.429 1.525a6.593 6.593 0 011.142 0c.036.003.108.036.137.146l.289 1.105c.147.56.55.967.997 1.189.174.086.341.183.501.29.417.278.97.423 1.53.27l1.102-.303c.11-.03.175.016.195.046.219.31.41.641.573.989.014.031.022.11-.059.19l-.815.806c-.411.406-.562.957-.53 1.456a4.588 4.588 0 010 .582c-.032.499.119 1.05.53 1.456l.815.806c.08.08.073.159.059.19a6.494 6.494 0 01-.573.99c-.02.029-.086.074-.195.045l-1.103-.303c-.559-.153-1.112-.008-1.529.27-.16.107-.327.204-.5.29-.449.222-.851.628-.998 1.189l-.289 1.105c-.029.11-.101.143-.137.146a6.613 6.613 0 01-1.142 0c-.036-.003-.108-.037-.137-.146l-.289-1.105c-.147-.56-.55-.967-.997-1.189a4.502 4.502 0 01-.501-.29c-.417-.278-.97-.423-1.53-.27l-1.102.303c-.11.03-.175-.016-.195-.046a6.492 6.492 0 01-.573-.989c-.014-.031-.022-.11.059-.19l.815-.806c.411-.406.562-.957.53-1.456a4.587 4.587 0 010-.582c.032-.499-.119-1.05-.53-1.456l-.815-.806c-.08-.08-.073-.159-.059-.19a6.44 6.44 0 01.573-.99c.02-.029.086-.074.195-.045l1.103.303c.559.153 1.112.008 1.529-.27.16-.107.327-.204.5-.29.449-.222.851-.628.998-1.189l.289-1.105c.029-.11.101-.143.137-.146zM8 10.5a2.5 2.5 0 100-5 2.5 2.5 0 000 5z" clipRule="evenodd" />
+              <svg
+                viewBox="0 0 16 16"
+                fill="currentColor"
+                className="w-3.5 h-3.5"
+              >
+                <path
+                  fillRule="evenodd"
+                  d="M7.429 1.525a6.593 6.593 0 011.142 0c.036.003.108.036.137.146l.289 1.105c.147.56.55.967.997 1.189.174.086.341.183.501.29.417.278.97.423 1.53.27l1.102-.303c.11-.03.175.016.195.046.219.31.41.641.573.989.014.031.022.11-.059.19l-.815.806c-.411.406-.562.957-.53 1.456a4.588 4.588 0 010 .582c-.032.499.119 1.05.53 1.456l.815.806c.08.08.073.159.059.19a6.494 6.494 0 01-.573.99c-.02.029-.086.074-.195.045l-1.103-.303c-.559-.153-1.112-.008-1.529.27-.16.107-.327.204-.5.29-.449.222-.851.628-.998 1.189l-.289 1.105c-.029.11-.101.143-.137.146a6.613 6.613 0 01-1.142 0c-.036-.003-.108-.037-.137-.146l-.289-1.105c-.147-.56-.55-.967-.997-1.189a4.502 4.502 0 01-.501-.29c-.417-.278-.97-.423-1.53-.27l-1.102.303c-.11.03-.175-.016-.195-.046a6.492 6.492 0 01-.573-.989c-.014-.031-.022-.11.059-.19l.815-.806c.411-.406.562-.957.53-1.456a4.587 4.587 0 010-.582c.032-.499-.119-1.05-.53-1.456l-.815-.806c-.08-.08-.073-.159-.059-.19a6.44 6.44 0 01.573-.99c.02-.029.086-.074.195-.045l1.103.303c.559.153 1.112.008 1.529-.27.16-.107.327-.204.5-.29.449-.222.851-.628.998-1.189l.289-1.105c.029-.11.101-.143.137-.146zM8 10.5a2.5 2.5 0 100-5 2.5 2.5 0 000 5z"
+                  clipRule="evenodd"
+                />
               </svg>
               Customize panel
             </button>

--- a/web/src/ws.ts
+++ b/web/src/ws.ts
@@ -1,5 +1,15 @@
 import { useStore } from "./store.js";
-import type { BrowserIncomingMessage, BrowserOutgoingMessage, ContentBlock, ChatMessage, TaskItem, ProcessItem, ProcessStatus, SdkSessionInfo, McpServerConfig } from "./types.js";
+import type {
+  BrowserIncomingMessage,
+  BrowserOutgoingMessage,
+  ContentBlock,
+  ChatMessage,
+  TaskItem,
+  ProcessItem,
+  ProcessStatus,
+  SdkSessionInfo,
+  McpServerConfig,
+} from "./types.js";
 import { generateUniqueSessionName } from "./utils/names.js";
 import { playNotificationSound } from "./utils/notification-sound.js";
 
@@ -65,7 +75,9 @@ function extractTasksFromBlocks(sessionId: string, blocks: ContentBlock[]) {
 
     // TodoWrite: full replacement — { todos: [{ content, status, activeForm }] }
     if (name === "TodoWrite") {
-      const todos = input.todos as { content?: string; status?: string; activeForm?: string }[] | undefined;
+      const todos = input.todos as
+        | { content?: string; status?: string; activeForm?: string }[]
+        | undefined;
       if (Array.isArray(todos)) {
         const tasks: TaskItem[] = todos.map((t, i) => ({
           id: String(i + 1),
@@ -102,15 +114,20 @@ function extractTasksFromBlocks(sessionId: string, blocks: ContentBlock[]) {
         const updates: Partial<TaskItem> = {};
         if (input.status) updates.status = input.status as TaskItem["status"];
         if (input.owner) updates.owner = input.owner as string;
-        if (input.activeForm !== undefined) updates.activeForm = input.activeForm as string;
-        if (input.addBlockedBy) updates.blockedBy = input.addBlockedBy as string[];
+        if (input.activeForm !== undefined)
+          updates.activeForm = input.activeForm as string;
+        if (input.addBlockedBy)
+          updates.blockedBy = input.addBlockedBy as string[];
         store.updateTask(sessionId, taskId, updates);
       }
     }
   }
 }
 
-function extractChangedFilesFromBlocks(sessionId: string, blocks: ContentBlock[]) {
+function extractChangedFilesFromBlocks(
+  sessionId: string,
+  blocks: ContentBlock[],
+) {
   const store = useStore.getState();
   const sessionCwd =
     store.sessions.get(sessionId)?.cwd ||
@@ -119,7 +136,10 @@ function extractChangedFilesFromBlocks(sessionId: string, blocks: ContentBlock[]
   for (const block of blocks) {
     if (block.type !== "tool_use") continue;
     const { name, input } = block;
-    if ((name === "Edit" || name === "Write") && typeof input.file_path === "string") {
+    if (
+      (name === "Edit" || name === "Write") &&
+      typeof input.file_path === "string"
+    ) {
       const resolvedPath = resolveSessionFilePath(input.file_path, sessionCwd);
       if (isPathInSessionScope(resolvedPath, sessionCwd)) {
         dirty = true;
@@ -130,9 +150,13 @@ function extractChangedFilesFromBlocks(sessionId: string, blocks: ContentBlock[]
 }
 
 /** Pending background Bash calls awaiting their tool_result (keyed by sessionId → toolUseId) */
-const pendingBackgroundBash = new Map<string, Map<string, { command: string; description: string; startedAt: number }>>();
+const pendingBackgroundBash = new Map<
+  string,
+  Map<string, { command: string; description: string; startedAt: number }>
+>();
 
-const BG_RESULT_REGEX = /Command running in background with ID:\s*(\S+)\.\s*Output is being written to:\s*(\S+)/;
+const BG_RESULT_REGEX =
+  /Command running in background with ID:\s*(\S+)\.\s*Output is being written to:\s*(\S+)/;
 
 function extractProcessesFromBlocks(sessionId: string, blocks: ContentBlock[]) {
   const store = useStore.getState();
@@ -161,11 +185,14 @@ function extractProcessesFromBlocks(sessionId: string, blocks: ContentBlock[]) {
       const sessionPending = pendingBackgroundBash.get(sessionId);
       const pending = sessionPending?.get(toolUseId);
       if (sessionPending && pending) {
-        const content = typeof block.content === "string"
-          ? block.content
-          : Array.isArray(block.content)
-            ? block.content.map((b) => ("text" in b ? (b as { text: string }).text : "")).join("")
-            : "";
+        const content =
+          typeof block.content === "string"
+            ? block.content
+            : Array.isArray(block.content)
+              ? block.content
+                  .map((b) => ("text" in b ? (b as { text: string }).text : ""))
+                  .join("")
+              : "";
 
         const match = content.match(BG_RESULT_REGEX);
         if (match) {
@@ -222,7 +249,8 @@ function summarizeSystemEvent(
   }
 
   if (event.subtype === "hook_response") {
-    const exitCode = typeof event.exit_code === "number" ? ` (exit ${event.exit_code})` : "";
+    const exitCode =
+      typeof event.exit_code === "number" ? ` (exit ${event.exit_code})` : "";
     return `Hook ${event.outcome}: ${event.hook_name} (${event.hook_event})${exitCode}.`;
   }
 
@@ -273,7 +301,10 @@ function setStreamingDraftMessage(sessionId: string, content: string) {
   store.setMessages(sessionId, messages);
 }
 
-function finalizeStreamingDraftMessage(sessionId: string, finalMessage: ChatMessage): boolean {
+function finalizeStreamingDraftMessage(
+  sessionId: string,
+  finalMessage: ChatMessage,
+): boolean {
   const draftId = streamingDraftMessageIdBySession.get(sessionId);
   if (!draftId) return false;
 
@@ -339,7 +370,9 @@ function getLastSeq(sessionId: string): number {
   try {
     const raw = localStorage.getItem(getLastSeqStorageKey(sessionId));
     const parsed = raw ? Number(raw) : 0;
-    const normalized = Number.isFinite(parsed) ? Math.max(0, Math.floor(parsed)) : 0;
+    const normalized = Number.isFinite(parsed)
+      ? Math.max(0, Math.floor(parsed))
+      : 0;
     lastSeqBySession.set(sessionId, normalized);
     return normalized;
   } catch {
@@ -372,7 +405,10 @@ function extractTextFromBlocks(blocks: ContentBlock[]): string {
     .join("\n");
 }
 
-function mergeContentBlocks(prev?: ContentBlock[], next?: ContentBlock[]): ContentBlock[] | undefined {
+function mergeContentBlocks(
+  prev?: ContentBlock[],
+  next?: ContentBlock[],
+): ContentBlock[] | undefined {
   const prevBlocks = prev || [];
   const nextBlocks = next || [];
   if (prevBlocks.length === 0 && nextBlocks.length === 0) return undefined;
@@ -392,11 +428,18 @@ function mergeContentBlocks(prev?: ContentBlock[], next?: ContentBlock[]): Conte
   return merged;
 }
 
-function mergeAssistantMessage(previous: ChatMessage, incoming: ChatMessage): ChatMessage {
-  const mergedBlocks = mergeContentBlocks(previous.contentBlocks, incoming.contentBlocks);
-  const mergedContent = mergedBlocks && mergedBlocks.length > 0
-    ? extractTextFromBlocks(mergedBlocks)
-    : (incoming.content || previous.content);
+function mergeAssistantMessage(
+  previous: ChatMessage,
+  incoming: ChatMessage,
+): ChatMessage {
+  const mergedBlocks = mergeContentBlocks(
+    previous.contentBlocks,
+    incoming.contentBlocks,
+  );
+  const mergedContent =
+    mergedBlocks && mergedBlocks.length > 0
+      ? extractTextFromBlocks(mergedBlocks)
+      : incoming.content || previous.content;
 
   return {
     ...previous,
@@ -413,7 +456,9 @@ function mergeAssistantMessage(previous: ChatMessage, incoming: ChatMessage): Ch
 function upsertAssistantMessage(sessionId: string, incoming: ChatMessage) {
   const store = useStore.getState();
   const existing = store.messages.get(sessionId) || [];
-  const index = existing.findIndex((m) => m.role === "assistant" && m.id === incoming.id);
+  const index = existing.findIndex(
+    (m) => m.role === "assistant" && m.id === incoming.id,
+  );
   if (index === -1) {
     store.appendMessage(sessionId, incoming);
     return;
@@ -509,6 +554,39 @@ function handleParsedMessage(
       }
       store.setSessionStatus(sessionId, "running");
 
+      // Track per-turn token usage for accurate context % (Claude Code)
+      const usage = msg.usage;
+      if (usage) {
+        const inputTokens = usage.input_tokens ?? 0;
+        const cacheRead = usage.cache_read_input_tokens ?? 0;
+        const cacheCreation = usage.cache_creation_input_tokens ?? 0;
+        const outputTokens = usage.output_tokens ?? 0;
+        const prev = store.sessions.get(sessionId)?.claude_token_details;
+        const details = {
+          inputTokens,
+          outputTokens,
+          cacheReadInputTokens: cacheRead,
+          cacheCreationInputTokens: cacheCreation,
+          contextWindow: prev?.contextWindow ?? 0,
+          maxOutputTokens: prev?.maxOutputTokens ?? 0,
+        };
+        const updates: Partial<{
+          claude_token_details: typeof details;
+          context_used_percent: number;
+        }> = {
+          claude_token_details: details,
+        };
+        if (details.contextWindow > 0) {
+          const pct = Math.round(
+            ((inputTokens + cacheRead + cacheCreation) /
+              details.contextWindow) *
+              100,
+          );
+          updates.context_used_percent = Math.max(0, Math.min(pct, 100));
+        }
+        store.updateSession(sessionId, updates);
+      }
+
       // Start timer if not already started (for non-streaming tool calls)
       if (!store.streamingStartedAt.has(sessionId)) {
         store.setStreamingStats(sessionId, { startedAt: Date.now() });
@@ -532,7 +610,10 @@ function handleParsedMessage(
           streamingPhaseBySession.delete(sessionId);
           clearStreamingDraftMessage(sessionId);
           if (!store.streamingStartedAt.has(sessionId)) {
-            store.setStreamingStats(sessionId, { startedAt: Date.now(), outputTokens: 0 });
+            store.setStreamingStats(sessionId, {
+              startedAt: Date.now(),
+              outputTokens: 0,
+            });
           }
         }
 
@@ -543,7 +624,10 @@ function handleParsedMessage(
             let current = store.streaming.get(sessionId) || "";
             const thinkingPrefix = "Thinking:\n";
             const responsePrefix = "\n\nResponse:\n";
-            if (streamingPhaseBySession.get(sessionId) === "thinking" && !current.includes(responsePrefix)) {
+            if (
+              streamingPhaseBySession.get(sessionId) === "thinking" &&
+              !current.includes(responsePrefix)
+            ) {
               current += responsePrefix;
             }
             streamingPhaseBySession.set(sessionId, "text");
@@ -551,13 +635,19 @@ function handleParsedMessage(
             store.setStreaming(sessionId, nextText);
             setStreamingDraftMessage(sessionId, nextText);
           }
-          if (delta?.type === "thinking_delta" && typeof delta.thinking === "string") {
+          if (
+            delta?.type === "thinking_delta" &&
+            typeof delta.thinking === "string"
+          ) {
             const current = store.streaming.get(sessionId) || "";
             const prefix = "Thinking:\n";
             const phase = streamingPhaseBySession.get(sessionId);
-            const base = phase === "thinking"
-              ? (current.startsWith(prefix) ? current : prefix)
-              : prefix;
+            const base =
+              phase === "thinking"
+                ? current.startsWith(prefix)
+                  ? current
+                  : prefix
+                : prefix;
             streamingPhaseBySession.set(sessionId, "thinking");
             const nextText = base + delta.thinking;
             store.setStreaming(sessionId, nextText);
@@ -569,7 +659,9 @@ function handleParsedMessage(
         if (evt.type === "message_delta") {
           const usage = (evt as { usage?: { output_tokens?: number } }).usage;
           if (usage?.output_tokens) {
-            store.setStreamingStats(sessionId, { outputTokens: usage.output_tokens });
+            store.setStreamingStats(sessionId, {
+              outputTokens: usage.output_tokens,
+            });
           }
         }
       }
@@ -582,7 +674,13 @@ function handleParsedMessage(
       processedToolUseIds.delete(sessionId);
 
       const r = data.data;
-      const sessionUpdates: Partial<{ total_cost_usd: number; num_turns: number; context_used_percent: number; total_lines_added: number; total_lines_removed: number }> = {
+      const sessionUpdates: Partial<{
+        total_cost_usd: number;
+        num_turns: number;
+        context_used_percent: number;
+        total_lines_added: number;
+        total_lines_removed: number;
+      }> = {
         total_cost_usd: r.total_cost_usd,
         num_turns: r.num_turns,
       };
@@ -593,14 +691,37 @@ function handleParsedMessage(
       if (typeof r.total_lines_removed === "number") {
         sessionUpdates.total_lines_removed = r.total_lines_removed;
       }
-      // Compute context % from modelUsage if available
+      // Store contextWindow from modelUsage, recompute context % using per-turn data
       if (r.modelUsage) {
         for (const usage of Object.values(r.modelUsage)) {
           if (usage.contextWindow > 0) {
-            const pct = Math.round(
-              ((usage.inputTokens + usage.outputTokens) / usage.contextWindow) * 100
-            );
-            sessionUpdates.context_used_percent = Math.max(0, Math.min(pct, 100));
+            const prev = store.sessions.get(sessionId)?.claude_token_details;
+            if (prev) {
+              prev.contextWindow = usage.contextWindow;
+              prev.maxOutputTokens = usage.maxOutputTokens;
+              const pct = Math.round(
+                ((prev.inputTokens +
+                  prev.cacheReadInputTokens +
+                  prev.cacheCreationInputTokens) /
+                  usage.contextWindow) *
+                  100,
+              );
+              sessionUpdates.context_used_percent = Math.max(
+                0,
+                Math.min(pct, 100),
+              );
+            } else {
+              // No per-turn data yet — fall back to cumulative formula
+              const pct = Math.round(
+                ((usage.inputTokens + usage.outputTokens) /
+                  usage.contextWindow) *
+                  100,
+              );
+              sessionUpdates.context_used_percent = Math.max(
+                0,
+                Math.min(pct, 100),
+              );
+            }
           }
         }
       }
@@ -616,7 +737,11 @@ function handleParsedMessage(
         playNotificationSound();
       }
       if (!document.hasFocus() && store.notificationDesktop) {
-        sendBrowserNotification("Session completed", "Claude finished the task", sessionId);
+        sendBrowserNotification(
+          "Session completed",
+          "Claude finished the task",
+          sessionId,
+        );
       }
       if (r.is_error && r.errors?.length) {
         store.appendMessage(sessionId, {
@@ -642,12 +767,14 @@ function handleParsedMessage(
       // Also extract tasks and changed files from permission requests
       const req = data.request;
       if (req.tool_name && req.input) {
-        const permBlocks = [{
-          type: "tool_use" as const,
-          id: req.tool_use_id,
-          name: req.tool_name,
-          input: req.input,
-        }];
+        const permBlocks = [
+          {
+            type: "tool_use" as const,
+            id: req.tool_use_id,
+            name: req.tool_name,
+            input: req.input,
+          },
+        ];
         extractTasksFromBlocks(sessionId, permBlocks);
         extractChangedFilesFromBlocks(sessionId, permBlocks);
         extractProcessesFromBlocks(sessionId, permBlocks);
@@ -757,7 +884,8 @@ function handleParsedMessage(
     case "session_name_update": {
       // Only apply auto-name if user hasn't manually renamed (still has random Adj+Noun name)
       const currentName = store.sessionNames.get(sessionId);
-      const isRandomName = currentName && /^[A-Z][a-z]+ [A-Z][a-z]+$/.test(currentName);
+      const isRandomName =
+        currentName && /^[A-Z][a-z]+ [A-Z][a-z]+$/.test(currentName);
       if (!currentName || isRandomName) {
         store.setSessionName(sessionId, data.name);
         store.markRecentlyRenamed(sessionId);
@@ -799,11 +927,16 @@ function handleParsedMessage(
             model: msg.model,
             stopReason: msg.stop_reason,
           };
-          const existingIndex = chatMessages.findIndex((m) => m.role === "assistant" && m.id === assistantMsg.id);
+          const existingIndex = chatMessages.findIndex(
+            (m) => m.role === "assistant" && m.id === assistantMsg.id,
+          );
           if (existingIndex === -1) {
             chatMessages.push(assistantMsg);
           } else {
-            chatMessages[existingIndex] = mergeAssistantMessage(chatMessages[existingIndex], assistantMsg);
+            chatMessages[existingIndex] = mergeAssistantMessage(
+              chatMessages[existingIndex],
+              assistantMsg,
+            );
           }
           // Also extract tasks, changed files, and background processes from history
           if (msg.content?.length) {
@@ -822,7 +955,13 @@ function handleParsedMessage(
             });
           }
           // Track cost/turns from history result, same as the live result handler
-          const resultUpdates: Partial<{ total_cost_usd: number; num_turns: number; context_used_percent: number; total_lines_added: number; total_lines_removed: number }> = {
+          const resultUpdates: Partial<{
+            total_cost_usd: number;
+            num_turns: number;
+            context_used_percent: number;
+            total_lines_added: number;
+            total_lines_removed: number;
+          }> = {
             total_cost_usd: r.total_cost_usd,
             num_turns: r.num_turns,
           };
@@ -834,10 +973,27 @@ function handleParsedMessage(
           }
           if (r.modelUsage) {
             for (const usage of Object.values(r.modelUsage)) {
-              if ((usage as { contextWindow: number; inputTokens: number; outputTokens: number }).contextWindow > 0) {
-                const u = usage as { contextWindow: number; inputTokens: number; outputTokens: number };
-                const pct = Math.round(((u.inputTokens + u.outputTokens) / u.contextWindow) * 100);
-                resultUpdates.context_used_percent = Math.max(0, Math.min(pct, 100));
+              if (
+                (
+                  usage as {
+                    contextWindow: number;
+                    inputTokens: number;
+                    outputTokens: number;
+                  }
+                ).contextWindow > 0
+              ) {
+                const u = usage as {
+                  contextWindow: number;
+                  inputTokens: number;
+                  outputTokens: number;
+                };
+                const pct = Math.round(
+                  ((u.inputTokens + u.outputTokens) / u.contextWindow) * 100,
+                );
+                resultUpdates.context_used_percent = Math.max(
+                  0,
+                  Math.min(pct, 100),
+                );
               }
             }
           }
@@ -900,11 +1056,10 @@ function handleParsedMessage(
         if (evt.seq <= previous) continue;
         setLastSeq(sessionId, evt.seq);
         latestProcessed = evt.seq;
-        handleParsedMessage(
-          sessionId,
-          evt.message as BrowserIncomingMessage,
-          { processSeq: false, ackSeqMessage: false },
-        );
+        handleParsedMessage(sessionId, evt.message as BrowserIncomingMessage, {
+          processSeq: false,
+          ackSeqMessage: false,
+        });
       }
       if (typeof latestProcessed === "number") {
         ackSeq(sessionId, latestProcessed);
@@ -1043,7 +1198,11 @@ export function sendMcpGetStatus(sessionId: string) {
   sendToSession(sessionId, { type: "mcp_get_status" });
 }
 
-export function sendMcpToggle(sessionId: string, serverName: string, enabled: boolean) {
+export function sendMcpToggle(
+  sessionId: string,
+  serverName: string,
+  enabled: boolean,
+) {
   sendToSession(sessionId, { type: "mcp_toggle", serverName, enabled });
 }
 
@@ -1051,7 +1210,10 @@ export function sendMcpReconnect(sessionId: string, serverName: string) {
   sendToSession(sessionId, { type: "mcp_reconnect", serverName });
 }
 
-export function sendMcpSetServers(sessionId: string, servers: Record<string, McpServerConfig>) {
+export function sendMcpSetServers(
+  sessionId: string,
+  servers: Record<string, McpServerConfig>,
+) {
   sendToSession(sessionId, { type: "mcp_set_servers", servers });
 }
 


### PR DESCRIPTION
## Summary

- Add a **context window usage display** for Claude Code sessions in the right panel (Context section), showing `used/total (%)` with a progress bar — matching the formula used by the Claude Code status line: `input_tokens + cache_read_input_tokens + cache_creation_input_tokens`
- Add a **"Compacting context..." spinner** in the message feed when `/compact` is running, so users know the UI hasn't frozen
- Fix context tracking to use **per-turn assistant message usage** instead of cumulative `modelUsage` from result messages (which was causing wildly incorrect values like 13% instead of 84%)

## Why

Users had no visibility into context window usage inside Companion — the only signal was a sudden "prompt too long" error. The status line in the terminal shows this correctly; Companion now matches it.

The `/compact` command works but gave no feedback while running (could take several seconds), leaving the UI appearing frozen.

## Changes

- `session-types.ts` — Added `claude_token_details` field to `SessionState`
- `ws-bridge.ts` — Track context from per-turn `assistant` message `usage` (not cumulative `modelUsage`); extract `contextWindow`/`maxOutputTokens` from `result`
- `ws.ts` — Same fix on the browser WebSocket handler
- `TaskPanel.tsx` — New `ClaudeContextSection` component with context bar, cost, and turn count
- `MessageFeed.tsx` — Compacting spinner shown when `sessionStatus === "compacting"`
- `claude-protocol-drift.test.ts` — Use short, formatter-stable method name markers
- `ws-bridge.test.ts` — Updated/added tests for per-turn context tracking behavior
- `Playground.tsx` — Mock data for new context section

## Screenshots

<img width="331" height="148" alt="image" src="https://github.com/user-attachments/assets/13a6d60d-f01e-4ce5-9f9e-cfc4b356a3c8" />

<img width="968" height="166" alt="image" src="https://github.com/user-attachments/assets/e564bfb5-3a08-47b9-8d8d-c3e2efe9de27" />

> The context bar now shows `used/total (%)` matching the terminal status line formula.
> The compacting spinner appears in the message feed during `/compact`.

## Testing

- `bun run typecheck` — clean
- `bun run test` — 1407/1407 passing (1 pre-existing flaky timeout in `routes.test.ts` unrelated to this PR)

## Review provenance

- Implemented by AI agent (Claude Sonnet 4.6)
- Human review: no

Issue: #129 
