### PR TITLE
feat(sidebar): redesign session items with status-first layout

### DIFF
--- a/web/src/components/Playground.tsx
+++ b/web/src/components/Playground.tsx
@@ -17,7 +17,9 @@ import { LinearLogo } from "./LinearLogo.js";
 import { SessionCreationProgress } from "./SessionCreationProgress.js";
 import { SessionLaunchOverlay } from "./SessionLaunchOverlay.js";
 import { PlaygroundUpdateOverlay } from "./UpdateOverlay.js";
+import { SessionItem } from "./SessionItem.js";
 import type { CreationProgressEvent } from "../types.js";
+import type { SessionItem as SessionItemType } from "../utils/project-grouping.js";
 
 // ─── Mock Data ──────────────────────────────────────────────────────────────
 
@@ -1501,7 +1503,157 @@ export function Playground() {
             </Card>
           </div>
         </Section>
+        {/* ─── Session Items ──────────────────────────────────── */}
+        <Section title="Session Items" description="Sidebar session rows — status dot, backend badge, Docker indicator, archive on hover">
+          <PlaygroundSessionItems />
+        </Section>
       </div>
+    </div>
+  );
+}
+
+// ─── Session Item Playground ─────────────────────────────────────────────────
+
+function mockSession(overrides: Partial<SessionItemType>): SessionItemType {
+  return {
+    id: `mock-${Math.random().toString(36).slice(2, 8)}`,
+    model: "claude-sonnet-4-20250514",
+    cwd: "/Users/dev/project",
+    gitBranch: "main",
+    isContainerized: false,
+    gitAhead: 0,
+    gitBehind: 0,
+    linesAdded: 0,
+    linesRemoved: 0,
+    isConnected: false,
+    status: null,
+    sdkState: null,
+    createdAt: Date.now(),
+    archived: false,
+    backendType: "claude",
+    repoRoot: "/Users/dev/project",
+    permCount: 0,
+    ...overrides,
+  };
+}
+
+const noopRef = { current: null };
+const noopSessionItemProps = {
+  onSelect: () => {},
+  onStartRename: () => {},
+  onArchive: (e: React.MouseEvent) => e.stopPropagation(),
+  onUnarchive: (e: React.MouseEvent) => e.stopPropagation(),
+  onDelete: (e: React.MouseEvent) => e.stopPropagation(),
+  onClearRecentlyRenamed: () => {},
+  editingSessionId: null,
+  editingName: "",
+  setEditingName: () => {},
+  onConfirmRename: () => {},
+  onCancelRename: () => {},
+  editInputRef: noopRef,
+};
+
+function PlaygroundSessionItems() {
+  return (
+    <div className="space-y-4 max-w-sm">
+      {/* Running — Claude Code */}
+      <Card label="Running — Claude Code">
+        <div className="bg-cc-sidebar rounded-lg p-1">
+          <SessionItem
+            session={mockSession({ isConnected: true, status: "running", backendType: "claude" })}
+            isActive={false}
+            sessionName="Refactor auth module"
+            permCount={0}
+            isRecentlyRenamed={false}
+            {...noopSessionItemProps}
+          />
+        </div>
+      </Card>
+
+      {/* Running — Codex + Docker */}
+      <Card label="Running — Codex + Docker">
+        <div className="bg-cc-sidebar rounded-lg p-1">
+          <SessionItem
+            session={mockSession({ isConnected: true, status: "running", backendType: "codex", isContainerized: true })}
+            isActive={false}
+            sessionName="Add payment flow"
+            permCount={0}
+            isRecentlyRenamed={false}
+            {...noopSessionItemProps}
+          />
+        </div>
+      </Card>
+
+      {/* Awaiting Input — 2 permissions */}
+      <Card label="Awaiting Input — 2 permissions pending">
+        <div className="bg-cc-sidebar rounded-lg p-1">
+          <SessionItem
+            session={mockSession({ isConnected: true, status: "running", backendType: "claude", permCount: 2 })}
+            isActive={false}
+            sessionName="Fix login bug"
+            permCount={2}
+            isRecentlyRenamed={false}
+            {...noopSessionItemProps}
+          />
+        </div>
+      </Card>
+
+      {/* Idle */}
+      <Card label="Idle — connected, not running">
+        <div className="bg-cc-sidebar rounded-lg p-1">
+          <SessionItem
+            session={mockSession({ isConnected: true, status: "idle", backendType: "claude" })}
+            isActive={false}
+            sessionName="Review PR #42"
+            permCount={0}
+            isRecentlyRenamed={false}
+            {...noopSessionItemProps}
+          />
+        </div>
+      </Card>
+
+      {/* Exited */}
+      <Card label="Exited — session stopped">
+        <div className="bg-cc-sidebar rounded-lg p-1">
+          <SessionItem
+            session={mockSession({ sdkState: "exited", backendType: "codex" })}
+            isActive={false}
+            sessionName="Deploy to staging"
+            permCount={0}
+            isRecentlyRenamed={false}
+            {...noopSessionItemProps}
+          />
+        </div>
+      </Card>
+
+      {/* Active (selected) */}
+      <Card label="Active (selected session)">
+        <div className="bg-cc-sidebar rounded-lg p-1">
+          <SessionItem
+            session={mockSession({ isConnected: true, status: "running", backendType: "claude", isContainerized: true })}
+            isActive={true}
+            sessionName="Build new dashboard"
+            permCount={0}
+            isRecentlyRenamed={false}
+            {...noopSessionItemProps}
+          />
+        </div>
+      </Card>
+
+      {/* Archived */}
+      <Card label="Archived session">
+        <div className="bg-cc-sidebar rounded-lg p-1">
+          <SessionItem
+            session={mockSession({ archived: true, backendType: "claude" })}
+            isActive={false}
+            isArchived={true}
+            sessionName="Old migration script"
+            permCount={0}
+            isRecentlyRenamed={false}
+            {...noopSessionItemProps}
+          />
+        </div>
+      </Card>
     </div>
   );
 }

--- a/web/src/index.css
+++ b/web/src/index.css
@@ -97,6 +97,12 @@
   }
 }
 
+@keyframes ring-pulse {
+  0% { box-shadow: 0 0 0 0 var(--color-cc-warning); }
+  70% { box-shadow: 0 0 0 4px transparent; }
+  100% { box-shadow: 0 0 0 0 transparent; }
+}
+
 /* Dark mode overrides */
 .dark {
   --color-cc-bg: #2b2a27;


### PR DESCRIPTION
## Summary
- Redesign sidebar session items from a two-row layout to a clean single-row design
- Add status dot indicator: green (running), amber with count (awaiting input), gray (idle), outline (exited)
- Replace colored backend dots with readable text badges: "CC" (Claude Code) / "CX" (Codex)
- Add hover-reveal archive button for quick access
- Remove visual clutter: git branch, git stats, timestamps, left status bar

## Why
The previous session item was overloaded with information (branch, timestamps, git stats, colored bars) that made it hard to quickly scan session status. This redesign prioritizes what matters most: session name, current status, and backend type.

## Testing
- `bun run typecheck` — passes
- `bun run test` — all 1421 tests pass (71 files)
- Playground section added with all 7 visual states (Running, Running+Docker, Awaiting Input, Idle, Exited, Active, Archived)

## Review provenance
- Implemented by AI agent (Claude Opus 4.6)
- Human review: no
