### PR TITLE
fix(web): send full Linear ticket description in session prompt

### DIFF
--- a/web/src/components/HomePage.tsx
+++ b/web/src/components/HomePage.tsx
@@ -546,10 +546,7 @@ export function HomePage() {
 
   function buildInitialMessage(msg: string): string {
     if (!selectedLinearIssue) return msg;
-    const description = selectedLinearIssue.description?.trim();
-    const safeDescription = description
-      ? (description.length > 1600 ? `${description.slice(0, 1600)}...` : description)
-      : "";
+    const description = (selectedLinearIssue.description ?? "").trim();
     const context = [
       "Linear issue context:",
       `- Identifier: ${selectedLinearIssue.identifier}`,
@@ -558,7 +555,7 @@ export function HomePage() {
       selectedLinearIssue.priorityLabel ? `- Priority: ${selectedLinearIssue.priorityLabel}` : "",
       selectedLinearIssue.teamName ? `- Team: ${selectedLinearIssue.teamName}` : "",
       `- URL: ${selectedLinearIssue.url}`,
-      safeDescription ? `- Description: ${safeDescription}` : "",
+      description ? `- Description:\n${description}` : "",
     ].filter(Boolean).join("\n");
     return `${context}\n\nUser request:\n${msg}`;
   }


### PR DESCRIPTION
## Summary
- Remove the 1600-character truncation on Linear ticket descriptions when building the initial session prompt
- Full description is now sent as context so the AI agent has complete ticket information

## Why
- Long Linear ticket descriptions were being cut off at 1600 chars, causing the AI to miss critical context from detailed tickets

## Testing
- `bun run typecheck` — passes
- `bun run test` — all 2886 tests pass
- Manual: select a Linear issue with a long description, create a session, verify the full description appears in the initial message

## Review provenance
- Implemented by AI agent
- Human review: no
