### PR TITLE
feat(web): make AI validation configurable per session

### DIFF
--- a/web/server/ai-validation-settings.test.ts
+++ b/web/server/ai-validation-settings.test.ts
@@ -1,0 +1,128 @@
+import { mkdtempSync, rmSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import {
+  _resetForTest,
+  updateSettings,
+} from "./settings-manager.js";
+import { getEffectiveAiValidation } from "./ai-validation-settings.js";
+import type { SessionState } from "./session-types.js";
+
+let tempDir: string;
+let settingsPath: string;
+
+/** Minimal SessionState with only the fields needed for testing */
+function makeSessionState(overrides: Partial<SessionState> = {}): SessionState {
+  return {
+    session_id: "test-session",
+    model: "",
+    cwd: "",
+    tools: [],
+    permissionMode: "default",
+    claude_code_version: "",
+    mcp_servers: [],
+    agents: [],
+    slash_commands: [],
+    skills: [],
+    total_cost_usd: 0,
+    num_turns: 0,
+    context_used_percent: 0,
+    is_compacting: false,
+    git_branch: "",
+    is_worktree: false,
+    is_containerized: false,
+    repo_root: "",
+    git_ahead: 0,
+    git_behind: 0,
+    total_lines_added: 0,
+    total_lines_removed: 0,
+    ...overrides,
+  };
+}
+
+beforeEach(() => {
+  tempDir = mkdtempSync(join(tmpdir(), "ai-validation-settings-test-"));
+  settingsPath = join(tempDir, "settings.json");
+  _resetForTest(settingsPath);
+});
+
+afterEach(() => {
+  rmSync(tempDir, { recursive: true, force: true });
+  _resetForTest();
+});
+
+describe("getEffectiveAiValidation", () => {
+  it("returns global defaults when session fields are undefined", () => {
+    // Global defaults: enabled=false, autoApprove=true, autoDeny=true
+    const session = makeSessionState();
+    const result = getEffectiveAiValidation(session);
+    expect(result.enabled).toBe(false);
+    expect(result.autoApprove).toBe(true);
+    expect(result.autoDeny).toBe(true);
+    expect(result.openrouterApiKey).toBe("");
+  });
+
+  it("returns global defaults when session fields are null (explicit inherit)", () => {
+    const session = makeSessionState({
+      aiValidationEnabled: null,
+      aiValidationAutoApprove: null,
+      aiValidationAutoDeny: null,
+    });
+    const result = getEffectiveAiValidation(session);
+    expect(result.enabled).toBe(false);
+    expect(result.autoApprove).toBe(true);
+    expect(result.autoDeny).toBe(true);
+  });
+
+  it("session override wins over global when session fields are set", () => {
+    // Set global to enabled
+    updateSettings({ aiValidationEnabled: true, aiValidationAutoApprove: true, aiValidationAutoDeny: true });
+
+    // Session overrides all three to different values
+    const session = makeSessionState({
+      aiValidationEnabled: false,
+      aiValidationAutoApprove: false,
+      aiValidationAutoDeny: false,
+    });
+    const result = getEffectiveAiValidation(session);
+    expect(result.enabled).toBe(false);
+    expect(result.autoApprove).toBe(false);
+    expect(result.autoDeny).toBe(false);
+  });
+
+  it("session enabled=true overrides global enabled=false", () => {
+    // Global: disabled
+    const session = makeSessionState({ aiValidationEnabled: true });
+    const result = getEffectiveAiValidation(session);
+    expect(result.enabled).toBe(true);
+  });
+
+  it("mixed: session sets enabled, inherits autoApprove/autoDeny from global", () => {
+    updateSettings({ aiValidationAutoApprove: false, aiValidationAutoDeny: false });
+
+    const session = makeSessionState({
+      aiValidationEnabled: true,
+      aiValidationAutoApprove: null, // inherit global (false)
+      aiValidationAutoDeny: undefined, // inherit global (false)
+    });
+    const result = getEffectiveAiValidation(session);
+    expect(result.enabled).toBe(true);
+    expect(result.autoApprove).toBe(false);
+    expect(result.autoDeny).toBe(false);
+  });
+
+  it("openrouterApiKey always comes from global settings", () => {
+    updateSettings({ openrouterApiKey: "sk-test-key-123" });
+
+    const session = makeSessionState({ aiValidationEnabled: true });
+    const result = getEffectiveAiValidation(session);
+    expect(result.openrouterApiKey).toBe("sk-test-key-123");
+  });
+
+  it("returns empty API key when global has none, regardless of session settings", () => {
+    const session = makeSessionState({ aiValidationEnabled: true });
+    const result = getEffectiveAiValidation(session);
+    expect(result.openrouterApiKey).toBe("");
+  });
+});

--- a/web/server/ai-validation-settings.ts
+++ b/web/server/ai-validation-settings.ts
@@ -1,0 +1,35 @@
+import { getSettings } from "./settings-manager.js";
+import type { SessionState } from "./session-types.js";
+
+export interface EffectiveAiValidationSettings {
+  enabled: boolean;
+  autoApprove: boolean;
+  autoDeny: boolean;
+  openrouterApiKey: string;
+}
+
+/**
+ * Resolve effective AI validation settings for a session.
+ * Session-level overrides take priority; falls back to global settings.
+ * The openrouterApiKey is always from global settings.
+ */
+export function getEffectiveAiValidation(
+  sessionState: SessionState,
+): EffectiveAiValidationSettings {
+  const global = getSettings();
+  return {
+    enabled:
+      sessionState.aiValidationEnabled != null
+        ? sessionState.aiValidationEnabled
+        : global.aiValidationEnabled,
+    autoApprove:
+      sessionState.aiValidationAutoApprove != null
+        ? sessionState.aiValidationAutoApprove
+        : global.aiValidationAutoApprove,
+    autoDeny:
+      sessionState.aiValidationAutoDeny != null
+        ? sessionState.aiValidationAutoDeny
+        : global.aiValidationAutoDeny,
+    openrouterApiKey: global.openrouterApiKey,
+  };
+}

--- a/web/server/session-types.ts
+++ b/web/server/session-types.ts
@@ -260,7 +260,8 @@ export type BrowserOutgoingMessage =
   | { type: "mcp_get_status"; client_msg_id?: string }
   | { type: "mcp_toggle"; serverName: string; enabled: boolean; client_msg_id?: string }
   | { type: "mcp_reconnect"; serverName: string; client_msg_id?: string }
-  | { type: "mcp_set_servers"; servers: Record<string, McpServerConfig>; client_msg_id?: string };
+  | { type: "mcp_set_servers"; servers: Record<string, McpServerConfig>; client_msg_id?: string }
+  | { type: "set_ai_validation"; aiValidationEnabled?: boolean | null; aiValidationAutoApprove?: boolean | null; aiValidationAutoDeny?: boolean | null; client_msg_id?: string };
 
 /** Messages the bridge sends to the browser */
 export type BrowserIncomingMessageBase =
@@ -355,6 +356,12 @@ export interface SessionState {
   agentId?: string;
   /** Human-readable name of the agent that spawned this session */
   agentName?: string;
+  /** Per-session AI validation override. null/undefined = use global default */
+  aiValidationEnabled?: boolean | null;
+  /** Per-session auto-approve override. null/undefined = use global default */
+  aiValidationAutoApprove?: boolean | null;
+  /** Per-session auto-deny override. null/undefined = use global default */
+  aiValidationAutoDeny?: boolean | null;
 }
 
 // ─── MCP Types ───────────────────────────────────────────────────────────────

--- a/web/server/ws-bridge-controls.ts
+++ b/web/server/ws-bridge-controls.ts
@@ -44,6 +44,25 @@ export function handleSetPermissionMode(
   sendToCLI(session, ndjson);
 }
 
+export function handleSetAiValidation(
+  session: Session,
+  msg: {
+    aiValidationEnabled?: boolean | null;
+    aiValidationAutoApprove?: boolean | null;
+    aiValidationAutoDeny?: boolean | null;
+  },
+): void {
+  if (msg.aiValidationEnabled !== undefined) {
+    session.state.aiValidationEnabled = msg.aiValidationEnabled;
+  }
+  if (msg.aiValidationAutoApprove !== undefined) {
+    session.state.aiValidationAutoApprove = msg.aiValidationAutoApprove;
+  }
+  if (msg.aiValidationAutoDeny !== undefined) {
+    session.state.aiValidationAutoDeny = msg.aiValidationAutoDeny;
+  }
+}
+
 export function handleControlResponse(
   session: Session,
   msg: CLIControlResponseMessage,

--- a/web/server/ws-bridge-types.ts
+++ b/web/server/ws-bridge-types.ts
@@ -7,6 +7,7 @@ import type {
   BufferedBrowserEvent,
 } from "./session-types.js";
 import type { CodexAdapter } from "./codex-adapter.js";
+import { getSettings } from "./settings-manager.js";
 
 export interface CLISocketData {
   kind: "cli";
@@ -87,5 +88,8 @@ export function makeDefaultState(
     git_behind: 0,
     total_lines_added: 0,
     total_lines_removed: 0,
+    aiValidationEnabled: getSettings().aiValidationEnabled,
+    aiValidationAutoApprove: getSettings().aiValidationAutoApprove,
+    aiValidationAutoDeny: getSettings().aiValidationAutoDeny,
   };
 }

--- a/web/src/components/AiValidationToggle.test.tsx
+++ b/web/src/components/AiValidationToggle.test.tsx
@@ -1,0 +1,136 @@
+// @vitest-environment jsdom
+import { describe, it, expect, beforeEach } from "vitest";
+import { fireEvent, render, screen } from "@testing-library/react";
+import "@testing-library/jest-dom";
+
+const mockSendSetAiValidation = vi.fn();
+
+vi.mock("../ws.js", () => ({
+  sendSetAiValidation: (...args: unknown[]) => mockSendSetAiValidation(...args),
+}));
+
+interface MockSessionState {
+  aiValidationEnabled?: boolean | null;
+  aiValidationAutoApprove?: boolean | null;
+  aiValidationAutoDeny?: boolean | null;
+}
+
+let mockSession: MockSessionState | undefined;
+const mockSetSessionAiValidation = vi.fn();
+
+vi.mock("../store.js", () => ({
+  useStore: Object.assign(
+    (selector: (s: Record<string, unknown>) => unknown) =>
+      selector({
+        sessions: new Map(mockSession ? [["test-session", mockSession]] : []),
+      }),
+    {
+      getState: () => ({
+        setSessionAiValidation: mockSetSessionAiValidation,
+      }),
+    },
+  ),
+}));
+
+import { AiValidationToggle } from "./AiValidationToggle.js";
+
+beforeEach(() => {
+  mockSession = {
+    aiValidationEnabled: false,
+    aiValidationAutoApprove: true,
+    aiValidationAutoDeny: true,
+  };
+  mockSendSetAiValidation.mockClear();
+  mockSetSessionAiValidation.mockClear();
+});
+
+describe("AiValidationToggle", () => {
+  it("renders shield icon button", () => {
+    render(<AiValidationToggle sessionId="test-session" />);
+    expect(screen.getByRole("button", { name: /toggle ai validation/i })).toBeInTheDocument();
+  });
+
+  it("shows 'Off' title when disabled", () => {
+    render(<AiValidationToggle sessionId="test-session" />);
+    const btn = screen.getByRole("button", { name: /toggle ai validation/i });
+    expect(btn).toHaveAttribute("title", "AI Validation: Off");
+  });
+
+  it("shows 'On' title when enabled", () => {
+    mockSession = { aiValidationEnabled: true, aiValidationAutoApprove: true, aiValidationAutoDeny: true };
+    render(<AiValidationToggle sessionId="test-session" />);
+    const btn = screen.getByRole("button", { name: /toggle ai validation/i });
+    expect(btn).toHaveAttribute("title", "AI Validation: On");
+  });
+
+  it("opens dropdown on click", () => {
+    render(<AiValidationToggle sessionId="test-session" />);
+    const btn = screen.getByRole("button", { name: /toggle ai validation/i });
+    fireEvent.click(btn);
+    expect(screen.getByText("AI Validation for this session")).toBeInTheDocument();
+    expect(screen.getByText("Enabled")).toBeInTheDocument();
+  });
+
+  it("does not show sub-toggles when validation is disabled", () => {
+    render(<AiValidationToggle sessionId="test-session" />);
+    fireEvent.click(screen.getByRole("button", { name: /toggle ai validation/i }));
+    // Should show Enabled toggle but not auto-approve/auto-deny
+    expect(screen.getByText("Enabled")).toBeInTheDocument();
+    expect(screen.queryByText("Auto-approve safe")).not.toBeInTheDocument();
+    expect(screen.queryByText("Auto-deny dangerous")).not.toBeInTheDocument();
+  });
+
+  it("shows sub-toggles when validation is enabled", () => {
+    mockSession = { aiValidationEnabled: true, aiValidationAutoApprove: true, aiValidationAutoDeny: true };
+    render(<AiValidationToggle sessionId="test-session" />);
+    fireEvent.click(screen.getByRole("button", { name: /toggle ai validation/i }));
+    expect(screen.getByText("Auto-approve safe")).toBeInTheDocument();
+    expect(screen.getByText("Auto-deny dangerous")).toBeInTheDocument();
+  });
+
+  it("clicking Enabled toggle sends WebSocket message and updates store", () => {
+    render(<AiValidationToggle sessionId="test-session" />);
+    fireEvent.click(screen.getByRole("button", { name: /toggle ai validation/i }));
+    fireEvent.click(screen.getByRole("button", { name: /toggle ai validation$/i }));
+
+    // Should optimistically update store
+    expect(mockSetSessionAiValidation).toHaveBeenCalledWith("test-session", { aiValidationEnabled: true });
+    // Should send WebSocket message
+    expect(mockSendSetAiValidation).toHaveBeenCalledWith("test-session", { aiValidationEnabled: true });
+  });
+
+  it("clicking auto-approve toggle sends correct message", () => {
+    mockSession = { aiValidationEnabled: true, aiValidationAutoApprove: true, aiValidationAutoDeny: true };
+    render(<AiValidationToggle sessionId="test-session" />);
+    fireEvent.click(screen.getByRole("button", { name: /toggle ai validation/i }));
+    fireEvent.click(screen.getByRole("button", { name: /toggle auto-approve/i }));
+
+    expect(mockSetSessionAiValidation).toHaveBeenCalledWith("test-session", { aiValidationAutoApprove: false });
+    expect(mockSendSetAiValidation).toHaveBeenCalledWith("test-session", { aiValidationAutoApprove: false });
+  });
+
+  it("clicking auto-deny toggle sends correct message", () => {
+    mockSession = { aiValidationEnabled: true, aiValidationAutoApprove: true, aiValidationAutoDeny: true };
+    render(<AiValidationToggle sessionId="test-session" />);
+    fireEvent.click(screen.getByRole("button", { name: /toggle ai validation/i }));
+    fireEvent.click(screen.getByRole("button", { name: /toggle auto-deny/i }));
+
+    expect(mockSetSessionAiValidation).toHaveBeenCalledWith("test-session", { aiValidationAutoDeny: false });
+    expect(mockSendSetAiValidation).toHaveBeenCalledWith("test-session", { aiValidationAutoDeny: false });
+  });
+
+  it("passes accessibility scan", async () => {
+    const { axe } = await import("vitest-axe");
+    const { container } = render(<AiValidationToggle sessionId="test-session" />);
+    const results = await axe(container);
+    expect(results).toHaveNoViolations();
+  });
+
+  it("passes accessibility scan with dropdown open", async () => {
+    const { axe } = await import("vitest-axe");
+    const { container } = render(<AiValidationToggle sessionId="test-session" />);
+    fireEvent.click(screen.getByRole("button", { name: /toggle ai validation/i }));
+    const results = await axe(container);
+    expect(results).toHaveNoViolations();
+  });
+});

--- a/web/src/components/AiValidationToggle.tsx
+++ b/web/src/components/AiValidationToggle.tsx
@@ -1,0 +1,115 @@
+import { useState, useRef, useEffect } from "react";
+import { useStore } from "../store.js";
+import { sendSetAiValidation } from "../ws.js";
+
+interface AiValidationToggleProps {
+  sessionId: string;
+}
+
+/**
+ * Per-session AI validation toggle that appears in the TopBar.
+ * Shows a shield icon that opens a dropdown with enable/disable
+ * and auto-approve/auto-deny sub-toggles.
+ */
+export function AiValidationToggle({ sessionId }: AiValidationToggleProps) {
+  const [open, setOpen] = useState(false);
+  const ref = useRef<HTMLDivElement>(null);
+  const session = useStore((s) => s.sessions.get(sessionId));
+
+  const enabled = session?.aiValidationEnabled ?? false;
+  const autoApprove = session?.aiValidationAutoApprove ?? true;
+  const autoDeny = session?.aiValidationAutoDeny ?? true;
+
+  // Close dropdown on outside click
+  useEffect(() => {
+    if (!open) return;
+    function handleClick(e: MouseEvent) {
+      if (ref.current && !ref.current.contains(e.target as Node)) {
+        setOpen(false);
+      }
+    }
+    document.addEventListener("mousedown", handleClick);
+    return () => document.removeEventListener("mousedown", handleClick);
+  }, [open]);
+
+  function toggle(
+    field: "aiValidationEnabled" | "aiValidationAutoApprove" | "aiValidationAutoDeny",
+    currentValue: boolean,
+  ) {
+    const newValue = !currentValue;
+    const patch = { [field]: newValue };
+    // Optimistic UI update
+    useStore.getState().setSessionAiValidation(sessionId, patch);
+    // Send to server via WebSocket
+    sendSetAiValidation(sessionId, patch);
+  }
+
+  return (
+    <div ref={ref} className="relative">
+      <button
+        onClick={() => setOpen(!open)}
+        className={`flex items-center justify-center w-8 h-8 rounded-md transition-colors cursor-pointer ${
+          enabled
+            ? "text-cc-success hover:bg-cc-hover"
+            : "text-cc-muted hover:text-cc-fg hover:bg-cc-hover"
+        }`}
+        title={enabled ? "AI Validation: On" : "AI Validation: Off"}
+        aria-label="Toggle AI validation settings"
+        aria-expanded={open}
+      >
+        {/* Shield icon */}
+        <svg viewBox="0 0 16 16" fill="currentColor" className="w-[15px] h-[15px]">
+          <path fillRule="evenodd" d="M8 1.246l.542.228c1.926.812 3.732.95 5.408.435l.61-.187v6.528a5.75 5.75 0 01-2.863 4.973L8 15.5l-3.697-2.277A5.75 5.75 0 011.44 8.25V1.722l.61.187c1.676.515 3.482.377 5.408-.435L8 1.246z" clipRule="evenodd" />
+        </svg>
+      </button>
+
+      {open && (
+        <div className="absolute right-0 top-full mt-1 z-50 w-64 bg-cc-bg border border-cc-border rounded-lg shadow-lg p-2 space-y-1">
+          <p className="text-[10px] text-cc-muted px-2 pt-1 pb-1">
+            AI Validation for this session
+          </p>
+
+          <button
+            type="button"
+            onClick={() => toggle("aiValidationEnabled", enabled)}
+            className="w-full flex items-center justify-between px-2 py-1.5 rounded-md hover:bg-cc-hover text-cc-fg transition-colors cursor-pointer"
+            aria-label="Toggle AI validation"
+          >
+            <span className="text-xs">Enabled</span>
+            <span className={`text-[10px] font-medium ${enabled ? "text-cc-success" : "text-cc-muted"}`}>
+              {enabled ? "On" : "Off"}
+            </span>
+          </button>
+
+          {enabled && (
+            <>
+              <button
+                type="button"
+                onClick={() => toggle("aiValidationAutoApprove", autoApprove)}
+                className="w-full flex items-center justify-between px-2 py-1.5 rounded-md hover:bg-cc-hover text-cc-fg transition-colors cursor-pointer"
+                aria-label="Toggle auto-approve safe tools"
+              >
+                <span className="text-xs">Auto-approve safe</span>
+                <span className={`text-[10px] font-medium ${autoApprove ? "text-cc-success" : "text-cc-muted"}`}>
+                  {autoApprove ? "On" : "Off"}
+                </span>
+              </button>
+
+              <button
+                type="button"
+                onClick={() => toggle("aiValidationAutoDeny", autoDeny)}
+                className="w-full flex items-center justify-between px-2 py-1.5 rounded-md hover:bg-cc-hover text-cc-fg transition-colors cursor-pointer"
+                aria-label="Toggle auto-deny dangerous tools"
+              >
+                <span className="text-xs">Auto-deny dangerous</span>
+                <span className={`text-[10px] font-medium ${autoDeny ? "text-cc-success" : "text-cc-muted"}`}>
+                  {autoDeny ? "On" : "Off"}
+                </span>
+              </button>
+            </>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/web/src/components/SettingsPage.tsx
+++ b/web/src/components/SettingsPage.tsx
@@ -592,7 +592,9 @@ export function SettingsPage({ embedded = false }: SettingsPageProps) {
                   When enabled, an AI model evaluates tool calls before they execute.
                   Safe operations are auto-approved, dangerous ones are blocked,
                   and uncertain cases are shown to you with a recommendation.
-                  Requires an OpenRouter API key.
+                  Requires an OpenRouter API key. These settings serve as defaults
+                  for new sessions. Each session can override AI validation
+                  independently via the shield icon in the session header.
                 </p>
 
                 <button

--- a/web/src/components/TopBar.tsx
+++ b/web/src/components/TopBar.tsx
@@ -1,6 +1,7 @@
 import { useCallback, useEffect, useMemo, useSyncExternalStore } from "react";
 import { useStore } from "../store.js";
 import { parseHash } from "../utils/routing.js";
+import { AiValidationToggle } from "./AiValidationToggle.js";
 
 type WorkspaceTab = "chat" | "diff" | "terminal" | "processes" | "editor";
 
@@ -232,6 +233,9 @@ export function TopBar() {
         )}
 
         <div className="flex items-center gap-0.5 shrink-0">
+          {showWorkspaceControls && currentSessionId && (
+            <AiValidationToggle sessionId={currentSessionId} />
+          )}
           <ThemeToggle />
           {showContextToggle && (
             <button

--- a/web/src/store.ts
+++ b/web/src/store.ts
@@ -172,6 +172,7 @@ interface AppState {
   addPermission: (sessionId: string, perm: PermissionRequest) => void;
   removePermission: (sessionId: string, requestId: string) => void;
   addAiResolvedPermission: (sessionId: string, entry: { request: PermissionRequest; behavior: "allow" | "deny"; reason: string; timestamp: number }) => void;
+  setSessionAiValidation: (sessionId: string, settings: { aiValidationEnabled?: boolean | null; aiValidationAutoApprove?: boolean | null; aiValidationAutoDeny?: boolean | null }) => void;
 
   // Task actions
   addTask: (sessionId: string, task: TaskItem) => void;
@@ -634,6 +635,15 @@ export const useStore = create<AppState>((set) => ({
       if (sessionEntries.length > 50) sessionEntries.splice(0, sessionEntries.length - 50);
       aiResolvedPermissions.set(sessionId, sessionEntries);
       return { aiResolvedPermissions };
+    }),
+
+  setSessionAiValidation: (sessionId, settings) =>
+    set((s) => {
+      const sessions = new Map(s.sessions);
+      const existing = sessions.get(sessionId);
+      if (!existing) return {};
+      sessions.set(sessionId, { ...existing, ...settings });
+      return { sessions };
     }),
 
   addTask: (sessionId, task) =>

--- a/web/src/ws.ts
+++ b/web/src/ws.ts
@@ -320,6 +320,7 @@ const IDEMPOTENT_OUTGOING_TYPES = new Set<BrowserOutgoingMessage["type"]>([
   "mcp_toggle",
   "mcp_reconnect",
   "mcp_set_servers",
+  "set_ai_validation",
 ]);
 
 function getWsUrl(sessionId: string): string {
@@ -1026,6 +1027,7 @@ export function sendToSession(sessionId: string, msg: BrowserOutgoingMessage) {
       case "mcp_toggle":
       case "mcp_reconnect":
       case "mcp_set_servers":
+      case "set_ai_validation":
         if (!msg.client_msg_id) {
           outgoing = { ...msg, client_msg_id: nextClientMsgId() };
         }
@@ -1051,4 +1053,15 @@ export function sendMcpReconnect(sessionId: string, serverName: string) {
 
 export function sendMcpSetServers(sessionId: string, servers: Record<string, McpServerConfig>) {
   sendToSession(sessionId, { type: "mcp_set_servers", servers });
+}
+
+export function sendSetAiValidation(
+  sessionId: string,
+  settings: {
+    aiValidationEnabled?: boolean | null;
+    aiValidationAutoApprove?: boolean | null;
+    aiValidationAutoDeny?: boolean | null;
+  },
+) {
+  sendToSession(sessionId, { type: "set_ai_validation", ...settings });
 }


### PR DESCRIPTION
## Summary
- Move AI validation settings (enabled, auto-approve, auto-deny) from global-only to per-session scope
- Global settings now serve as defaults that new sessions inherit at creation time
- Each session can override AI validation independently via a shield icon toggle in the TopBar

## What changed
- **Backend**: Added `aiValidationEnabled`, `aiValidationAutoApprove`, `aiValidationAutoDeny` optional fields to `SessionState`. Created `getEffectiveAiValidation()` helper for session → global cascade. Added `set_ai_validation` WebSocket message handler.
- **Frontend**: New `AiValidationToggle` component in TopBar with dropdown. Updated `SettingsPage` to clarify global settings are defaults for new sessions. Updated Playground with mocks.
- **Tests**: 7 backend unit tests for settings resolution + 11 component tests including accessibility scans.

## Why
AI Validation was previously activated globally — all sessions shared the same config. Users need the ability to enable/disable AI validation on individual sessions (e.g., enable it on a risky session while keeping it off on a trusted one).

Closes THE-191

## Testing
- `bun run typecheck` — passes
- `bun run test` — all 2839 tests pass (110 test files), including 18 new tests
- Manual: create sessions, toggle AI validation per-session via shield icon in TopBar

## Review provenance
- Implemented by AI agent (Claude Code)
- Human review: no
