### PR TITLE
docs(readme): add global installation and CLI commands reference

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,20 +13,46 @@
 </p>
 
 ## Quick start
-Requirements:
-- Bun
-- Claude Code and/or Codex CLI available on your machine
 
-Run:
+**Requirements:** [Bun](https://bun.sh) + [Claude Code](https://docs.anthropic.com/en/docs/claude-code) and/or [Codex](https://github.com/openai/codex) CLI.
+
+### Try it instantly
+
 ```bash
 bunx the-companion
 ```
-Open `http://localhost:3456`.
 
-Alternative foreground command:
+Open [http://localhost:3456](http://localhost:3456).
+
+### Install globally
+
 ```bash
-the-companion serve
+bun install -g the-companion
+
+# Register as a background service (launchd on macOS, systemd on Linux)
+the-companion install
+
+# Start the service
+the-companion start
 ```
+
+Open [http://localhost:3456](http://localhost:3456). The server runs in the background and survives reboots.
+
+## CLI commands
+
+| Command | Description |
+|---|---|
+| `the-companion` | Start server in foreground (default) |
+| `the-companion serve` | Start server in foreground (explicit) |
+| `the-companion install` | Register as a background service (launchd/systemd) |
+| `the-companion start` | Start the background service |
+| `the-companion stop` | Stop the background service |
+| `the-companion restart` | Restart the background service |
+| `the-companion uninstall` | Remove the background service |
+| `the-companion status` | Show service status |
+| `the-companion logs` | Tail service log files |
+
+**Options:** `--port <n>` overrides the default port (3456).
 
 ## Why this is useful
 - **Parallel sessions**: work on multiple tasks without juggling terminals.


### PR DESCRIPTION
## Summary
- Restructured Quick Start with two clear paths: "Try it instantly" (`bunx`) and "Install globally" (`bun install -g`)
- Added CLI commands reference table covering all service management commands
- Added `--port` option documentation

## Why
The README only showed `bunx the-companion`. Users who want a permanent installation didn't know about `bun install -g the-companion`, `the-companion install`, and `the-companion start`.

## Testing
- Verified all documented commands match `web/bin/cli.ts`

## Review provenance
- Implemented by AI agent
- Human review: no
