### PR TITLE
fix(codex): normalize rate-limit reset timestamps

### DIFF
--- a/web/server/codex-adapter.test.ts
+++ b/web/server/codex-adapter.test.ts
@@ -1728,8 +1728,8 @@ describe("CodexAdapter", () => {
 
     const rl = adapter.getRateLimits();
     expect(rl).toBeDefined();
-    expect(rl!.primary).toEqual({ usedPercent: 25, windowDurationMins: 300, resetsAt: 1730947200 });
-    expect(rl!.secondary).toEqual({ usedPercent: 10, windowDurationMins: 10080, resetsAt: 1731552000 });
+    expect(rl!.primary).toEqual({ usedPercent: 25, windowDurationMins: 300, resetsAt: 1730947200 * 1000 });
+    expect(rl!.secondary).toEqual({ usedPercent: 10, windowDurationMins: 10080, resetsAt: 1731552000 * 1000 });
   });
 
   it("updates rate limits on account/rateLimits/updated notification", async () => {
@@ -1756,7 +1756,7 @@ describe("CodexAdapter", () => {
 
     const rl = adapter.getRateLimits();
     expect(rl).toBeDefined();
-    expect(rl!.primary).toEqual({ usedPercent: 50, windowDurationMins: 300, resetsAt: 1730947200 });
+    expect(rl!.primary).toEqual({ usedPercent: 50, windowDurationMins: 300, resetsAt: 1730947200 * 1000 });
     expect(rl!.secondary).toBeNull();
   });
 

--- a/web/server/codex-adapter.ts
+++ b/web/server/codex-adapter.ts
@@ -1801,9 +1801,24 @@ export class CodexAdapter {
   private updateRateLimits(data: Record<string, unknown>): void {
     const rl = data?.rateLimits as Record<string, unknown> | undefined;
     if (!rl) return;
+    const toEpochMs = (value: unknown): number => {
+      if (typeof value !== "number" || !Number.isFinite(value) || value <= 0) {
+        return 0;
+      }
+      return value < 1_000_000_000_000 ? value * 1000 : value;
+    };
+    const normalizeLimit = (raw: unknown): { usedPercent: number; windowDurationMins: number; resetsAt: number } | null => {
+      if (!raw || typeof raw !== "object") return null;
+      const limit = raw as Record<string, unknown>;
+      return {
+        usedPercent: typeof limit.usedPercent === "number" ? limit.usedPercent : 0,
+        windowDurationMins: typeof limit.windowDurationMins === "number" ? limit.windowDurationMins : 0,
+        resetsAt: toEpochMs(limit.resetsAt),
+      };
+    };
     this._rateLimits = {
-      primary: rl.primary as { usedPercent: number; windowDurationMins: number; resetsAt: number } | null,
-      secondary: rl.secondary as { usedPercent: number; windowDurationMins: number; resetsAt: number } | null,
+      primary: normalizeLimit(rl.primary),
+      secondary: normalizeLimit(rl.secondary),
     };
     // Forward rate limits to browser for UI display
     this.emit({

--- a/web/server/routes/system-routes.ts
+++ b/web/server/routes/system-routes.ts
@@ -33,11 +33,15 @@ export function registerSystemRoutes(
     if (session?.backendType === "codex") {
       const rl = deps.wsBridge.getCodexRateLimits(sessionId);
       if (!rl) return c.json(empty);
+      const toEpochMs = (value: number): number => (
+        value > 0 && value < 1_000_000_000_000 ? value * 1000 : value
+      );
       const mapLimit = (l: { usedPercent: number; windowDurationMins: number; resetsAt: number } | null) => {
         if (!l) return null;
+        const resetsAtMs = toEpochMs(l.resetsAt);
         return {
           utilization: l.usedPercent,
-          resets_at: l.resetsAt ? new Date(l.resetsAt * 1000).toISOString() : null,
+          resets_at: resetsAtMs ? new Date(resetsAtMs).toISOString() : null,
         };
       };
       return c.json({

--- a/web/src/utils/format.test.ts
+++ b/web/src/utils/format.test.ts
@@ -86,6 +86,13 @@ describe("formatCodexResetTime", () => {
     const result = formatCodexResetTime(Date.now() + 2 * 86_400_000 + 5 * 3_600_000);
     expect(result).toMatch(/^\d+d \d+h$/);
   });
+
+  it("accepts epoch-seconds input for future timestamps", () => {
+    // Compatibility coverage: codex rate-limit payloads may still be second-based.
+    const futureSeconds = Math.floor((Date.now() + 45 * 60_000) / 1000);
+    expect(formatCodexResetTime(futureSeconds)).toMatch(/^\d+m$/);
+  });
+
 });
 
 describe("formatWindowDuration", () => {

--- a/web/src/utils/format.ts
+++ b/web/src/utils/format.ts
@@ -37,7 +37,8 @@ export function formatResetTime(resetsAt: string): string {
  * Returns "now" if the timestamp is in the past.
  */
 export function formatCodexResetTime(resetsAtMs: number): string {
-  const diffMs = resetsAtMs - Date.now();
+  const normalized = resetsAtMs > 0 && resetsAtMs < 1_000_000_000_000 ? resetsAtMs * 1000 : resetsAtMs;
+  const diffMs = normalized - Date.now();
   if (diffMs <= 0) return "now";
   const days = Math.floor(diffMs / 86_400_000);
   const hours = Math.floor((diffMs % 86_400_000) / 3_600_000);


### PR DESCRIPTION
## Summary
- normalize Codex `resetsAt` values to epoch-milliseconds in the adapter
- make session usage-limits mapping robust to both seconds and milliseconds
- harden frontend Codex reset formatter for second-based compatibility
- update backend/frontend tests to lock the timestamp contract and compatibility behavior

## Why
- Codex rate-limit reset countdowns were incorrect because some paths treated `resetsAt` as seconds while UI formatting expected milliseconds.

## Testing
- `cd web && bun run test server/codex-adapter.test.ts server/routes.test.ts src/utils/format.test.ts`
- pre-commit hook also ran full checks (`tsc --noEmit` and `vitest run --coverage`)

## Review provenance
- Implemented by AI agent
- Human review: no
