### PR TITLE
feat(ui): mobile ribbon layout for chat input

### DIFF
--- a/web/src/components/Composer.tsx
+++ b/web/src/components/Composer.tsx
@@ -555,11 +555,11 @@ export function Composer({ sessionId }: { sessionId: string }) {
             </div>
           )}
 
-          <div className="flex items-end gap-2 px-2.5 py-2">
+          <div className="flex items-end gap-2 px-2.5 py-2 flex-wrap sm:flex-nowrap">
             <button
               onClick={toggleMode}
               disabled={!isConnected}
-              className={`mb-0.5 flex items-center gap-1.5 px-2.5 py-1.5 rounded-md text-[12px] font-semibold transition-all border select-none shrink-0 ${
+              className={`mb-0.5 flex items-center gap-1.5 px-2.5 py-1.5 rounded-md text-[12px] font-semibold transition-all border select-none shrink-0 order-2 sm:order-none ${
                 !isConnected
                   ? "opacity-30 cursor-not-allowed text-cc-muted border-transparent"
                   : isPlan
@@ -579,7 +579,7 @@ export function Composer({ sessionId }: { sessionId: string }) {
                   <path d="M8.5 4l4 4-4 4" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" fill="none" />
                 </svg>
               )}
-              <span>{modeLabel}</span>
+              <span className="hidden sm:inline">{modeLabel}</span>
             </button>
 
             <textarea
@@ -596,12 +596,12 @@ export function Composer({ sessionId }: { sessionId: string }) {
                 : "Waiting for CLI connection..."}
               disabled={!isConnected}
               rows={1}
-              className="flex-1 min-w-0 px-2 py-1.5 text-base sm:text-sm bg-transparent resize-none focus:outline-none text-cc-fg font-sans-ui placeholder:text-cc-muted disabled:opacity-50 overflow-y-auto"
+              className="flex-1 min-w-0 px-2 py-1.5 text-base sm:text-sm bg-transparent resize-none focus:outline-none text-cc-fg font-sans-ui placeholder:text-cc-muted disabled:opacity-50 overflow-y-auto basis-full sm:basis-auto order-1 sm:order-none"
               style={{ minHeight: "36px", maxHeight: "200px" }}
             />
 
             {/* Right: image + send/stop */}
-            <div className="mb-0.5 flex items-center gap-1.5 shrink-0">
+            <div className="mb-0.5 flex items-center gap-1.5 shrink-0 order-3 sm:order-none ml-auto sm:ml-0">
               <button
                 onClick={() => {
                   const defaultName = text.trim().slice(0, 32);


### PR DESCRIPTION
## Summary

- On mobile screens (<640px), the chat Composer input uses a ribbon layout
- Textarea spans full width on the first row
- Mode button (icon-only on mobile) and action buttons wrap to a second row below
- Uses Tailwind responsive classes (`flex-wrap`, `order`, `basis`) with `sm:` breakpoint

## Motivation

On mobile devices (360px-414px screens), the mode button label, textarea, and 3 action buttons all compete for the same horizontal row, leaving the textarea ~80px wide — unusable for typing. This change makes the textarea span full width with buttons on a ribbon row below.

## Layout

**Desktop (>640px):** unchanged — single horizontal row
```
[>> mode] [textarea...............] [save] [img] [send]
```

**Mobile (<=640px):** ribbon layout
```
[Type a message...                        ]
[>>] [save] [img]                   [send]
```

## Test plan

- [ ] Open session chat on a narrow browser window or mobile device
- [ ] Textarea should span near-full width
- [ ] Mode icon + action buttons should form ribbon row below
- [ ] On desktop (>640px), layout unchanged (single row)
- [ ] Mode button shows icon-only on mobile, label+icon on desktop

🤖 Generated with [Claude Code](https://claude.com/claude-code)