### PR TITLE
fix(sidebar): prevent hover overlay and restore archived click

### DIFF
--- a/web/src/components/SessionItem.tsx
+++ b/web/src/components/SessionItem.tsx
@@ -31,7 +31,7 @@ function deriveStatus(s: SessionItemType): DerivedStatus {
   return "exited";
 }
 
-function StatusDot({ status, permCount }: { status: DerivedStatus; permCount: number }) {
+function StatusDot({ status }: { status: DerivedStatus }) {
   switch (status) {
     case "running":
       return (
@@ -44,11 +44,6 @@ function StatusDot({ status, permCount }: { status: DerivedStatus; permCount: nu
       return (
         <span className="relative shrink-0 w-2 h-2">
           <span className="w-2 h-2 rounded-full bg-cc-warning block animate-[ring-pulse_1.5s_ease-out_infinite]" />
-          {permCount > 0 && (
-            <span className="absolute -top-1.5 -right-2.5 min-w-[14px] h-[14px] flex items-center justify-center rounded-full bg-cc-warning text-white text-[9px] font-bold leading-none px-0.5">
-              {permCount}
-            </span>
-          )}
         </span>
       );
     case "idle":
@@ -139,7 +134,7 @@ export function SessionItem({
           e.preventDefault();
           onStartRename(s.id, label);
         }}
-        className={`w-full flex items-center gap-2 py-2 px-2.5 min-h-[44px] rounded-lg transition-colors duration-100 cursor-pointer ${
+        className={`w-full flex items-center gap-2 py-2 pl-2.5 pr-12 min-h-[44px] rounded-lg transition-colors duration-100 cursor-pointer ${
           isActive
             ? "bg-cc-active"
             : "hover:bg-cc-hover"
@@ -147,7 +142,7 @@ export function SessionItem({
       >
         {/* Status dot */}
         {!isEditing && (
-          <StatusDot status={derivedStatus} permCount={permCount} />
+          <StatusDot status={derivedStatus} />
         )}
 
         {/* Session name / edit input */}
@@ -211,7 +206,7 @@ export function SessionItem({
             e.stopPropagation();
             onArchive(e, s.id);
           }}
-          className="absolute right-7 top-1/2 -translate-y-1/2 p-1 rounded-md opacity-0 sm:group-hover:opacity-100 hover:bg-cc-border text-cc-muted hover:text-cc-fg transition-all cursor-pointer"
+          className="absolute right-7 top-1/2 -translate-y-1/2 p-1 rounded-md opacity-0 pointer-events-none sm:group-hover:opacity-100 sm:group-hover:pointer-events-auto hover:bg-cc-border text-cc-muted hover:text-cc-fg transition-all cursor-pointer"
           title="Archive"
           aria-label="Archive session"
         >
@@ -228,7 +223,7 @@ export function SessionItem({
           e.stopPropagation();
           setMenuOpen(!menuOpen);
         }}
-        className="absolute right-1 top-1/2 -translate-y-1/2 p-1 rounded-md opacity-100 sm:opacity-0 sm:group-hover:opacity-100 hover:bg-cc-border text-cc-muted hover:text-cc-fg transition-all cursor-pointer"
+        className="absolute right-1 top-1/2 -translate-y-1/2 p-1 rounded-md opacity-100 pointer-events-auto sm:opacity-0 sm:pointer-events-none sm:group-hover:opacity-100 sm:group-hover:pointer-events-auto hover:bg-cc-border text-cc-muted hover:text-cc-fg transition-all cursor-pointer"
         title="Session actions"
         aria-label="Session actions"
       >

--- a/web/src/components/Sidebar.test.tsx
+++ b/web/src/components/Sidebar.test.tsx
@@ -360,9 +360,7 @@ describe("Sidebar", () => {
     expect(menuButton).toHaveClass("sm:group-hover:opacity-100");
   });
 
-  it("permission count renders on the status dot when permissions are pending", () => {
-    // The redesigned session item shows permission count as a superscript
-    // badge on the status dot, not as a separate positioned element.
+  it("pending permissions render a yellow awaiting status dot", () => {
     const session = makeSession("s1");
     const sdk = makeSdkSession("s1");
     mockState = createMockState({
@@ -373,10 +371,8 @@ describe("Sidebar", () => {
     });
 
     render(<Sidebar />);
-    const permBadge = screen.getAllByText("1").find((node) =>
-      node.classList.contains("bg-cc-warning") && node.classList.contains("rounded-full"),
-    );
-    expect(permBadge).toBeTruthy();
+    const awaitingDot = document.querySelector(".bg-cc-warning.animate-\\[ring-pulse_1\\.5s_ease-out_infinite\\]");
+    expect(awaitingDot).toBeTruthy();
   });
 
   it("archived sessions section shows count", () => {
@@ -540,7 +536,7 @@ describe("Sidebar", () => {
     expect(otherElement.closest(".animate-name-appear")).toBeFalsy();
   });
 
-  it("permission badge shows count for sessions with pending permissions", () => {
+  it("session keeps awaiting state with multiple pending permissions", () => {
     const session = makeSession("s1");
     const sdk = makeSdkSession("s1");
     const permMap = new Map<string, unknown>([
@@ -555,8 +551,25 @@ describe("Sidebar", () => {
     });
 
     render(<Sidebar />);
-    // The permission count badge shows "2"
-    expect(screen.getByText("2")).toBeInTheDocument();
+    const awaitingDot = document.querySelector(".bg-cc-warning.animate-\\[ring-pulse_1\\.5s_ease-out_infinite\\]");
+    expect(awaitingDot).toBeTruthy();
+  });
+
+  it("archived session row is clickable after opening archived section", () => {
+    const sdk = makeSdkSession("s1", { archived: true, model: "archived-clickable" });
+    mockState = createMockState({
+      sdkSessions: [sdk],
+    });
+
+    render(<Sidebar />);
+    fireEvent.click(screen.getByText(/Archived \(1\)/));
+
+    const archivedRowButton = screen.getByText("archived-clickable").closest("button");
+    expect(archivedRowButton).toBeInTheDocument();
+    if (!archivedRowButton) throw new Error("Archived row button not found");
+
+    fireEvent.click(archivedRowButton);
+    expect(window.location.hash).toBe("#/session/s1");
   });
 
   it("session does not render git data from sdkInfo (redesign removes git display)", () => {


### PR DESCRIPTION
## Summary
- fix session row action hover behavior so hidden action buttons no longer intercept clicks
- keep archived session rows clickable in the Archived section
- simplify pending-permission visual by removing the numeric yellow badge and keeping a yellow awaiting indicator only
- update sidebar tests for the new permission indicator behavior and archived row clickability regression

## Why
- archived session rows could become hard to click because absolutely-positioned action buttons still captured pointer events while visually hidden
- hover overlays could visually stack on top of row content and feel broken
- permission count badge styling was too noisy for this compact row layout

## Testing
- `cd web && bun run typecheck`
- `cd web && bun run test src/components/Sidebar.test.tsx`
- pre-commit hook also ran full test suite successfully

## Screenshot
- UI change verified locally in sidebar session rows (hover + archived section behavior)

## Review provenance
- Implemented by AI agent (Codex)
- Human review: no
