### PR TITLE
fix(editor): replace vscode tab with codemirror behind settings

### DIFF
--- a/web/package.json
+++ b/web/package.json
@@ -38,6 +38,8 @@
     "test:codex-contract": "vitest run server/codex-protocol-*.test.ts"
   },
   "dependencies": {
+    "@codemirror/view": "^6.39.15",
+    "@uiw/react-codemirror": "^4.25.4",
     "croner": "^10.0.1",
     "diff": "^8.0.3",
     "hono": "^4.7.0",

--- a/web/server/auto-namer.test.ts
+++ b/web/server/auto-namer.test.ts
@@ -20,6 +20,7 @@ beforeEach(() => {
     linearAutoTransition: false,
     linearAutoTransitionStateId: "",
     linearAutoTransitionStateName: "",
+    editorTabEnabled: false,
     updatedAt: 0,
   });
 });
@@ -46,6 +47,7 @@ describe("generateSessionTitle", () => {
       linearAutoTransition: false,
       linearAutoTransitionStateId: "",
       linearAutoTransitionStateName: "",
+      editorTabEnabled: false,
       updatedAt: 0,
     });
 
@@ -79,6 +81,7 @@ describe("generateSessionTitle", () => {
       linearAutoTransition: false,
       linearAutoTransitionStateId: "",
       linearAutoTransitionStateName: "",
+      editorTabEnabled: false,
       updatedAt: 0,
     });
     mockFetch.mockResolvedValueOnce({
@@ -153,6 +156,7 @@ describe("generateSessionTitle", () => {
       linearAutoTransition: false,
       linearAutoTransitionStateId: "",
       linearAutoTransitionStateName: "",
+      editorTabEnabled: false,
       updatedAt: 0,
     });
     mockFetch.mockResolvedValueOnce({

--- a/web/server/routes.test.ts
+++ b/web/server/routes.test.ts
@@ -63,12 +63,20 @@ vi.mock("./settings-manager.js", () => ({
     openrouterApiKey: "",
     openrouterModel: "openrouter/free",
     linearApiKey: "",
+    linearAutoTransition: false,
+    linearAutoTransitionStateId: "",
+    linearAutoTransitionStateName: "",
+    editorTabEnabled: false,
     updatedAt: 0,
   })),
   updateSettings: vi.fn((patch) => ({
     openrouterApiKey: patch.openrouterApiKey ?? "",
     openrouterModel: patch.openrouterModel ?? "openrouter/free",
     linearApiKey: patch.linearApiKey ?? "",
+    linearAutoTransition: patch.linearAutoTransition ?? false,
+    linearAutoTransitionStateId: patch.linearAutoTransitionStateId ?? "",
+    linearAutoTransitionStateName: patch.linearAutoTransitionStateName ?? "",
+    editorTabEnabled: patch.editorTabEnabled ?? false,
     updatedAt: Date.now(),
   })),
 }));
@@ -1352,6 +1360,7 @@ describe("GET /api/settings", () => {
       linearAutoTransition: false,
       linearAutoTransitionStateId: "",
       linearAutoTransitionStateName: "",
+      editorTabEnabled: false,
       updatedAt: 123,
     });
 
@@ -1365,6 +1374,7 @@ describe("GET /api/settings", () => {
       linearApiKeyConfigured: false,
       linearAutoTransition: false,
       linearAutoTransitionStateName: "",
+      editorTabEnabled: false,
     });
   });
 
@@ -1376,6 +1386,7 @@ describe("GET /api/settings", () => {
       linearAutoTransition: false,
       linearAutoTransitionStateId: "",
       linearAutoTransitionStateName: "",
+      editorTabEnabled: false,
       updatedAt: 123,
     });
 
@@ -1389,6 +1400,7 @@ describe("GET /api/settings", () => {
       linearApiKeyConfigured: true,
       linearAutoTransition: false,
       linearAutoTransitionStateName: "",
+      editorTabEnabled: false,
     });
   });
 });
@@ -1402,6 +1414,7 @@ describe("PUT /api/settings", () => {
       linearAutoTransition: false,
       linearAutoTransitionStateId: "",
       linearAutoTransitionStateName: "",
+      editorTabEnabled: false,
       updatedAt: 456,
     });
 
@@ -1419,6 +1432,7 @@ describe("PUT /api/settings", () => {
       linearAutoTransition: undefined,
       linearAutoTransitionStateId: undefined,
       linearAutoTransitionStateName: undefined,
+      editorTabEnabled: undefined,
     });
     const json = await res.json();
     expect(json).toEqual({
@@ -1427,6 +1441,7 @@ describe("PUT /api/settings", () => {
       linearApiKeyConfigured: false,
       linearAutoTransition: false,
       linearAutoTransitionStateName: "",
+      editorTabEnabled: false,
     });
   });
 
@@ -1438,6 +1453,7 @@ describe("PUT /api/settings", () => {
       linearAutoTransition: false,
       linearAutoTransitionStateId: "",
       linearAutoTransitionStateName: "",
+      editorTabEnabled: false,
       updatedAt: 789,
     });
 
@@ -1455,6 +1471,7 @@ describe("PUT /api/settings", () => {
       linearAutoTransition: undefined,
       linearAutoTransitionStateId: undefined,
       linearAutoTransitionStateName: undefined,
+      editorTabEnabled: undefined,
     });
   });
 
@@ -1466,6 +1483,7 @@ describe("PUT /api/settings", () => {
       linearAutoTransition: false,
       linearAutoTransitionStateId: "",
       linearAutoTransitionStateName: "",
+      editorTabEnabled: false,
       updatedAt: 999,
     });
 
@@ -1483,6 +1501,7 @@ describe("PUT /api/settings", () => {
       linearAutoTransition: undefined,
       linearAutoTransitionStateId: undefined,
       linearAutoTransitionStateName: undefined,
+      editorTabEnabled: undefined,
     });
   });
 
@@ -1522,6 +1541,18 @@ describe("PUT /api/settings", () => {
     expect(json).toEqual({ error: "openrouterApiKey must be a string" });
   });
 
