### PR TITLE
feat(web): move git fetch/checkout/pull inside Docker container

### DIFF
--- a/web/server/routes.test.ts
+++ b/web/server/routes.test.ts
@@ -797,6 +797,140 @@ describe("POST /api/sessions/create", () => {
     // CLI should NOT have been launched
     expect(launcher.launch).not.toHaveBeenCalled();
   });
+
+  it("skips host git ops for Docker sessions and runs them in container instead", async () => {
+    // THE-189: git fetch/checkout/pull should happen inside the container, not on the host.
+    vi.mocked(gitUtils.getRepoInfo).mockReturnValue({
+      repoRoot: "/repo",
+      repoName: "my-repo",
+      currentBranch: "main",
+      defaultBranch: "main",
+      isWorktree: false,
+    } as any);
+    vi.mocked(envManager.getEnv).mockReturnValue({
+      name: "Docker",
+      slug: "docker",
+      variables: { CLAUDE_CODE_OAUTH_TOKEN: "token" },
+      baseImage: "the-companion:latest",
+      createdAt: 1000,
+      updatedAt: 1000,
+    } as any);
+    vi.mocked(envManager.getEffectiveImage).mockReturnValue("the-companion:latest");
+    vi.spyOn(containerManager, "createContainer").mockReturnValueOnce({
+      containerId: "cid-git",
+      name: "companion-git",
+      image: "the-companion:latest",
+      portMappings: [],
+      hostCwd: "/repo",
+      containerCwd: "/workspace",
+      state: "running",
+    });
+    vi.spyOn(containerManager, "retrack").mockImplementation(() => {});
+    const gitOpsSpy = vi.spyOn(containerManager, "gitOpsInContainer").mockReturnValueOnce({
+      fetchOk: true,
+      checkoutOk: true,
+      pullOk: true,
+      errors: [],
+    });
+
+    const res = await app.request("/api/sessions/create", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ cwd: "/repo", branch: "feat/new", envSlug: "docker" }),
+    });
+
+    expect(res.status).toBe(200);
+    // Host git ops should NOT have been called
+    expect(gitUtils.gitFetch).not.toHaveBeenCalled();
+    expect(gitUtils.checkoutOrCreateBranch).not.toHaveBeenCalled();
+    expect(gitUtils.gitPull).not.toHaveBeenCalled();
+    // In-container git ops SHOULD have been called
+    expect(gitOpsSpy).toHaveBeenCalledWith("cid-git", expect.objectContaining({
+      branch: "feat/new",
+      currentBranch: "main",
+    }));
+  });
+
+  it("does not call gitOpsInContainer for Docker sessions without a branch", async () => {
+    // When no branch is specified, no git ops at all (host or container).
+    vi.mocked(envManager.getEnv).mockReturnValue({
+      name: "Docker",
+      slug: "docker",
+      variables: { CLAUDE_CODE_OAUTH_TOKEN: "token" },
+      baseImage: "the-companion:latest",
+      createdAt: 1000,
+      updatedAt: 1000,
+    } as any);
+    vi.mocked(envManager.getEffectiveImage).mockReturnValue("the-companion:latest");
+    vi.spyOn(containerManager, "createContainer").mockReturnValueOnce({
+      containerId: "cid-nobranch",
+      name: "companion-nobranch",
+      image: "the-companion:latest",
+      portMappings: [],
+      hostCwd: "/test",
+      containerCwd: "/workspace",
+      state: "running",
+    });
+    vi.spyOn(containerManager, "retrack").mockImplementation(() => {});
+    const gitOpsSpy = vi.spyOn(containerManager, "gitOpsInContainer");
+
+    const res = await app.request("/api/sessions/create", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ cwd: "/test", envSlug: "docker" }),
+    });
+
+    expect(res.status).toBe(200);
+    expect(gitOpsSpy).not.toHaveBeenCalled();
+  });
+
+  it("returns 400 and cleans up container when in-container checkout fails", async () => {
+    // THE-189: checkout failure inside container should clean up and return error.
+    vi.mocked(gitUtils.getRepoInfo).mockReturnValue({
+      repoRoot: "/repo",
+      repoName: "my-repo",
+      currentBranch: "main",
+      defaultBranch: "main",
+      isWorktree: false,
+    } as any);
+    vi.mocked(envManager.getEnv).mockReturnValue({
+      name: "Docker",
+      slug: "docker",
+      variables: { CLAUDE_CODE_OAUTH_TOKEN: "token" },
+      baseImage: "the-companion:latest",
+      createdAt: 1000,
+      updatedAt: 1000,
+    } as any);
+    vi.mocked(envManager.getEffectiveImage).mockReturnValue("the-companion:latest");
+    vi.spyOn(containerManager, "createContainer").mockReturnValueOnce({
+      containerId: "cid-failcheckout",
+      name: "companion-failcheckout",
+      image: "the-companion:latest",
+      portMappings: [],
+      hostCwd: "/repo",
+      containerCwd: "/workspace",
+      state: "running",
+    });
+    const removeSpy = vi.spyOn(containerManager, "removeContainer").mockImplementation(() => {});
+    vi.spyOn(containerManager, "gitOpsInContainer").mockReturnValueOnce({
+      fetchOk: true,
+      checkoutOk: false,
+      pullOk: false,
+      errors: ['checkout: branch "nonexistent" does not exist'],
+    });
+
+    const res = await app.request("/api/sessions/create", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ cwd: "/repo", branch: "nonexistent", envSlug: "docker" }),
+    });
+
+    expect(res.status).toBe(400);
+    const json = await res.json();
+    expect(json.error).toContain("Failed to checkout branch");
+    expect(removeSpy).toHaveBeenCalled();
+    expect(launcher.launch).not.toHaveBeenCalled();
+  });
 });
 
 describe("GET /api/sessions", () => {
@@ -3651,6 +3785,136 @@ describe("POST /api/sessions/create-stream", () => {
     // No done event
     expect(events.find((e) => e.event === "done")).toBeUndefined();
 
+    // CLI should NOT be launched
+    expect(launcher.launch).not.toHaveBeenCalled();
+  });
+
+  it("skips host git ops and emits in-container git progress for Docker sessions with branch", async () => {
+    // THE-189: git ops should run inside the container, not on the host.
+    vi.mocked(gitUtils.getRepoInfo).mockReturnValue({
+      repoRoot: "/repo",
+      repoName: "my-repo",
+      currentBranch: "main",
+      defaultBranch: "main",
+      isWorktree: false,
+    } as any);
+    vi.mocked(envManager.getEnv).mockReturnValue({
+      name: "Docker",
+      slug: "docker",
+      variables: { CLAUDE_CODE_OAUTH_TOKEN: "token" },
+      baseImage: "the-companion:latest",
+      createdAt: 1000,
+      updatedAt: 1000,
+    } as any);
+    vi.mocked(envManager.getEffectiveImage).mockReturnValue("the-companion:latest");
+    vi.spyOn(containerManager, "createContainer").mockReturnValueOnce({
+      containerId: "cid-git-stream",
+      name: "companion-git-stream",
+      image: "the-companion:latest",
+      portMappings: [],
+      hostCwd: "/repo",
+      containerCwd: "/workspace",
+      state: "running",
+    });
+    vi.spyOn(containerManager, "retrack").mockImplementation(() => {});
+    const gitOpsSpy = vi.spyOn(containerManager, "gitOpsInContainer").mockReturnValueOnce({
+      fetchOk: true,
+      checkoutOk: true,
+      pullOk: true,
+      errors: [],
+    });
+
+    const res = await app.request("/api/sessions/create-stream", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ cwd: "/repo", branch: "feat/new", envSlug: "docker" }),
+    });
+
+    expect(res.status).toBe(200);
+    const events = await parseSSE(res);
+    const steps = events
+      .filter((e) => e.event === "progress")
+      .map((e) => JSON.parse(e.data).step);
+
+    // Host git ops should NOT have been called
+    expect(gitUtils.gitFetch).not.toHaveBeenCalled();
+    expect(gitUtils.checkoutOrCreateBranch).not.toHaveBeenCalled();
+    expect(gitUtils.gitPull).not.toHaveBeenCalled();
+
+    // In-container git ops SHOULD have been called
+    expect(gitOpsSpy).toHaveBeenCalledWith("cid-git-stream", expect.objectContaining({
+      branch: "feat/new",
+      currentBranch: "main",
+    }));
+
+    // Git progress events should appear AFTER container creation steps
+    expect(steps).toContain("creating_container");
+    expect(steps).toContain("copying_workspace");
+    expect(steps).toContain("fetching_git");
+    expect(steps).toContain("pulling_git");
+    const containerIdx = steps.indexOf("creating_container");
+    const fetchIdx = steps.indexOf("fetching_git");
+    expect(fetchIdx).toBeGreaterThan(containerIdx);
+
+    // Session should be launched
+    expect(launcher.launch).toHaveBeenCalled();
+  });
+
+  it("emits checkout error and cleans up when in-container checkout fails (stream)", async () => {
+    // THE-189: checkout failure inside container should emit error and clean up.
+    vi.mocked(gitUtils.getRepoInfo).mockReturnValue({
+      repoRoot: "/repo",
+      repoName: "my-repo",
+      currentBranch: "main",
+      defaultBranch: "main",
+      isWorktree: false,
+    } as any);
+    vi.mocked(envManager.getEnv).mockReturnValue({
+      name: "Docker",
+      slug: "docker",
+      variables: { CLAUDE_CODE_OAUTH_TOKEN: "token" },
+      baseImage: "the-companion:latest",
+      createdAt: 1000,
+      updatedAt: 1000,
+    } as any);
+    vi.mocked(envManager.getEffectiveImage).mockReturnValue("the-companion:latest");
+    vi.spyOn(containerManager, "createContainer").mockReturnValueOnce({
+      containerId: "cid-fail-git",
+      name: "companion-fail-git",
+      image: "the-companion:latest",
+      portMappings: [],
+      hostCwd: "/repo",
+      containerCwd: "/workspace",
+      state: "running",
+    });
+    const removeSpy = vi.spyOn(containerManager, "removeContainer").mockImplementation(() => {});
+    vi.spyOn(containerManager, "gitOpsInContainer").mockReturnValueOnce({
+      fetchOk: true,
+      checkoutOk: false,
+      pullOk: false,
+      errors: ['checkout: branch "nonexistent" does not exist'],
+    });
+
+    const res = await app.request("/api/sessions/create-stream", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ cwd: "/repo", branch: "nonexistent", envSlug: "docker" }),
+    });
+
+    expect(res.status).toBe(200);
+    const events = await parseSSE(res);
+
+    // Should have error event for checkout failure
+    const errorEvent = events.find((e) => e.event === "error");
+    expect(errorEvent).toBeDefined();
+    const errorData = JSON.parse(errorEvent!.data);
+    expect(errorData.error).toContain("Failed to checkout branch");
+    expect(errorData.step).toBe("checkout_branch");
+
+    // Container should be cleaned up
+    expect(removeSpy).toHaveBeenCalled();
+    // No done event
+    expect(events.find((e) => e.event === "done")).toBeUndefined();
     // CLI should NOT be launched
     expect(launcher.launch).not.toHaveBeenCalled();
   });


