### PR TITLE
feat(notifications): standardize chrome foreground notification events

### DIFF
--- a/web/server/session-types.ts
+++ b/web/server/session-types.ts
@@ -216,6 +216,19 @@ export interface CLIAuthStatusMessage {
   session_id: string;
 }
 
+export type NotificationEventType = "session_completed" | "permission_needed";
+
+export interface NotificationEvent {
+  id: string;
+  event_type: NotificationEventType;
+  session_id: string;
+  title: string;
+  body: string;
+  timestamp: number;
+  request_id?: string;
+  tool_name?: string;
+}
+
 export interface CLIControlResponseMessage {
   type: "control_response";
   response: {
@@ -284,6 +297,7 @@ export type BrowserIncomingMessageBase =
   | { type: "permission_cancelled"; request_id: string }
   | { type: "tool_progress"; tool_use_id: string; tool_name: string; elapsed_time_seconds: number }
   | { type: "tool_use_summary"; summary: string; tool_use_ids: string[] }
+  | { type: "notification_event"; event: NotificationEvent }
   | { type: "status_change"; status: "compacting" | "idle" | "running" | null }
   | { type: "auth_status"; isAuthenticating: boolean; output: string[]; error?: string }
   | { type: "error"; message: string }

--- a/web/server/ws-bridge.test.ts
+++ b/web/server/ws-bridge.test.ts
@@ -955,6 +955,10 @@ describe("CLI message routing", () => {
     const resultBroadcast = calls.find((c: any) => c.type === "result");
     expect(resultBroadcast).toBeDefined();
     expect(resultBroadcast.data.total_cost_usd).toBe(0.05);
+    const notifyBroadcast = calls.find((c: any) => c.type === "notification_event");
+    expect(notifyBroadcast).toBeDefined();
+    expect(notifyBroadcast.event.event_type).toBe("session_completed");
+    expect(notifyBroadcast.event.session_id).toBe("s1");
   });
 
   it("result: refreshes git branch and broadcasts session_update when branch changes", () => {
@@ -1081,6 +1085,10 @@ describe("CLI message routing", () => {
     expect(permBroadcast).toBeDefined();
     expect(permBroadcast.request.request_id).toBe("req-42");
     expect(permBroadcast.request.tool_name).toBe("Bash");
+    const notifyBroadcast = calls.find((c: any) => c.type === "notification_event");
+    expect(notifyBroadcast).toBeDefined();
+    expect(notifyBroadcast.event.event_type).toBe("permission_needed");
+    expect(notifyBroadcast.event.request_id).toBe("req-42");
   });
 
   it("tool_progress: broadcasts", () => {


### PR DESCRIPTION
## Summary
- standardize notification events from the server via a new browser WebSocket `notification_event` message
- emit `session_completed` notifications on successful `result` messages
- emit `permission_needed` notifications when tool permission requests arrive
- consume `notification_event` in the browser WS client for desktop Chrome notifications
- add desktop notification dedupe and click deep-linking to `#/session/:id`
- add tests in `ws-bridge.test.ts` and `ws.test.ts` for event emission, click behavior, and deduplication

## Why
- Phase 1A needs Chrome foreground notification validation before introducing service worker and Web Push complexity
- this creates a backend-driven notification contract we can reuse for Phase 1B (PWA push)

## Testing
- `cd web && bun run test ws.test.ts server/ws-bridge.test.ts`
- `cd web && bun run typecheck`

## Review provenance
- Implemented by AI agent
- Human review: no