+  it("returns 400 for non-boolean editor tab setting", async () => {
+    const res = await app.request("/api/settings", {
+      method: "PUT",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ editorTabEnabled: "yes" }),
+    });
+
+    expect(res.status).toBe(400);
+    const json = await res.json();
+    expect(json).toEqual({ error: "editorTabEnabled must be a boolean" });
+  });
+
   it("returns 400 when no settings fields are provided", async () => {
     const res = await app.request("/api/settings", {
       method: "PUT",
@@ -1551,6 +1582,7 @@ describe("GET /api/linear/issues", () => {
       linearAutoTransition: false,
       linearAutoTransitionStateId: "",
       linearAutoTransitionStateName: "",
+      editorTabEnabled: false,
       updatedAt: 0,
     });
 
@@ -1568,6 +1600,7 @@ describe("GET /api/linear/issues", () => {
       linearAutoTransition: false,
       linearAutoTransitionStateId: "",
       linearAutoTransitionStateName: "",
+      editorTabEnabled: false,
       updatedAt: 0,
     });
 
@@ -1639,6 +1672,7 @@ describe("GET /api/linear/issues", () => {
       linearAutoTransition: false,
       linearAutoTransitionStateId: "",
       linearAutoTransitionStateName: "",
+      editorTabEnabled: false,
       updatedAt: 0,
     });
 
@@ -1717,6 +1751,7 @@ describe("GET /api/linear/issues", () => {
       linearAutoTransition: false,
       linearAutoTransitionStateId: "",
       linearAutoTransitionStateName: "",
+      editorTabEnabled: false,
       updatedAt: 0,
     });
 
@@ -1760,6 +1795,7 @@ describe("GET /api/linear/connection", () => {
       linearAutoTransition: false,
       linearAutoTransitionStateId: "",
       linearAutoTransitionStateName: "",
+      editorTabEnabled: false,
       updatedAt: 0,
     });
 
@@ -1777,6 +1813,7 @@ describe("GET /api/linear/connection", () => {
       linearAutoTransition: false,
       linearAutoTransitionStateId: "",
       linearAutoTransitionStateName: "",
+      editorTabEnabled: false,
       updatedAt: 0,
     });
 
@@ -1816,6 +1853,7 @@ describe("POST /api/linear/issues/:id/transition", () => {
       linearAutoTransition: false,
       linearAutoTransitionStateId: "state-123",
       linearAutoTransitionStateName: "In Progress",
+      editorTabEnabled: false,
       updatedAt: 0,
     });
 
@@ -1838,6 +1876,7 @@ describe("POST /api/linear/issues/:id/transition", () => {
       linearAutoTransition: true,
       linearAutoTransitionStateId: "",
       linearAutoTransitionStateName: "",
+      editorTabEnabled: false,
       updatedAt: 0,
     });
 
@@ -1859,6 +1898,7 @@ describe("POST /api/linear/issues/:id/transition", () => {
       linearAutoTransition: true,
       linearAutoTransitionStateId: "state-123",
       linearAutoTransitionStateName: "In Progress",
+      editorTabEnabled: false,
       updatedAt: 0,
     });
 
@@ -1881,6 +1921,7 @@ describe("POST /api/linear/issues/:id/transition", () => {
       linearAutoTransition: true,
       linearAutoTransitionStateId: "state-doing",
       linearAutoTransitionStateName: "Doing",
+      editorTabEnabled: false,
       updatedAt: 0,
     });
 
@@ -1938,6 +1979,7 @@ describe("POST /api/linear/issues/:id/transition", () => {
       linearAutoTransition: true,
       linearAutoTransitionStateId: "state-doing",
       linearAutoTransitionStateName: "Doing",
+      editorTabEnabled: false,
       updatedAt: 0,
     });
 
@@ -1974,6 +2016,7 @@ describe("GET /api/linear/projects", () => {
       linearAutoTransition: false,
       linearAutoTransitionStateId: "",
       linearAutoTransitionStateName: "",
+      editorTabEnabled: false,
       updatedAt: 0,
     });
 
@@ -1991,6 +2034,7 @@ describe("GET /api/linear/projects", () => {
       linearAutoTransition: false,
       linearAutoTransitionStateId: "",
       linearAutoTransitionStateName: "",
+      editorTabEnabled: false,
       updatedAt: 0,
     });
 
@@ -2039,6 +2083,7 @@ describe("GET /api/linear/project-issues", () => {
       linearAutoTransition: false,
       linearAutoTransitionStateId: "",
       linearAutoTransitionStateName: "",
+      editorTabEnabled: false,
       updatedAt: 0,
     });
 
@@ -2056,6 +2101,7 @@ describe("GET /api/linear/project-issues", () => {
       linearAutoTransition: false,
       linearAutoTransitionStateId: "",
       linearAutoTransitionStateName: "",
+      editorTabEnabled: false,
       updatedAt: 0,
     });
 
@@ -2119,6 +2165,7 @@ describe("GET /api/linear/project-issues", () => {
       linearAutoTransition: false,
       linearAutoTransitionStateId: "",
       linearAutoTransitionStateName: "",
+      editorTabEnabled: false,
       updatedAt: 0,
     });
 

--- a/web/server/routes.ts
+++ b/web/server/routes.ts
@@ -1475,6 +1475,7 @@ export function createRoutes(
       linearApiKeyConfigured: !!settings.linearApiKey.trim(),
       linearAutoTransition: settings.linearAutoTransition,
       linearAutoTransitionStateName: settings.linearAutoTransitionStateName,
+      editorTabEnabled: settings.editorTabEnabled,
     });
   });
 
@@ -1498,9 +1499,13 @@ export function createRoutes(
     if (body.linearAutoTransitionStateName !== undefined && typeof body.linearAutoTransitionStateName !== "string") {
       return c.json({ error: "linearAutoTransitionStateName must be a string" }, 400);
     }
+    if (body.editorTabEnabled !== undefined && typeof body.editorTabEnabled !== "boolean") {
+      return c.json({ error: "editorTabEnabled must be a boolean" }, 400);
+    }
     const hasAnyField = body.openrouterApiKey !== undefined || body.openrouterModel !== undefined
       || body.linearApiKey !== undefined || body.linearAutoTransition !== undefined
-      || body.linearAutoTransitionStateId !== undefined || body.linearAutoTransitionStateName !== undefined;
+      || body.linearAutoTransitionStateId !== undefined || body.linearAutoTransitionStateName !== undefined
+      || body.editorTabEnabled !== undefined;
     if (!hasAnyField) {
       return c.json({ error: "At least one settings field is required" }, 400);
     }
@@ -1535,6 +1540,10 @@ export function createRoutes(
         typeof body.linearAutoTransitionStateName === "string"
           ? body.linearAutoTransitionStateName.trim()
           : undefined,
+      editorTabEnabled:
+        typeof body.editorTabEnabled === "boolean"
+          ? body.editorTabEnabled
+          : undefined,
     });
 
     return c.json({
@@ -1543,6 +1552,7 @@ export function createRoutes(
       linearApiKeyConfigured: !!settings.linearApiKey.trim(),
       linearAutoTransition: settings.linearAutoTransition,
       linearAutoTransitionStateName: settings.linearAutoTransitionStateName,
+      editorTabEnabled: settings.editorTabEnabled,
     });
   });
 

