### PR TITLE
feat(fs): add show hidden files toggle and mkdir to folder picker

### DIFF
--- a/web/src/api.test.ts
+++ b/web/src/api.test.ts
@@ -213,6 +213,16 @@ describe("listDirs", () => {
     const [url] = mockFetch.mock.calls[0];
     expect(url).toBe("/api/fs/list");
   });
+
+  it("includes showHidden param when requested", async () => {
+    mockFetch.mockResolvedValueOnce(mockResponse({ path: "/home", dirs: [], home: "/home" }));
+
+    await api.listDirs("/home/user", { showHidden: true });
+
+    const [url] = mockFetch.mock.calls[0];
+    expect(url).toContain("showHidden=1");
+    expect(url).toContain(`path=${encodeURIComponent("/home/user")}`);
+  });
 });
 
 // ===========================================================================

--- a/web/src/api.ts
+++ b/web/src/api.ts
@@ -559,10 +559,16 @@ export const api = {
       { name },
     ),
 
-  listDirs: (path?: string) =>
-    get<DirListResult>(
-      `/fs/list${path ? `?path=${encodeURIComponent(path)}` : ""}`,
-    ),
+  listDirs: (path?: string, opts?: { showHidden?: boolean }) => {
+    const params = new URLSearchParams();
+    if (path) params.set("path", path);
+    if (opts?.showHidden) params.set("showHidden", "1");
+    const qs = params.toString();
+    return get<DirListResult>(`/fs/list${qs ? `?${qs}` : ""}`);
+  },
+
+  createDir: (path: string) =>
+    post<{ ok: boolean; path: string }>("/fs/mkdir", { path }),
 
   getHome: () => get<{ home: string; cwd: string }>("/fs/home"),
 


### PR DESCRIPTION
## Summary

- Add `showHidden` query param to `GET /api/fs/list` to optionally include dotfiles/dotdirs
- Add `POST /api/fs/mkdir` endpoint for creating new directories from the folder picker
- Update `FolderPicker` component with "Show hidden" checkbox (persisted in localStorage) and "+ New Folder" button
- Update `api.listDirs()` signature to accept `{ showHidden }` option and add `api.createDir()` method
- Add test coverage for `showHidden` parameter

## Motivation

When selecting a project folder in the new session dialog, hidden directories (e.g. `.config`, `.local`) are not visible. This makes it impossible to select dotfile-based project paths without manually typing them. Similarly, there's no way to create a new folder from the picker UI.

## Test plan

- [ ] Open new session → folder picker → verify "Show hidden" checkbox appears
- [ ] Toggle "Show hidden" on → dotfiles/dotdirs should appear
- [ ] Toggle off → dotdirs hidden again; preference persists across reload
- [ ] Click "+ New Folder" → enter name → folder created and navigated into
- [ ] `GET /api/fs/list?showHidden=1` returns dotdirs; without param, they're filtered
- [ ] `POST /api/fs/mkdir` creates directory recursively
- [ ] Existing tests pass (`bun test`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)