### PR TITLE
fix(web): broadcast session name update on manual rename

### DIFF
--- a/web/server/routes.test.ts
+++ b/web/server/routes.test.ts
@@ -233,6 +233,7 @@ function createMockBridge() {
     getAllSessions: vi.fn(() => []),
     getCodexRateLimits: vi.fn(() => null),
     markContainerized: vi.fn(),
+    broadcastNameUpdate: vi.fn(),
   } as any;
 }
 
@@ -2868,6 +2869,8 @@ describe("PATCH /api/sessions/:id/name", () => {
     const json = await res.json();
     expect(json).toEqual({ ok: true, name: "Fix auth bug" });
     expect(sessionNames.setName).toHaveBeenCalledWith("s1", "Fix auth bug");
+    // Verify the name update is broadcast to connected browsers via WebSocket
+    expect(bridge.broadcastNameUpdate).toHaveBeenCalledWith("s1", "Fix auth bug");
   });
 
   it("trims whitespace from name", async () => {

--- a/web/server/routes.ts
+++ b/web/server/routes.ts
@@ -1015,6 +1015,7 @@ export function createRoutes(
     const session = launcher.getSession(id);
     if (!session) return c.json({ error: "Session not found" }, 404);
     sessionNames.setName(id, body.name.trim());
+    wsBridge.broadcastNameUpdate(id, body.name.trim());
     return c.json({ ok: true, name: body.name.trim() });
   });
 


### PR DESCRIPTION
## Summary
- The PATCH `/sessions/:id/name` endpoint stored the renamed session name server-side but did **not** broadcast the change to connected browsers via WebSocket
- Added `wsBridge.broadcastNameUpdate()` call to match what the auto-naming flow already does in `index.ts:117`
- Added test assertion verifying the broadcast is called

## Why
When renaming a Docker session (or any session), other connected browser tabs/windows wouldn't see the rename. The auto-naming path already broadcasts correctly — this fix brings manual rename in line with that.

## Testing
- `bun run typecheck` passes
- `bun run test` passes (524 tests in routes suite)
- Added assertion in existing rename test to verify `broadcastNameUpdate` is called

## Review provenance
- Implemented by AI agent
- Human review: no

Closes THE-192