--- a/web/server/settings-manager.test.ts
+++ b/web/server/settings-manager.test.ts
@@ -31,6 +31,7 @@ describe("settings-manager", () => {
       linearAutoTransition: false,
       linearAutoTransitionStateId: "",
       linearAutoTransitionStateName: "",
+      editorTabEnabled: false,
       updatedAt: 0,
     });
   });
@@ -69,6 +70,7 @@ describe("settings-manager", () => {
       linearAutoTransition: false,
       linearAutoTransitionStateId: "",
       linearAutoTransitionStateName: "",
+      editorTabEnabled: false,
       updatedAt: 123,
     });
   });
@@ -114,6 +116,7 @@ describe("settings-manager", () => {
       linearAutoTransition: false,
       linearAutoTransitionStateId: "",
       linearAutoTransitionStateName: "",
+      editorTabEnabled: false,
       updatedAt: 0,
     });
   });
@@ -138,5 +141,10 @@ describe("settings-manager", () => {
     expect(updated.openrouterApiKey).toBe("or-key");
     expect(updated.openrouterModel).toBe("openai/gpt-4o-mini");
     expect(updated.linearApiKey).toBe("lin_api_123");
+  });
+
+  it("updates editorTabEnabled", () => {
+    const updated = updateSettings({ editorTabEnabled: true });
+    expect(updated.editorTabEnabled).toBe(true);
   });
 });

--- a/web/server/settings-manager.ts
+++ b/web/server/settings-manager.ts
@@ -16,6 +16,7 @@ export interface CompanionSettings {
   linearAutoTransition: boolean;
   linearAutoTransitionStateId: string;
   linearAutoTransitionStateName: string;
+  editorTabEnabled: boolean;
   updatedAt: number;
 }
 
@@ -30,6 +31,7 @@ let settings: CompanionSettings = {
   linearAutoTransition: false,
   linearAutoTransitionStateId: "",
   linearAutoTransitionStateName: "",
+  editorTabEnabled: false,
   updatedAt: 0,
 };
 
@@ -44,6 +46,7 @@ function normalize(raw: Partial<CompanionSettings> | null | undefined): Companio
     linearAutoTransition: typeof raw?.linearAutoTransition === "boolean" ? raw.linearAutoTransition : false,
     linearAutoTransitionStateId: typeof raw?.linearAutoTransitionStateId === "string" ? raw.linearAutoTransitionStateId : "",
     linearAutoTransitionStateName: typeof raw?.linearAutoTransitionStateName === "string" ? raw.linearAutoTransitionStateName : "",
+    editorTabEnabled: typeof raw?.editorTabEnabled === "boolean" ? raw.editorTabEnabled : false,
     updatedAt: typeof raw?.updatedAt === "number" ? raw.updatedAt : 0,
   };
 }
