### PR TITLE
feat(diff): use git diff as source of truth; show A/M/D status icons and deleted files

### DIFF
--- a/web/src/api.ts
+++ b/web/src/api.ts
@@ -739,6 +739,10 @@ export const api = {
     get<{ path: string; diff: string }>(
       `/fs/diff?path=${encodeURIComponent(path)}${base ? `&base=${encodeURIComponent(base)}` : ""}`,
     ),
+  getChangedFiles: (cwd: string, base?: "last-commit" | "default-branch") =>
+    get<{ files: Array<{ path: string; status: string }> }>(
+      `/fs/changed-files?cwd=${encodeURIComponent(cwd)}${base ? `&base=${encodeURIComponent(base)}` : ""}`,
+    ),
   getClaudeMdFiles: (cwd: string) =>
     get<{ cwd: string; files: { path: string; content: string }[] }>(
       `/fs/claude-md?cwd=${encodeURIComponent(cwd)}`,

--- a/web/src/components/TopBar.tsx
+++ b/web/src/components/TopBar.tsx
@@ -63,17 +63,9 @@ export function TopBar() {
   const quickTerminalTabs = useStore((s) => s.quickTerminalTabs);
   const openQuickTerminal = useStore((s) => s.openQuickTerminal);
   const resetQuickTerminal = useStore((s) => s.resetQuickTerminal);
-  const changedFilesCount = useStore((s) => {
-    if (!currentSessionId) return 0;
-    const cwd =
-      s.sessions.get(currentSessionId)?.cwd ||
-      s.sdkSessions.find((sdk) => sdk.sessionId === currentSessionId)?.cwd;
-    const files = s.changedFiles.get(currentSessionId);
-    if (!files) return 0;
-    if (!cwd) return files.size;
-    const prefix = `${cwd}/`;
-    return [...files].filter((fp) => fp === cwd || fp.startsWith(prefix)).length;
-  });
+  const changedFilesCount = useStore((s) =>
+    currentSessionId ? (s.gitChangedFilesCount.get(currentSessionId) ?? 0) : 0
+  );
 
   const cwd = useStore((s) => {
     if (!currentSessionId) return null;

--- a/web/src/ws.test.ts
+++ b/web/src/ws.test.ts
@@ -326,7 +326,7 @@ describe("handleMessage: assistant", () => {
     expect(state.sessionStatus.get("s1")).toBe("running");
   });
 
-  it("tracks changed files using session cwd for relative tool paths", () => {
+  it("bumps changedFilesTick for in-scope relative tool paths", () => {
     wsModule.connectSession("s1");
     fireMessage({ type: "session_init", session: makeSession("s1") });
 
@@ -351,11 +351,10 @@ describe("handleMessage: assistant", () => {
       parent_tool_use_id: null,
     });
 
-    const changed = useStore.getState().changedFiles.get("s1");
-    expect(changed?.has("/home/user/web/server/index.ts")).toBe(true);
+    expect(useStore.getState().changedFilesTick.get("s1")).toBe(1);
   });
 
-  it("ignores changed files outside the session cwd", () => {
+  it("does not bump changedFilesTick for files outside session cwd", () => {
     wsModule.connectSession("s1");
     fireMessage({ type: "session_init", session: makeSession("s1") });
 
@@ -380,11 +379,10 @@ describe("handleMessage: assistant", () => {
       parent_tool_use_id: null,
     });
 
-    const changed = useStore.getState().changedFiles.get("s1");
-    expect(changed).toBeUndefined();
+    expect(useStore.getState().changedFilesTick.get("s1")).toBeUndefined();
   });
 
-  it("tracks changed files with absolute paths when inside cwd", () => {
+  it("bumps changedFilesTick for absolute paths when inside cwd", () => {
     wsModule.connectSession("s1");
     fireMessage({ type: "session_init", session: makeSession("s1") });
 
@@ -409,8 +407,7 @@ describe("handleMessage: assistant", () => {
       parent_tool_use_id: null,
     });
 
-    const changed = useStore.getState().changedFiles.get("s1");
-    expect(changed?.has("/home/user/README.md")).toBe(true);
+    expect(useStore.getState().changedFilesTick.get("s1")).toBe(1);
   });
 });
 

--- a/web/src/ws.ts
+++ b/web/src/ws.ts
@@ -114,16 +114,18 @@ function extractChangedFilesFromBlocks(sessionId: string, blocks: ContentBlock[]
   const sessionCwd =
     store.sessions.get(sessionId)?.cwd ||
     store.sdkSessions.find((sdk) => sdk.sessionId === sessionId)?.cwd;
+  let dirty = false;
   for (const block of blocks) {
     if (block.type !== "tool_use") continue;
     const { name, input } = block;
     if ((name === "Edit" || name === "Write") && typeof input.file_path === "string") {
       const resolvedPath = resolveSessionFilePath(input.file_path, sessionCwd);
       if (isPathInSessionScope(resolvedPath, sessionCwd)) {
-        store.addChangedFile(sessionId, resolvedPath);
+        dirty = true;
       }
     }
   }
+  if (dirty) store.bumpChangedFilesTick(sessionId);
 }
 
 function sendBrowserNotification(title: string, body: string, tag: string) {


### PR DESCRIPTION
## Summary

The diff panel previously tracked file changes by watching `Edit`/`Write`
tool calls. This approach missed:
- Files deleted via bash (`rm`, `git rm`, etc.)
- Files committed mid-session (worktrees) — `git diff HEAD` returned nothing

This PR replaces tool-call tracking with a real `git diff` query, making
the panel a reliable view of all changes vs the configured base.

## Changes

- **New `GET /fs/changed-files` endpoint** — runs `git diff --name-status`
  against the session's working directory.
- **Respects the "Compare against" global setting** — `last-commit` compares
  against HEAD (uncommitted changes + untracked files only); `default-branch`
  compares against the origin merge-base, capturing all commits made on the
  branch plus any uncommitted/untracked changes.
- **Deleted files now appear** in the diff panel list.
- **A / M / D status icons** next to each file (green = added, orange =
  modified, red = deleted).
- **Badge count matches panel count** — `gitChangedFilesCount` is stored per
  session in Zustand and updated continuously (even when the diff tab is
  closed) so the TopBar badge is always accurate.
- **Security**: branch names are shell-escaped before interpolation.
- **Store cleanup**: replaced `changedFiles` Map<Set> + `addChangedFile` +
  `clearChangedFiles` with a lean `changedFilesTick` counter used only as a
  re-fetch trigger.

## Fixes vs original PR #376

- **Endpoint placed in `fs-routes.ts`** (not `routes.ts`) to match the post-refactor architecture from #379
- **`bumpChangedFilesTick` batched per message** — the original bumped once per `Edit`/`Write` block, triggering redundant API calls when a message had multiple tool uses
- **`shellEscapeArg` added to `fs-routes.ts`** where it's actually needed

## Testing

- Typecheck: passes
- All 1473 tests pass across 75 test files

## Review provenance

- Original implementation by @cedricfarinazzo in #376
- Rebased and fixed by AI agent (conflict resolution + architectural fixes)
- Human review: no

🤖 Generated with [Claude Code](https://claude.com/claude-code)
