### PR TITLE
fix(server): support Windows PATH separators and binary resolution

### DIFF
--- a/web/server/cli-launcher.ts
+++ b/web/server/cli-launcher.ts
@@ -724,7 +724,8 @@ export class CliLauncher {
       const binaryDir = resolve(binary, "..");
       const siblingNode = join(binaryDir, "node");
       const enrichedPath = getEnrichedPath();
-      const spawnPath = [binaryDir, ...enrichedPath.split(":")].filter(Boolean).join(":");
+      const separator = process.platform === "win32" ? ";" : ":";
+      const spawnPath = [binaryDir, ...enrichedPath.split(separator)].filter(Boolean).join(separator);
 
       if (existsSync(siblingNode)) {
         let codexScript: string;
@@ -943,7 +944,8 @@ export class CliLauncher {
       const binaryDir = resolve(binary, "..");
       const siblingNode = join(binaryDir, "node");
       const enrichedPath = getEnrichedPath();
-      const spawnPath = [binaryDir, ...enrichedPath.split(":")].filter(Boolean).join(":");
+      const separator = process.platform === "win32" ? ";" : ":";
+      const spawnPath = [binaryDir, ...enrichedPath.split(separator)].filter(Boolean).join(separator);
 
       if (existsSync(siblingNode)) {
         let codexScript: string;

--- a/web/server/path-resolver.ts
+++ b/web/server/path-resolver.ts
@@ -96,7 +96,8 @@ export function buildFallbackPath(): string {
     } catch { /* ignore */ }
   }
 
-  return [...new Set(candidates.filter((dir) => existsSync(dir)))].join(":");
+  const separator = process.platform === "win32" ? ";" : ":";
+  return [...new Set(candidates.filter((dir) => existsSync(dir)))].join(separator);
 }
 
 // ─── Enriched PATH (cached) ───────────────────────────────────────────────────
@@ -113,9 +114,10 @@ export function getEnrichedPath(): string {
 
   const currentPath = process.env.PATH || "";
   const userPath = captureUserShellPath();
+  const separator = process.platform === "win32" ? ";" : ":";
 
   // Merge: user shell PATH first (takes precedence), then current process PATH
-  const allDirs = [...userPath.split(":"), ...currentPath.split(":")];
+  const allDirs = [...userPath.split(separator), ...currentPath.split(separator)];
   const seen = new Set<string>();
   const deduped: string[] = [];
   for (const dir of allDirs) {
@@ -125,7 +127,7 @@ export function getEnrichedPath(): string {
     }
   }
 
-  _cachedPath = deduped.join(":");
+  _cachedPath = deduped.join(separator);
   return _cachedPath;
 }
 
@@ -146,8 +148,11 @@ export function resolveBinary(name: string): string | null {
   }
 
   const enrichedPath = getEnrichedPath();
+  const isWindows = process.platform === "win32";
+  const cmd = isWindows ? "where" : "which";
+
   try {
-    const resolved = execSync(`which ${name.replace(/[^a-zA-Z0-9._@/-]/g, "")}`, {
+    const resolved = execSync(`${cmd} ${name.replace(/[^a-zA-Z0-9._@/-]/g, "")}`, {
 
       encoding: "utf-8",
       timeout: 5_000,

--- a/web/server/service.ts
+++ b/web/server/service.ts
@@ -155,7 +155,8 @@ WantedBy=default.target
 
 function resolveBinPath(): string {
   try {
-    const binPath = execSync("which the-companion", { encoding: "utf-8" }).trim();
+    const cmd = process.platform === "win32" ? "where" : "which";
+    const binPath = execSync(`${cmd} the-companion`, { encoding: "utf-8" }).trim();
     if (binPath) return binPath;
   } catch {
     // not found globally


### PR DESCRIPTION
- Use platform-specific PATH separator (';' on Windows, ':' on Unix)
- Replace 'which' with 'where' command on Windows for binary resolution
- Apply fix consistently across cli-launcher, path-resolver, and service modules