@@ -72,7 +75,7 @@ export function getSettings(): CompanionSettings {
 }
 
 export function updateSettings(
-  patch: Partial<Pick<CompanionSettings, "openrouterApiKey" | "openrouterModel" | "linearApiKey" | "linearAutoTransition" | "linearAutoTransitionStateId" | "linearAutoTransitionStateName">>,
+  patch: Partial<Pick<CompanionSettings, "openrouterApiKey" | "openrouterModel" | "linearApiKey" | "linearAutoTransition" | "linearAutoTransitionStateId" | "linearAutoTransitionStateName" | "editorTabEnabled">>,
 ): CompanionSettings {
   ensureLoaded();
   settings = normalize({
@@ -82,6 +85,7 @@ export function updateSettings(
     linearAutoTransition: patch.linearAutoTransition ?? settings.linearAutoTransition,
     linearAutoTransitionStateId: patch.linearAutoTransitionStateId ?? settings.linearAutoTransitionStateId,
     linearAutoTransitionStateName: patch.linearAutoTransitionStateName ?? settings.linearAutoTransitionStateName,
+    editorTabEnabled: patch.editorTabEnabled ?? settings.editorTabEnabled,
     updatedAt: Date.now(),
   });
   persist();

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -38,6 +38,9 @@ export default function App() {
   const taskPanelOpen = useStore((s) => s.taskPanelOpen);
   const homeResetKey = useStore((s) => s.homeResetKey);
   const activeTab = useStore((s) => s.activeTab);
+  const editorTabEnabled = useStore((s) => s.editorTabEnabled);
+  const setEditorTabEnabled = useStore((s) => s.setEditorTabEnabled);
+  const setActiveTab = useStore((s) => s.setActiveTab);
   const sessionCreating = useStore((s) => s.sessionCreating);
   const sessionCreatingBackend = useStore((s) => s.sessionCreatingBackend);
   const creationProgress = useStore((s) => s.creationProgress);
@@ -61,6 +64,18 @@ export default function App() {
   useEffect(() => {
     document.documentElement.classList.toggle("dark", darkMode);
   }, [darkMode]);
+
+  useEffect(() => {
+    api.getSettings().then((settings) => {
+      setEditorTabEnabled(settings.editorTabEnabled);
+    }).catch(() => {});
+  }, [setEditorTabEnabled]);
+
+  useEffect(() => {
+    if (!editorTabEnabled && activeTab === "editor") {
+      setActiveTab("chat");
+    }
+  }, [editorTabEnabled, activeTab, setActiveTab]);
 
   // Capture the localStorage-restored session ID during render (before any effects run)
   // so the mount logic can use it even if the hash-sync branch would clear it.
@@ -188,7 +203,7 @@ export default function App() {
                         onClosePanel={() => useStore.getState().setActiveTab("chat")}
                       />
                     )
-                    : activeTab === "editor"
+                    : activeTab === "editor" && editorTabEnabled
                       ? <SessionEditorPane sessionId={currentSessionId} />
                       : (
                         <SessionTerminalDock sessionId={currentSessionId} suppressPanel>

--- a/web/src/api.ts
+++ b/web/src/api.ts
@@ -321,6 +321,7 @@ export interface AppSettings {
   linearApiKeyConfigured: boolean;
   linearAutoTransition: boolean;
   linearAutoTransitionStateName: string;
+  editorTabEnabled: boolean;
 }
 
 export interface LinearWorkflowState {
@@ -612,6 +613,7 @@ export const api = {
     linearAutoTransition?: boolean;
     linearAutoTransitionStateId?: string;
     linearAutoTransitionStateName?: string;
+    editorTabEnabled?: boolean;
   }) => put<AppSettings>("/settings", data),
   searchLinearIssues: (query: string, limit = 8) =>
     get<{ issues: LinearIssue[] }>(

--- a/web/src/components/SessionEditorPane.tsx
+++ b/web/src/components/SessionEditorPane.tsx
@@ -1,86 +1,263 @@
-import { useEffect, useState } from "react";
-import { api, type EditorStartResult } from "../api.js";
+import { useCallback, useEffect, useMemo, useState } from "react";
+import CodeMirror from "@uiw/react-codemirror";
+import { EditorView } from "@codemirror/view";
+import { api, type TreeNode } from "../api.js";
 import { useStore } from "../store.js";
 
 interface SessionEditorPaneProps {
   sessionId: string;
 }
 
-export function SessionEditorPane({ sessionId }: SessionEditorPaneProps) {
-  const [state, setState] = useState<EditorStartResult | null>(null);
-  const [loading, setLoading] = useState(true);
-  const setEditorUrl = useStore((s) => s.setEditorUrl);
+function flattenFiles(nodes: TreeNode[]): TreeNode[] {
+  const out: TreeNode[] = [];
+  for (const node of nodes) {
+    if (node.type === "file") {
+      out.push(node);
+      continue;
+    }
+    if (node.children?.length) {
+      out.push(...flattenFiles(node.children));
+    }
+  }
+  return out;
+}
 
-  useEffect(() => {
-    let cancelled = false;
-    setLoading(true);
-    setState(null);
+function relPath(cwd: string, path: string): string {
+  if (path.startsWith(`${cwd}/`)) return path.slice(cwd.length + 1);
+  return path;
+}
 
-    api.startEditor(sessionId)
-      .then((res) => {
-        if (cancelled) return;
-        setState(res);
-        if (res.available && res.url) {
-          setEditorUrl(sessionId, res.url);
-        }
-      })
-      .catch((err) => {
-        if (cancelled) return;
-        setState({
-          available: false,
-          installed: false,
-          mode: "host",
-          message: err instanceof Error ? err.message : "Failed to start VS Code editor",
-        });
-      })
-      .finally(() => {
-        if (!cancelled) setLoading(false);
-      });
+interface TreeEntryProps {
+  node: TreeNode;
+  depth: number;
+  cwd: string;
+  selectedPath: string | null;
+  onSelect: (path: string) => void;
+}
 
-    return () => {
-      cancelled = true;
-    };
-  }, [sessionId]);
-
-  if (loading) {
+function TreeEntry({ node, depth, cwd, selectedPath, onSelect }: TreeEntryProps) {
+  const [open, setOpen] = useState(depth < 1);
+  if (node.type === "directory") {
     return (
-      <div className="h-full flex items-center justify-center p-4 text-sm text-cc-muted">
-        Starting VS Code editor...
+      <div>
+        <button
+          type="button"
+          onClick={() => setOpen((v) => !v)}
+          className="w-full flex items-center gap-1.5 py-1.5 pr-2 text-left text-xs text-cc-muted hover:text-cc-fg hover:bg-cc-hover rounded cursor-pointer"
+          style={{ paddingLeft: `${8 + depth * 12}px` }}
+          aria-label={`Toggle ${relPath(cwd, node.path)}`}
+        >
+          <span className="w-3 inline-flex justify-center">{open ? "▾" : "▸"}</span>
+          <span className="truncate">{node.name}</span>
+        </button>
+        {open && node.children?.map((child) => (
+          <TreeEntry
+            key={child.path}
+            node={child}
+            depth={depth + 1}
+            cwd={cwd}
+            selectedPath={selectedPath}
+            onSelect={onSelect}
+          />
+        ))}
       </div>
     );
   }
 
-  if (!state?.available || !state.url) {
+  const selected = selectedPath === node.path;
+  return (
+    <button
+      type="button"
+      onClick={() => onSelect(node.path)}
+      className={`w-full py-1.5 pr-2 text-left text-xs rounded truncate cursor-pointer ${
+        selected ? "bg-cc-active text-cc-fg" : "text-cc-muted hover:text-cc-fg hover:bg-cc-hover"
+      }`}
+      style={{ paddingLeft: `${26 + depth * 12}px` }}
+      title={relPath(cwd, node.path)}
+    >
+      {node.name}
+    </button>
+  );
+}
+
+export function SessionEditorPane({ sessionId }: SessionEditorPaneProps) {
+  const darkMode = useStore((s) => s.darkMode);
+  const cwd = useStore((s) =>
+    s.sessions.get(sessionId)?.cwd
+    || s.sdkSessions.find((sdk) => sdk.sessionId === sessionId)?.cwd
+    || null,
+  );
+  const [tree, setTree] = useState<TreeNode[]>([]);
+  const [loadingTree, setLoadingTree] = useState(true);
+  const [selectedPath, setSelectedPath] = useState<string | null>(null);
+  const [content, setContent] = useState("");
+  const [originalContent, setOriginalContent] = useState("");
+  const [loadingFile, setLoadingFile] = useState(false);
+  const [saving, setSaving] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [saved, setSaved] = useState(false);
+
+  const dirty = content !== originalContent;
+  const files = useMemo(() => flattenFiles(tree), [tree]);
+
+  useEffect(() => {
+    if (!cwd) {
+      setLoadingTree(false);
+      return;
+    }
+    let cancelled = false;
+    setLoadingTree(true);
+    setError(null);
+    api.getFileTree(cwd).then((res) => {
+      if (cancelled) return;
+      setTree(res.tree);
+      const firstFile = flattenFiles(res.tree)[0];
+      setSelectedPath(firstFile?.path ?? null);
+    }).catch((err) => {
+      if (cancelled) return;
+      setError(err instanceof Error ? err.message : "Failed to load file tree");
+      setTree([]);
+      setSelectedPath(null);
+    }).finally(() => {
+      if (!cancelled) setLoadingTree(false);
+    });
+    return () => {
+      cancelled = true;
+    };
+  }, [cwd]);
+
+  useEffect(() => {
+    if (!selectedPath) {
+      setContent("");
+      setOriginalContent("");
+      return;
+    }
+    let cancelled = false;
+    setLoadingFile(true);
+    setError(null);
+    api.readFile(selectedPath).then((res) => {
+      if (cancelled) return;
+      setContent(res.content);
+      setOriginalContent(res.content);
+    }).catch((err) => {
+      if (cancelled) return;
+      setError(err instanceof Error ? err.message : "Failed to read file");
+      setContent("");
+      setOriginalContent("");
+    }).finally(() => {
+      if (!cancelled) setLoadingFile(false);
+    });
+    return () => {
+      cancelled = true;
+    };
+  }, [selectedPath]);
+
+  const saveCurrentFile = useCallback(() => {
+    if (!selectedPath || saving || !dirty) return;
+    setSaving(true);
+    setSaved(false);
+    setError(null);
+    api.writeFile(selectedPath, content).then(() => {
+      setOriginalContent(content);
+      setSaved(true);
+      window.setTimeout(() => setSaved(false), 1500);
+    }).catch((err) => {
+      setError(err instanceof Error ? err.message : "Failed to save file");
+    }).finally(() => {
+      setSaving(false);
+    });
+  }, [content, dirty, saving, selectedPath]);
+
+  useEffect(() => {
+    const onKeyDown = (event: KeyboardEvent) => {
+      if (!(event.metaKey || event.ctrlKey) || event.key.toLowerCase() !== "s") return;
+      event.preventDefault();
+      saveCurrentFile();
+    };
+    window.addEventListener("keydown", onKeyDown);
+    return () => window.removeEventListener("keydown", onKeyDown);
+  }, [saveCurrentFile]);
+
+  if (!cwd) {
     return (
-      <div className="h-full flex items-center justify-center p-6">
-        <div className="max-w-sm rounded-xl border border-cc-border bg-cc-bg p-4">
-          <h3 className="text-sm font-semibold text-cc-fg">VS Code editor unavailable</h3>
-          <p className="mt-2 text-xs text-cc-muted">
-            {state?.message || "VS Code editor could not be started for this session."}
-          </p>
-        </div>
+      <div className="h-full flex items-center justify-center p-4 text-sm text-cc-muted">
+        Editor unavailable while session is reconnecting.
       </div>
     );
   }
 
   return (
-    <div className="h-full min-h-0 flex flex-col bg-cc-bg">
-      <div className="px-3 py-2 border-b border-cc-border bg-cc-sidebar flex items-center justify-between gap-2">
-        <span className="text-xs text-cc-muted font-medium">VS Code</span>
-        <a
-          href={state.url}
-          target="_blank"
-          rel="noreferrer"
-          className="px-2 py-1 rounded-md text-[11px] text-cc-muted hover:text-cc-fg hover:bg-cc-hover transition-colors"
-        >
-          Open in new tab
-        </a>
+    <div className="h-full min-h-0 flex bg-cc-bg">
+      <aside className="w-[280px] shrink-0 border-r border-cc-border bg-cc-sidebar/60 flex flex-col min-h-0">
+        <div className="px-3 py-2 border-b border-cc-border text-xs text-cc-muted font-medium">Files</div>
+        <div className="flex-1 min-h-0 overflow-auto p-1.5">
+          {loadingTree && <div className="px-2 py-2 text-xs text-cc-muted">Loading files...</div>}
+          {!loadingTree && files.length === 0 && <div className="px-2 py-2 text-xs text-cc-muted">No editable files found.</div>}
+          {!loadingTree && tree.map((node) => (
+            <TreeEntry
+              key={node.path}
+              node={node}
+              depth={0}
+              cwd={cwd}
+              selectedPath={selectedPath}
+              onSelect={(nextPath) => {
+                if (dirty && !window.confirm("Discard unsaved changes?")) return;
+                setSelectedPath(nextPath);
+              }}
+            />
+          ))}
+        </div>
+      </aside>
+
+      <div className="flex-1 min-h-0 flex flex-col">
+        <div className="px-3 py-2 border-b border-cc-border bg-cc-sidebar flex items-center justify-between gap-3">
+          <div className="min-w-0">
+            <p className="text-[11px] text-cc-muted truncate">{selectedPath ? relPath(cwd, selectedPath) : "No file selected"}</p>
+            {dirty && <p className="text-[10px] text-amber-500">Unsaved changes</p>}
+            {saved && <p className="text-[10px] text-cc-success">Saved</p>}
+          </div>
+          <button
+            type="button"
+            onClick={saveCurrentFile}
+            disabled={!selectedPath || saving || loadingFile || !dirty}
+            className={`px-3 py-1.5 rounded-md text-xs font-medium transition-colors ${
+              !selectedPath || saving || loadingFile || !dirty
+                ? "bg-cc-hover text-cc-muted cursor-not-allowed"
+                : "bg-cc-primary text-white hover:bg-cc-primary-hover cursor-pointer"
+            }`}
+          >
+            {saving ? "Saving..." : "Save"}
+          </button>
+        </div>
+
+        {error && (
+          <div className="m-3 px-3 py-2 rounded-lg bg-cc-error/10 border border-cc-error/30 text-xs text-cc-error">
+            {error}
+          </div>
+        )}
+
+        <div className="flex-1 min-h-0">
+          {loadingFile ? (
+            <div className="h-full flex items-center justify-center text-sm text-cc-muted">Loading file...</div>
+          ) : selectedPath ? (
+            <CodeMirror
+              value={content}
+              onChange={(value) => setContent(value)}
+              extensions={[EditorView.lineWrapping]}
+              theme={darkMode ? "dark" : "light"}
+              basicSetup={{
+                foldGutter: true,
+                dropCursor: false,
+                allowMultipleSelections: false,
+              }}
+              className="h-full text-sm"
+              height="100%"
+            />
+          ) : (
+            <div className="h-full flex items-center justify-center text-sm text-cc-muted">Select a file to start editing.</div>
+          )}
+        </div>
       </div>
-      <iframe
-        title="VS Code editor"
-        src={state.url}
-        className="flex-1 min-h-0 w-full border-0 bg-cc-bg"
-      />
     </div>
   );
 }

--- a/web/src/components/SettingsPage.test.tsx
+++ b/web/src/components/SettingsPage.test.tsx
@@ -19,6 +19,7 @@ interface MockStoreState {
   setNotificationDesktop: ReturnType<typeof vi.fn>;
   setUpdateInfo: ReturnType<typeof vi.fn>;
   setUpdateOverlayActive: ReturnType<typeof vi.fn>;
+  setEditorTabEnabled: ReturnType<typeof vi.fn>;
 }
 
 let mockState: MockStoreState;
@@ -34,6 +35,7 @@ function createMockState(overrides: Partial<MockStoreState> = {}): MockStoreStat
     setNotificationDesktop: vi.fn(),
     setUpdateInfo: vi.fn(),
     setUpdateOverlayActive: vi.fn(),
+    setEditorTabEnabled: vi.fn(),
     ...overrides,
   };
 }
@@ -79,10 +81,18 @@ beforeEach(() => {
   mockApi.getSettings.mockResolvedValue({
     openrouterApiKeyConfigured: true,
     openrouterModel: "openrouter/free",
+    linearApiKeyConfigured: false,
+    linearAutoTransition: false,
+    linearAutoTransitionStateName: "",
+    editorTabEnabled: false,
   });
   mockApi.updateSettings.mockResolvedValue({
     openrouterApiKeyConfigured: true,
     openrouterModel: "openrouter/free",
+    linearApiKeyConfigured: false,
+    linearAutoTransition: false,
+    linearAutoTransitionStateName: "",
+    editorTabEnabled: false,
   });
   mockApi.forceCheckForUpdate.mockResolvedValue({
     currentVersion: "0.22.1",
@@ -112,6 +122,10 @@ describe("SettingsPage", () => {
     mockApi.getSettings.mockResolvedValueOnce({
       openrouterApiKeyConfigured: false,
       openrouterModel: "openrouter/free",
+      linearApiKeyConfigured: false,
+      linearAutoTransition: false,
+      linearAutoTransitionStateName: "",
+      editorTabEnabled: false,
     });
 
     render(<SettingsPage />);
@@ -142,6 +156,7 @@ describe("SettingsPage", () => {
       expect(mockApi.updateSettings).toHaveBeenCalledWith({
         openrouterApiKey: "or-key",
         openrouterModel: "openai/gpt-4o-mini",
+        editorTabEnabled: false,
       });
     });
 
@@ -160,6 +175,7 @@ describe("SettingsPage", () => {
     await waitFor(() => {
       expect(mockApi.updateSettings).toHaveBeenCalledWith({
         openrouterModel: "openrouter/free",
+        editorTabEnabled: false,
       });
     });
   });
@@ -176,6 +192,22 @@ describe("SettingsPage", () => {
     await waitFor(() => {
       expect(mockApi.updateSettings).toHaveBeenCalledWith({
         openrouterModel: "openai/gpt-4o-mini",
+        editorTabEnabled: false,
+      });
+    });
+  });
+
+  it("saves editor tab toggle in settings payload", async () => {
+    render(<SettingsPage />);
+    await screen.findByText("OpenRouter key configured");
+
+    fireEvent.click(screen.getByRole("button", { name: /Enable Editor tab \(CodeMirror\)/i }));
+    fireEvent.click(screen.getByRole("button", { name: "Save" }));
+
+    await waitFor(() => {
+      expect(mockApi.updateSettings).toHaveBeenCalledWith({
+        openrouterModel: "openrouter/free",
+        editorTabEnabled: true,
       });
     });
   });
@@ -220,6 +252,10 @@ describe("SettingsPage", () => {
     let resolveSave: ((value: {
       openrouterApiKeyConfigured: boolean;
       openrouterModel: string;
+      linearApiKeyConfigured: boolean;
+      linearAutoTransition: boolean;
+      linearAutoTransitionStateName: string;
+      editorTabEnabled: boolean;
     }) => void) | undefined;
     mockApi.updateSettings.mockReturnValueOnce(
       new Promise((resolve) => {
@@ -240,6 +276,10 @@ describe("SettingsPage", () => {
     resolveSave?.({
       openrouterApiKeyConfigured: true,
       openrouterModel: "openrouter/free",
+      linearApiKeyConfigured: false,
+      linearAutoTransition: false,
+      linearAutoTransitionStateName: "",
+      editorTabEnabled: false,
     });
 
     await screen.findByText("Settings saved.");

--- a/web/src/components/SettingsPage.tsx
+++ b/web/src/components/SettingsPage.tsx
@@ -11,6 +11,7 @@ interface SettingsPageProps {
 export function SettingsPage({ embedded = false }: SettingsPageProps) {
   const [openrouterApiKey, setOpenrouterApiKey] = useState("");
   const [openrouterModel, setOpenrouterModel] = useState("openrouter/free");
+  const [editorTabEnabled, setEditorTabEnabled] = useState(false);
   const [configured, setConfigured] = useState(false);
   const [loading, setLoading] = useState(true);
   const [saving, setSaving] = useState(false);
@@ -27,6 +28,7 @@ export function SettingsPage({ embedded = false }: SettingsPageProps) {
   const updateInfo = useStore((s) => s.updateInfo);
   const setUpdateInfo = useStore((s) => s.setUpdateInfo);
   const setUpdateOverlayActive = useStore((s) => s.setUpdateOverlayActive);
+  const setStoreEditorTabEnabled = useStore((s) => s.setEditorTabEnabled);
   const notificationApiAvailable = typeof Notification !== "undefined";
   const [checkingUpdates, setCheckingUpdates] = useState(false);
   const [updatingApp, setUpdatingApp] = useState(false);
@@ -40,6 +42,8 @@ export function SettingsPage({ embedded = false }: SettingsPageProps) {
       .then((s) => {
         setConfigured(s.openrouterApiKeyConfigured);
         setOpenrouterModel(s.openrouterModel || "openrouter/free");
+        setEditorTabEnabled(s.editorTabEnabled);
+        setStoreEditorTabEnabled(s.editorTabEnabled);
       })
       .catch((e: unknown) => setError(e instanceof Error ? e.message : String(e)))
       .finally(() => setLoading(false));
@@ -52,8 +56,9 @@ export function SettingsPage({ embedded = false }: SettingsPageProps) {
     setSaved(false);
     try {
       const nextKey = openrouterApiKey.trim();
-      const payload: { openrouterApiKey?: string; openrouterModel: string } = {
+      const payload: { openrouterApiKey?: string; openrouterModel: string; editorTabEnabled: boolean } = {
         openrouterModel: openrouterModel.trim() || "openrouter/free",
+        editorTabEnabled,
       };
       if (nextKey) {
         payload.openrouterApiKey = nextKey;
@@ -61,6 +66,8 @@ export function SettingsPage({ embedded = false }: SettingsPageProps) {
 
       const res = await api.updateSettings(payload);
       setConfigured(res.openrouterApiKeyConfigured);
+      setEditorTabEnabled(res.editorTabEnabled);
+      setStoreEditorTabEnabled(res.editorTabEnabled);
       setOpenrouterApiKey("");
       setSaved(true);
       setTimeout(() => setSaved(false), 1800);
@@ -165,6 +172,20 @@ export function SettingsPage({ embedded = false }: SettingsPageProps) {
               placeholder="openrouter/free"
               className="w-full px-3 py-2.5 text-sm bg-cc-input-bg border border-cc-border rounded-lg text-cc-fg placeholder:text-cc-muted focus:outline-none focus:border-cc-primary/60"
             />
+          </div>
+
+          <div className="pt-1">
+            <button
+              type="button"
+              onClick={() => setEditorTabEnabled((v) => !v)}
+              className="w-full flex items-center justify-between px-3 py-2 rounded-lg text-sm bg-cc-hover text-cc-fg hover:bg-cc-active transition-colors cursor-pointer"
+            >
+              <span>Enable Editor tab (CodeMirror)</span>
+              <span className="text-xs text-cc-muted">{editorTabEnabled ? "On" : "Off"}</span>
+            </button>
+            <p className="mt-1.5 text-xs text-cc-muted">
+              Shows a simple in-app file editor in the session tabs.
+            </p>
           </div>
 
           {error && (

--- a/web/src/components/TopBar.test.tsx
+++ b/web/src/components/TopBar.test.tsx
@@ -16,6 +16,7 @@ interface MockStoreState {
   setSidebarOpen: ReturnType<typeof vi.fn>;
   taskPanelOpen: boolean;
   setTaskPanelOpen: ReturnType<typeof vi.fn>;
+  editorTabEnabled: boolean;
   activeTab: "chat" | "diff" | "terminal" | "editor";
   setActiveTab: ReturnType<typeof vi.fn>;
   markChatTabReentry: ReturnType<typeof vi.fn>;
@@ -40,6 +41,7 @@ function resetStore(overrides: Partial<MockStoreState> = {}) {
     setSidebarOpen: vi.fn(),
     taskPanelOpen: false,
     setTaskPanelOpen: vi.fn(),
+    editorTabEnabled: true,
     activeTab: "chat",
     setActiveTab: vi.fn(),
     markChatTabReentry: vi.fn(),
@@ -150,6 +152,12 @@ describe("TopBar", () => {
     expect(btn).toBeDisabled();
     fireEvent.click(btn);
     expect(storeState.openQuickTerminal).not.toHaveBeenCalled();
+  });
+
+  it("hides editor tab when editor feature is disabled in settings", () => {
+    resetStore({ editorTabEnabled: false });
+    render(<TopBar />);
+    expect(screen.queryByRole("button", { name: "Editor tab" })).not.toBeInTheDocument();
   });
 
   it("keeps terminal tab active when clicking shell while already active", () => {

--- a/web/src/components/TopBar.tsx
+++ b/web/src/components/TopBar.tsx
@@ -55,9 +55,9 @@ export function TopBar() {
   const taskPanelOpen = useStore((s) => s.taskPanelOpen);
   const setTaskPanelOpen = useStore((s) => s.setTaskPanelOpen);
   const activeTab = useStore((s) => s.activeTab);
+  const editorTabEnabled = useStore((s) => s.editorTabEnabled);
   const setActiveTab = useStore((s) => s.setActiveTab);
   const markChatTabReentry = useStore((s) => s.markChatTabReentry);
-  const editorUrl = useStore((s) => currentSessionId ? s.editorUrls.get(currentSessionId) : undefined);
   const [claudeMdOpen, setClaudeMdOpen] = useState(false);
   const quickTerminalOpen = useStore((s) => s.quickTerminalOpen);
   const quickTerminalTabs = useStore((s) => s.quickTerminalTabs);
@@ -118,9 +118,10 @@ export function TopBar() {
   const showWorkspaceControls = !!(currentSessionId && isSessionView);
   const showContextToggle = route.page === "session" && !!currentSessionId;
   const workspaceTabs = useMemo(() => {
-    const tabs: WorkspaceTab[] = ["chat", "diff", "terminal", "editor"];
+    const tabs: WorkspaceTab[] = ["chat", "diff", "terminal"];
+    if (editorTabEnabled) tabs.push("editor");
     return tabs;
-  }, []);
+  }, [editorTabEnabled]);
 
   const activateWorkspaceTab = (tab: WorkspaceTab) => {
     if (tab === "terminal") {
@@ -292,37 +293,24 @@ export function TopBar() {
               >
                 Shell
               </button>
-              <button
-                ref={editorTabRef}
-                onClick={() => activateWorkspaceTab("editor")}
-                disabled={!cwd}
-                className={`px-3.5 border text-[12px] font-semibold transition-colors ${
-                  !cwd
-                    ? "h-8 mb-px bg-transparent text-cc-muted/50 border-transparent rounded-[8px_8px_0_0] cursor-not-allowed"
-                    : activeTab === "editor"
-                      ? "relative z-10 h-9 -mb-px text-cc-fg border-cc-border/80 border-b-transparent rounded-[14px_14px_0_0] cursor-pointer"
-                      : "h-8 mb-px bg-transparent text-cc-muted border-transparent rounded-[8px_8px_0_0] hover:bg-cc-hover/70 hover:text-cc-fg cursor-pointer"
-                }`}
-                style={activeTab === "editor" ? { backgroundColor: sampledTabColors.editor || activeTabSurfaceColor } : undefined}
-                title={!cwd ? "Editor unavailable while session is reconnecting" : "VS Code editor"}
-                aria-label="Editor tab"
-              >
-                Editor
-              </button>
-              {editorUrl && (
-                <a
-                  href={editorUrl}
-                  target="_blank"
-                  rel="noreferrer"
-                  className="h-8 mb-px px-1.5 flex items-center rounded-md text-cc-muted hover:text-cc-fg hover:bg-cc-hover/70 transition-colors"
-                  title="Open editor in new window"
-                  aria-label="Open editor in new window"
+              {editorTabEnabled && (
+                <button
+                  ref={editorTabRef}
+                  onClick={() => activateWorkspaceTab("editor")}
+                  disabled={!cwd}
+                  className={`px-3.5 border text-[12px] font-semibold transition-colors ${
+                    !cwd
+                      ? "h-8 mb-px bg-transparent text-cc-muted/50 border-transparent rounded-[8px_8px_0_0] cursor-not-allowed"
+                      : activeTab === "editor"
+                        ? "relative z-10 h-9 -mb-px text-cc-fg border-cc-border/80 border-b-transparent rounded-[14px_14px_0_0] cursor-pointer"
+                        : "h-8 mb-px bg-transparent text-cc-muted border-transparent rounded-[8px_8px_0_0] hover:bg-cc-hover/70 hover:text-cc-fg cursor-pointer"
+                  }`}
+                  style={activeTab === "editor" ? { backgroundColor: sampledTabColors.editor || activeTabSurfaceColor } : undefined}
+                  title={!cwd ? "Editor unavailable while session is reconnecting" : "Editor"}
+                  aria-label="Editor tab"
                 >
-                  <svg viewBox="0 0 16 16" fill="currentColor" className="w-3 h-3">
-                    <path d="M6.22 8.72a.75.75 0 001.06 1.06l5.22-5.22v1.69a.75.75 0 001.5 0v-3.5a.75.75 0 00-.75-.75h-3.5a.75.75 0 000 1.5h1.69L6.22 8.72z" />
-                    <path d="M3.5 6.75c0-.69.56-1.25 1.25-1.25H7A.75.75 0 007 4H4.75A2.75 2.75 0 002 6.75v4.5A2.75 2.75 0 004.75 14h4.5A2.75 2.75 0 0012 11.25V9a.75.75 0 00-1.5 0v2.25c0 .69-.56 1.25-1.25 1.25h-4.5c-.69 0-1.25-.56-1.25-1.25v-4.5z" />
-                  </svg>
-                </a>
+                  Editor
+                </button>
               )}
               <div
                 className="hidden lg:flex h-8 mb-px items-center pl-2"

--- a/web/src/store.ts
+++ b/web/src/store.ts
@@ -93,6 +93,7 @@ interface AppState {
   taskPanelConfig: TaskPanelConfig;
   taskPanelConfigMode: boolean;
   homeResetKey: number;
+  editorTabEnabled: boolean;
   activeTab: "chat" | "diff" | "terminal" | "editor";
   editorUrls: Map<string, string>;
   chatTabReentryTickBySession: Map<string, number>;
@@ -174,6 +175,7 @@ interface AppState {
   setUpdateInfo: (info: UpdateInfo | null) => void;
   dismissUpdate: (version: string) => void;
   setUpdateOverlayActive: (active: boolean) => void;
+  setEditorTabEnabled: (enabled: boolean) => void;
 
   // Diff panel actions
   setActiveTab: (tab: "chat" | "diff" | "terminal" | "editor") => void;
@@ -318,6 +320,7 @@ export const useStore = create<AppState>((set) => ({
   taskPanelConfig: getInitialTaskPanelConfig(),
   taskPanelConfigMode: false,
   homeResetKey: 0,
+  editorTabEnabled: false,
   activeTab: "chat",
   editorUrls: new Map(),
   chatTabReentryTickBySession: new Map(),
@@ -757,6 +760,7 @@ export const useStore = create<AppState>((set) => ({
     set({ updateDismissedVersion: version });
   },
   setUpdateOverlayActive: (active) => set({ updateOverlayActive: active }),
+  setEditorTabEnabled: (enabled) => set({ editorTabEnabled: enabled }),
 
   setActiveTab: (tab) => set({ activeTab: tab }),
   setEditorUrl: (sessionId, url) =>
@@ -882,6 +886,7 @@ export const useStore = create<AppState>((set) => ({
       prStatus: new Map(),
       linkedLinearIssues: new Map(),
       taskPanelConfigMode: false,
+      editorTabEnabled: false,
       activeTab: "chat" as const,
       editorUrls: new Map(),
       chatTabReentryTickBySession: new Map(),


### PR DESCRIPTION
## Summary
- replace the session `Editor` pane implementation from embedded VS Code startup to a simple in-app CodeMirror editor
- add a new persisted setting `editorTabEnabled` exposed via `/api/settings`
- add a settings toggle to enable/disable the `Editor` tab, and hide the tab when disabled
- keep behavior safe by switching back to `chat` if the editor tab is disabled while active

## Why
- remove runtime dependency on host/container `code-server` startup for basic editing
- provide a lighter editing workflow that is consistent across environments
- keep the editor feature opt-in for product clarity

## Testing
- `cd web && bun run typecheck`
- `cd web && bunx vitest run server/settings-manager.test.ts server/auto-namer.test.ts server/routes.test.ts src/components/TopBar.test.tsx src/components/SettingsPage.test.tsx src/components/SessionEditorPane.test.tsx`
- pre-commit hook also ran full checks (`tsc` + `vitest run --coverage`) successfully

## Review provenance
- Implemented by AI agent
- Human review: no
