### PR TITLE
refactor(frontend): stabilize frontend with dead code removal, memory leak fixes, and component extraction

### DIFF
--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useRef, useSyncExternalStore } from "react";
+import { lazy, Suspense, useEffect, useMemo, useRef, useSyncExternalStore } from "react";
 import { useStore } from "./store.js";
 import { connectSession } from "./ws.js";
 import { api } from "./api.js";
@@ -10,19 +10,29 @@ import { TopBar } from "./components/TopBar.js";
 import { HomePage } from "./components/HomePage.js";
 import { TaskPanel } from "./components/TaskPanel.js";
 import { DiffPanel } from "./components/DiffPanel.js";
-import { Playground } from "./components/Playground.js";
 import { UpdateBanner } from "./components/UpdateBanner.js";
-import { SettingsPage } from "./components/SettingsPage.js";
-import { IntegrationsPage } from "./components/IntegrationsPage.js";
-import { LinearSettingsPage } from "./components/LinearSettingsPage.js";
-import { PromptsPage } from "./components/PromptsPage.js";
-import { EnvManager } from "./components/EnvManager.js";
-import { CronManager } from "./components/CronManager.js";
-import { TerminalPage } from "./components/TerminalPage.js";
 import { SessionLaunchOverlay } from "./components/SessionLaunchOverlay.js";
 import { SessionTerminalDock } from "./components/SessionTerminalDock.js";
 import { SessionEditorPane } from "./components/SessionEditorPane.js";
 import { UpdateOverlay } from "./components/UpdateOverlay.js";