### PR DESCRIPTION
## Summary
- Move git fetch/checkout/pull operations inside the Docker container instead of running them on the host
- For Docker sessions, git operations now happen after workspace copy + git auth seeding inside the container
- Non-Docker sessions are unchanged (git ops still run on host)

## Why
When creating a Docker session with a branch, git operations were running on the host before the container was created, unnecessarily mutating the host repo. The git operations should happen inside the container where the actual work will be done.

## Changes
- **`container-manager.ts`**: Added `gitOpsInContainer()` method that runs git fetch/checkout/pull inside a container at `/workspace`
- **`routes.ts`**: Both `/sessions/create` and `/sessions/create-stream` now resolve `effectiveImage` early, skip host git ops for Docker sessions, and run them inside the container after workspace copy
- **Tests**: 11 new tests covering the new method and both endpoints

## New session flow for Docker sessions
```
1. Resolve environment + Docker image (moved up)
2. Auth check for containers
3. [skip host git ops]
4. Pull/build Docker image
5. Create container
6. Copy workspace to container
7. Reseed git auth
8. git fetch in container ← new
9. git checkout in container ← new
10. git pull in container ← new
11. Run init script
12. Launch CLI
```

## Testing
- `bun run typecheck` passes
- `bun run test` — all 2626 tests pass (104 test files)
- 6 new tests for `gitOpsInContainer()` in container-manager
- 5 new tests in routes for Docker session git ordering

## Review provenance
- Implemented by AI agent
- Human review: no

Closes THE-189