+
+// Lazy-loaded route-level pages (not needed for initial render)
+const Playground = lazy(() => import("./components/Playground.js").then((m) => ({ default: m.Playground })));
+const SettingsPage = lazy(() => import("./components/SettingsPage.js").then((m) => ({ default: m.SettingsPage })));
+const IntegrationsPage = lazy(() => import("./components/IntegrationsPage.js").then((m) => ({ default: m.IntegrationsPage })));
+const LinearSettingsPage = lazy(() => import("./components/LinearSettingsPage.js").then((m) => ({ default: m.LinearSettingsPage })));
+const PromptsPage = lazy(() => import("./components/PromptsPage.js").then((m) => ({ default: m.PromptsPage })));
+const EnvManager = lazy(() => import("./components/EnvManager.js").then((m) => ({ default: m.EnvManager })));
+const CronManager = lazy(() => import("./components/CronManager.js").then((m) => ({ default: m.CronManager })));
+const TerminalPage = lazy(() => import("./components/TerminalPage.js").then((m) => ({ default: m.TerminalPage })));
+
+function LazyFallback() {
+  return (
+    <div className="flex items-center justify-center h-full">
+      <div className="text-sm text-cc-muted">Loading...</div>
+    </div>
+  );
+}
 
 function useHash() {
   return useSyncExternalStore(
@@ -119,7 +129,7 @@ export default function App() {
   }, []);
 
   if (route.page === "playground") {
-    return <Playground />;
+    return <Suspense fallback={<LazyFallback />}><Playground /></Suspense>;
   }
 
   return (
@@ -151,43 +161,43 @@ export default function App() {
         <div className="flex-1 overflow-hidden relative">
           {isSettingsPage && (
             <div className="absolute inset-0">
-              <SettingsPage embedded />
+              <Suspense fallback={<LazyFallback />}><SettingsPage embedded /></Suspense>
             </div>
           )}
 
           {isPromptsPage && (
             <div className="absolute inset-0">
-              <PromptsPage embedded />
+              <Suspense fallback={<LazyFallback />}><PromptsPage embedded /></Suspense>
             </div>
           )}
 
           {isIntegrationsPage && (
             <div className="absolute inset-0">
-              <IntegrationsPage embedded />
+              <Suspense fallback={<LazyFallback />}><IntegrationsPage embedded /></Suspense>
             </div>
           )}
 
           {isLinearIntegrationPage && (
             <div className="absolute inset-0">
-              <LinearSettingsPage embedded />
+              <Suspense fallback={<LazyFallback />}><LinearSettingsPage embedded /></Suspense>
             </div>
           )}
 
           {isTerminalPage && (
             <div className="absolute inset-0">
-              <TerminalPage />
+              <Suspense fallback={<LazyFallback />}><TerminalPage /></Suspense>
             </div>
           )}
 
           {isEnvironmentsPage && (
             <div className="absolute inset-0">
-              <EnvManager embedded />
+              <Suspense fallback={<LazyFallback />}><EnvManager embedded /></Suspense>
             </div>
           )}
 
           {isScheduledPage && (
             <div className="absolute inset-0">
-              <CronManager embedded />
+              <Suspense fallback={<LazyFallback />}><CronManager embedded /></Suspense>
             </div>
           )}
 

--- a/web/src/components/ChatView.tsx
+++ b/web/src/components/ChatView.tsx
@@ -1,6 +1,7 @@
 import { useMemo } from "react";
 import { useStore } from "../store.js";
 import { api } from "../api.js";
+import { captureException } from "../analytics.js";
 import { MessageFeed } from "./MessageFeed.js";
 import { Composer } from "./Composer.js";
 import { PermissionBanner } from "./PermissionBanner.js";
@@ -26,7 +27,7 @@ export function ChatView({ sessionId }: { sessionId: string }) {
             CLI disconnected
           </span>
           <button
-            onClick={() => api.relaunchSession(sessionId).catch(console.error)}
+            onClick={() => api.relaunchSession(sessionId).catch(captureException)}
             className="text-xs font-medium px-3 py-1 rounded-md bg-cc-warning/20 hover:bg-cc-warning/30 text-cc-warning transition-colors cursor-pointer"
           >
             Reconnect

--- a/web/src/components/Composer.tsx
+++ b/web/src/components/Composer.tsx
@@ -5,26 +5,9 @@ import { CLAUDE_MODES, CODEX_MODES } from "../utils/backends.js";
 import { api, type SavedPrompt } from "../api.js";
 import type { ModeOption } from "../utils/backends.js";
 
+import { readFileAsBase64, type ImageAttachment } from "../utils/image.js";
+
 let idCounter = 0;
-
-interface ImageAttachment {
-  name: string;
-  base64: string;
-  mediaType: string;
-}
-
-function readFileAsBase64(file: File): Promise<{ base64: string; mediaType: string }> {
-  return new Promise((resolve, reject) => {
-    const reader = new FileReader();
-    reader.onload = () => {
-      const dataUrl = reader.result as string;
-      const base64 = dataUrl.split(",")[1];
-      resolve({ base64, mediaType: file.type });
-    };
-    reader.onerror = reject;
-    reader.readAsDataURL(file);
-  });
-}
 
 interface CommandItem {
   name: string;

--- a/web/src/components/CronManager.tsx
+++ b/web/src/components/CronManager.tsx
@@ -1,9 +1,10 @@
-import { useState, useEffect, useCallback, useRef } from "react";
+import { useState, useEffect, useCallback, useRef, useMemo } from "react";
 import { createPortal } from "react-dom";
 import { api, type CronJobInfo } from "../api.js";
 import { getModelsForBackend, getDefaultModel, toModelOptions, type ModelOption } from "../utils/backends.js";
 import { FolderPicker } from "./FolderPicker.js";
 import { timeAgo } from "../utils/time-ago.js";
+import { useClickOutside } from "../utils/use-click-outside.js";
 
 interface Props {
   onClose?: () => void;
@@ -566,16 +567,9 @@ function JobForm({
   }, []); // eslint-disable-line react-hooks/exhaustive-deps
 
   // Close model dropdown on outside click
-  useEffect(() => {
-    if (!showModelDropdown) return;
-    function handleClick(e: PointerEvent) {
-      if (modelDropdownRef.current && !modelDropdownRef.current.contains(e.target as Node)) {
-        setShowModelDropdown(false);
-      }
-    }
-    document.addEventListener("pointerdown", handleClick);
-    return () => document.removeEventListener("pointerdown", handleClick);
-  }, [showModelDropdown]);
+  const modelDropdownRefs = useMemo(() => [modelDropdownRef], []);
+  const closeModelDropdown = useCallback(() => setShowModelDropdown(false), []);
+  useClickOutside(modelDropdownRefs, closeModelDropdown, showModelDropdown);
 
   // Folder display label
   const dirLabel = form.cwd

--- a/web/src/components/MessageFeed.test.tsx
+++ b/web/src/components/MessageFeed.test.tsx
@@ -90,9 +90,9 @@ beforeEach(() => {
 });
 
 // ─── Pure functions tested through component output ──────────────────────────
-// Since formatElapsed, formatTokens, getToolOnlyName, extractToolItems,
-// groupToolMessages, groupMessages are not exported, we test them through the
-// component's rendered output.
+// Since getToolOnlyName, extractToolItems, groupToolMessages, groupMessages
+// are not exported, we test them through the component's rendered output.
+// (formatElapsed and formatTokenCount are now in utils/format.ts with their own tests.)
 
 // ─── formatElapsed (tested via generation stats bar) ─────────────────────────
 

--- a/web/src/components/MessageFeed.tsx
+++ b/web/src/components/MessageFeed.tsx
@@ -3,21 +3,10 @@ import { useStore } from "../store.js";
 import { MessageBubble } from "./MessageBubble.js";
 import { getToolIcon, getToolLabel, getPreview, ToolIcon } from "./ToolBlock.js";
 import type { ChatMessage, ContentBlock } from "../types.js";
+import { formatElapsed, formatTokenCount } from "../utils/format.js";
 
 const FEED_PAGE_SIZE = 100;
 const savedDistanceFromBottomBySession = new Map<string, number>();
-
-function formatElapsed(ms: number): string {
-  const secs = Math.floor(ms / 1000);
-  if (secs < 60) return `${secs}s`;
-  const mins = Math.floor(secs / 60);
-  return `${mins}m ${secs % 60}s`;
-}
-
-function formatTokens(n: number): string {
-  if (n >= 1000) return `${(n / 1000).toFixed(1)}k`;
-  return String(n);
-}
 
 const EMPTY_MESSAGES: ChatMessage[] = [];
 
@@ -561,7 +550,7 @@ export function MessageFeed({ sessionId }: { sessionId: string }) {
               {(streamingOutputTokens ?? 0) > 0 && (
                 <>
                   <span className="text-cc-muted/40">·</span>
-                  <span>↓ {formatTokens(streamingOutputTokens!)}</span>
+                  <span>↓ {formatTokenCount(streamingOutputTokens!)}</span>
                 </>
               )}
               <span className="text-cc-muted/60">)</span>

--- a/web/src/components/SectionErrorBoundary.test.tsx
+++ b/web/src/components/SectionErrorBoundary.test.tsx
@@ -1,0 +1,62 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/react";
+import { SectionErrorBoundary } from "./SectionErrorBoundary.js";
+
+// Suppress React error boundary console.error noise during tests
+vi.spyOn(console, "error").mockImplementation(() => {});
+
+function ThrowingChild({ shouldThrow }: { shouldThrow: boolean }) {
+  if (shouldThrow) throw new Error("test crash");
+  return <div>child content</div>;
+}
+
+describe("SectionErrorBoundary", () => {
+  it("renders children when no error occurs", () => {
+    render(
+      <SectionErrorBoundary label="Test">
+        <div>hello</div>
+      </SectionErrorBoundary>,
+    );
+    expect(screen.getByText("hello")).toBeTruthy();
+  });
+
+  it("shows fallback UI with label when child throws", () => {
+    render(
+      <SectionErrorBoundary label="Usage Limits">
+        <ThrowingChild shouldThrow />
+      </SectionErrorBoundary>,
+    );
+    expect(screen.getByText("Usage Limits failed to load")).toBeTruthy();
+    expect(screen.getByText("Retry")).toBeTruthy();
+  });
+
+  it("shows generic fallback when no label provided", () => {
+    render(
+      <SectionErrorBoundary>
+        <ThrowingChild shouldThrow />
+      </SectionErrorBoundary>,
+    );
+    expect(screen.getByText("Section failed to load")).toBeTruthy();
+  });
+
+  it("resets error state when Retry button is clicked", () => {
+    // Render with throwing child — should show error fallback
+    render(
+      <SectionErrorBoundary label="Test">
+        <ThrowingChild shouldThrow />
+      </SectionErrorBoundary>,
+    );
+
+    expect(screen.getByText("Test failed to load")).toBeTruthy();
+
+    // Click Retry resets hasError, React tries to render children again.
+    // Since ThrowingChild still throws, it catches again and shows fallback.
+    // This verifies that clicking Retry doesn't crash and the boundary handles re-throws.
+    fireEvent.click(screen.getByText("Retry"));
+
+    // Error boundary should catch the re-throw and show fallback again
+    expect(screen.getByText("Test failed to load")).toBeTruthy();
+    expect(screen.getByText("Retry")).toBeTruthy();
+  });
+});

--- a/web/src/components/SectionErrorBoundary.tsx
+++ b/web/src/components/SectionErrorBoundary.tsx
@@ -1,0 +1,49 @@
+import { Component, type ReactNode } from "react";
+import { captureException } from "../analytics.js";
+
+interface Props {
+  children: ReactNode;
+  /** Optional label shown in the error UI (e.g. section name) */
+  label?: string;
+}
+
+interface State {
+  hasError: boolean;
+}
+
+/**
+ * Catches render errors within a section and displays a compact fallback,
+ * preventing a single broken section from crashing the entire app.
+ */
+export class SectionErrorBoundary extends Component<Props, State> {
+  state: State = { hasError: false };
+
+  static getDerivedStateFromError(): State {
+    return { hasError: true };
+  }
+
+  componentDidCatch(error: Error) {
+    captureException(error, { section: this.props.label });
+  }
+
+  render() {
+    if (this.state.hasError) {
+      return (
+        <div className="px-4 py-3 border-b border-cc-border">
+          <div className="flex items-center justify-between gap-2">
+            <span className="text-xs text-cc-error">
+              {this.props.label ? `${this.props.label} failed to load` : "Section failed to load"}
+            </span>
+            <button
+              className="text-[10px] text-cc-muted hover:text-cc-fg px-2 py-0.5 rounded bg-cc-hover cursor-pointer"
+              onClick={() => this.setState({ hasError: false })}
+            >
+              Retry
+            </button>
+          </div>
+        </div>
+      );
+    }
+    return this.props.children;
+  }
+}

--- a/web/src/components/SessionTerminalDock.test.tsx
+++ b/web/src/components/SessionTerminalDock.test.tsx
@@ -18,7 +18,6 @@ interface MockStoreState {
   openQuickTerminal: ReturnType<typeof vi.fn>;
   closeQuickTerminalTab: ReturnType<typeof vi.fn>;
   setActiveQuickTerminalTabId: ReturnType<typeof vi.fn>;
-  setQuickTerminalPlacement: ReturnType<typeof vi.fn>;
   sessions: Map<string, { cwd?: string; is_containerized?: boolean }>;
   sdkSessions: { sessionId: string; cwd?: string; containerId?: string }[];
 }
@@ -36,7 +35,6 @@ function resetStore(overrides: Partial<MockStoreState> = {}) {
     openQuickTerminal: vi.fn(),
     closeQuickTerminalTab: vi.fn(),
     setActiveQuickTerminalTabId: vi.fn(),
-    setQuickTerminalPlacement: vi.fn(),
     sessions: new Map([["s1", { cwd: "/repo" }]]),
     sdkSessions: [],
     ...overrides,

--- a/web/src/components/TopBar.test.tsx
+++ b/web/src/components/TopBar.test.tsx
@@ -20,7 +20,6 @@ interface MockStoreState {
   activeTab: "chat" | "diff" | "terminal" | "editor";
   setActiveTab: ReturnType<typeof vi.fn>;
   markChatTabReentry: ReturnType<typeof vi.fn>;
-  editorUrls: Map<string, string>;
   quickTerminalOpen: boolean;
   quickTerminalTabs: { id: string; label: string; cwd: string; containerId?: string }[];
   openQuickTerminal: ReturnType<typeof vi.fn>;
@@ -45,7 +44,6 @@ function resetStore(overrides: Partial<MockStoreState> = {}) {
     activeTab: "chat",
     setActiveTab: vi.fn(),
     markChatTabReentry: vi.fn(),
-    editorUrls: new Map(),
     quickTerminalOpen: false,
     quickTerminalTabs: [],
     openQuickTerminal: vi.fn(),

--- a/web/src/components/UpdateBanner.tsx
+++ b/web/src/components/UpdateBanner.tsx
@@ -1,6 +1,7 @@
 import { useState } from "react";
 import { useStore } from "../store.js";
 import { api } from "../api.js";
+import { captureException } from "../analytics.js";
 
 export function UpdateBanner() {
   const updateInfo = useStore((s) => s.updateInfo);
@@ -18,7 +19,7 @@ export function UpdateBanner() {
       // Show the full-screen updating overlay
       useStore.getState().setUpdateOverlayActive(true);
     } catch (err) {
-      console.error("Update failed:", err);
+      captureException(err);
       setUpdating(false);
     }
   };

--- a/web/src/components/UpdateOverlay.tsx
+++ b/web/src/components/UpdateOverlay.tsx
@@ -53,7 +53,7 @@ function useServerPoll(active: boolean) {
           setPhase("ready");
           // Brief pause to show the success state, then reload
           setTimeout(() => {
-            window.location.reload();
+            if (mountedRef.current) window.location.reload();
           }, 800);
         })
         .catch(() => {

--- a/web/src/components/home/BranchPicker.tsx
+++ b/web/src/components/home/BranchPicker.tsx
@@ -1,0 +1,225 @@
+import { useState, useEffect, useRef } from "react";
+import { api, type GitRepoInfo, type GitBranchInfo } from "../../api.js";
+
+interface BranchPickerProps {
+  cwd: string;
+  gitRepoInfo: GitRepoInfo | null;
+  selectedBranch: string;
+  isNewBranch: boolean;
+  useWorktree: boolean;
+  onBranchChange: (branch: string, isNew: boolean) => void;
+  onWorktreeChange: (useWorktree: boolean) => void;
+  /** Expose branches + pull check to parent for session creation */
+  onBranchesLoaded: (branches: GitBranchInfo[]) => void;
+}
+
+export function BranchPicker({
+  cwd,
+  gitRepoInfo,
+  selectedBranch,
+  isNewBranch,
+  useWorktree,
+  onBranchChange,
+  onWorktreeChange,
+  onBranchesLoaded,
+}: BranchPickerProps) {
+  const [branches, setBranches] = useState<GitBranchInfo[]>([]);
+  const [showBranchDropdown, setShowBranchDropdown] = useState(false);
+  const [branchFilter, setBranchFilter] = useState("");
+
+  const branchDropdownRef = useRef<HTMLDivElement>(null);
+
+  // Close dropdown on outside click
+  useEffect(() => {
+    function handleClick(e: MouseEvent) {
+      if (branchDropdownRef.current && !branchDropdownRef.current.contains(e.target as Node)) {
+        setShowBranchDropdown(false);
+      }
+    }
+    document.addEventListener("pointerdown", handleClick);
+    return () => document.removeEventListener("pointerdown", handleClick);
+  }, []);
+
+  // Fetch branches when git repo changes
+  useEffect(() => {
+    if (gitRepoInfo) {
+      api.listBranches(gitRepoInfo.repoRoot).then((b) => {
+        setBranches(b);
+        onBranchesLoaded(b);
+      }).catch(() => {
+        setBranches([]);
+        onBranchesLoaded([]);
+      });
+    } else {
+      setBranches([]);
+      onBranchesLoaded([]);
+    }
+  }, [gitRepoInfo]); // eslint-disable-line react-hooks/exhaustive-deps
+
+  if (!gitRepoInfo) return null;
+
+  return (
+    <>
+      {/* Branch picker */}
+      <div className="relative" ref={branchDropdownRef}>
+        <button
+          onClick={() => {
+            if (!showBranchDropdown && gitRepoInfo) {
+              api.gitFetch(gitRepoInfo.repoRoot)
+                .catch(() => {})
+                .finally(() => {
+                  api.listBranches(gitRepoInfo.repoRoot).then((b) => {
+                    setBranches(b);
+                    onBranchesLoaded(b);
+                  }).catch(() => {
+                    setBranches([]);
+                    onBranchesLoaded([]);
+                  });
+                });
+            }
+            setShowBranchDropdown(!showBranchDropdown);
+            setBranchFilter("");
+          }}
+          className="flex items-center gap-1.5 px-2 py-1 text-xs rounded-md transition-colors cursor-pointer text-cc-muted hover:text-cc-fg hover:bg-cc-hover"
+        >
+          <svg viewBox="0 0 16 16" fill="currentColor" className="w-3 h-3 opacity-60">
+            <path d="M5 3.25a.75.75 0 11-1.5 0 .75.75 0 011.5 0zm0 2.122a2.25 2.25 0 10-1.5 0v.378A2.5 2.5 0 007.5 8h1a1 1 0 010 2h-1A2.5 2.5 0 005 12.5v.128a2.25 2.25 0 101.5 0V12.5a1 1 0 011-1h1a2.5 2.5 0 000-5h-1a1 1 0 01-1-1V5.372zM4.25 12a.75.75 0 100 1.5.75.75 0 000-1.5z" />
+          </svg>
+          <span className="max-w-[100px] sm:max-w-[160px] truncate font-mono-code">
+            {selectedBranch || gitRepoInfo.currentBranch}
+          </span>
+          <svg viewBox="0 0 16 16" fill="currentColor" className="w-3 h-3 opacity-50">
+            <path d="M4 6l4 4 4-4" />
+          </svg>
+        </button>
+        {showBranchDropdown && (
+          <div className="absolute left-0 bottom-full mb-1 w-72 max-w-[calc(100vw-2rem)] bg-cc-card border border-cc-border rounded-[10px] shadow-lg z-10 overflow-hidden">
+            {/* Search/filter input */}
+            <div className="px-2 py-2 border-b border-cc-border">
+              <input
+                type="text"
+                value={branchFilter}
+                onChange={(e) => setBranchFilter(e.target.value)}
+                placeholder="Filter or create branch..."
+                className="w-full px-2 py-1 text-base sm:text-xs bg-cc-input-bg border border-cc-border rounded-md text-cc-fg font-mono-code placeholder:text-cc-muted focus:outline-none focus:border-cc-primary/50"
+                autoFocus
+                onKeyDown={(e) => {
+                  if (e.key === "Escape") {
+                    setShowBranchDropdown(false);
+                  }
+                }}
+              />
+            </div>
+            {/* Branch list */}
+            <div className="max-h-[240px] overflow-y-auto py-1">
+              {(() => {
+                const filter = branchFilter.toLowerCase().trim();
+                const localBranches = branches.filter((b) => !b.isRemote && (!filter || b.name.toLowerCase().includes(filter)));
+                const remoteBranches = branches.filter((b) => b.isRemote && (!filter || b.name.toLowerCase().includes(filter)));
+                const exactMatch = branches.some((b) => b.name.toLowerCase() === filter);
+                const hasResults = localBranches.length > 0 || remoteBranches.length > 0;
+
+                return (
+                  <>
+                    {/* Local branches */}
+                    {localBranches.length > 0 && (
+                      <>
+                        <div className="px-3 py-1 text-[10px] text-cc-muted uppercase tracking-wider">Local</div>
+                        {localBranches.map((b) => (
+                          <button
+                            key={b.name}
+                            onClick={() => {
+                              onBranchChange(b.name, false);
+                              setShowBranchDropdown(false);
+                            }}
+                            className={`w-full px-3 py-1.5 text-xs text-left hover:bg-cc-hover transition-colors cursor-pointer flex items-center gap-2 ${
+                              b.name === selectedBranch ? "text-cc-primary font-medium" : "text-cc-fg"
+                            }`}
+                          >
+                            <span className="truncate font-mono-code">{b.name}</span>
+                            <span className="ml-auto flex items-center gap-1.5 shrink-0">
+                              {b.ahead > 0 && (
+                                <span className="text-[9px] text-green-500">{b.ahead}&#8593;</span>
+                              )}
+                              {b.behind > 0 && (
+                                <span className="text-[9px] text-amber-500">{b.behind}&#8595;</span>
+                              )}
+                              {b.worktreePath && (
+                                <span className="text-[9px] px-1 py-0.5 rounded bg-blue-500/15 text-blue-600 dark:text-blue-400">wt</span>
+                              )}
+                              {b.isCurrent && (
+                                <span className="text-[9px] px-1 py-0.5 rounded bg-green-500/15 text-green-600 dark:text-green-400">current</span>
+                              )}
+                            </span>
+                          </button>
+                        ))}
+                      </>
+                    )}
+                    {/* Remote branches */}
+                    {remoteBranches.length > 0 && (
+                      <>
+                        <div className="px-3 py-1 text-[10px] text-cc-muted uppercase tracking-wider mt-1">Remote</div>
+                        {remoteBranches.map((b) => (
+                          <button
+                            key={`remote-${b.name}`}
+                            onClick={() => {
+                              onBranchChange(b.name, false);
+                              setShowBranchDropdown(false);
+                            }}
+                            className={`w-full px-3 py-1.5 text-xs text-left hover:bg-cc-hover transition-colors cursor-pointer flex items-center gap-2 ${
+                              b.name === selectedBranch ? "text-cc-primary font-medium" : "text-cc-fg"
+                            }`}
+                          >
+                            <span className="truncate font-mono-code">{b.name}</span>
+                            <span className="text-[9px] px-1 py-0.5 rounded bg-cc-hover text-cc-muted ml-auto shrink-0">remote</span>
+                          </button>
+                        ))}
+                      </>
+                    )}
+                    {/* No results */}
+                    {!hasResults && filter && (
+                      <div className="px-3 py-2 text-xs text-cc-muted text-center">No matching branches</div>
+                    )}
+                    {/* Create new branch option */}
+                    {filter && !exactMatch && (
+                      <div className="border-t border-cc-border mt-1 pt-1">
+                        <button
+                          onClick={() => {
+                            onBranchChange(branchFilter.trim(), true);
+                            setShowBranchDropdown(false);
+                          }}
+                          className="w-full px-3 py-1.5 text-xs text-left hover:bg-cc-hover transition-colors cursor-pointer flex items-center gap-2 text-cc-primary"
+                        >
+                          <svg viewBox="0 0 16 16" fill="currentColor" className="w-3 h-3 shrink-0">
+                            <path d="M8 2a.75.75 0 01.75.75v4.5h4.5a.75.75 0 010 1.5h-4.5v4.5a.75.75 0 01-1.5 0v-4.5h-4.5a.75.75 0 010-1.5h4.5v-4.5A.75.75 0 018 2z" />
+                          </svg>
+                          <span>Create <span className="font-mono-code font-medium">{branchFilter.trim()}</span></span>
+                        </button>
+                      </div>
+                    )}
+                  </>
+                );
+              })()}
+            </div>
+          </div>
+        )}
+      </div>
+
+      {/* Worktree toggle */}
+      <button
+        onClick={() => onWorktreeChange(!useWorktree)}
+        className={`flex items-center gap-1.5 px-2 py-1 text-xs rounded-md transition-colors cursor-pointer ${
+          useWorktree
+            ? "bg-cc-primary/15 text-cc-primary font-medium"
+            : "text-cc-muted hover:text-cc-fg hover:bg-cc-hover"
+        }`}
+        title="Create an isolated worktree for this session"
+      >
+        <svg viewBox="0 0 16 16" fill="currentColor" className="w-3.5 h-3.5 opacity-70">
+          <path d="M5 3.25a.75.75 0 11-1.5 0 .75.75 0 011.5 0zm0 2.122a2.25 2.25 0 10-1.5 0v5.256a2.25 2.25 0 101.5 0V5.372zM4.25 12a.75.75 0 100 1.5.75.75 0 000-1.5zm7.5-9.5a.75.75 0 100 1.5.75.75 0 000-1.5zm-2.25.75a2.25 2.25 0 113 2.122V7A2.5 2.5 0 0010 9.5H6a1 1 0 000 2h4a2.5 2.5 0 012.5 2.5v.628a2.25 2.25 0 11-1.5 0V14a1 1 0 00-1-1H6a2.5 2.5 0 01-2.5-2.5V10a2.5 2.5 0 012.5-2.5h4a1 1 0 001-1V5.372a2.25 2.25 0 01-1.5-2.122z" />
+        </svg>
+        <span>Worktree</span>
+      </button>
+    </>
+  );
+}

--- a/web/src/components/home/LinearSection.tsx
+++ b/web/src/components/home/LinearSection.tsx
@@ -1,0 +1,544 @@
+import { useState, useEffect, useRef } from "react";
+import { api, type LinearIssue, type LinearProject, type LinearProjectMapping, type GitRepoInfo } from "../../api.js";
+import { resolveLinearBranch } from "../../utils/linear-branch.js";
+import { LinearLogo } from "../LinearLogo.js";
+
+interface LinearSectionProps {
+  cwd: string;
+  gitRepoInfo: GitRepoInfo | null;
+  linearConfigured: boolean;
+  selectedLinearIssue: LinearIssue | null;
+  onIssueSelect: (issue: LinearIssue | null) => void;
+  /** Called when a Linear issue selection sets a new branch (for session creation) */
+  onBranchFromIssue: (branch: string, isNew: boolean) => void;
+}
+
+export function LinearSection({
+  cwd,
+  gitRepoInfo,
+  linearConfigured,
+  selectedLinearIssue,
+  onIssueSelect,
+  onBranchFromIssue,
+}: LinearSectionProps) {
+  // Linear issue search state
+  const [linearQuery, setLinearQuery] = useState("");
+  const [linearIssues, setLinearIssues] = useState<LinearIssue[]>([]);
+  const [showLinearDropdown, setShowLinearDropdown] = useState(false);
+  const [linearSearching, setLinearSearching] = useState(false);
+  const [linearSearchError, setLinearSearchError] = useState("");
+  const [showLinearStartWarning, setShowLinearStartWarning] = useState(false);
+
+  // Linear project mapping state
+  const [linearMapping, setLinearMapping] = useState<LinearProjectMapping | null>(null);
+  const [recentIssues, setRecentIssues] = useState<LinearIssue[]>([]);
+  const [recentIssuesLoading, setRecentIssuesLoading] = useState(false);
+  const [recentIssuesError, setRecentIssuesError] = useState("");
+  const [showAttachProjectDropdown, setShowAttachProjectDropdown] = useState(false);
+  const [availableProjects, setAvailableProjects] = useState<LinearProject[]>([]);
+  const [projectsLoading, setProjectsLoading] = useState(false);
+  const [projectSearchQuery, setProjectSearchQuery] = useState("");
+  const [searchAllProjects, setSearchAllProjects] = useState(false);
+  const [globalSearchResults, setGlobalSearchResults] = useState<LinearIssue[]>([]);
+  const [globalSearching, setGlobalSearching] = useState(false);
+
+  const linearDropdownRef = useRef<HTMLDivElement>(null);
+
+  // Close dropdowns on outside click
+  useEffect(() => {
+    function handleClick(e: MouseEvent) {
+      if (linearDropdownRef.current && !linearDropdownRef.current.contains(e.target as Node)) {
+        setShowLinearDropdown(false);
+        setShowAttachProjectDropdown(false);
+      }
+    }
+    document.addEventListener("pointerdown", handleClick);
+    return () => document.removeEventListener("pointerdown", handleClick);
+  }, []);
+
+  // When gitRepoInfo changes, check for Linear project mapping and fetch recent issues
+  useEffect(() => {
+    if (!gitRepoInfo || !linearConfigured) {
+      setLinearMapping(null);
+      setRecentIssues([]);
+      return;
+    }
+
+    let active = true;
+    setRecentIssuesLoading(true);
+    setRecentIssuesError("");
+
+    (async () => {
+      try {
+        const { mapping } = await api.getLinearProjectMapping(gitRepoInfo.repoRoot);
+        if (!active) return;
+        setLinearMapping(mapping);
+        if (mapping) {
+          const { issues } = await api.getLinearProjectIssues(mapping.projectId, 10);
+          if (!active) return;
+          setRecentIssues(issues);
+        } else {
+          setRecentIssues([]);
+        }
+      } catch (e: unknown) {
+        if (!active) return;
+        setRecentIssuesError(e instanceof Error ? e.message : String(e));
+      } finally {
+        if (active) setRecentIssuesLoading(false);
+      }
+    })();
+
+    return () => { active = false; };
+  }, [gitRepoInfo, linearConfigured]);
+
+  // Linear issue search effect
+  useEffect(() => {
+    if (!linearConfigured) return;
+    const query = linearQuery.trim();
+    if (query.length < 2) {
+      setLinearIssues([]);
+      setLinearSearchError("");
+      setLinearSearching(false);
+      return;
+    }
+
+    let active = true;
+    setLinearSearching(true);
+    setLinearSearchError("");
+    const timer = setTimeout(() => {
+      api.searchLinearIssues(query, 8).then((res) => {
+        if (!active) return;
+        setLinearIssues(res.issues);
+      }).catch((e: unknown) => {
+        if (!active) return;
+        setLinearIssues([]);
+        setLinearSearchError(e instanceof Error ? e.message : String(e));
+      }).finally(() => {
+        if (!active) return;
+        setLinearSearching(false);
+      });
+    }, 400);
+
+    return () => {
+      active = false;
+      clearTimeout(timer);
+    };
+  }, [linearConfigured, linearQuery]);
+
+  // Global search effect — triggers when "Search all projects" is enabled and projectSearchQuery has 2+ chars
+  useEffect(() => {
+    if (!linearConfigured || !searchAllProjects) {
+      setGlobalSearchResults([]);
+      setGlobalSearching(false);
+      return;
+    }
+    const query = projectSearchQuery.trim();
+    if (query.length < 2) {
+      setGlobalSearchResults([]);
+      setGlobalSearching(false);
+      return;
+    }
+
+    let active = true;
+    setGlobalSearching(true);
+    const timer = setTimeout(() => {
+      api.searchLinearIssues(query, 10).then((res) => {
+        if (!active) return;
+        setGlobalSearchResults(res.issues);
+      }).catch(() => {
+        if (!active) return;
+        setGlobalSearchResults([]);
+      }).finally(() => {
+        if (!active) return;
+        setGlobalSearching(false);
+      });
+    }, 400);
+
+    return () => {
+      active = false;
+      clearTimeout(timer);
+    };
+  }, [linearConfigured, searchAllProjects, projectSearchQuery]);
+
+  function handleSelectLinearIssue(issue: LinearIssue, closeDropdown = false) {
+    onIssueSelect(issue);
+    setLinearQuery(`${issue.identifier} - ${issue.title}`);
+    const branch = resolveLinearBranch(issue);
+    onBranchFromIssue(branch, true);
+    if (closeDropdown) {
+      setShowLinearDropdown(false);
+    }
+  }
+
+  function handleClearIssue() {
+    onIssueSelect(null);
+    setLinearQuery("");
+    setLinearIssues([]);
+    setLinearSearchError("");
+  }
+
+  async function handleAttachProject(project: LinearProject) {
+    if (!gitRepoInfo) return;
+    try {
+      const { mapping } = await api.upsertLinearProjectMapping({
+        repoRoot: gitRepoInfo.repoRoot,
+        projectId: project.id,
+        projectName: project.name,
+      });
+      setLinearMapping(mapping);
+      setShowAttachProjectDropdown(false);
+      setRecentIssuesLoading(true);
+      setRecentIssuesError("");
+      const { issues } = await api.getLinearProjectIssues(project.id, 10);
+      setRecentIssues(issues);
+    } catch (e: unknown) {
+      setRecentIssuesError(e instanceof Error ? e.message : String(e));
+    } finally {
+      setRecentIssuesLoading(false);
+    }
+  }
+
+  async function handleDetachProject() {
+    if (!gitRepoInfo) return;
+    try {
+      await api.removeLinearProjectMapping(gitRepoInfo.repoRoot);
+    } catch {
+      // ignore
+    }
+    setLinearMapping(null);
+    setRecentIssues([]);
+    onIssueSelect(null);
+    setLinearQuery("");
+  }
+
+  function handleOpenAttachDropdown() {
+    if (!linearConfigured) {
+      window.location.hash = "#/integrations/linear";
+      return;
+    }
+    setShowAttachProjectDropdown(true);
+    if (availableProjects.length === 0) {
+      setProjectsLoading(true);
+      api.listLinearProjects()
+        .then(({ projects }) => setAvailableProjects(projects))
+        .catch(() => {})
+        .finally(() => setProjectsLoading(false));
+    }
+  }
+
+  if (!linearConfigured) return null;
+
+  return (
+    <aside className="space-y-2 mt-0.5" ref={linearDropdownRef}>
+      <div className="relative rounded-[12px] border border-cc-border bg-cc-card/90 px-2.5 py-2">
+        <div className="flex items-center gap-2 flex-wrap">
+          <span className="text-[11px] uppercase tracking-wide text-cc-muted">Context</span>
+
+          {/* When a project is attached, show project badge */}
+          {linearMapping ? (
+            <div className="inline-flex items-center gap-1.5 px-2.5 py-1.5 rounded-lg text-xs border border-cc-primary/35 bg-cc-primary/10 text-cc-primary">
+              <LinearLogo className="w-3.5 h-3.5" />
+              <span>{linearMapping.projectName}</span>
+              <button
+                type="button"
+                onClick={handleDetachProject}
+                className="ml-0.5 hover:text-cc-error transition-colors cursor-pointer"
+                title="Detach Linear project"
+              >
+                <svg viewBox="0 0 16 16" fill="currentColor" className="w-3 h-3">
+                  <path d="M4.646 4.646a.5.5 0 01.708 0L8 7.293l2.646-2.647a.5.5 0 01.708.708L8.707 8l2.647 2.646a.5.5 0 01-.708.708L8 8.707l-2.646 2.647a.5.5 0 01-.708-.708L7.293 8 4.646 5.354a.5.5 0 010-.708z" />
+                </svg>
+              </button>
+            </div>
+          ) : (
+            <>
+              {/* Linear button — search or configure */}
+              <button
+                type="button"
+                onClick={() => {
+                  if (!linearConfigured) {
+                    window.location.hash = "#/integrations/linear";
+                    return;
+                  }
+                  setShowLinearDropdown(!showLinearDropdown);
+                }}
+                className={`inline-flex items-center gap-1.5 px-2.5 py-1.5 rounded-lg text-xs border transition-colors cursor-pointer ${
+                  selectedLinearIssue
+                    ? "border-cc-primary/35 bg-cc-primary/10 text-cc-primary"
+                    : linearConfigured
+                      ? "border-cc-border bg-cc-hover/70 text-cc-fg hover:bg-cc-hover"
+                      : "border-amber-500/25 bg-amber-500/10 text-amber-600 dark:text-amber-300"
+                }`}
+              >
+                <LinearLogo className="w-3.5 h-3.5" />
+                <span>Linear</span>
+              </button>
+
+              {/* Attach project button (only when Linear is configured and in a git repo) */}
+              {linearConfigured && gitRepoInfo && (
+                <button
+                  type="button"
+                  onClick={handleOpenAttachDropdown}
+                  className="inline-flex items-center gap-1 px-2 py-1.5 rounded-lg text-[11px] border border-dashed border-cc-border text-cc-muted hover:text-cc-fg hover:border-cc-primary/40 transition-colors cursor-pointer"
+                >
+                  <svg viewBox="0 0 16 16" fill="currentColor" className="w-3 h-3">
+                    <path d="M8 2a.5.5 0 01.5.5v5h5a.5.5 0 010 1h-5v5a.5.5 0 01-1 0v-5h-5a.5.5 0 010-1h5v-5A.5.5 0 018 2z" />
+                  </svg>
+                  <span>Attach project</span>
+                </button>
+              )}
+
+              {!linearConfigured && (
+                <span className="text-[11px] text-amber-600 dark:text-amber-300">
+                  Configure Linear to attach an issue.
+                </span>
+              )}
+            </>
+          )}
+        </div>
+
+        {/* Issue browser with inline search (when project is attached) */}
+        {linearMapping && (() => {
+          const query = projectSearchQuery.trim().toLowerCase();
+          const filteredIssues = !searchAllProjects && query
+            ? recentIssues.filter((i) =>
+                i.identifier.toLowerCase().includes(query) ||
+                i.title.toLowerCase().includes(query))
+            : searchAllProjects ? [] : recentIssues;
+          const displayIssues = searchAllProjects ? globalSearchResults : filteredIssues;
+
+          return (
+            <div className="mt-2">
+              {/* Selected issue badge */}
+              {selectedLinearIssue && (
+                <div className="flex items-center gap-2 mb-2">
+                  <div className="flex-1 min-w-0 text-xs text-cc-primary truncate">
+                    <span className="font-mono-code">{selectedLinearIssue.identifier}</span> - {selectedLinearIssue.title}
+                  </div>
+                  <button
+                    type="button"
+                    onClick={() => {
+                      onIssueSelect(null);
+                      setLinearQuery("");
+                    }}
+                    className="text-cc-muted hover:text-cc-fg transition-colors cursor-pointer shrink-0"
+                    title="Remove issue"
+                  >
+                    <svg viewBox="0 0 16 16" fill="currentColor" className="w-3.5 h-3.5">
+                      <path d="M4.646 4.646a.5.5 0 01.708 0L8 7.293l2.646-2.647a.5.5 0 01.708.708L8.707 8l2.647 2.646a.5.5 0 01-.708.708L8 8.707l-2.646 2.647a.5.5 0 01-.708-.708L7.293 8 4.646 5.354a.5.5 0 010-.708z" />
+                    </svg>
+                  </button>
+                </div>
+              )}
+
+              {/* Inline search input */}
+              <input
+                type="text"
+                value={projectSearchQuery}
+                onChange={(e) => setProjectSearchQuery(e.target.value)}
+                placeholder={searchAllProjects ? "Search all projects..." : "Filter issues..."}
+                className="w-full px-2 py-1.5 text-xs bg-cc-input-bg border border-cc-border rounded-md text-cc-fg placeholder:text-cc-muted focus:outline-none focus:border-cc-primary/60"
+              />
+
+              {/* Issue list */}
+              {recentIssuesLoading ? (
+                <div className="px-1 py-1.5 text-xs text-cc-muted">Loading recent issues...</div>
+              ) : recentIssuesError ? (
+                <div className="px-1 py-1.5 text-xs text-cc-error">{recentIssuesError}</div>
+              ) : globalSearching ? (
+                <div className="px-1 py-1.5 text-xs text-cc-muted">Searching...</div>
+              ) : searchAllProjects && query.length < 2 ? (
+                <div className="px-1 py-1.5 text-xs text-cc-muted">Type at least 2 characters to search all projects...</div>
+              ) : displayIssues.length === 0 ? (
+                <div className="px-1 py-1.5 text-xs text-cc-muted">
+                  {query ? "No matching issues" : "No active issues found"}
+                </div>
+              ) : (
+                <div className="max-h-56 overflow-y-auto -mx-0.5 mt-1">
+                  {displayIssues.map((issue) => (
+                    <button
+                      key={issue.id}
+                      type="button"
+                      onClick={() => handleSelectLinearIssue(issue)}
+                      className={`w-full px-2 py-1.5 text-left rounded-md transition-colors cursor-pointer ${
+                        selectedLinearIssue?.id === issue.id
+                          ? "bg-cc-primary/10 border border-cc-primary/30"
+                          : "hover:bg-cc-hover"
+                      }`}
+                    >
+                      <div className="text-xs text-cc-fg truncate">
+                        <span className="font-mono-code">{issue.identifier}</span> {issue.title}
+                      </div>
+                      <div className="text-[10px] text-cc-muted truncate">
+                        {[issue.stateName, issue.priorityLabel].filter(Boolean).join(" - ")}
+                      </div>
+                    </button>
+                  ))}
+                </div>
+              )}
+
+              {/* Search all projects toggle */}
+              <label className="mt-1.5 flex items-center gap-1.5 cursor-pointer">
+                <input
+                  type="checkbox"
+                  checked={searchAllProjects}
+                  onChange={(e) => {
+                    setSearchAllProjects(e.target.checked);
+                    if (!e.target.checked) {
+                      setGlobalSearchResults([]);
+                    }
+                  }}
+                  className="rounded border-cc-border text-cc-primary focus:ring-cc-primary/30 cursor-pointer"
+                />
+                <span className="text-[11px] text-cc-muted">Search all projects</span>
+              </label>
+            </div>
+          );
+        })()}
+
+        {/* Attach project dropdown */}
+        {showAttachProjectDropdown && (
+          <div className="absolute left-2.5 right-2.5 top-[44px] bg-cc-card border border-cc-border rounded-[10px] shadow-lg z-20 overflow-hidden">
+            <div className="p-2 border-b border-cc-border">
+              <div className="flex items-center justify-between">
+                <span className="text-xs text-cc-fg font-medium">Attach a Linear project to this repo</span>
+                <button
+                  type="button"
+                  onClick={() => setShowAttachProjectDropdown(false)}
+                  className="px-2 py-1 rounded-md text-xs bg-cc-hover text-cc-muted hover:text-cc-fg transition-colors cursor-pointer"
+                >
+                  Close
+                </button>
+              </div>
+            </div>
+            {projectsLoading ? (
+              <div className="px-3 py-2 text-xs text-cc-muted">Loading projects...</div>
+            ) : availableProjects.length === 0 ? (
+              <div className="px-3 py-2 text-xs text-cc-muted">No projects found</div>
+            ) : (
+              <div className="max-h-48 overflow-y-auto">
+                {availableProjects.map((project) => (
+                  <button
+                    key={project.id}
+                    type="button"
+                    onClick={() => handleAttachProject(project)}
+                    className="w-full px-3 py-2 text-left hover:bg-cc-hover transition-colors cursor-pointer"
+                  >
+                    <div className="text-xs text-cc-fg">{project.name}</div>
+                  </button>
+                ))}
+              </div>
+            )}
+          </div>
+        )}
+
+        {/* Search dropdown (used as fallback when mapping exists, or primary when no mapping) */}
+        {showLinearDropdown && linearConfigured && (
+          <div className="absolute left-2.5 right-2.5 top-[44px] bg-cc-card border border-cc-border rounded-[10px] shadow-lg z-20 overflow-hidden">
+            <div className="p-2 border-b border-cc-border">
+              <div className="flex items-center gap-2">
+                <input
+                  type="text"
+                  value={linearQuery}
+                  onChange={(e) => {
+                    setLinearQuery(e.target.value);
+                  }}
+                  onFocus={() => setShowLinearDropdown(true)}
+                  autoFocus
+                  placeholder="ENG-123 or issue title"
+                  className="w-full px-2.5 py-2 text-sm bg-cc-input-bg border border-cc-border rounded-md text-cc-fg placeholder:text-cc-muted focus:outline-none focus:border-cc-primary/60"
+                />
+                <button
+                  type="button"
+                  onClick={() => {
+                    setShowLinearDropdown(false);
+                  }}
+                  className="px-2 py-2 rounded-md text-xs bg-cc-hover text-cc-muted hover:text-cc-fg transition-colors cursor-pointer"
+                >
+                  Close
+                </button>
+              </div>
+              <div className="mt-1.5 flex items-center justify-between text-[11px] text-cc-muted">
+                <span>Attach an issue to this draft</span>
+                <button
+                  type="button"
+                  onClick={() => {
+                    window.location.hash = "#/integrations/linear";
+                  }}
+                  className="hover:text-cc-fg underline underline-offset-2 cursor-pointer"
+                >
+                  Settings
+                </button>
+              </div>
+            </div>
+
+            {linearQuery.trim().length < 2 && (
+              <div className="px-3 py-2 text-xs text-cc-muted">Type at least 2 characters…</div>
+            )}
+            {linearQuery.trim().length >= 2 && linearSearching && (
+              <div className="px-3 py-2 text-xs text-cc-muted">Searching Linear...</div>
+            )}
+            {linearQuery.trim().length >= 2 && !linearSearching && linearSearchError && (
+              <div className="px-3 py-2 text-xs text-cc-error">{linearSearchError}</div>
+            )}
+            {linearQuery.trim().length >= 2 && !linearSearching && !linearSearchError && linearIssues.length === 0 && (
+              <div className="px-3 py-2 text-xs text-cc-muted">No matching issues</div>
+            )}
+            {linearQuery.trim().length >= 2 && !linearSearching && !linearSearchError && (
+              <div className="max-h-56 overflow-y-auto">
+                {linearIssues.map((issue) => (
+                  <button
+                    key={issue.id}
+                    type="button"
+                    onClick={() => handleSelectLinearIssue(issue, true)}
+                    className="w-full px-3 py-2 text-left hover:bg-cc-hover transition-colors cursor-pointer"
+                  >
+                    <div className="text-xs text-cc-fg truncate">
+                      <span className="font-mono-code">{issue.identifier}</span> - {issue.title}
+                    </div>
+                    <div className="text-[10px] text-cc-muted truncate">
+                      {[issue.stateName, issue.teamName].filter(Boolean).join(" • ")}
+                    </div>
+                  </button>
+                ))}
+              </div>
+            )}
+          </div>
+        )}
+
+        <button
+          type="button"
+          onClick={() => {
+            window.location.hash = "#/integrations/linear";
+          }}
+          className="absolute top-2 right-2 inline-flex h-7 w-7 items-center justify-center rounded-md text-cc-muted hover:text-cc-fg hover:bg-cc-hover transition-colors cursor-pointer"
+          title="Linear settings"
+        >
+          <svg viewBox="0 0 20 20" fill="currentColor" className="w-3.5 h-3.5">
+            <path fillRule="evenodd" d="M11.49 3.17c-.38-1.56-2.6-1.56-2.98 0a1.53 1.53 0 01-2.29.95c-1.35-.8-2.92.77-2.12 2.12.54.9.07 2.04-.95 2.29-1.56.38-1.56 2.6 0 2.98 1.02.25 1.49 1.39.95 2.29-.8 1.35.77 2.92 2.12 2.12.9-.54 2.04-.07 2.29.95.38 1.56 2.6 1.56 2.98 0 .25-1.02 1.39-1.49 2.29-.95 1.35.8 2.92-.77 2.12-2.12-.54-.9-.07-2.04.95-2.29 1.56-.38 1.56-2.6 0-2.98-1.02-.25-1.49-1.39-.95-2.29.8-1.35-.77-2.92-2.12-2.12-.9.54-2.04.07-2.29-.95zM10 13a3 3 0 100-6 3 3 0 000 6z" clipRule="evenodd" />
+          </svg>
+        </button>
+      </div>
+
+      {showLinearStartWarning && (
+        <div className="p-3 rounded-[10px] bg-amber-500/10 border border-amber-500/20">
+          <p className="text-xs text-amber-700 dark:text-amber-300 leading-snug">
+            Warning: Linear is not configured. Continue anyway?
+          </p>
+          <div className="flex gap-2 mt-2.5">
+            <button
+              type="button"
+              onClick={() => {
+                setShowLinearStartWarning(false);
+                window.location.hash = "#/integrations/linear";
+              }}
+              className="px-2.5 py-1 text-[11px] font-medium rounded-md bg-cc-hover text-cc-fg hover:bg-cc-active transition-colors cursor-pointer"
+            >
+              Configurer Linear
+            </button>
+          </div>
+        </div>
+      )}
+    </aside>
+  );
+}

--- a/web/src/utils/format.test.ts
+++ b/web/src/utils/format.test.ts
@@ -1,0 +1,107 @@
+import { describe, it, expect } from "vitest";
+import {
+  formatTokenCount,
+  formatElapsed,
+  formatResetTime,
+  formatCodexResetTime,
+  formatWindowDuration,
+} from "./format.js";
+
+describe("formatTokenCount", () => {
+  it("returns plain number for values under 1000", () => {
+    expect(formatTokenCount(0)).toBe("0");
+    expect(formatTokenCount(500)).toBe("500");
+    expect(formatTokenCount(999)).toBe("999");
+  });
+
+  it("formats with 'k' suffix for values >= 1000", () => {
+    expect(formatTokenCount(1000)).toBe("1.0k");
+    expect(formatTokenCount(1500)).toBe("1.5k");
+    expect(formatTokenCount(50_000)).toBe("50.0k");
+    expect(formatTokenCount(999_999)).toBe("1000.0k");
+  });
+
+  it("formats with 'M' suffix for values >= 1,000,000", () => {
+    expect(formatTokenCount(1_000_000)).toBe("1.0M");
+    expect(formatTokenCount(2_500_000)).toBe("2.5M");
+    expect(formatTokenCount(10_000_000)).toBe("10.0M");
+  });
+});
+
+describe("formatElapsed", () => {
+  it("formats sub-minute durations as seconds", () => {
+    expect(formatElapsed(0)).toBe("0s");
+    expect(formatElapsed(5000)).toBe("5s");
+    expect(formatElapsed(59_999)).toBe("59s");
+  });
+
+  it("formats durations >= 60s as minutes and seconds", () => {
+    expect(formatElapsed(60_000)).toBe("1m 0s");
+    expect(formatElapsed(150_000)).toBe("2m 30s");
+    expect(formatElapsed(3_600_000)).toBe("60m 0s");
+  });
+});
+
+describe("formatResetTime", () => {
+  it("returns 'now' for past timestamps", () => {
+    const past = new Date(Date.now() - 60_000).toISOString();
+    expect(formatResetTime(past)).toBe("now");
+  });
+
+  it("returns minutes only when under 1 hour", () => {
+    const future = new Date(Date.now() + 30 * 60_000).toISOString();
+    expect(formatResetTime(future)).toMatch(/^\d+m$/);
+  });
+
+  it("returns hours and minutes when under 1 day", () => {
+    const future = new Date(Date.now() + 2 * 3_600_000 + 15 * 60_000).toISOString();
+    expect(formatResetTime(future)).toMatch(/^\d+h\d+m$/);
+  });
+
+  it("returns days, hours, and minutes for multi-day durations", () => {
+    const future = new Date(Date.now() + 2 * 86_400_000 + 3 * 3_600_000).toISOString();
+    expect(formatResetTime(future)).toMatch(/^\d+d \d+h\d+m$/);
+  });
+
+  it("returns 'N/A' for invalid input", () => {
+    expect(formatResetTime("not-a-date")).toBe("N/A");
+  });
+});
+
+describe("formatCodexResetTime", () => {
+  it("returns 'now' for past timestamps", () => {
+    expect(formatCodexResetTime(Date.now() - 1000)).toBe("now");
+  });
+
+  it("returns minutes only when under 1 hour", () => {
+    expect(formatCodexResetTime(Date.now() + 30 * 60_000)).toMatch(/^\d+m$/);
+  });
+
+  it("returns hours and minutes when under 1 day", () => {
+    const result = formatCodexResetTime(Date.now() + 3 * 3_600_000 + 10 * 60_000);
+    expect(result).toMatch(/^\d+h\d+m$/);
+  });
+
+  it("returns days and hours for multi-day durations", () => {
+    const result = formatCodexResetTime(Date.now() + 2 * 86_400_000 + 5 * 3_600_000);
+    expect(result).toMatch(/^\d+d \d+h$/);
+  });
+});
+
+describe("formatWindowDuration", () => {
+  it("returns minutes for short durations", () => {
+    expect(formatWindowDuration(30)).toBe("30m");
+    expect(formatWindowDuration(59)).toBe("59m");
+  });
+
+  it("returns hours for durations >= 60 minutes", () => {
+    expect(formatWindowDuration(60)).toBe("1h");
+    expect(formatWindowDuration(120)).toBe("2h");
+    expect(formatWindowDuration(90)).toBe("2h"); // rounds
+  });
+
+  it("returns days for durations >= 1440 minutes", () => {
+    expect(formatWindowDuration(1440)).toBe("1d");
+    expect(formatWindowDuration(2880)).toBe("2d");
+  });
+});

--- a/web/src/utils/format.ts
+++ b/web/src/utils/format.ts
@@ -1,0 +1,66 @@
+/**
+ * Format a token count with k/M suffixes for compact display.
+ */
+export function formatTokenCount(n: number): string {
+  if (n >= 1_000_000) return `${(n / 1_000_000).toFixed(1)}M`;
+  if (n >= 1_000) return `${(n / 1_000).toFixed(1)}k`;
+  return String(n);
+}
+
+/**
+ * Format an elapsed duration in milliseconds as "Xs" or "Xm Ys".
+ */
+export function formatElapsed(ms: number): string {
+  const secs = Math.floor(ms / 1000);
+  if (secs < 60) return `${secs}s`;
+  const mins = Math.floor(secs / 60);
+  return `${mins}m ${secs % 60}s`;
+}
+
+/**
+ * Format a countdown from a future ISO-8601 timestamp to a compact "Xd Yh Zm" string.
+ * Returns "now" if the timestamp is in the past.
+ */
+export function formatResetTime(resetsAt: string): string {
+  try {
+    const diffMs = new Date(resetsAt).getTime() - Date.now();
+    if (!Number.isFinite(diffMs)) return "N/A";
+    if (diffMs <= 0) return "now";
+    return formatCountdownMs(diffMs);
+  } catch {
+    return "N/A";
+  }
+}
+
+/**
+ * Format a countdown from a future epoch-ms timestamp to a compact "Xd Yh" / "XhYm" / "Xm" string.
+ * Returns "now" if the timestamp is in the past.
+ */
+export function formatCodexResetTime(resetsAtMs: number): string {
+  const diffMs = resetsAtMs - Date.now();
+  if (diffMs <= 0) return "now";
+  const days = Math.floor(diffMs / 86_400_000);
+  const hours = Math.floor((diffMs % 86_400_000) / 3_600_000);
+  const minutes = Math.floor((diffMs % 3_600_000) / 60_000);
+  if (days > 0) return `${days}d ${hours}h`;
+  if (hours > 0) return `${hours}h${minutes}m`;
+  return `${minutes}m`;
+}
+
+/**
+ * Format a window duration in minutes as "Xd" / "Xh" / "Xm".
+ */
+export function formatWindowDuration(mins: number): string {
+  if (mins >= 1440) return `${Math.round(mins / 1440)}d`;
+  if (mins >= 60) return `${Math.round(mins / 60)}h`;
+  return `${mins}m`;
+}
+
+function formatCountdownMs(diffMs: number): string {
+  const days = Math.floor(diffMs / 86_400_000);
+  const hours = Math.floor((diffMs % 86_400_000) / 3_600_000);
+  const minutes = Math.floor((diffMs % 3_600_000) / 60_000);
+  if (days > 0) return `${days}d ${hours}h${minutes}m`;
+  if (hours > 0) return `${hours}h${minutes}m`;
+  return `${minutes}m`;
+}

--- a/web/src/utils/image.test.ts
+++ b/web/src/utils/image.test.ts
@@ -1,0 +1,31 @@
+// @vitest-environment jsdom
+import { describe, it, expect } from "vitest";
+import { readFileAsBase64 } from "./image.js";
+
+describe("readFileAsBase64", () => {
+  it("reads a text file and returns base64 + mediaType", async () => {
+    // Create a Blob-backed File with known content
+    const content = "hello world";
+    const file = new File([content], "test.txt", { type: "text/plain" });
+
+    const result = await readFileAsBase64(file);
+
+    // The base64 of "hello world" is "aGVsbG8gd29ybGQ="
+    expect(result.base64).toBe("aGVsbG8gd29ybGQ=");
+    expect(result.mediaType).toBe("text/plain");
+  });
+
+  it("reads an image file and returns correct mediaType", async () => {
+    // Create a minimal 1x1 PNG file (valid PNG header)
+    const pngBytes = new Uint8Array([
+      0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a, // PNG header
+    ]);
+    const file = new File([pngBytes], "pixel.png", { type: "image/png" });
+
+    const result = await readFileAsBase64(file);
+
+    expect(result.mediaType).toBe("image/png");
+    expect(typeof result.base64).toBe("string");
+    expect(result.base64.length).toBeGreaterThan(0);
+  });
+});

--- a/web/src/utils/image.ts
+++ b/web/src/utils/image.ts
@@ -1,0 +1,18 @@
+export interface ImageAttachment {
+  name: string;
+  base64: string;
+  mediaType: string;
+}
+
+export function readFileAsBase64(file: File): Promise<{ base64: string; mediaType: string }> {
+  return new Promise((resolve, reject) => {
+    const reader = new FileReader();
+    reader.onload = () => {
+      const dataUrl = reader.result as string;
+      const base64 = dataUrl.split(",")[1];
+      resolve({ base64, mediaType: file.type });
+    };
+    reader.onerror = reject;
+    reader.readAsDataURL(file);
+  });
+}

--- a/web/src/utils/use-click-outside.ts
+++ b/web/src/utils/use-click-outside.ts
@@ -1,0 +1,30 @@
+import { useEffect, type RefObject } from "react";
+
+/**
+ * Calls `onClickOutside` when a pointer event occurs outside all provided refs.
+ * Each ref in the array is checked — if the click target is inside any of them,
+ * the callback is not fired.
+ *
+ * @param refs - Array of refs whose elements are considered "inside"
+ * @param onClickOutside - Callback fired when click is outside all refs
+ * @param enabled - Optional flag to conditionally enable/disable the listener (default: true)
+ */
+export function useClickOutside(
+  refs: RefObject<HTMLElement | null>[],
+  onClickOutside: () => void,
+  enabled = true,
+): void {
+  useEffect(() => {
+    if (!enabled) return;
+    function handlePointerDown(e: PointerEvent) {
+      const isInside = refs.some(
+        (ref) => ref.current && ref.current.contains(e.target as Node),
+      );
+      if (!isInside) {
+        onClickOutside();
+      }
+    }
+    document.addEventListener("pointerdown", handlePointerDown);
+    return () => document.removeEventListener("pointerdown", handlePointerDown);
+  }, [refs, onClickOutside, enabled]);
+}


### PR DESCRIPTION
## Summary
- Remove dead store code (`setEditorUrl`/`editorUrls`, `setQuickTerminalPlacement`) and fix missing `removeSession()` cleanup for `chatTabReentryTickBySession`
- Fix `lastSeqBySession` memory leak in `ws.ts` — entries for deleted sessions persisted until page reload
- Split `HomePage.tsx` from 1,554 lines (48 useState hooks) to 887 lines by extracting `LinearSection` and `BranchPicker` into `components/home/`
- Includes all Round 1 stabilization: WS race condition fix, unbounded `processedToolUseIds` fix, double polling fix, shared utilities extraction (`format.ts`, `image.ts`, `use-click-outside.ts`), `SectionErrorBoundary`, lazy loading of 8 route-level components

## Changes
- **Dead code removal**: `editorUrls` state (never read), `setEditorUrl` action (never called), `setQuickTerminalPlacement` action (never called)
- **Memory leak fixes**: `lastSeqBySession.delete()` in `disconnectSession()`, `chatTabReentryTickBySession` cleanup in `removeSession()`
- **Component extraction**: `LinearSection.tsx` (~350 lines of Linear state/effects/JSX), `BranchPicker.tsx` (~200 lines of branch dropdown/worktree)
- **Utility dedup**: `readFileAsBase64` consolidated from 2 files, 5 format functions consolidated from 2 files
- **Error boundaries**: New `SectionErrorBoundary` component wrapping TaskPanel sections
- **Lazy loading**: 8 route-level pages converted to `React.lazy()` with `Suspense` fallback

## Test plan
- [x] `bun run typecheck` passes (only pre-existing codemirror errors)
- [x] `bun run test` — all 1,447 tests pass (+23 new tests for format/image/SectionErrorBoundary)
- [x] `bun run build` produces clean build
- [ ] Manual smoke test: create session, run tool, check TaskPanel, switch sessions, check Playground

## Review provenance
- Implemented by AI agent (Claude Opus 4.6)
- Human review: no
