### PR TITLE
feat(web): add Deepgram push-to-talk speech-to-text integration

### DIFF
--- a/web/server/auto-namer.test.ts
+++ b/web/server/auto-namer.test.ts
@@ -24,6 +24,7 @@ beforeEach(() => {
     aiValidationEnabled: false,
     aiValidationAutoApprove: true,
     aiValidationAutoDeny: true,
+    deepgramApiKey: "",
     updatedAt: 0,
   });
 });
@@ -54,6 +55,7 @@ describe("generateSessionTitle", () => {
       aiValidationEnabled: false,
       aiValidationAutoApprove: true,
       aiValidationAutoDeny: true,
+      deepgramApiKey: "",
       updatedAt: 0,
     });
 
@@ -91,6 +93,7 @@ describe("generateSessionTitle", () => {
       aiValidationEnabled: false,
       aiValidationAutoApprove: true,
       aiValidationAutoDeny: true,
+      deepgramApiKey: "",
       updatedAt: 0,
     });
     mockFetch.mockResolvedValueOnce({
@@ -169,6 +172,7 @@ describe("generateSessionTitle", () => {
       aiValidationEnabled: false,
       aiValidationAutoApprove: true,
       aiValidationAutoDeny: true,
+      deepgramApiKey: "",
       updatedAt: 0,
     });
     mockFetch.mockResolvedValueOnce({

--- a/web/server/routes.test.ts
+++ b/web/server/routes.test.ts
@@ -79,6 +79,7 @@ vi.mock("./settings-manager.js", () => ({
     aiValidationEnabled: false,
     aiValidationAutoApprove: true,
     aiValidationAutoDeny: true,
+    deepgramApiKey: "",
     updatedAt: 0,
   })),
   updateSettings: vi.fn((patch) => ({
@@ -1720,6 +1721,7 @@ describe("GET /api/settings", () => {
       aiValidationEnabled: false,
       aiValidationAutoApprove: true,
       aiValidationAutoDeny: true,
+      deepgramApiKey: "",
       updatedAt: 123,
     });
 
@@ -1737,6 +1739,7 @@ describe("GET /api/settings", () => {
       aiValidationEnabled: false,
       aiValidationAutoApprove: true,
       aiValidationAutoDeny: true,
+      deepgramApiKeyConfigured: false,
     });
   });
 
@@ -1752,6 +1755,7 @@ describe("GET /api/settings", () => {
       aiValidationEnabled: false,
       aiValidationAutoApprove: true,
       aiValidationAutoDeny: true,
+      deepgramApiKey: "",
       updatedAt: 123,
     });
 
@@ -1769,6 +1773,7 @@ describe("GET /api/settings", () => {
       aiValidationEnabled: false,
       aiValidationAutoApprove: true,
       aiValidationAutoDeny: true,
+      deepgramApiKeyConfigured: false,
     });
   });
 });
@@ -1786,6 +1791,7 @@ describe("PUT /api/settings", () => {
       aiValidationEnabled: false,
       aiValidationAutoApprove: true,
       aiValidationAutoDeny: true,
+      deepgramApiKey: "",
       updatedAt: 456,
     });
 
@@ -1807,6 +1813,7 @@ describe("PUT /api/settings", () => {
       aiValidationEnabled: undefined,
       aiValidationAutoApprove: undefined,
       aiValidationAutoDeny: undefined,
+      deepgramApiKey: undefined,
     });
     const json = await res.json();
     expect(json).toEqual({
@@ -1819,6 +1826,7 @@ describe("PUT /api/settings", () => {
       aiValidationEnabled: false,
       aiValidationAutoApprove: true,
       aiValidationAutoDeny: true,
+      deepgramApiKeyConfigured: false,
     });
   });
 
@@ -1834,6 +1842,7 @@ describe("PUT /api/settings", () => {
       aiValidationEnabled: false,
       aiValidationAutoApprove: true,
       aiValidationAutoDeny: true,
+      deepgramApiKey: "",
       updatedAt: 789,
     });
 
@@ -1852,6 +1861,10 @@ describe("PUT /api/settings", () => {
       linearAutoTransitionStateId: undefined,
       linearAutoTransitionStateName: undefined,
       editorTabEnabled: undefined,
+      aiValidationEnabled: undefined,
+      aiValidationAutoApprove: undefined,
+      aiValidationAutoDeny: undefined,
+      deepgramApiKey: undefined,
     });
   });
 
@@ -1867,6 +1880,7 @@ describe("PUT /api/settings", () => {
       aiValidationEnabled: false,
       aiValidationAutoApprove: true,
       aiValidationAutoDeny: true,
+      deepgramApiKey: "",
       updatedAt: 999,
     });
 
@@ -1885,6 +1899,10 @@ describe("PUT /api/settings", () => {
       linearAutoTransitionStateId: undefined,
       linearAutoTransitionStateName: undefined,
       editorTabEnabled: undefined,
+      aiValidationEnabled: undefined,
+      aiValidationAutoApprove: undefined,
+      aiValidationAutoDeny: undefined,
+      deepgramApiKey: undefined,
     });
   });
 
@@ -1969,6 +1987,7 @@ describe("GET /api/linear/issues", () => {
       aiValidationEnabled: false,
       aiValidationAutoApprove: true,
       aiValidationAutoDeny: true,
+      deepgramApiKey: "",
       updatedAt: 0,
     });
 
@@ -1990,6 +2009,7 @@ describe("GET /api/linear/issues", () => {
       aiValidationEnabled: false,
       aiValidationAutoApprove: true,
       aiValidationAutoDeny: true,
+      deepgramApiKey: "",
       updatedAt: 0,
     });
 
@@ -2065,6 +2085,7 @@ describe("GET /api/linear/issues", () => {
       aiValidationEnabled: false,
       aiValidationAutoApprove: true,
       aiValidationAutoDeny: true,
+      deepgramApiKey: "",
       updatedAt: 0,
     });
 
@@ -2147,6 +2168,7 @@ describe("GET /api/linear/issues", () => {
       aiValidationEnabled: false,
       aiValidationAutoApprove: true,
       aiValidationAutoDeny: true,
+      deepgramApiKey: "",
       updatedAt: 0,
     });
 
@@ -2194,6 +2216,7 @@ describe("GET /api/linear/connection", () => {
       aiValidationEnabled: false,
       aiValidationAutoApprove: true,
       aiValidationAutoDeny: true,
+      deepgramApiKey: "",
       updatedAt: 0,
     });
 
@@ -2215,6 +2238,7 @@ describe("GET /api/linear/connection", () => {
       aiValidationEnabled: false,
       aiValidationAutoApprove: true,
       aiValidationAutoDeny: true,
+      deepgramApiKey: "",
       updatedAt: 0,
     });
 
@@ -2259,6 +2283,7 @@ describe("POST /api/linear/issues/:id/transition", () => {
       aiValidationEnabled: false,
       aiValidationAutoApprove: true,
       aiValidationAutoDeny: true,
+      deepgramApiKey: "",
       updatedAt: 0,
     });
 
@@ -2285,6 +2310,7 @@ describe("POST /api/linear/issues/:id/transition", () => {
       aiValidationEnabled: false,
       aiValidationAutoApprove: true,
       aiValidationAutoDeny: true,
+      deepgramApiKey: "",
       updatedAt: 0,
     });
 
@@ -2310,6 +2336,7 @@ describe("POST /api/linear/issues/:id/transition", () => {
       aiValidationEnabled: false,
       aiValidationAutoApprove: true,
       aiValidationAutoDeny: true,
+      deepgramApiKey: "",
       updatedAt: 0,
     });
 
@@ -2336,6 +2363,7 @@ describe("POST /api/linear/issues/:id/transition", () => {
       aiValidationEnabled: false,
       aiValidationAutoApprove: true,
       aiValidationAutoDeny: true,
+      deepgramApiKey: "",
       updatedAt: 0,
     });
 
@@ -2397,6 +2425,7 @@ describe("POST /api/linear/issues/:id/transition", () => {
       aiValidationEnabled: false,
       aiValidationAutoApprove: true,
       aiValidationAutoDeny: true,
+      deepgramApiKey: "",
       updatedAt: 0,
     });
 
@@ -2437,6 +2466,7 @@ describe("GET /api/linear/projects", () => {
       aiValidationEnabled: false,
       aiValidationAutoApprove: true,
       aiValidationAutoDeny: true,
+      deepgramApiKey: "",
       updatedAt: 0,
     });
 
@@ -2458,6 +2488,7 @@ describe("GET /api/linear/projects", () => {
       aiValidationEnabled: false,
       aiValidationAutoApprove: true,
       aiValidationAutoDeny: true,
+      deepgramApiKey: "",
       updatedAt: 0,
     });
 
@@ -2510,6 +2541,7 @@ describe("GET /api/linear/project-issues", () => {
       aiValidationEnabled: false,
       aiValidationAutoApprove: true,
       aiValidationAutoDeny: true,
+      deepgramApiKey: "",
       updatedAt: 0,
     });
 
@@ -2531,6 +2563,7 @@ describe("GET /api/linear/project-issues", () => {
       aiValidationEnabled: false,
       aiValidationAutoApprove: true,
       aiValidationAutoDeny: true,
+      deepgramApiKey: "",
       updatedAt: 0,
     });
 
@@ -2598,6 +2631,7 @@ describe("GET /api/linear/project-issues", () => {
       aiValidationEnabled: false,
       aiValidationAutoApprove: true,
       aiValidationAutoDeny: true,
+      deepgramApiKey: "",
       updatedAt: 0,
     });
 

--- a/web/server/routes.test.ts
+++ b/web/server/routes.test.ts
@@ -1954,6 +1954,18 @@ describe("PUT /api/settings", () => {
     expect(json).toEqual({ error: "editorTabEnabled must be a boolean" });
   });
 
+  it("returns 400 for non-string deepgram key", async () => {
+    const res = await app.request("/api/settings", {
+      method: "PUT",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ deepgramApiKey: 123 }),
+    });
+
+    expect(res.status).toBe(400);
+    const json = await res.json();
+    expect(json).toEqual({ error: "deepgramApiKey must be a string" });
+  });
+
   it("returns 400 when no settings fields are provided", async () => {
     const res = await app.request("/api/settings", {
       method: "PUT",

--- a/web/server/routes.ts
+++ b/web/server/routes.ts
@@ -31,6 +31,7 @@ import { registerSettingsRoutes } from "./routes/settings-routes.js";
 import { registerGitRoutes } from "./routes/git-routes.js";
 import { registerSystemRoutes } from "./routes/system-routes.js";
 import { registerLinearRoutes } from "./routes/linear-routes.js";
+import { registerDeepgramRoutes } from "./routes/deepgram-routes.js";
 import { discoverClaudeSessions } from "./claude-session-discovery.js";
 import { getClaudeSessionHistoryPage } from "./claude-session-history.js";
 import { verifyToken, getToken, getLanAddress, regenerateToken, getAllAddresses } from "./auth-manager.js";
@@ -1487,6 +1488,10 @@ export function createRoutes(
   // ─── Linear ────────────────────────────────────────────────────────
 
   registerLinearRoutes(api);
+
+  // ─── Deepgram ──────────────────────────────────────────────────────
+
+  registerDeepgramRoutes(api);
 
   registerGitRoutes(api, prPoller);
   registerSystemRoutes(api, {

--- a/web/server/routes/deepgram-routes.test.ts
+++ b/web/server/routes/deepgram-routes.test.ts
@@ -1,0 +1,221 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { Hono } from "hono";
+import { registerDeepgramRoutes } from "./deepgram-routes.js";
+
+// Mock settings-manager to control deepgramApiKey
+let mockSettings = { deepgramApiKey: "" };
+
+vi.mock("../settings-manager.js", () => ({
+  getSettings: () => ({ ...mockSettings }),
+}));
+
+// Mock global fetch to simulate Deepgram API responses
+const mockFetch = vi.fn();
+vi.stubGlobal("fetch", mockFetch);
+
+function createApp() {
+  const app = new Hono();
+  registerDeepgramRoutes(app);
+  return app;
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockSettings = { deepgramApiKey: "" };
+});
+
+describe("POST /deepgram/transcribe", () => {
+  it("returns 400 when no API key is configured", async () => {
+    const app = createApp();
+    const formData = new FormData();
+    formData.append("audio", new Blob(["fake"], { type: "audio/webm" }), "test.webm");
+
+    const res = await app.request("/deepgram/transcribe", {
+      method: "POST",
+      body: formData,
+    });
+
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error).toBe("Deepgram API key is not configured");
+  });
+
+  it("returns 400 when no audio file is provided", async () => {
+    mockSettings.deepgramApiKey = "dg_test_key";
+    const app = createApp();
+    const formData = new FormData();
+
+    const res = await app.request("/deepgram/transcribe", {
+      method: "POST",
+      body: formData,
+    });
+
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error).toBe("No audio file provided");
+  });
+
+  it("returns transcript on successful transcription", async () => {
+    mockSettings.deepgramApiKey = "dg_test_key";
+    mockFetch.mockResolvedValueOnce(
+      new Response(
+        JSON.stringify({
+          results: {
+            channels: [
+              {
+                alternatives: [
+                  { transcript: "Hello world" },
+                ],
+              },
+            ],
+          },
+        }),
+        { status: 200 },
+      ),
+    );
+
+    const app = createApp();
+    const formData = new FormData();
+    formData.append("audio", new Blob(["fake-audio-data"], { type: "audio/webm" }), "test.webm");
+
+    const res = await app.request("/deepgram/transcribe", {
+      method: "POST",
+      body: formData,
+    });
+
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.text).toBe("Hello world");
+
+    // Verify the fetch was called with the correct Deepgram URL and auth header
+    expect(mockFetch).toHaveBeenCalledTimes(1);
+    const [url, opts] = mockFetch.mock.calls[0];
+    expect(url).toContain("https://api.deepgram.com/v1/listen");
+    expect(opts.headers.Authorization).toBe("Token dg_test_key");
+  });
+
+  it("returns 502 on Deepgram API error", async () => {
+    mockSettings.deepgramApiKey = "dg_test_key";
+    mockFetch.mockResolvedValueOnce(
+      new Response("Internal Server Error", { status: 500 }),
+    );
+
+    const app = createApp();
+    const formData = new FormData();
+    formData.append("audio", new Blob(["fake-audio-data"], { type: "audio/webm" }), "test.webm");
+
+    const res = await app.request("/deepgram/transcribe", {
+      method: "POST",
+      body: formData,
+    });
+
+    expect(res.status).toBe(502);
+    const body = await res.json();
+    expect(body.error).toContain("Deepgram error: 500");
+  });
+
+  it("returns 401 when Deepgram returns 401", async () => {
+    mockSettings.deepgramApiKey = "dg_invalid_key";
+    mockFetch.mockResolvedValueOnce(
+      new Response("Unauthorized", { status: 401 }),
+    );
+
+    const app = createApp();
+    const formData = new FormData();
+    formData.append("audio", new Blob(["fake-audio-data"], { type: "audio/webm" }), "test.webm");
+
+    const res = await app.request("/deepgram/transcribe", {
+      method: "POST",
+      body: formData,
+    });
+
+    expect(res.status).toBe(401);
+  });
+
+  it("passes keywords to Deepgram query params", async () => {
+    mockSettings.deepgramApiKey = "dg_test_key";
+    mockFetch.mockResolvedValueOnce(
+      new Response(
+        JSON.stringify({
+          results: { channels: [{ alternatives: [{ transcript: "test" }] }] },
+        }),
+        { status: 200 },
+      ),
+    );
+
+    const app = createApp();
+    const formData = new FormData();
+    formData.append("audio", new Blob(["fake"], { type: "audio/webm" }), "test.webm");
+
+    const res = await app.request("/deepgram/transcribe?keywords=react,typescript", {
+      method: "POST",
+      body: formData,
+    });
+
+    expect(res.status).toBe(200);
+    const [url] = mockFetch.mock.calls[0];
+    expect(url).toContain("keywords=react");
+    expect(url).toContain("keywords=typescript");
+  });
+});
+
+describe("POST /deepgram/verify", () => {
+  it("returns connected false when no API key configured", async () => {
+    const app = createApp();
+
+    const res = await app.request("/deepgram/verify", { method: "POST" });
+
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.connected).toBe(false);
+    expect(body.error).toBe("No API key configured");
+  });
+
+  it("returns connected true with project name on valid key", async () => {
+    mockSettings.deepgramApiKey = "dg_valid_key";
+    mockFetch.mockResolvedValueOnce(
+      new Response(
+        JSON.stringify({
+          projects: [{ name: "My DG Project" }],
+        }),
+        { status: 200 },
+      ),
+    );
+
+    const app = createApp();
+    const res = await app.request("/deepgram/verify", { method: "POST" });
+
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.connected).toBe(true);
+    expect(body.projectName).toBe("My DG Project");
+  });
+
+  it("returns connected false on invalid key", async () => {
+    mockSettings.deepgramApiKey = "dg_invalid_key";
+    mockFetch.mockResolvedValueOnce(
+      new Response("Unauthorized", { status: 401 }),
+    );
+
+    const app = createApp();
+    const res = await app.request("/deepgram/verify", { method: "POST" });
+
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.connected).toBe(false);
+    expect(body.error).toContain("401");
+  });
+
+  it("returns connected false on network error", async () => {
+    mockSettings.deepgramApiKey = "dg_test_key";
+    mockFetch.mockRejectedValueOnce(new Error("Network error"));
+
+    const app = createApp();
+    const res = await app.request("/deepgram/verify", { method: "POST" });
+
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.connected).toBe(false);
+    expect(body.error).toBe("Network error");
+  });
+});

--- a/web/server/routes/deepgram-routes.ts
+++ b/web/server/routes/deepgram-routes.ts
@@ -1,0 +1,110 @@
+import type { Hono } from "hono";
+import { getSettings } from "../settings-manager.js";
+
+export function registerDeepgramRoutes(api: Hono): void {
+  /**
+   * POST /deepgram/transcribe
+   * Accepts audio via multipart/form-data, proxies to Deepgram REST API,
+   * returns transcribed text. Optional ?keywords= query param for enrichment.
+   */
+  api.post("/deepgram/transcribe", async (c) => {
+    const settings = getSettings();
+    const apiKey = settings.deepgramApiKey.trim();
+    if (!apiKey) {
+      return c.json({ error: "Deepgram API key is not configured" }, 400);
+    }
+
+    const formData = await c.req.formData().catch(() => null);
+    if (!formData) {
+      return c.json({ error: "Invalid form data" }, 400);
+    }
+
+    const audioFile = formData.get("audio") as File | null;
+    if (!audioFile) {
+      return c.json({ error: "No audio file provided" }, 400);
+    }
+
+    const audioBuffer = await audioFile.arrayBuffer();
+    if (audioBuffer.byteLength === 0) {
+      return c.json({ error: "Audio file is empty" }, 400);
+    }
+
+    // Optional keyword enrichment from query params
+    const keywordsParam = c.req.query("keywords");
+
+    const params = new URLSearchParams({
+      model: "nova-3",
+      smart_format: "true",
+      punctuate: "true",
+    });
+    if (keywordsParam) {
+      for (const kw of keywordsParam.split(",").map((k) => k.trim()).filter(Boolean)) {
+        params.append("keywords", kw);
+      }
+    }
+
+    let dgResponse: Response;
+    try {
+      dgResponse = await fetch(
+        `https://api.deepgram.com/v1/listen?${params.toString()}`,
+        {
+          method: "POST",
+          headers: {
+            Authorization: `Token ${apiKey}`,
+            "Content-Type": audioFile.type || "audio/webm",
+          },
+          body: audioBuffer,
+        },
+      );
+    } catch (err) {
+      return c.json(
+        { error: `Failed to reach Deepgram: ${err instanceof Error ? err.message : String(err)}` },
+        502,
+      );
+    }
+
+    if (!dgResponse.ok) {
+      const errBody = await dgResponse.text().catch(() => "");
+      return c.json(
+        { error: `Deepgram error: ${dgResponse.status} ${errBody}` },
+        dgResponse.status === 401 ? 401 : 502,
+      );
+    }
+
+    const result = await dgResponse.json();
+    const transcript =
+      result?.results?.channels?.[0]?.alternatives?.[0]?.transcript || "";
+
+    return c.json({ text: transcript });
+  });
+
+  /**
+   * POST /deepgram/verify
+   * Validates the stored Deepgram API key by calling the projects endpoint.
+   * Returns { connected, projectName?, error? }.
+   */
+  api.post("/deepgram/verify", async (c) => {
+    const settings = getSettings();
+    const apiKey = settings.deepgramApiKey.trim();
+    if (!apiKey) {
+      return c.json({ connected: false, error: "No API key configured" });
+    }
+
+    try {
+      const res = await fetch("https://api.deepgram.com/v1/projects", {
+        headers: { Authorization: `Token ${apiKey}` },
+      });
+      if (res.ok) {
+        const data = await res.json();
+        const projectName = data?.projects?.[0]?.name || "Deepgram";
+        return c.json({ connected: true, projectName });
+      }
+      return c.json({ connected: false, error: `API returned ${res.status}` });
+    } catch (err) {
+      return c.json({
+        connected: false,
+        error: err instanceof Error ? err.message : String(err),
+      });
+    }
+  });
+}

--- a/web/server/routes/settings-routes.ts
+++ b/web/server/routes/settings-routes.ts
@@ -15,6 +15,7 @@ export function registerSettingsRoutes(api: Hono): void {
       aiValidationEnabled: settings.aiValidationEnabled,
       aiValidationAutoApprove: settings.aiValidationAutoApprove,
       aiValidationAutoDeny: settings.aiValidationAutoDeny,
+      deepgramApiKeyConfigured: !!settings.deepgramApiKey.trim(),
     });
   });
 
@@ -50,12 +51,16 @@ export function registerSettingsRoutes(api: Hono): void {
     if (body.aiValidationAutoDeny !== undefined && typeof body.aiValidationAutoDeny !== "boolean") {
       return c.json({ error: "aiValidationAutoDeny must be a boolean" }, 400);
     }
+    if (body.deepgramApiKey !== undefined && typeof body.deepgramApiKey !== "string") {
+      return c.json({ error: "deepgramApiKey must be a string" }, 400);
+    }
     const hasAnyField = body.openrouterApiKey !== undefined || body.openrouterModel !== undefined
       || body.linearApiKey !== undefined || body.linearAutoTransition !== undefined
       || body.linearAutoTransitionStateId !== undefined || body.linearAutoTransitionStateName !== undefined
       || body.editorTabEnabled !== undefined
       || body.aiValidationEnabled !== undefined || body.aiValidationAutoApprove !== undefined
-      || body.aiValidationAutoDeny !== undefined;
+      || body.aiValidationAutoDeny !== undefined
+      || body.deepgramApiKey !== undefined;
     if (!hasAnyField) {
       return c.json({ error: "At least one settings field is required" }, 400);
     }
@@ -105,6 +110,10 @@ export function registerSettingsRoutes(api: Hono): void {
         typeof body.aiValidationAutoDeny === "boolean"
           ? body.aiValidationAutoDeny
           : undefined,
+      deepgramApiKey:
+        typeof body.deepgramApiKey === "string"
+          ? body.deepgramApiKey.trim()
+          : undefined,
     });
 
     return c.json({
@@ -117,6 +126,7 @@ export function registerSettingsRoutes(api: Hono): void {
       aiValidationEnabled: settings.aiValidationEnabled,
       aiValidationAutoApprove: settings.aiValidationAutoApprove,
       aiValidationAutoDeny: settings.aiValidationAutoDeny,
+      deepgramApiKeyConfigured: !!settings.deepgramApiKey.trim(),
     });
   });
 }

--- a/web/server/settings-manager.test.ts
+++ b/web/server/settings-manager.test.ts
@@ -35,6 +35,7 @@ describe("settings-manager", () => {
       aiValidationEnabled: false,
       aiValidationAutoApprove: true,
       aiValidationAutoDeny: true,
+      deepgramApiKey: "",
       updatedAt: 0,
     });
   });
@@ -77,6 +78,7 @@ describe("settings-manager", () => {
       aiValidationEnabled: false,
       aiValidationAutoApprove: true,
       aiValidationAutoDeny: true,
+      deepgramApiKey: "",
       updatedAt: 123,
     });
   });
@@ -126,6 +128,7 @@ describe("settings-manager", () => {
       aiValidationEnabled: false,
       aiValidationAutoApprove: true,
       aiValidationAutoDeny: true,
+      deepgramApiKey: "",
       updatedAt: 0,
     });
   });

--- a/web/server/settings-manager.ts
+++ b/web/server/settings-manager.ts
@@ -20,6 +20,7 @@ export interface CompanionSettings {
   aiValidationEnabled: boolean;
   aiValidationAutoApprove: boolean;
   aiValidationAutoDeny: boolean;
+  deepgramApiKey: string;
   updatedAt: number;
 }
 
@@ -38,6 +39,7 @@ let settings: CompanionSettings = {
   aiValidationEnabled: false,
   aiValidationAutoApprove: true,
   aiValidationAutoDeny: true,
+  deepgramApiKey: "",
   updatedAt: 0,
 };
 
@@ -56,6 +58,7 @@ function normalize(raw: Partial<CompanionSettings> | null | undefined): Companio
     aiValidationEnabled: typeof raw?.aiValidationEnabled === "boolean" ? raw.aiValidationEnabled : false,
     aiValidationAutoApprove: typeof raw?.aiValidationAutoApprove === "boolean" ? raw.aiValidationAutoApprove : true,
     aiValidationAutoDeny: typeof raw?.aiValidationAutoDeny === "boolean" ? raw.aiValidationAutoDeny : true,
+    deepgramApiKey: typeof raw?.deepgramApiKey === "string" ? raw.deepgramApiKey : "",
     updatedAt: typeof raw?.updatedAt === "number" ? raw.updatedAt : 0,
   };
 }
@@ -84,7 +87,7 @@ export function getSettings(): CompanionSettings {
 }
 
 export function updateSettings(
-  patch: Partial<Pick<CompanionSettings, "openrouterApiKey" | "openrouterModel" | "linearApiKey" | "linearAutoTransition" | "linearAutoTransitionStateId" | "linearAutoTransitionStateName" | "editorTabEnabled" | "aiValidationEnabled" | "aiValidationAutoApprove" | "aiValidationAutoDeny">>,
+  patch: Partial<Pick<CompanionSettings, "openrouterApiKey" | "openrouterModel" | "linearApiKey" | "linearAutoTransition" | "linearAutoTransitionStateId" | "linearAutoTransitionStateName" | "editorTabEnabled" | "aiValidationEnabled" | "aiValidationAutoApprove" | "aiValidationAutoDeny" | "deepgramApiKey">>,
 ): CompanionSettings {
   ensureLoaded();
   settings = normalize({
@@ -98,6 +101,7 @@ export function updateSettings(
     aiValidationEnabled: patch.aiValidationEnabled ?? settings.aiValidationEnabled,
     aiValidationAutoApprove: patch.aiValidationAutoApprove ?? settings.aiValidationAutoApprove,
     aiValidationAutoDeny: patch.aiValidationAutoDeny ?? settings.aiValidationAutoDeny,
+    deepgramApiKey: patch.deepgramApiKey ?? settings.deepgramApiKey,
     updatedAt: Date.now(),
   });
   persist();

--- a/web/server/ws-bridge-codex.test.ts
+++ b/web/server/ws-bridge-codex.test.ts
@@ -121,6 +121,7 @@ describe("attachCodexAdapterHandlers", () => {
       aiValidationEnabled: false,
       aiValidationAutoApprove: true,
       aiValidationAutoDeny: true,
+      deepgramApiKey: "",
       updatedAt: 0,
     });
   });
@@ -872,6 +873,7 @@ describe("attachCodexAdapterHandlers", () => {
         aiValidationEnabled: true,
         aiValidationAutoApprove: true,
         aiValidationAutoDeny: true,
+        deepgramApiKey: "",
         updatedAt: 0,
       });
     }
@@ -1035,6 +1037,7 @@ describe("attachCodexAdapterHandlers", () => {
         aiValidationEnabled: false,  // disabled
         aiValidationAutoApprove: true,
         aiValidationAutoDeny: true,
+        deepgramApiKey: "",
         updatedAt: 0,
       });
 
@@ -1068,6 +1071,7 @@ describe("attachCodexAdapterHandlers", () => {
         aiValidationEnabled: true,
         aiValidationAutoApprove: true,
         aiValidationAutoDeny: true,
+        deepgramApiKey: "",
         updatedAt: 0,
       });
 
@@ -1166,6 +1170,7 @@ describe("attachCodexAdapterHandlers", () => {
         aiValidationEnabled: true,
         aiValidationAutoApprove: false,  // disabled
         aiValidationAutoDeny: true,
+        deepgramApiKey: "",
         updatedAt: 0,
       });
 
@@ -1209,6 +1214,7 @@ describe("attachCodexAdapterHandlers", () => {
         aiValidationEnabled: true,
         aiValidationAutoApprove: true,
         aiValidationAutoDeny: false,  // disabled
+        deepgramApiKey: "",
         updatedAt: 0,
       });
 

--- a/web/src/App.test.tsx
+++ b/web/src/App.test.tsx
@@ -1,0 +1,593 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { render, screen, waitFor, act } from "@testing-library/react";
+
+// ─── Mock external modules ───────────────────────────────────────────────────
+
+vi.mock("./analytics.js", () => ({
+  capturePageView: vi.fn(),
+}));
+
+vi.mock("./ws.js", () => ({
+  connectSession: vi.fn(),
+}));
+
+const mockApi = {
+  getChangedFiles: vi.fn().mockResolvedValue({ files: [] }),
+  checkForUpdate: vi.fn().mockResolvedValue({ updateAvailable: false }),
+};
+
+vi.mock("./api.js", () => ({
+  api: {
+    getChangedFiles: (...args: unknown[]) => mockApi.getChangedFiles(...args),
+    checkForUpdate: (...args: unknown[]) => mockApi.checkForUpdate(...args),
+  },
+}));
+
+// ─── Mock all child components to avoid deep dependency chains ───────────────
+// This lets us test App's routing and layout logic without rendering every child.
+
+vi.mock("./components/LoginPage.js", () => ({
+  LoginPage: () => <div data-testid="login-page">LoginPage</div>,
+}));
+
+vi.mock("./components/Sidebar.js", () => ({
+  Sidebar: () => <div data-testid="sidebar">Sidebar</div>,
+}));
+
+vi.mock("./components/ChatView.js", () => ({
+  ChatView: ({ sessionId }: { sessionId: string }) => (
+    <div data-testid="chat-view">ChatView:{sessionId}</div>
+  ),
+}));
+
+vi.mock("./components/TopBar.js", () => ({
+  TopBar: () => <div data-testid="top-bar">TopBar</div>,
+}));
+
+vi.mock("./components/HomePage.js", () => ({
+  HomePage: () => <div data-testid="home-page">HomePage</div>,
+}));
+
+vi.mock("./components/TaskPanel.js", () => ({
+  TaskPanel: ({ sessionId }: { sessionId: string }) => (
+    <div data-testid="task-panel">TaskPanel:{sessionId}</div>
+  ),
+}));
+
+vi.mock("./components/DiffPanel.js", () => ({
+  DiffPanel: ({ sessionId }: { sessionId: string }) => (
+    <div data-testid="diff-panel">DiffPanel:{sessionId}</div>
+  ),
+}));
+
+vi.mock("./components/UpdateBanner.js", () => ({
+  UpdateBanner: () => <div data-testid="update-banner">UpdateBanner</div>,
+}));
+
+vi.mock("./components/SessionLaunchOverlay.js", () => ({
+  SessionLaunchOverlay: () => <div data-testid="session-launch-overlay">SessionLaunchOverlay</div>,
+}));
+
+vi.mock("./components/SessionTerminalDock.js", () => ({
+  SessionTerminalDock: ({ children }: { children?: React.ReactNode }) => (
+    <div data-testid="session-terminal-dock">{children}</div>
+  ),
+}));
+
+vi.mock("./components/SessionEditorPane.js", () => ({
+  SessionEditorPane: ({ sessionId }: { sessionId: string }) => (
+    <div data-testid="session-editor-pane">Editor:{sessionId}</div>
+  ),
+}));
+
+vi.mock("./components/UpdateOverlay.js", () => ({
+  UpdateOverlay: ({ active }: { active: boolean }) => (
+    <div data-testid="update-overlay">{active ? "active" : "inactive"}</div>
+  ),
+}));
+
+// Mock lazy-loaded components — they must return default export modules
+vi.mock("./components/Playground.js", () => ({
+  Playground: () => <div data-testid="playground">Playground</div>,
+}));
+
+vi.mock("./components/SettingsPage.js", () => ({
+  SettingsPage: () => <div data-testid="settings-page">SettingsPage</div>,
+}));
+
+vi.mock("./components/IntegrationsPage.js", () => ({
+  IntegrationsPage: () => <div data-testid="integrations-page">IntegrationsPage</div>,
+}));
+
+vi.mock("./components/LinearSettingsPage.js", () => ({
+  LinearSettingsPage: () => <div data-testid="linear-settings">LinearSettings</div>,
+}));
+
+vi.mock("./components/DeepgramSettingsPage.js", () => ({
+  DeepgramSettingsPage: () => <div data-testid="deepgram-settings">DeepgramSettings</div>,
+}));
+
+vi.mock("./components/PromptsPage.js", () => ({
+  PromptsPage: () => <div data-testid="prompts-page">PromptsPage</div>,
+}));
+
+vi.mock("./components/EnvManager.js", () => ({
+  EnvManager: () => <div data-testid="env-manager">EnvManager</div>,
+}));
+
+vi.mock("./components/CronManager.js", () => ({
+  CronManager: () => <div data-testid="cron-manager">CronManager</div>,
+}));
+
+vi.mock("./components/AgentsPage.js", () => ({
+  AgentsPage: () => <div data-testid="agents-page">AgentsPage</div>,
+}));
+
+vi.mock("./components/TerminalPage.js", () => ({
+  TerminalPage: () => <div data-testid="terminal-page">TerminalPage</div>,
+}));
+
+vi.mock("./components/ProcessPanel.js", () => ({
+  ProcessPanel: ({ sessionId }: { sessionId: string }) => (
+    <div data-testid="process-panel">ProcessPanel:{sessionId}</div>
+  ),
+}));
+
+// Mock routing utilities — parseHash is the key function that controls rendering
+vi.mock("./utils/routing.js", () => ({
+  parseHash: vi.fn().mockReturnValue({ page: "home" }),
+  navigateToSession: vi.fn(),
+  sessionHash: vi.fn((id: string) => `#/session/${id}`),
+}));
+
+// ─── Mock store ──────────────────────────────────────────────────────────────
+
+interface MockStoreState {
+  isAuthenticated: boolean;
+  darkMode: boolean;
+  currentSessionId: string | null;
+  sidebarOpen: boolean;
+  taskPanelOpen: boolean;
+  homeResetKey: number;
+  activeTab: "chat" | "diff" | "terminal" | "processes" | "editor";
+  setActiveTab: ReturnType<typeof vi.fn>;
+  sessionCreating: boolean;
+  sessionCreatingBackend: string | null;
+  creationProgress: unknown[] | null;
+  creationError: string | null;
+  updateOverlayActive: boolean;
+  changedFilesTick: Map<string, number>;
+  diffBase: string;
+  setGitChangedFilesCount: ReturnType<typeof vi.fn>;
+  sessions: Map<string, { cwd?: string }>;
+  sdkSessions: { sessionId: string; cwd?: string }[];
+  setCurrentSession: ReturnType<typeof vi.fn>;
+  setSidebarOpen: ReturnType<typeof vi.fn>;
+  setTaskPanelOpen: ReturnType<typeof vi.fn>;
+  clearCreation: ReturnType<typeof vi.fn>;
+  setUpdateInfo: ReturnType<typeof vi.fn>;
+  setSdkSessions: ReturnType<typeof vi.fn>;
+}
+
+let storeState: MockStoreState;
+
+function resetStore(overrides: Partial<MockStoreState> = {}) {
+  storeState = {
+    isAuthenticated: true,
+    darkMode: false,
+    currentSessionId: null,
+    sidebarOpen: false,
+    taskPanelOpen: false,
+    homeResetKey: 0,
+    activeTab: "chat",
+    setActiveTab: vi.fn(),
+    sessionCreating: false,
+    sessionCreatingBackend: null,
+    creationProgress: null,
+    creationError: null,
+    updateOverlayActive: false,
+    changedFilesTick: new Map(),
+    diffBase: "HEAD",
+    setGitChangedFilesCount: vi.fn(),
+    sessions: new Map(),
+    sdkSessions: [],
+    setCurrentSession: vi.fn(),
+    setSidebarOpen: vi.fn(),
+    setTaskPanelOpen: vi.fn(),
+    clearCreation: vi.fn(),
+    setUpdateInfo: vi.fn(),
+    setSdkSessions: vi.fn(),
+    ...overrides,
+  };
+}
+
+vi.mock("./store.js", () => ({
+  useStore: Object.assign(
+    (selector: (s: MockStoreState) => unknown) => selector(storeState),
+    { getState: () => storeState },
+  ),
+}));
+
+import App from "./App.js";
+import { parseHash } from "./utils/routing.js";
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  resetStore();
+  window.location.hash = "";
+  // Reset parseHash to return home by default
+  vi.mocked(parseHash).mockReturnValue({ page: "home" });
+});
+
+afterEach(() => {
+  window.location.hash = "";
+});
+
+// ─── Authentication gate ─────────────────────────────────────────────────────
+
+describe("App authentication", () => {
+  it("renders LoginPage when not authenticated", () => {
+    // Validates the auth gate shows the login screen for unauthenticated users.
+    resetStore({ isAuthenticated: false });
+    render(<App />);
+    expect(screen.getByTestId("login-page")).toBeTruthy();
+  });
+
+  it("does not render main layout when not authenticated", () => {
+    // Validates that the main app shell (sidebar, topbar) is hidden for unauthenticated users.
+    resetStore({ isAuthenticated: false });
+    render(<App />);
+    expect(screen.queryByTestId("sidebar")).toBeNull();
+    expect(screen.queryByTestId("top-bar")).toBeNull();
+  });
+});
+
+// ─── Home route ──────────────────────────────────────────────────────────────
+
+describe("App home route", () => {
+  it("renders the main layout with sidebar and topbar when authenticated", () => {
+    // Validates the main app chrome renders on the home route.
+    render(<App />);
+    expect(screen.getByTestId("sidebar")).toBeTruthy();
+    expect(screen.getByTestId("top-bar")).toBeTruthy();
+    expect(screen.getByTestId("update-banner")).toBeTruthy();
+  });
+
+  it("renders HomePage when no session is selected", () => {
+    // Validates the home page shows when there is no active session.
+    render(<App />);
+    expect(screen.getByTestId("home-page")).toBeTruthy();
+  });
+});
+
+// ─── Session route ───────────────────────────────────────────────────────────
+
+describe("App session route", () => {
+  it("renders ChatView when a session is active with chat tab", async () => {
+    // Validates the ChatView component renders for an active session on the chat tab.
+    vi.mocked(parseHash).mockReturnValue({ page: "session", sessionId: "s1" });
+    resetStore({
+      currentSessionId: "s1",
+      activeTab: "chat",
+      sessions: new Map([["s1", { cwd: "/test" }]]),
+    });
+
+    render(<App />);
+    expect(screen.getByTestId("chat-view")).toBeTruthy();
+    expect(screen.getByText("ChatView:s1")).toBeTruthy();
+  });
+
+  it("renders DiffPanel when diff tab is active", async () => {
+    // Validates the diff view shows when the diff tab is selected.
+    vi.mocked(parseHash).mockReturnValue({ page: "session", sessionId: "s1" });
+    resetStore({
+      currentSessionId: "s1",
+      activeTab: "diff",
+      sessions: new Map([["s1", { cwd: "/test" }]]),
+    });
+
+    render(<App />);
+    expect(screen.getByTestId("diff-panel")).toBeTruthy();
+  });
+
+  it("renders SessionTerminalDock when terminal tab is active", async () => {
+    // Validates the terminal dock renders for the terminal tab.
+    vi.mocked(parseHash).mockReturnValue({ page: "session", sessionId: "s1" });
+    resetStore({
+      currentSessionId: "s1",
+      activeTab: "terminal",
+      sessions: new Map([["s1", { cwd: "/test" }]]),
+    });
+
+    render(<App />);
+    expect(screen.getByTestId("session-terminal-dock")).toBeTruthy();
+  });
+
+  it("renders SessionEditorPane when editor tab is active", async () => {
+    // Validates the editor pane renders when the editor tab is selected.
+    vi.mocked(parseHash).mockReturnValue({ page: "session", sessionId: "s1" });
+    resetStore({
+      currentSessionId: "s1",
+      activeTab: "editor",
+      sessions: new Map([["s1", { cwd: "/test" }]]),
+    });
+
+    render(<App />);
+    expect(screen.getByTestId("session-editor-pane")).toBeTruthy();
+  });
+
+  it("renders ProcessPanel when processes tab is active", async () => {
+    // Validates the process panel renders for the processes tab.
+    vi.mocked(parseHash).mockReturnValue({ page: "session", sessionId: "s1" });
+    resetStore({
+      currentSessionId: "s1",
+      activeTab: "processes",
+      sessions: new Map([["s1", { cwd: "/test" }]]),
+    });
+
+    render(<App />);
+
+    await waitFor(() => {
+      expect(screen.getByTestId("process-panel")).toBeTruthy();
+    });
+  });
+
+  it("renders TaskPanel when a session is active and task panel is open", () => {
+    // Validates the task panel renders alongside the session view.
+    vi.mocked(parseHash).mockReturnValue({ page: "session", sessionId: "s1" });
+    resetStore({
+      currentSessionId: "s1",
+      taskPanelOpen: true,
+      sessions: new Map([["s1", { cwd: "/test" }]]),
+    });
+
+    render(<App />);
+    expect(screen.getByTestId("task-panel")).toBeTruthy();
+  });
+});
+
+// ─── Settings route ──────────────────────────────────────────────────────────
+
+describe("App settings route", () => {
+  it("renders SettingsPage for #/settings", async () => {
+    // Validates the settings page renders when navigated to.
+    vi.mocked(parseHash).mockReturnValue({ page: "settings" });
+    render(<App />);
+
+    await waitFor(() => {
+      expect(screen.getByTestId("settings-page")).toBeTruthy();
+    });
+  });
+});
+
+// ─── Prompts route ───────────────────────────────────────────────────────────
+
+describe("App prompts route", () => {
+  it("renders PromptsPage for #/prompts", async () => {
+    // Validates the prompts page renders when navigated to.
+    vi.mocked(parseHash).mockReturnValue({ page: "prompts" });
+    render(<App />);
+
+    await waitFor(() => {
+      expect(screen.getByTestId("prompts-page")).toBeTruthy();
+    });
+  });
+});
+
+// ─── Integrations routes ─────────────────────────────────────────────────────
+
+describe("App integrations routes", () => {
+  it("renders IntegrationsPage for #/integrations", async () => {
+    // Validates the integrations hub page renders.
+    vi.mocked(parseHash).mockReturnValue({ page: "integrations" });
+    render(<App />);
+
+    await waitFor(() => {
+      expect(screen.getByTestId("integrations-page")).toBeTruthy();
+    });
+  });
+
+  it("renders LinearSettingsPage for #/integrations/linear", async () => {
+    // Validates the Linear integration page renders.
+    vi.mocked(parseHash).mockReturnValue({ page: "integration-linear" });
+    render(<App />);
+
+    await waitFor(() => {
+      expect(screen.getByTestId("linear-settings")).toBeTruthy();
+    });
+  });
+
+  it("renders DeepgramSettingsPage for #/integrations/deepgram", async () => {
+    // Validates the Deepgram integration page renders.
+    vi.mocked(parseHash).mockReturnValue({ page: "integration-deepgram" });
+    render(<App />);
+
+    await waitFor(() => {
+      expect(screen.getByTestId("deepgram-settings")).toBeTruthy();
+    });
+  });
+});
+
+// ─── Terminal route ──────────────────────────────────────────────────────────
+
+describe("App terminal route", () => {
+  it("renders TerminalPage for #/terminal", async () => {
+    // Validates the terminal page renders when navigated to.
+    vi.mocked(parseHash).mockReturnValue({ page: "terminal" });
+    render(<App />);
+
+    await waitFor(() => {
+      expect(screen.getByTestId("terminal-page")).toBeTruthy();
+    });
+  });
+});
+
+// ─── Environments route ──────────────────────────────────────────────────────
+
+describe("App environments route", () => {
+  it("renders EnvManager for #/environments", async () => {
+    // Validates the environment manager renders when navigated to.
+    vi.mocked(parseHash).mockReturnValue({ page: "environments" });
+    render(<App />);
+
+    await waitFor(() => {
+      expect(screen.getByTestId("env-manager")).toBeTruthy();
+    });
+  });
+});
+
+// ─── Agents route ────────────────────────────────────────────────────────────
+
+describe("App agents route", () => {
+  it("renders AgentsPage for #/agents", async () => {
+    // Validates the agents page renders when navigated to.
+    vi.mocked(parseHash).mockReturnValue({ page: "agents" });
+    render(<App />);
+
+    await waitFor(() => {
+      expect(screen.getByTestId("agents-page")).toBeTruthy();
+    });
+  });
+
+  it("renders AgentsPage for agent-detail route", async () => {
+    // Validates the agent detail view renders via the agents page.
+    vi.mocked(parseHash).mockReturnValue({ page: "agent-detail", agentId: "a1" });
+    render(<App />);
+
+    await waitFor(() => {
+      expect(screen.getByTestId("agents-page")).toBeTruthy();
+    });
+  });
+});
+
+// ─── Playground route ────────────────────────────────────────────────────────
+
+describe("App playground route", () => {
+  it("renders Playground for #/playground", async () => {
+    // Validates the component playground renders (standalone, no sidebar).
+    vi.mocked(parseHash).mockReturnValue({ page: "playground" });
+    render(<App />);
+
+    await waitFor(() => {
+      expect(screen.getByTestId("playground")).toBeTruthy();
+    });
+    // Playground renders standalone without sidebar
+    expect(screen.queryByTestId("sidebar")).toBeNull();
+  });
+});
+
+// ─── Dark mode ───────────────────────────────────────────────────────────────
+
+describe("App dark mode", () => {
+  it("toggles dark class on document element based on darkMode store state", () => {
+    // Validates the dark mode CSS class is applied to the document root.
+    resetStore({ darkMode: true });
+    render(<App />);
+    expect(document.documentElement.classList.contains("dark")).toBe(true);
+  });
+
+  it("removes dark class when darkMode is false", () => {
+    // Validates dark mode class is removed when disabled.
+    document.documentElement.classList.add("dark");
+    resetStore({ darkMode: false });
+    render(<App />);
+    expect(document.documentElement.classList.contains("dark")).toBe(false);
+  });
+});
+
+// ─── Update overlay ──────────────────────────────────────────────────────────
+
+describe("App update overlay", () => {
+  it("renders UpdateOverlay component", () => {
+    // Validates the update overlay is always present in the DOM.
+    render(<App />);
+    expect(screen.getByTestId("update-overlay")).toBeTruthy();
+  });
+
+  it("passes active state to UpdateOverlay", () => {
+    // Validates the overlay receives the correct active prop.
+    resetStore({ updateOverlayActive: true });
+    render(<App />);
+    expect(screen.getByText("active")).toBeTruthy();
+  });
+});
+
+// ─── Session launch overlay ──────────────────────────────────────────────────
+
+describe("App session launch overlay", () => {
+  it("renders SessionLaunchOverlay when session is being created", () => {
+    // Validates the launch overlay appears during session creation.
+    vi.mocked(parseHash).mockReturnValue({ page: "home" });
+    resetStore({
+      sessionCreating: true,
+      creationProgress: [{ label: "Starting...", status: "done" }],
+    });
+
+    render(<App />);
+    expect(screen.getByTestId("session-launch-overlay")).toBeTruthy();
+  });
+
+  it("does not render SessionLaunchOverlay when not creating", () => {
+    // Validates the overlay is hidden when no session is being created.
+    render(<App />);
+    expect(screen.queryByTestId("session-launch-overlay")).toBeNull();
+  });
+});
+
+// ─── Sidebar overlay ─────────────────────────────────────────────────────────
+
+describe("App sidebar", () => {
+  it("renders mobile overlay backdrop when sidebar is open", () => {
+    // Validates the dark overlay backdrop renders behind the sidebar on mobile.
+    resetStore({ sidebarOpen: true });
+    const { container } = render(<App />);
+
+    // The overlay backdrop has bg-black/30 class
+    const backdrop = container.querySelector(".bg-black\\/30");
+    expect(backdrop).toBeTruthy();
+  });
+});
+
+// ─── Context panel toggle ────────────────────────────────────────────────────
+
+describe("App task panel", () => {
+  it("shows 'Open context panel' button when task panel is closed and session active", () => {
+    // Validates the collapsed context panel shows a toggle button.
+    vi.mocked(parseHash).mockReturnValue({ page: "session", sessionId: "s1" });
+    resetStore({
+      currentSessionId: "s1",
+      taskPanelOpen: false,
+      sessions: new Map([["s1", { cwd: "/test" }]]),
+    });
+
+    render(<App />);
+    expect(screen.getByTitle("Open context panel")).toBeTruthy();
+  });
+
+  it("renders task panel overlay backdrop when panel is open on mobile", () => {
+    // Validates the dark overlay appears behind the task panel on small screens.
+    vi.mocked(parseHash).mockReturnValue({ page: "session", sessionId: "s1" });
+    resetStore({
+      currentSessionId: "s1",
+      taskPanelOpen: true,
+      sessions: new Map([["s1", { cwd: "/test" }]]),
+    });
+
+    const { container } = render(<App />);
+    // Two backdrops may exist (sidebar + task panel); at least one for task panel
+    const backdrops = container.querySelectorAll(".bg-black\\/30");
+    expect(backdrops.length).toBeGreaterThanOrEqual(1);
+  });
+});
+
+// ─── Accessibility ───────────────────────────────────────────────────────────
+
+describe("App accessibility", () => {
+  it("passes axe accessibility checks on home route", async () => {
+    const { axe } = await import("vitest-axe");
+    const { container } = render(<App />);
+    const results = await axe(container);
+    expect(results).toHaveNoViolations();
+  });
+});

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -22,6 +22,7 @@ const Playground = lazy(() => import("./components/Playground.js").then((m) => (
 const SettingsPage = lazy(() => import("./components/SettingsPage.js").then((m) => ({ default: m.SettingsPage })));
 const IntegrationsPage = lazy(() => import("./components/IntegrationsPage.js").then((m) => ({ default: m.IntegrationsPage })));
 const LinearSettingsPage = lazy(() => import("./components/LinearSettingsPage.js").then((m) => ({ default: m.LinearSettingsPage })));
+const DeepgramSettingsPage = lazy(() => import("./components/DeepgramSettingsPage.js").then((m) => ({ default: m.DeepgramSettingsPage })));
 const PromptsPage = lazy(() => import("./components/PromptsPage.js").then((m) => ({ default: m.PromptsPage })));
 const EnvManager = lazy(() => import("./components/EnvManager.js").then((m) => ({ default: m.EnvManager })));
 const CronManager = lazy(() => import("./components/CronManager.js").then((m) => ({ default: m.CronManager })));
@@ -65,6 +66,7 @@ export default function App() {
   const isPromptsPage = route.page === "prompts";
   const isIntegrationsPage = route.page === "integrations";
   const isLinearIntegrationPage = route.page === "integration-linear";
+  const isDeepgramIntegrationPage = route.page === "integration-deepgram";
   const isTerminalPage = route.page === "terminal";
   const isEnvironmentsPage = route.page === "environments";
   const isScheduledPage = route.page === "scheduled";
@@ -207,6 +209,12 @@ export default function App() {
           {isLinearIntegrationPage && (
             <div className="absolute inset-0">
               <Suspense fallback={<LazyFallback />}><LinearSettingsPage embedded /></Suspense>
+            </div>
+          )}
+
+          {isDeepgramIntegrationPage && (
+            <div className="absolute inset-0">
+              <Suspense fallback={<LazyFallback />}><DeepgramSettingsPage embedded /></Suspense>
             </div>
           )}
 

--- a/web/src/api.test.ts
+++ b/web/src/api.test.ts
@@ -1780,6 +1780,68 @@ describe("saved prompts API", () => {
 });
 
 // ===========================================================================
+// Deepgram API
+// ===========================================================================
+describe("Deepgram API", () => {
+  it("verifyDeepgramConnection sends POST to /api/deepgram/verify", async () => {
+    const data = { connected: true, projectName: "My DG Project" };
+    mockFetch.mockResolvedValueOnce(mockResponse(data));
+
+    const result = await api.verifyDeepgramConnection();
+
+    const [url, opts] = mockFetch.mock.calls[0];
+    expect(url).toBe("/api/deepgram/verify");
+    expect(opts.method).toBe("POST");
+    expect(result).toEqual(data);
+  });
+
+  it("transcribeAudio sends FormData to /api/deepgram/transcribe", async () => {
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      status: 200,
+      statusText: "OK",
+      json: () => Promise.resolve({ text: "Hello world" }),
+    });
+
+    const blob = new Blob(["fake-audio"], { type: "audio/webm" });
+    const result = await api.transcribeAudio(blob);
+
+    const [url, opts] = mockFetch.mock.calls[0];
+    expect(url).toBe("/api/deepgram/transcribe");
+    expect(opts.method).toBe("POST");
+    expect(opts.body).toBeInstanceOf(FormData);
+    expect(result).toEqual({ text: "Hello world" });
+  });
+
+  it("transcribeAudio includes keywords in query params", async () => {
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      status: 200,
+      statusText: "OK",
+      json: () => Promise.resolve({ text: "React is great" }),
+    });
+
+    const blob = new Blob(["fake-audio"], { type: "audio/webm" });
+    await api.transcribeAudio(blob, "react,typescript");
+
+    const [url] = mockFetch.mock.calls[0];
+    expect(url).toBe(`/api/deepgram/transcribe?keywords=${encodeURIComponent("react,typescript")}`);
+  });
+
+  it("transcribeAudio throws on non-ok response", async () => {
+    mockFetch.mockResolvedValueOnce({
+      ok: false,
+      status: 502,
+      statusText: "Bad Gateway",
+      json: () => Promise.resolve({ error: "Deepgram error: 500" }),
+    });
+
+    const blob = new Blob(["fake-audio"], { type: "audio/webm" });
+    await expect(api.transcribeAudio(blob)).rejects.toThrow("Deepgram error: 500");
+  });
+});
+
+// ===========================================================================
 // PUT / PATCH / DELETE error handling (verifies these HTTP helpers work like post/get)
 // ===========================================================================
 describe("put() error handling", () => {

--- a/web/src/api.ts
+++ b/web/src/api.ts
@@ -380,6 +380,7 @@ export interface AppSettings {
   aiValidationEnabled: boolean;
   aiValidationAutoApprove: boolean;
   aiValidationAutoDeny: boolean;
+  deepgramApiKeyConfigured: boolean;
 }
 
 export interface LinearWorkflowState {
@@ -835,6 +836,7 @@ export const api = {
     linearAutoTransitionStateId?: string;
     linearAutoTransitionStateName?: string;
     editorTabEnabled?: boolean;
+    deepgramApiKey?: string;
   }) => put<AppSettings>("/settings", data),
   searchLinearIssues: (query: string, limit = 8) =>
     get<{ issues: LinearIssue[] }>(
@@ -880,6 +882,32 @@ export const api = {
       `/linear/issues/${encodeURIComponent(issueId)}/comments`,
       { body },
     ),
+
+  // Deepgram
+  verifyDeepgramConnection: () =>
+    post<{ connected: boolean; projectName?: string; error?: string }>(
+      "/deepgram/verify",
+    ),
+  transcribeAudio: async (audioBlob: Blob, keywords?: string): Promise<{ text: string }> => {
+    const formData = new FormData();
+    formData.append("audio", audioBlob, "recording.webm");
+    const params = keywords ? `?keywords=${encodeURIComponent(keywords)}` : "";
+    const start = nowMs();
+    const res = await fetch(`${BASE}/deepgram/transcribe${params}`, {
+      method: "POST",
+      headers: { ...getAuthHeaders() },
+      body: formData,
+    });
+    const durationMs = nowMs() - start;
+    handle401(res.status);
+    if (!res.ok) {
+      trackApiFailure("POST", "/deepgram/transcribe", durationMs, res.status);
+      const err = await res.json().catch(() => ({ error: res.statusText }));
+      throw new Error(err.error || res.statusText);
+    }
+    trackApiSuccess("POST", "/deepgram/transcribe", durationMs, res.status);
+    return res.json();
+  },
 
   // Git operations
   getRepoInfo: (path: string) =>

--- a/web/src/components/Composer.test.tsx
+++ b/web/src/components/Composer.test.tsx
@@ -23,6 +23,7 @@ vi.mock("../api.js", () => ({
     gitPull: vi.fn().mockResolvedValue({ success: true, output: "", git_ahead: 0, git_behind: 0 }),
     listPrompts: (...args: unknown[]) => mockListPrompts(...args),
     createPrompt: (...args: unknown[]) => mockCreatePrompt(...args),
+    getSettings: vi.fn().mockResolvedValue({ deepgramApiKeyConfigured: false }),
   },
 }));
 

--- a/web/src/components/Composer.test.tsx
+++ b/web/src/components/Composer.test.tsx
@@ -549,6 +549,91 @@ describe("Composer layout", () => {
   });
 });
 
+// ─── Microphone / push-to-talk ───────────────────────────────────────────────
+
+describe("Composer microphone button", () => {
+  it("mic button is hidden when Deepgram is not configured", async () => {
+    // Default mock returns deepgramApiKeyConfigured: false
+    render(<Composer sessionId="s1" />);
+    await waitFor(() => {
+      // The button should not be present at all
+      expect(screen.queryByLabelText("Push-to-talk microphone")).toBeNull();
+    });
+  });
+
+  it("mic button is shown when Deepgram is configured", async () => {
+    // Override the mock to return deepgramConfigured: true
+    const { api } = await import("../api.js");
+    vi.mocked(api.getSettings).mockResolvedValueOnce({
+      deepgramApiKeyConfigured: true,
+      openrouterApiKeyConfigured: false,
+      openrouterModel: "openrouter/free",
+      linearApiKeyConfigured: false,
+      linearAutoTransition: false,
+      linearAutoTransitionStateName: "",
+      editorTabEnabled: false,
+      aiValidationEnabled: false,
+      aiValidationAutoApprove: false,
+      aiValidationAutoDeny: false,
+    });
+
+    render(<Composer sessionId="s1" />);
+
+    // Wait for the mic button to appear (rendered for both mobile and desktop)
+    const micButtons = await screen.findAllByLabelText("Push-to-talk microphone");
+    expect(micButtons.length).toBeGreaterThanOrEqual(1);
+  });
+
+  it("mic button has proper accessible label", async () => {
+    const { api } = await import("../api.js");
+    vi.mocked(api.getSettings).mockResolvedValueOnce({
+      deepgramApiKeyConfigured: true,
+      openrouterApiKeyConfigured: false,
+      openrouterModel: "openrouter/free",
+      linearApiKeyConfigured: false,
+      linearAutoTransition: false,
+      linearAutoTransitionStateName: "",
+      editorTabEnabled: false,
+      aiValidationEnabled: false,
+      aiValidationAutoApprove: false,
+      aiValidationAutoDeny: false,
+    });
+
+    render(<Composer sessionId="s1" />);
+
+    const micButtons = await screen.findAllByLabelText("Push-to-talk microphone");
+    // Both mobile and desktop buttons should have the label
+    expect(micButtons.length).toBe(2);
+    micButtons.forEach((btn) => {
+      expect(btn.tagName).toBe("BUTTON");
+    });
+  });
+
+  it("mic button is disabled when not connected", async () => {
+    setupMockStore({ isConnected: false });
+    const { api } = await import("../api.js");
+    vi.mocked(api.getSettings).mockResolvedValueOnce({
+      deepgramApiKeyConfigured: true,
+      openrouterApiKeyConfigured: false,
+      openrouterModel: "openrouter/free",
+      linearApiKeyConfigured: false,
+      linearAutoTransition: false,
+      linearAutoTransitionStateName: "",
+      editorTabEnabled: false,
+      aiValidationEnabled: false,
+      aiValidationAutoApprove: false,
+      aiValidationAutoDeny: false,
+    });
+
+    render(<Composer sessionId="s1" />);
+
+    const micButtons = await screen.findAllByLabelText("Push-to-talk microphone");
+    micButtons.forEach((btn) => {
+      expect(btn.hasAttribute("disabled")).toBe(true);
+    });
+  });
+});
+
 describe("Composer save prompt", () => {
   it("shows save error when create prompt fails", async () => {
     // Validates API failures are visible to the user instead of being silently ignored.

--- a/web/src/components/Composer.test.tsx
+++ b/web/src/components/Composer.test.tsx
@@ -659,3 +659,692 @@ describe("Composer save prompt", () => {
     expect(results).toHaveNoViolations();
   });
 });
+
+// ─── Image paste and upload handling ─────────────────────────────────────────
+
+vi.mock("../utils/image.js", () => ({
+  readFileAsBase64: vi.fn().mockResolvedValue({ base64: "dGVzdA==", mediaType: "image/png" }),
+}));
+
+describe("Composer image handling", () => {
+  it("displays image thumbnails when images are attached via file input", async () => {
+    // Validates the image preview area renders thumbnails after file selection.
+    const { container } = render(<Composer sessionId="s1" />);
+    const fileInput = container.querySelector("input[type='file']") as HTMLInputElement;
+
+    // Simulate selecting an image file
+    const file = new File(["fake-png-data"], "test.png", { type: "image/png" });
+    Object.defineProperty(fileInput, "files", { value: [file] });
+    fireEvent.change(fileInput);
+
+    // Wait for the image thumbnail to appear
+    const img = await waitFor(() => {
+      const imgs = container.querySelectorAll("img[alt='test.png']");
+      expect(imgs.length).toBeGreaterThanOrEqual(1);
+      return imgs[0];
+    });
+    expect(img).toBeTruthy();
+  });
+
+  it("removes an image when the remove button is clicked", async () => {
+    // Validates images can be removed from the attachment preview.
+    const { container } = render(<Composer sessionId="s1" />);
+    const fileInput = container.querySelector("input[type='file']") as HTMLInputElement;
+
+    const file = new File(["data"], "removable.png", { type: "image/png" });
+    Object.defineProperty(fileInput, "files", { value: [file] });
+    fireEvent.change(fileInput);
+
+    await waitFor(() => {
+      expect(container.querySelectorAll("img[alt='removable.png']").length).toBeGreaterThanOrEqual(1);
+    });
+
+    // Click the remove button (has aria-label "Remove image")
+    const removeBtn = screen.getAllByLabelText("Remove image")[0];
+    fireEvent.click(removeBtn);
+
+    await waitFor(() => {
+      expect(container.querySelectorAll("img[alt='removable.png']").length).toBe(0);
+    });
+  });
+
+  it("handles paste of images from clipboard", async () => {
+    // Validates that pasting an image from clipboard attaches it.
+    const { container } = render(<Composer sessionId="s1" />);
+    const textarea = container.querySelector("textarea")!;
+
+    const file = new File(["clipboard-data"], "pasted.png", { type: "image/png" });
+    const clipboardData = {
+      items: [
+        {
+          type: "image/png",
+          getAsFile: () => file,
+        },
+      ],
+    };
+
+    fireEvent.paste(textarea, { clipboardData });
+
+    // Wait for the pasted image to appear in the preview
+    await waitFor(() => {
+      const imgs = container.querySelectorAll("img");
+      expect(imgs.length).toBeGreaterThanOrEqual(1);
+    });
+  });
+
+  it("does not prevent default for non-image paste", () => {
+    // Validates text-only paste is not intercepted by the image handler.
+    const { container } = render(<Composer sessionId="s1" />);
+    const textarea = container.querySelector("textarea")!;
+
+    const clipboardData = {
+      items: [
+        {
+          type: "text/plain",
+          getAsFile: () => null,
+        },
+      ],
+    };
+
+    // Should not throw, and should let default behavior through
+    fireEvent.paste(textarea, { clipboardData });
+    // No images should be added
+    expect(container.querySelectorAll("img")).toHaveLength(0);
+  });
+
+  it("sends images along with the message", async () => {
+    // Validates that attached images are included in the user_message payload.
+    const { container } = render(<Composer sessionId="s1" />);
+    const textarea = container.querySelector("textarea")!;
+    const fileInput = container.querySelector("input[type='file']") as HTMLInputElement;
+
+    // Attach an image
+    const file = new File(["img"], "send-me.png", { type: "image/png" });
+    Object.defineProperty(fileInput, "files", { value: [file] });
+    fireEvent.change(fileInput);
+
+    await waitFor(() => {
+      expect(container.querySelectorAll("img[alt='send-me.png']").length).toBeGreaterThanOrEqual(1);
+    });
+
+    // Type text and send
+    fireEvent.change(textarea, { target: { value: "Check this image" } });
+    fireEvent.keyDown(textarea, { key: "Enter", shiftKey: false });
+
+    expect(mockSendToSession).toHaveBeenCalledWith("s1", expect.objectContaining({
+      type: "user_message",
+      content: "Check this image",
+      images: [{ media_type: "image/png", data: "dGVzdA==" }],
+    }));
+  });
+
+  it("clears images after sending a message", async () => {
+    // Validates that attached images are removed after successful send.
+    const { container } = render(<Composer sessionId="s1" />);
+    const textarea = container.querySelector("textarea")!;
+    const fileInput = container.querySelector("input[type='file']") as HTMLInputElement;
+
+    const file = new File(["img"], "clear-me.png", { type: "image/png" });
+    Object.defineProperty(fileInput, "files", { value: [file] });
+    fireEvent.change(fileInput);
+
+    await waitFor(() => {
+      expect(container.querySelectorAll("img[alt='clear-me.png']").length).toBeGreaterThanOrEqual(1);
+    });
+
+    fireEvent.change(textarea, { target: { value: "sending" } });
+    fireEvent.keyDown(textarea, { key: "Enter", shiftKey: false });
+
+    // Images should be cleared
+    await waitFor(() => {
+      expect(container.querySelectorAll("img[alt='clear-me.png']").length).toBe(0);
+    });
+  });
+
+  it("ignores non-image files in file input", async () => {
+    // Validates that non-image files are skipped during file selection.
+    const { container } = render(<Composer sessionId="s1" />);
+    const fileInput = container.querySelector("input[type='file']") as HTMLInputElement;
+
+    const file = new File(["text"], "doc.txt", { type: "text/plain" });
+    Object.defineProperty(fileInput, "files", { value: [file] });
+    fireEvent.change(fileInput);
+
+    // Small delay to allow any async processing
+    await waitFor(() => {
+      expect(container.querySelectorAll("img")).toHaveLength(0);
+    });
+  });
+
+  it("clicking the attach image button triggers file input", () => {
+    // Validates the + button (attach image) opens the file picker.
+    const { container } = render(<Composer sessionId="s1" />);
+    const fileInput = container.querySelector("input[type='file']") as HTMLInputElement;
+    const clickSpy = vi.spyOn(fileInput, "click");
+
+    // Click the desktop "Attach image" button
+    fireEvent.click(screen.getAllByTitle("Attach image")[0]);
+
+    expect(clickSpy).toHaveBeenCalled();
+    clickSpy.mockRestore();
+  });
+});
+
+// ─── Save prompt dialog full flow ────────────────────────────────────────────
+
+describe("Composer save prompt dialog", () => {
+  it("opens save prompt dialog and populates default name from text", () => {
+    // Validates the save dialog opens with a pre-filled name derived from the current text.
+    const { container } = render(<Composer sessionId="s1" />);
+    const textarea = container.querySelector("textarea")!;
+
+    fireEvent.change(textarea, { target: { value: "My great prompt content" } });
+    fireEvent.click(screen.getAllByTitle("Save as prompt")[0]);
+
+    const titleInput = screen.getByPlaceholderText("Prompt title") as HTMLInputElement;
+    expect(titleInput.value).toBe("My great prompt content");
+  });
+
+  it("successfully saves a prompt and closes the dialog", async () => {
+    // Validates the full save flow: open dialog -> type name -> save -> dialog closes.
+    mockCreatePrompt.mockResolvedValue({
+      id: "p-ok",
+      name: "Saved",
+      content: "Body",
+      scope: "global",
+      createdAt: Date.now(),
+      updatedAt: Date.now(),
+    });
+    const { container } = render(<Composer sessionId="s1" />);
+    const textarea = container.querySelector("textarea")!;
+
+    fireEvent.change(textarea, { target: { value: "Save me" } });
+    fireEvent.click(screen.getAllByTitle("Save as prompt")[0]);
+    expect(screen.getByText("Save prompt")).toBeTruthy();
+
+    const titleInput = screen.getByPlaceholderText("Prompt title");
+    fireEvent.change(titleInput, { target: { value: "My Prompt" } });
+    fireEvent.click(screen.getByText("Save"));
+
+    // After successful save, dialog should close
+    await waitFor(() => {
+      expect(screen.queryByText("Save prompt")).toBeNull();
+    });
+  });
+
+  it("cancel button closes the save prompt dialog", () => {
+    // Validates the cancel button dismisses the dialog without saving.
+    const { container } = render(<Composer sessionId="s1" />);
+    const textarea = container.querySelector("textarea")!;
+
+    fireEvent.change(textarea, { target: { value: "Some text" } });
+    fireEvent.click(screen.getAllByTitle("Save as prompt")[0]);
+    expect(screen.getByText("Save prompt")).toBeTruthy();
+
+    fireEvent.click(screen.getByText("Cancel"));
+
+    expect(screen.queryByText("Save prompt")).toBeNull();
+  });
+
+  it("save button is disabled when prompt name is empty", () => {
+    // Validates the Save button cannot be clicked without a title.
+    const { container } = render(<Composer sessionId="s1" />);
+    const textarea = container.querySelector("textarea")!;
+
+    fireEvent.change(textarea, { target: { value: "Some text" } });
+    fireEvent.click(screen.getAllByTitle("Save as prompt")[0]);
+
+    const titleInput = screen.getByPlaceholderText("Prompt title") as HTMLInputElement;
+    fireEvent.change(titleInput, { target: { value: "" } });
+
+    const saveBtn = screen.getByText("Save");
+    expect(saveBtn.hasAttribute("disabled")).toBe(true);
+  });
+
+  it("clears error when user types in the prompt title input", async () => {
+    // Validates that typing in the title field dismisses any previous error message.
+    mockCreatePrompt.mockRejectedValue(new Error("Duplicate name"));
+    const { container } = render(<Composer sessionId="s1" />);
+    const textarea = container.querySelector("textarea")!;
+
+    fireEvent.change(textarea, { target: { value: "Body" } });
+    fireEvent.click(screen.getAllByTitle("Save as prompt")[0]);
+
+    const titleInput = screen.getByPlaceholderText("Prompt title");
+    fireEvent.change(titleInput, { target: { value: "Dup" } });
+    fireEvent.click(screen.getByText("Save"));
+
+    // Wait for error to appear
+    await screen.findByText("Duplicate name");
+
+    // Type in the title field to clear the error
+    fireEvent.change(titleInput, { target: { value: "New name" } });
+
+    await waitFor(() => {
+      expect(screen.queryByText("Duplicate name")).toBeNull();
+    });
+  });
+
+  it("save prompt button is disabled when not connected", () => {
+    // Validates the save prompt bookmark button is disabled when CLI is disconnected.
+    setupMockStore({ isConnected: false });
+    const { container } = render(<Composer sessionId="s1" />);
+    const textarea = container.querySelector("textarea")!;
+
+    // Even if there's text, button should be disabled
+    fireEvent.change(textarea, { target: { value: "text" } });
+    const saveButtons = screen.getAllByTitle("Save as prompt");
+    saveButtons.forEach((btn) => {
+      expect(btn.hasAttribute("disabled")).toBe(true);
+    });
+  });
+
+  it("toggles save prompt dialog open and closed", () => {
+    // Validates clicking the save button a second time closes the dialog.
+    const { container } = render(<Composer sessionId="s1" />);
+    const textarea = container.querySelector("textarea")!;
+
+    fireEvent.change(textarea, { target: { value: "Toggle me" } });
+    const saveBtn = screen.getAllByTitle("Save as prompt")[0];
+
+    // Open
+    fireEvent.click(saveBtn);
+    expect(screen.getByText("Save prompt")).toBeTruthy();
+
+    // Close by clicking again
+    fireEvent.click(saveBtn);
+    expect(screen.queryByText("Save prompt")).toBeNull();
+  });
+});
+
+// ─── Mode toggle via button click ────────────────────────────────────────────
+
+describe("Composer mode toggle button", () => {
+  it("clicking mode toggle switches to plan mode", () => {
+    // Validates clicking the mode button sends set_permission_mode with "plan".
+    setupMockStore({ isConnected: true, session: { permissionMode: "acceptEdits" } });
+    render(<Composer sessionId="s1" />);
+
+    const modeBtn = screen.getAllByTitle("Toggle mode (Shift+Tab)")[0];
+    fireEvent.click(modeBtn);
+
+    expect(mockSendToSession).toHaveBeenCalledWith("s1", {
+      type: "set_permission_mode",
+      mode: "plan",
+    });
+    expect(mockUpdateSession).toHaveBeenCalledWith("s1", { permissionMode: "plan" });
+    expect(mockSetPreviousPermissionMode).toHaveBeenCalledWith("s1", "acceptEdits");
+  });
+
+  it("clicking mode toggle restores previous mode from plan", () => {
+    // Validates toggling back from plan restores the previous permission mode.
+    setupMockStore({ isConnected: true, session: { permissionMode: "plan" } });
+    render(<Composer sessionId="s1" />);
+
+    const modeBtn = screen.getAllByTitle("Toggle mode (Shift+Tab)")[0];
+    fireEvent.click(modeBtn);
+
+    // Should restore to "acceptEdits" (the previousPermissionMode default)
+    expect(mockSendToSession).toHaveBeenCalledWith("s1", {
+      type: "set_permission_mode",
+      mode: "acceptEdits",
+    });
+    expect(mockUpdateSession).toHaveBeenCalledWith("s1", { permissionMode: "acceptEdits" });
+  });
+
+  it("mode toggle is disabled when not connected", () => {
+    // Validates mode button is non-interactive when CLI is disconnected.
+    setupMockStore({ isConnected: false });
+    render(<Composer sessionId="s1" />);
+
+    const modeBtns = screen.getAllByTitle("Toggle mode (Shift+Tab)");
+    modeBtns.forEach((btn) => {
+      expect(btn.hasAttribute("disabled")).toBe(true);
+    });
+  });
+
+  it("displays plan mode label and styling when in plan mode", () => {
+    // Validates the mode button shows "plan" label when permission mode is plan.
+    setupMockStore({ isConnected: true, session: { permissionMode: "plan" } });
+    render(<Composer sessionId="s1" />);
+
+    const modeBtns = screen.getAllByTitle("Toggle mode (Shift+Tab)");
+    // At least one should display "plan" text
+    const hasPlanLabel = modeBtns.some((btn) => btn.textContent?.toLowerCase().includes("plan"));
+    expect(hasPlanLabel).toBe(true);
+  });
+});
+
+// ─── handleInput and syncCaret ───────────────────────────────────────────────
+
+describe("Composer textarea input handling", () => {
+  it("handleInput updates caret position from selection", () => {
+    // Validates that typing in the textarea tracks the caret position for mention detection.
+    const { container } = render(<Composer sessionId="s1" />);
+    const textarea = container.querySelector("textarea")! as HTMLTextAreaElement;
+
+    // Simulate typing with a specific selectionStart
+    fireEvent.change(textarea, {
+      target: { value: "Hello @w", selectionStart: 8 },
+    });
+
+    // The textarea value should be updated
+    expect(textarea.value).toBe("Hello @w");
+  });
+
+  it("syncCaret updates on click", () => {
+    // Validates clicking in the textarea updates the internal caret position.
+    const { container } = render(<Composer sessionId="s1" />);
+    const textarea = container.querySelector("textarea")! as HTMLTextAreaElement;
+
+    fireEvent.change(textarea, { target: { value: "Some text here" } });
+    // Simulate clicking at position 5
+    Object.defineProperty(textarea, "selectionStart", { value: 5, writable: true });
+    fireEvent.click(textarea);
+
+    // No error should occur — syncCaret should work silently
+    expect(textarea.value).toBe("Some text here");
+  });
+
+  it("syncCaret updates on keyUp", () => {
+    // Validates arrow key navigation updates the caret position for mention detection.
+    const { container } = render(<Composer sessionId="s1" />);
+    const textarea = container.querySelector("textarea")! as HTMLTextAreaElement;
+
+    fireEvent.change(textarea, { target: { value: "test" } });
+    Object.defineProperty(textarea, "selectionStart", { value: 2, writable: true });
+    fireEvent.keyUp(textarea, { key: "ArrowLeft" });
+
+    expect(textarea.value).toBe("test");
+  });
+});
+
+// ─── Slash menu Tab selection ────────────────────────────────────────────────
+
+describe("Composer slash menu Tab selection", () => {
+  it("Tab key selects the highlighted slash command", () => {
+    // Validates that Tab fills the command into the textarea without sending.
+    setupMockStore({
+      session: {
+        slash_commands: ["help", "clear"],
+        skills: [],
+      },
+    });
+    const { container } = render(<Composer sessionId="s1" />);
+    const textarea = container.querySelector("textarea")! as HTMLTextAreaElement;
+
+    fireEvent.change(textarea, { target: { value: "/" } });
+    expect(screen.getByText("/help")).toBeTruthy();
+
+    fireEvent.keyDown(textarea, { key: "Tab", shiftKey: false });
+
+    // Should fill in the first command
+    expect(textarea.value).toBe("/help ");
+    expect(mockSendToSession).not.toHaveBeenCalled();
+  });
+
+  it("ArrowUp wraps to the last item in slash menu", () => {
+    // Validates ArrowUp from the first item wraps to the last item.
+    setupMockStore({
+      session: {
+        slash_commands: ["help", "clear"],
+        skills: [],
+      },
+    });
+    const { container } = render(<Composer sessionId="s1" />);
+    const textarea = container.querySelector("textarea")! as HTMLTextAreaElement;
+
+    fireEvent.change(textarea, { target: { value: "/" } });
+
+    // ArrowUp from index 0 should wrap to last item
+    fireEvent.keyDown(textarea, { key: "ArrowUp" });
+    fireEvent.keyDown(textarea, { key: "Enter" });
+
+    // Should select the last command (clear)
+    expect(textarea.value).toBe("/clear ");
+  });
+});
+
+// ─── Mention menu keyboard navigation ───────────────────────────────────────
+
+describe("Composer mention menu keyboard", () => {
+  it("Escape in mention menu does not send a message", async () => {
+    // Validates pressing Escape while the @-mention menu is open does not trigger
+    // a message send — the key event should be consumed by the menu handler.
+    mockListPrompts.mockResolvedValue([
+      {
+        id: "p1",
+        name: "my-prompt",
+        content: "Prompt content",
+        scope: "global",
+        createdAt: Date.now(),
+        updatedAt: Date.now(),
+      },
+    ]);
+    const { container } = render(<Composer sessionId="s1" />);
+    const textarea = container.querySelector("textarea")!;
+
+    fireEvent.change(textarea, { target: { value: "@my", selectionStart: 3 } });
+    await screen.findByText("@my-prompt");
+
+    fireEvent.keyDown(textarea, { key: "Escape" });
+
+    // The Escape should be consumed — no message sent, text unchanged
+    expect(mockSendToSession).not.toHaveBeenCalled();
+    expect((textarea as HTMLTextAreaElement).value).toBe("@my");
+  });
+
+  it("ArrowDown navigates in the mention menu", async () => {
+    // Validates arrow navigation cycles through @-mention suggestions.
+    mockListPrompts.mockResolvedValue([
+      {
+        id: "p1",
+        name: "alpha",
+        content: "Alpha content",
+        scope: "global",
+        createdAt: Date.now(),
+        updatedAt: Date.now(),
+      },
+      {
+        id: "p2",
+        name: "beta",
+        content: "Beta content",
+        scope: "global",
+        createdAt: Date.now(),
+        updatedAt: Date.now(),
+      },
+    ]);
+    const { container } = render(<Composer sessionId="s1" />);
+    const textarea = container.querySelector("textarea")!;
+
+    fireEvent.change(textarea, { target: { value: "@", selectionStart: 1 } });
+    await screen.findByText("@alpha");
+
+    // Navigate down then select with Tab
+    fireEvent.keyDown(textarea, { key: "ArrowDown" });
+    fireEvent.keyDown(textarea, { key: "Tab", shiftKey: false });
+
+    // Should have selected the second prompt (beta)
+    expect((textarea as HTMLTextAreaElement).value).toContain("Beta content");
+    expect(mockSendToSession).not.toHaveBeenCalled();
+  });
+
+  it("ArrowUp navigates backwards in the mention menu", async () => {
+    // Validates ArrowUp navigates upward through @-mention suggestions.
+    mockListPrompts.mockResolvedValue([
+      {
+        id: "p1",
+        name: "first",
+        content: "First content",
+        scope: "global",
+        createdAt: Date.now(),
+        updatedAt: Date.now(),
+      },
+      {
+        id: "p2",
+        name: "second",
+        content: "Second content",
+        scope: "global",
+        createdAt: Date.now(),
+        updatedAt: Date.now(),
+      },
+    ]);
+    const { container } = render(<Composer sessionId="s1" />);
+    const textarea = container.querySelector("textarea")!;
+
+    fireEvent.change(textarea, { target: { value: "@", selectionStart: 1 } });
+    await screen.findByText("@first");
+
+    // ArrowUp from first position should wrap to last
+    fireEvent.keyDown(textarea, { key: "ArrowUp" });
+    fireEvent.keyDown(textarea, { key: "Enter", shiftKey: false });
+
+    // Should have selected the second (last) prompt
+    expect((textarea as HTMLTextAreaElement).value).toContain("Second content");
+  });
+
+  it("Enter/Tab does nothing when mention menu is open but empty", async () => {
+    // Validates Enter does not send when the mention menu is open with no matching prompts.
+    mockListPrompts.mockResolvedValue([
+      {
+        id: "p1",
+        name: "unique-name",
+        content: "Content",
+        scope: "global",
+        createdAt: Date.now(),
+        updatedAt: Date.now(),
+      },
+    ]);
+    const { container } = render(<Composer sessionId="s1" />);
+    const textarea = container.querySelector("textarea")!;
+
+    // Type @ with a query that matches nothing
+    fireEvent.change(textarea, { target: { value: "@zzz", selectionStart: 4 } });
+
+    // Small wait for menu to react
+    await waitFor(() => {
+      // Menu is open but should have no matches for "zzz"
+      expect(screen.queryByText("@unique-name")).toBeNull();
+    });
+
+    fireEvent.keyDown(textarea, { key: "Enter", shiftKey: false });
+
+    // Should not send
+    expect(mockSendToSession).not.toHaveBeenCalled();
+  });
+
+  it("Tab selects a prompt from mention menu", async () => {
+    // Validates Tab key inserts the prompt content from the @-mention menu.
+    mockListPrompts.mockResolvedValue([
+      {
+        id: "p1",
+        name: "tab-test",
+        content: "Tab selected content",
+        scope: "global",
+        createdAt: Date.now(),
+        updatedAt: Date.now(),
+      },
+    ]);
+    const { container } = render(<Composer sessionId="s1" />);
+    const textarea = container.querySelector("textarea")!;
+
+    fireEvent.change(textarea, { target: { value: "@tab", selectionStart: 4 } });
+    await screen.findByText("@tab-test");
+
+    fireEvent.keyDown(textarea, { key: "Tab", shiftKey: false });
+
+    expect((textarea as HTMLTextAreaElement).value).toContain("Tab selected content");
+  });
+});
+
+// ─── Codex backend mode label ────────────────────────────────────────────────
+
+describe("Composer codex backend", () => {
+  it("shows codex mode labels when backend is codex", () => {
+    // Validates that the mode button shows Codex-specific labels (e.g. "auto" instead of "agent").
+    setupMockStore({
+      isConnected: true,
+      session: { backend_type: "codex", permissionMode: "bypassPermissions" },
+    });
+    render(<Composer sessionId="s1" />);
+
+    const modeBtns = screen.getAllByTitle("Toggle mode (Shift+Tab)");
+    const hasAutoLabel = modeBtns.some((btn) => btn.textContent?.toLowerCase().includes("auto"));
+    expect(hasAutoLabel).toBe(true);
+  });
+
+  it("restores previous codex mode when toggling back from plan", () => {
+    // Validates that toggling off plan mode on Codex restores the stored previous mode.
+    setupMockStore({
+      isConnected: true,
+      session: { backend_type: "codex", permissionMode: "plan" },
+    });
+    // Set previous mode to bypassPermissions (the typical codex default)
+    const prevMap = new Map<string, string>();
+    prevMap.set("s1", "bypassPermissions");
+    (mockStoreState as Record<string, unknown>).previousPermissionMode = prevMap;
+
+    render(<Composer sessionId="s1" />);
+
+    const modeBtn = screen.getAllByTitle("Toggle mode (Shift+Tab)")[0];
+    fireEvent.click(modeBtn);
+
+    // Should restore to bypassPermissions from previous mode
+    expect(mockSendToSession).toHaveBeenCalledWith("s1", {
+      type: "set_permission_mode",
+      mode: "bypassPermissions",
+    });
+  });
+});
+
+// ─── Mobile action row rendering ─────────────────────────────────────────────
+
+describe("Composer mobile action row", () => {
+  it("renders mobile upload image button", () => {
+    // Validates the mobile-specific upload button is present.
+    render(<Composer sessionId="s1" />);
+
+    const uploadBtns = screen.getAllByTitle("Upload image");
+    expect(uploadBtns.length).toBeGreaterThanOrEqual(1);
+  });
+
+  it("mobile upload button is disabled when not connected", () => {
+    // Validates the mobile upload button is disabled when CLI is disconnected.
+    setupMockStore({ isConnected: false });
+    render(<Composer sessionId="s1" />);
+
+    const uploadBtns = screen.getAllByTitle("Upload image");
+    uploadBtns.forEach((btn) => {
+      expect(btn.hasAttribute("disabled")).toBe(true);
+    });
+  });
+});
+
+// ─── Plan mode border styling ────────────────────────────────────────────────
+
+describe("Composer plan mode styling", () => {
+  it("applies plan mode border class when in plan mode", () => {
+    // Validates the input container gets a distinct border in plan mode.
+    setupMockStore({ isConnected: true, session: { permissionMode: "plan" } });
+    const { container } = render(<Composer sessionId="s1" />);
+
+    // The outer container div should have the plan border class
+    const inputContainer = container.querySelector(".sm\\:border-cc-primary\\/40");
+    expect(inputContainer).toBeTruthy();
+  });
+});
+
+// ─── Push-to-talk keyboard shortcut ──────────────────────────────────────────
+
+describe("Composer push-to-talk keyboard shortcut", () => {
+  it("Ctrl+Shift+M does nothing when deepgram is not configured", () => {
+    // Validates the keyboard shortcut is inactive without Deepgram setup.
+    const { container } = render(<Composer sessionId="s1" />);
+    const textarea = container.querySelector("textarea")!;
+
+    // Should not throw; deepgramConfigured defaults to false
+    fireEvent.keyDown(textarea, { key: "m", ctrlKey: true, shiftKey: true });
+
+    expect(mockSendToSession).not.toHaveBeenCalled();
+  });
+});

--- a/web/src/components/Composer.tsx
+++ b/web/src/components/Composer.tsx
@@ -9,6 +9,7 @@ import { MentionMenu } from "./MentionMenu.js";
 import { useMentionMenu } from "../utils/use-mention-menu.js";
 
 import { readFileAsBase64, type ImageAttachment } from "../utils/image.js";
+import { useAudioRecorder } from "../utils/use-audio-recorder.js";
 
 let idCounter = 0;
 
@@ -40,6 +41,30 @@ export function Composer({ sessionId }: { sessionId: string }) {
   const isCodex = sessionData?.backend_type === "codex";
   const modes: ModeOption[] = isCodex ? CODEX_MODES : CLAUDE_MODES;
   const modeLabel = modes.find((m) => m.value === currentMode)?.label?.toLowerCase() || currentMode;
+
+  const [deepgramConfigured, setDeepgramConfigured] = useState(false);
+  useEffect(() => {
+    api.getSettings().then((s) => setDeepgramConfigured(s.deepgramApiKeyConfigured)).catch(() => {});
+  }, []);
+
+  const { state: recordingState, startRecording, stopRecording } = useAudioRecorder({
+    onTranscript: (transcribedText) => {
+      setText((prev) => {
+        const separator = prev.trim() ? " " : "";
+        return prev + separator + transcribedText;
+      });
+      // Auto-resize textarea after transcript insertion
+      requestAnimationFrame(() => {
+        if (textareaRef.current) {
+          textareaRef.current.style.height = "auto";
+          textareaRef.current.style.height = Math.min(textareaRef.current.scrollHeight, 200) + "px";
+        }
+      });
+    },
+    onError: (err) => {
+      console.warn("Transcription error:", err);
+    },
+  });
 
   const mention = useMentionMenu({
     text,
@@ -222,6 +247,17 @@ export function Composer({ sessionId }: { sessionId: string }) {
       && ((e.key === "Enter" && !e.shiftKey) || (e.key === "Tab" && !e.shiftKey))
     ) {
       e.preventDefault();
+      return;
+    }
+
+    // Push-to-talk keyboard shortcut (Ctrl+Shift+M)
+    if (e.key === "m" && e.ctrlKey && e.shiftKey && deepgramConfigured) {
+      e.preventDefault();
+      if (recordingState === "recording") {
+        stopRecording();
+      } else if (recordingState === "idle") {
+        startRecording();
+      }
       return;
     }
 
@@ -528,6 +564,47 @@ export function Composer({ sessionId }: { sessionId: string }) {
                 <path d="M2 11l3-3 2 2 3-4 4 5" strokeLinecap="round" strokeLinejoin="round" />
               </svg>
             </button>
+
+            {/* Push-to-talk microphone (mobile) */}
+            {deepgramConfigured && (
+              <button
+                onTouchStart={(e) => { e.preventDefault(); startRecording(); }}
+                onTouchEnd={(e) => { e.preventDefault(); stopRecording(); }}
+                onMouseDown={startRecording}
+                onMouseUp={stopRecording}
+                onMouseLeave={() => { if (recordingState === "recording") stopRecording(); }}
+                disabled={!isConnected || recordingState === "transcribing"}
+                className={`flex items-center justify-center w-8 h-8 rounded-md transition-colors ${
+                  recordingState === "recording"
+                    ? "text-cc-error bg-cc-error/10 animate-pulse cursor-pointer"
+                    : recordingState === "transcribing"
+                      ? "text-cc-muted opacity-50 cursor-wait"
+                      : isConnected
+                        ? "text-cc-muted hover:text-cc-fg hover:bg-cc-hover cursor-pointer"
+                        : "text-cc-muted opacity-30 cursor-not-allowed"
+                }`}
+                title={
+                  recordingState === "recording"
+                    ? "Release to transcribe"
+                    : recordingState === "transcribing"
+                      ? "Transcribing..."
+                      : "Hold to record (push-to-talk)"
+                }
+                aria-label={
+                  recordingState === "recording"
+                    ? "Recording - release to transcribe"
+                    : recordingState === "transcribing"
+                      ? "Transcribing audio"
+                      : "Push-to-talk microphone"
+                }
+              >
+                <svg viewBox="0 0 16 16" fill="none" stroke="currentColor" strokeWidth="1.5" className="w-4 h-4">
+                  <path d="M8 1.5a2 2 0 0 0-2 2v4a2 2 0 0 0 4 0v-4a2 2 0 0 0-2-2z" fill={recordingState === "recording" ? "currentColor" : "none"} />
+                  <path d="M12 6.5v1a4 4 0 0 1-8 0v-1" strokeLinecap="round" />
+                  <path d="M8 11.5v2.5M6 14h4" strokeLinecap="round" />
+                </svg>
+              </button>
+            )}
           </div>
 
           {/* Textarea row */}
@@ -620,6 +697,45 @@ export function Composer({ sessionId }: { sessionId: string }) {
                 <path d="M4 2.75h8A1.25 1.25 0 0113.25 4v9.25L8 10.5l-5.25 2.75V4A1.25 1.25 0 014 2.75z" />
               </svg>
             </button>
+
+            {/* Push-to-talk microphone (desktop) */}
+            {deepgramConfigured && (
+              <button
+                onMouseDown={startRecording}
+                onMouseUp={stopRecording}
+                onMouseLeave={() => { if (recordingState === "recording") stopRecording(); }}
+                disabled={!isConnected || recordingState === "transcribing"}
+                className={`flex items-center justify-center w-8 h-8 rounded-md transition-colors ${
+                  recordingState === "recording"
+                    ? "text-cc-error bg-cc-error/10 animate-pulse cursor-pointer"
+                    : recordingState === "transcribing"
+                      ? "text-cc-muted opacity-50 cursor-wait"
+                      : isConnected
+                        ? "text-cc-muted hover:text-cc-fg hover:bg-cc-hover cursor-pointer"
+                        : "text-cc-muted opacity-30 cursor-not-allowed"
+                }`}
+                title={
+                  recordingState === "recording"
+                    ? "Release to transcribe"
+                    : recordingState === "transcribing"
+                      ? "Transcribing..."
+                      : "Hold to record (Ctrl+Shift+M)"
+                }
+                aria-label={
+                  recordingState === "recording"
+                    ? "Recording - release to transcribe"
+                    : recordingState === "transcribing"
+                      ? "Transcribing audio"
+                      : "Push-to-talk microphone"
+                }
+              >
+                <svg viewBox="0 0 16 16" fill="none" stroke="currentColor" strokeWidth="1.5" className="w-4 h-4">
+                  <path d="M8 1.5a2 2 0 0 0-2 2v4a2 2 0 0 0 4 0v-4a2 2 0 0 0-2-2z" fill={recordingState === "recording" ? "currentColor" : "none"} />
+                  <path d="M12 6.5v1a4 4 0 0 1-8 0v-1" strokeLinecap="round" />
+                  <path d="M8 11.5v2.5M6 14h4" strokeLinecap="round" />
+                </svg>
+              </button>
+            )}
 
             {/* Mode toggle */}
             <button

--- a/web/src/components/DeepgramLogo.tsx
+++ b/web/src/components/DeepgramLogo.tsx
@@ -1,0 +1,31 @@
+interface DeepgramLogoProps {
+  className?: string;
+}
+
+export function DeepgramLogo({ className }: DeepgramLogoProps) {
+  return (
+    <svg
+      viewBox="0 0 24 24"
+      fill="none"
+      aria-hidden="true"
+      className={className}
+    >
+      <path
+        d="M12 2a4 4 0 0 0-4 4v5a4 4 0 0 0 8 0V6a4 4 0 0 0-4-4z"
+        fill="currentColor"
+      />
+      <path
+        d="M18 10v1a6 6 0 0 1-12 0v-1"
+        stroke="currentColor"
+        strokeWidth="2"
+        strokeLinecap="round"
+      />
+      <path
+        d="M12 17v4M9 21h6"
+        stroke="currentColor"
+        strokeWidth="2"
+        strokeLinecap="round"
+      />
+    </svg>
+  );
+}

--- a/web/src/components/DeepgramSettingsPage.test.tsx
+++ b/web/src/components/DeepgramSettingsPage.test.tsx
@@ -1,0 +1,128 @@
+// @vitest-environment jsdom
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import "@testing-library/jest-dom";
+
+interface MockStoreState {
+  currentSessionId: string | null;
+}
+
+let mockState: MockStoreState;
+
+const mockApi = {
+  getSettings: vi.fn(),
+  updateSettings: vi.fn(),
+  verifyDeepgramConnection: vi.fn(),
+};
+
+vi.mock("../api.js", () => ({
+  api: {
+    getSettings: (...args: unknown[]) => mockApi.getSettings(...args),
+    updateSettings: (...args: unknown[]) => mockApi.updateSettings(...args),
+    verifyDeepgramConnection: (...args: unknown[]) => mockApi.verifyDeepgramConnection(...args),
+  },
+}));
+
+vi.mock("../store.js", () => {
+  const useStoreFn = (selector: (state: MockStoreState) => unknown) => selector(mockState);
+  useStoreFn.getState = () => mockState;
+  return { useStore: useStoreFn };
+});
+
+import { DeepgramSettingsPage } from "./DeepgramSettingsPage.js";
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockState = { currentSessionId: null };
+  mockApi.getSettings.mockResolvedValue({
+    openrouterApiKeyConfigured: false,
+    openrouterModel: "openrouter/free",
+    linearApiKeyConfigured: false,
+    deepgramApiKeyConfigured: true,
+  });
+  mockApi.updateSettings.mockResolvedValue({
+    openrouterApiKeyConfigured: false,
+    openrouterModel: "openrouter/free",
+    linearApiKeyConfigured: false,
+    deepgramApiKeyConfigured: true,
+  });
+  mockApi.verifyDeepgramConnection.mockResolvedValue({
+    connected: true,
+    projectName: "My Project",
+  });
+});
+
+describe("DeepgramSettingsPage", () => {
+  it("loads Deepgram configuration status", async () => {
+    render(<DeepgramSettingsPage />);
+    expect(mockApi.getSettings).toHaveBeenCalledTimes(1);
+    expect(await screen.findByText("Deepgram key configured")).toBeInTheDocument();
+  });
+
+  it("saves trimmed Deepgram API key", async () => {
+    render(<DeepgramSettingsPage />);
+    await screen.findByText("Deepgram key configured");
+
+    fireEvent.change(screen.getByLabelText("Deepgram API Key"), {
+      target: { value: "  dg_api_123  " },
+    });
+    fireEvent.click(screen.getByRole("button", { name: "Save" }));
+
+    await waitFor(() => {
+      expect(mockApi.updateSettings).toHaveBeenCalledWith({ deepgramApiKey: "dg_api_123" });
+    });
+    expect(mockApi.verifyDeepgramConnection).toHaveBeenCalled();
+    expect(await screen.findByText("Integration saved.")).toBeInTheDocument();
+  });
+
+  it("shows an error when saving empty key", async () => {
+    render(<DeepgramSettingsPage />);
+    await screen.findByText("Deepgram key configured");
+
+    fireEvent.click(screen.getByRole("button", { name: "Save" }));
+    expect(await screen.findByText("Please enter a Deepgram API key.")).toBeInTheDocument();
+    expect(mockApi.updateSettings).not.toHaveBeenCalled();
+  });
+
+  it("verifies connection when Verify is clicked", async () => {
+    render(<DeepgramSettingsPage />);
+    await screen.findByText("Deepgram key configured");
+
+    fireEvent.click(screen.getByRole("button", { name: "Verify" }));
+
+    await waitFor(() => {
+      expect(mockApi.verifyDeepgramConnection).toHaveBeenCalled();
+    });
+    expect(await screen.findByText("Deepgram connection verified.")).toBeInTheDocument();
+  });
+
+  it("disconnects Deepgram integration", async () => {
+    mockApi.updateSettings.mockResolvedValueOnce({
+      openrouterApiKeyConfigured: false,
+      openrouterModel: "openrouter/free",
+      linearApiKeyConfigured: false,
+      deepgramApiKeyConfigured: false,
+    });
+
+    render(<DeepgramSettingsPage />);
+    await screen.findByText("Deepgram key configured");
+
+    fireEvent.click(screen.getByRole("button", { name: "Disconnect" }));
+
+    await waitFor(() => {
+      expect(mockApi.updateSettings).toHaveBeenCalledWith({ deepgramApiKey: "" });
+    });
+    expect(await screen.findByText("Deepgram disconnected.")).toBeInTheDocument();
+  });
+
+  it("shows connected status with project name", async () => {
+    render(<DeepgramSettingsPage />);
+
+    // Wait for the connection check to complete
+    await waitFor(() => {
+      expect(mockApi.verifyDeepgramConnection).toHaveBeenCalled();
+    });
+
+    expect(await screen.findByText("Connected")).toBeInTheDocument();
+    expect(await screen.findByText("My Project")).toBeInTheDocument();
+  });
+});

--- a/web/src/components/DeepgramSettingsPage.tsx
+++ b/web/src/components/DeepgramSettingsPage.tsx
@@ -1,0 +1,276 @@
+import { useEffect, useState } from "react";
+import { api } from "../api.js";
+import { navigateHome, navigateToSession } from "../utils/routing.js";
+import { useStore } from "../store.js";
+import { DeepgramLogo } from "./DeepgramLogo.js";
+
+interface DeepgramSettingsPageProps {
+  embedded?: boolean;
+}
+
+export function DeepgramSettingsPage({ embedded = false }: DeepgramSettingsPageProps) {
+  const [deepgramApiKey, setDeepgramApiKey] = useState("");
+  const [configured, setConfigured] = useState(false);
+  const [connected, setConnected] = useState(false);
+  const [projectName, setProjectName] = useState("");
+  const [loading, setLoading] = useState(true);
+  const [saving, setSaving] = useState(false);
+  const [checkingConnection, setCheckingConnection] = useState(false);
+  const [error, setError] = useState("");
+  const [saved, setSaved] = useState(false);
+  const [connectionNote, setConnectionNote] = useState("");
+
+  async function refreshConnectionStatus() {
+    setCheckingConnection(true);
+    setError("");
+    setConnectionNote("");
+    try {
+      const info = await api.verifyDeepgramConnection();
+      setConnected(info.connected);
+      setProjectName(info.projectName || "");
+      if (info.connected) {
+        setConnectionNote("Deepgram connection verified.");
+      } else if (info.error) {
+        setError(info.error);
+      }
+    } catch (e: unknown) {
+      setConnected(false);
+      setProjectName("");
+      setConnectionNote("");
+      setError(e instanceof Error ? e.message : String(e));
+    } finally {
+      setCheckingConnection(false);
+    }
+  }
+
+  useEffect(() => {
+    api.getSettings()
+      .then((settings) => {
+        setConfigured(settings.deepgramApiKeyConfigured);
+        if (settings.deepgramApiKeyConfigured) {
+          refreshConnectionStatus().catch(() => {});
+        }
+      })
+      .catch((e: unknown) => setError(e instanceof Error ? e.message : String(e)))
+      .finally(() => setLoading(false));
+  }, []);
+
+  async function onSave(e: React.FormEvent) {
+    e.preventDefault();
+    const trimmed = deepgramApiKey.trim();
+    if (!trimmed) {
+      setError("Please enter a Deepgram API key.");
+      return;
+    }
+
+    setSaving(true);
+    setError("");
+    setSaved(false);
+    setConnectionNote("");
+    try {
+      const settings = await api.updateSettings({ deepgramApiKey: trimmed });
+      setConfigured(settings.deepgramApiKeyConfigured);
+      setDeepgramApiKey("");
+      setSaved(true);
+      await refreshConnectionStatus();
+      setTimeout(() => setSaved(false), 1800);
+    } catch (e: unknown) {
+      setError(e instanceof Error ? e.message : String(e));
+    } finally {
+      setSaving(false);
+    }
+  }
+
+  async function onDisconnect() {
+    setSaving(true);
+    setError("");
+    setSaved(false);
+    setConnectionNote("");
+    try {
+      const settings = await api.updateSettings({ deepgramApiKey: "" });
+      setConfigured(settings.deepgramApiKeyConfigured);
+      setConnected(false);
+      setProjectName("");
+      setDeepgramApiKey("");
+      setConnectionNote("Deepgram disconnected.");
+    } catch (e: unknown) {
+      setError(e instanceof Error ? e.message : String(e));
+    } finally {
+      setSaving(false);
+    }
+  }
+
+  return (
+    <div className={`${embedded ? "h-full" : "h-[100dvh]"} bg-cc-bg text-cc-fg font-sans-ui antialiased overflow-y-auto`}>
+      <div className="max-w-5xl mx-auto px-4 sm:px-8 py-6 sm:py-10 pb-safe">
+        <div className="flex items-start justify-between gap-3 mb-6">
+          <div>
+            <h1 className="text-xl font-semibold text-cc-fg">Deepgram Settings</h1>
+            <p className="mt-1 text-sm text-cc-muted">
+              Configure push-to-talk speech-to-text for dictation in the Composer.
+            </p>
+          </div>
+          <div className="flex items-center gap-2">
+            <button
+              onClick={() => {
+                window.location.hash = "#/integrations";
+              }}
+              className="px-3 py-2.5 min-h-[44px] rounded-lg text-sm text-cc-muted hover:text-cc-fg hover:bg-cc-hover transition-colors cursor-pointer"
+            >
+              Integrations
+            </button>
+            {!embedded && (
+              <button
+                onClick={() => {
+                  const sessionId = useStore.getState().currentSessionId;
+                  if (sessionId) {
+                    navigateToSession(sessionId);
+                  } else {
+                    navigateHome();
+                  }
+                }}
+                className="px-3 py-2.5 min-h-[44px] rounded-lg text-sm text-cc-muted hover:text-cc-fg hover:bg-cc-hover transition-colors cursor-pointer"
+              >
+                Back
+              </button>
+            )}
+          </div>
+        </div>
+
+        <section className="relative overflow-hidden bg-cc-card border border-cc-border rounded-xl p-4 sm:p-6 mb-4">
+          <div className="absolute inset-0 pointer-events-none bg-[radial-gradient(circle_at_top_right,rgba(6,182,212,0.1),transparent_45%)]" />
+          <div className="relative flex items-start justify-between gap-4 flex-wrap">
+            <div className="min-w-0">
+              <div className="inline-flex items-center gap-2 px-2.5 py-1 rounded-full border border-cc-border bg-cc-hover/60 text-xs text-cc-muted">
+                <DeepgramLogo className="w-3.5 h-3.5 text-cc-fg" />
+                <span>Deepgram Integration</span>
+              </div>
+              <h2 className="mt-3 text-lg sm:text-xl font-semibold text-cc-fg">
+                Voice-to-text in your Composer
+              </h2>
+              <p className="mt-1.5 text-sm text-cc-muted max-w-2xl">
+                Hold the microphone button to dictate. Audio is transcribed server-side via Deepgram — your API key never leaves the backend.
+              </p>
+              <div className="mt-3 flex flex-wrap gap-2 text-[11px]">
+                <span className="px-2 py-1 rounded-md bg-cc-hover text-cc-muted">Push-to-talk in Composer</span>
+                <span className="px-2 py-1 rounded-md bg-cc-hover text-cc-muted">Server-side transcription</span>
+                <span className="px-2 py-1 rounded-md bg-cc-hover text-cc-muted">No key exposure in browser</span>
+              </div>
+            </div>
+            <div className="shrink-0 rounded-xl border border-cc-border bg-cc-bg px-3 py-2 text-right min-w-[170px]">
+              <p className="text-[11px] text-cc-muted uppercase tracking-wide">Status</p>
+              <p className={`mt-1 text-sm font-medium ${connected ? "text-cc-success" : configured ? "text-amber-500" : "text-cc-muted"}`}>
+                {connected ? "Connected" : configured ? "Needs verification" : "Not connected"}
+              </p>
+              <p className="mt-0.5 text-[11px] text-cc-muted truncate">{projectName || "No project linked yet"}</p>
+            </div>
+          </div>
+        </section>
+
+        <form onSubmit={onSave} className="bg-cc-card border border-cc-border rounded-xl p-4 sm:p-5 space-y-4">
+          <h2 className="text-sm font-semibold text-cc-fg flex items-center gap-2">
+            <DeepgramLogo className="w-4 h-4 text-cc-fg" />
+            <span>Deepgram Credentials</span>
+          </h2>
+          <div>
+            <label className="block text-sm font-medium mb-1.5" htmlFor="deepgram-key">
+              Deepgram API Key
+            </label>
+            <input
+              id="deepgram-key"
+              type="password"
+              value={deepgramApiKey}
+              onChange={(e) => setDeepgramApiKey(e.target.value)}
+              placeholder={configured ? "Configured. Enter a new key to replace." : "Enter your Deepgram API key"}
+              className="w-full px-3 py-2.5 text-sm bg-cc-input-bg border border-cc-border rounded-lg text-cc-fg placeholder:text-cc-muted focus:outline-none focus:border-cc-primary/60"
+            />
+            <p className="mt-1.5 text-xs text-cc-muted">
+              Used to transcribe audio from push-to-talk dictation. Get a key at{" "}
+              <a href="https://console.deepgram.com" target="_blank" rel="noopener noreferrer" className="text-cc-primary hover:underline">
+                console.deepgram.com
+              </a>.
+            </p>
+          </div>
+
+          {error && (
+            <div className="px-3 py-2 rounded-lg bg-cc-error/10 border border-cc-error/20 text-xs text-cc-error">
+              {error}
+            </div>
+          )}
+
+          {connectionNote && (
+            <div className="px-3 py-2 rounded-lg bg-cc-success/10 border border-cc-success/20 text-xs text-cc-success">
+              {connectionNote}
+            </div>
+          )}
+
+          {saved && (
+            <div className="px-3 py-2 rounded-lg bg-cc-success/10 border border-cc-success/20 text-xs text-cc-success">
+              Integration saved.
+            </div>
+          )}
+
+          <div className="flex items-center justify-between gap-3 flex-wrap">
+            <span className="text-xs text-cc-muted">
+              {loading ? "Loading..." : configured ? "Deepgram key configured" : "Deepgram key not configured"}
+            </span>
+            <div className="flex items-center gap-2">
+              <button
+                type="button"
+                onClick={onDisconnect}
+                disabled={saving || loading || !configured}
+                className={`px-3 py-2 rounded-lg text-sm font-medium transition-colors ${
+                  saving || loading || !configured
+                    ? "bg-cc-hover text-cc-muted cursor-not-allowed"
+                    : "bg-cc-error/10 hover:bg-cc-error/20 text-cc-error cursor-pointer"
+                }`}
+              >
+                Disconnect
+              </button>
+              <button
+                type="button"
+                onClick={() => {
+                  refreshConnectionStatus().catch(() => {});
+                }}
+                disabled={checkingConnection || loading || !configured}
+                className={`px-3 py-2 rounded-lg text-sm font-medium transition-colors ${
+                  checkingConnection || loading || !configured
+                    ? "bg-cc-hover text-cc-muted cursor-not-allowed"
+                    : "bg-cc-hover hover:bg-cc-active text-cc-fg cursor-pointer"
+                }`}
+              >
+                {checkingConnection ? "Checking..." : "Verify"}
+              </button>
+              <button
+                type="submit"
+                disabled={saving || loading}
+                className={`px-3 py-2 rounded-lg text-sm font-medium transition-colors ${
+                  saving || loading
+                    ? "bg-cc-hover text-cc-muted cursor-not-allowed"
+                    : "bg-cc-primary hover:bg-cc-primary-hover text-white cursor-pointer"
+                }`}
+              >
+                {saving ? "Saving..." : "Save"}
+              </button>
+            </div>
+          </div>
+        </form>
+
+        <section className="mt-4 grid grid-cols-1 md:grid-cols-3 gap-3">
+          <div className="bg-cc-card border border-cc-border rounded-xl p-4">
+            <p className="text-[11px] uppercase tracking-wide text-cc-muted">1. Configure</p>
+            <p className="mt-1 text-sm text-cc-fg">Add a Deepgram API key and verify the connection.</p>
+          </div>
+          <div className="bg-cc-card border border-cc-border rounded-xl p-4">
+            <p className="text-[11px] uppercase tracking-wide text-cc-muted">2. Hold</p>
+            <p className="mt-1 text-sm text-cc-fg">Hold the microphone button in the Composer to record.</p>
+          </div>
+          <div className="bg-cc-card border border-cc-border rounded-xl p-4">
+            <p className="text-[11px] uppercase tracking-wide text-cc-muted">3. Release</p>
+            <p className="mt-1 text-sm text-cc-fg">Release to transcribe — text appears in the message input.</p>
+          </div>
+        </section>
+      </div>
+    </div>
+  );
+}

--- a/web/src/components/IntegrationsPage.test.tsx
+++ b/web/src/components/IntegrationsPage.test.tsx
@@ -11,12 +11,14 @@ let mockState: MockStoreState;
 const mockApi = {
   getSettings: vi.fn(),
   getLinearConnection: vi.fn(),
+  verifyDeepgramConnection: vi.fn(),
 };
 
 vi.mock("../api.js", () => ({
   api: {
     getSettings: (...args: unknown[]) => mockApi.getSettings(...args),
     getLinearConnection: (...args: unknown[]) => mockApi.getLinearConnection(...args),
+    verifyDeepgramConnection: (...args: unknown[]) => mockApi.verifyDeepgramConnection(...args),
   },
 }));
 
@@ -35,6 +37,7 @@ beforeEach(() => {
     openrouterApiKeyConfigured: false,
     openrouterModel: "openrouter/free",
     linearApiKeyConfigured: true,
+    deepgramApiKeyConfigured: true,
   });
   mockApi.getLinearConnection.mockResolvedValue({
     connected: true,
@@ -42,6 +45,10 @@ beforeEach(() => {
     viewerEmail: "ada@example.com",
     teamName: "Engineering",
     teamKey: "ENG",
+  });
+  mockApi.verifyDeepgramConnection.mockResolvedValue({
+    connected: true,
+    projectName: "My Project",
   });
   window.location.hash = "#/integrations";
 });
@@ -52,8 +59,10 @@ describe("IntegrationsPage", () => {
 
     expect(mockApi.getSettings).toHaveBeenCalledTimes(1);
     await screen.findByText("Linear");
-    await screen.findByLabelText("Connected");
-    expect(screen.getByText("Ada • Engineering")).toBeInTheDocument();
+    // Both Linear and Deepgram cards may show "Connected" dots
+    const dots = await screen.findAllByLabelText("Connected");
+    expect(dots.length).toBeGreaterThanOrEqual(1);
+    expect(screen.getByText("Ada \u2022 Engineering")).toBeInTheDocument();
   });
 
   it("opens dedicated Linear settings page from card", async () => {
@@ -65,5 +74,41 @@ describe("IntegrationsPage", () => {
     await waitFor(() => {
       expect(window.location.hash).toBe("#/integrations/linear");
     });
+  });
+
+  it("shows Deepgram card with live status", async () => {
+    render(<IntegrationsPage />);
+
+    expect(mockApi.getSettings).toHaveBeenCalledTimes(1);
+    await screen.findByText("Deepgram");
+    // Both Linear and Deepgram should show connected dots
+    const connectedDots = await screen.findAllByLabelText("Connected");
+    expect(connectedDots.length).toBe(2);
+    expect(screen.getByText("My Project")).toBeInTheDocument();
+  });
+
+  it("opens dedicated Deepgram settings page from card", async () => {
+    render(<IntegrationsPage />);
+
+    await screen.findByRole("button", { name: "Open Deepgram settings" });
+    fireEvent.click(screen.getByRole("button", { name: "Open Deepgram settings" }));
+
+    await waitFor(() => {
+      expect(window.location.hash).toBe("#/integrations/deepgram");
+    });
+  });
+
+  it("does not call verifyDeepgramConnection when not configured", async () => {
+    mockApi.getSettings.mockResolvedValue({
+      openrouterApiKeyConfigured: false,
+      openrouterModel: "openrouter/free",
+      linearApiKeyConfigured: false,
+      deepgramApiKeyConfigured: false,
+    });
+
+    render(<IntegrationsPage />);
+
+    await screen.findByText("Deepgram");
+    expect(mockApi.verifyDeepgramConnection).not.toHaveBeenCalled();
   });
 });

--- a/web/src/components/IntegrationsPage.tsx
+++ b/web/src/components/IntegrationsPage.tsx
@@ -3,6 +3,7 @@ import { api } from "../api.js";
 import { navigateHome, navigateToSession } from "../utils/routing.js";
 import { useStore } from "../store.js";
 import { LinearLogo } from "./LinearLogo.js";
+import { DeepgramLogo } from "./DeepgramLogo.js";
 
 interface IntegrationsPageProps {
   embedded?: boolean;
@@ -12,6 +13,9 @@ export function IntegrationsPage({ embedded = false }: IntegrationsPageProps) {
   const [linearConfigured, setLinearConfigured] = useState(false);
   const [linearConnected, setLinearConnected] = useState(false);
   const [linearViewerLabel, setLinearViewerLabel] = useState("");
+  const [deepgramConfigured, setDeepgramConfigured] = useState(false);
+  const [deepgramConnected, setDeepgramConnected] = useState(false);
+  const [deepgramProjectName, setDeepgramProjectName] = useState("");
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState("");
 
@@ -19,13 +23,31 @@ export function IntegrationsPage({ embedded = false }: IntegrationsPageProps) {
     api.getSettings()
       .then((settings) => {
         setLinearConfigured(settings.linearApiKeyConfigured);
-        if (!settings.linearApiKeyConfigured) return;
-        return api.getLinearConnection().then((info) => {
-          setLinearConnected(info.connected);
-          const label = info.viewerName || info.viewerEmail || "Connected account";
-          const team = info.teamName ? ` • ${info.teamName}` : "";
-          setLinearViewerLabel(`${label}${team}`);
-        });
+        setDeepgramConfigured(settings.deepgramApiKeyConfigured);
+
+        const promises: Promise<void>[] = [];
+
+        if (settings.linearApiKeyConfigured) {
+          promises.push(
+            api.getLinearConnection().then((info) => {
+              setLinearConnected(info.connected);
+              const label = info.viewerName || info.viewerEmail || "Connected account";
+              const team = info.teamName ? ` \u2022 ${info.teamName}` : "";
+              setLinearViewerLabel(`${label}${team}`);
+            }),
+          );
+        }
+
+        if (settings.deepgramApiKeyConfigured) {
+          promises.push(
+            api.verifyDeepgramConnection().then((info) => {
+              setDeepgramConnected(info.connected);
+              setDeepgramProjectName(info.projectName || "");
+            }),
+          );
+        }
+
+        return Promise.all(promises);
       })
       .catch((e: unknown) => setError(e instanceof Error ? e.message : String(e)))
       .finally(() => setLoading(false));
@@ -36,6 +58,14 @@ export function IntegrationsPage({ embedded = false }: IntegrationsPageProps) {
     : linearConnected
       ? "Connected"
       : linearConfigured
+        ? "Needs verification"
+        : "Not connected";
+
+  const deepgramStatus = loading
+    ? "Checking..."
+    : deepgramConnected
+      ? "Connected"
+      : deepgramConfigured
         ? "Needs verification"
         : "Not connected";
 
@@ -72,6 +102,7 @@ export function IntegrationsPage({ embedded = false }: IntegrationsPageProps) {
           </div>
         )}
 
+        {/* Linear card */}
         <section className="group relative overflow-hidden rounded-3xl border border-cc-border/80 bg-cc-card p-5 pb-16 sm:p-7 sm:pb-7 transition-all duration-300 hover:border-cc-primary/35 hover:shadow-[0_18px_44px_rgba(0,0,0,0.18)]">
           <div className="pointer-events-none absolute inset-0 bg-[radial-gradient(80%_140%_at_100%_0%,rgba(251,146,60,0.18),transparent_52%)]" />
           <div className="pointer-events-none absolute inset-0 opacity-30 bg-[linear-gradient(120deg,transparent_0%,rgba(255,255,255,0.04)_35%,transparent_62%)]" />
@@ -107,6 +138,52 @@ export function IntegrationsPage({ embedded = false }: IntegrationsPageProps) {
               }}
               aria-label="Open Linear settings"
               title="Open Linear settings"
+              className="absolute bottom-0 right-0 sm:bottom-0 sm:right-0 inline-flex h-10 w-10 items-center justify-center rounded-full border border-cc-primary/28 bg-cc-primary/12 text-cc-fg transition-colors hover:border-cc-primary/50 hover:bg-cc-primary/20 focus:outline-none focus:ring-2 focus:ring-cc-primary/35 cursor-pointer"
+            >
+              <svg viewBox="0 0 24 24" className="h-4.5 w-4.5" fill="none" stroke="currentColor" strokeWidth="1.8" aria-hidden="true">
+                <path d="M9.67 4.53 10 2h4l.33 2.53a7.9 7.9 0 0 1 1.7.7l2.03-1.55 2.83 2.83-1.55 2.03c.28.54.51 1.1.7 1.7L22 10v4l-2.53.33a7.9 7.9 0 0 1-.7 1.7l1.55 2.03-2.83 2.83-2.03-1.55c-.54.28-1.1.51-1.7.7L14 22h-4l-.33-2.53a7.9 7.9 0 0 1-1.7-.7l-2.03 1.55-2.83-2.83 1.55-2.03a7.9 7.9 0 0 1-.7-1.7L2 14v-4l2.53-.33c.19-.6.42-1.16.7-1.7L3.68 5.94 6.5 3.1l2.03 1.55c.54-.28 1.1-.51 1.7-.7Z" />
+                <circle cx="12" cy="12" r="3.2" />
+              </svg>
+            </button>
+          </div>
+        </section>
+
+        {/* Deepgram card */}
+        <section className="group relative overflow-hidden rounded-3xl border border-cc-border/80 bg-cc-card p-5 pb-16 sm:p-7 sm:pb-7 mt-6 transition-all duration-300 hover:border-cc-primary/35 hover:shadow-[0_18px_44px_rgba(0,0,0,0.18)]">
+          <div className="pointer-events-none absolute inset-0 bg-[radial-gradient(80%_140%_at_100%_0%,rgba(6,182,212,0.18),transparent_52%)]" />
+          <div className="pointer-events-none absolute inset-0 opacity-30 bg-[linear-gradient(120deg,transparent_0%,rgba(255,255,255,0.04)_35%,transparent_62%)]" />
+          <div className="relative min-w-0">
+            <div className="min-w-0">
+              <div className="inline-flex items-center gap-2 rounded-full border border-cc-border bg-cc-hover/55 px-3 py-1.5 text-xs tracking-wide text-cc-muted">
+                <DeepgramLogo className="h-3.5 w-3.5 text-cc-fg" />
+                <span>Deepgram</span>
+                {deepgramConnected && (
+                  <span
+                    className="inline-block h-1.5 w-1.5 rounded-full bg-cc-success shadow-[0_0_0_3px_rgba(34,197,94,0.15)]"
+                    aria-label="Connected"
+                    title="Connected"
+                  />
+                )}
+              </div>
+              <div className="mt-4 flex flex-wrap items-center gap-2.5">
+                <h2 className="text-[clamp(1.45rem,2.6vw,2rem)] font-semibold leading-[1.12] tracking-tight text-cc-fg">
+                  Push-to-talk dictation
+                </h2>
+              </div>
+              <p className="mt-2 max-w-2xl text-sm leading-relaxed text-cc-muted sm:text-[15px]">
+                Hold the microphone button in the Composer to speak. Audio is transcribed server-side and inserted as text.
+              </p>
+              <div className="mt-4 inline-flex max-w-full items-center rounded-lg border border-cc-border/80 bg-black/10 px-3 py-1.5 text-xs text-cc-muted/95">
+                <span className="truncate">{deepgramProjectName || "No project linked yet"}</span>
+              </div>
+            </div>
+            <button
+              type="button"
+              onClick={() => {
+                window.location.hash = "#/integrations/deepgram";
+              }}
+              aria-label="Open Deepgram settings"
+              title="Open Deepgram settings"
               className="absolute bottom-0 right-0 sm:bottom-0 sm:right-0 inline-flex h-10 w-10 items-center justify-center rounded-full border border-cc-primary/28 bg-cc-primary/12 text-cc-fg transition-colors hover:border-cc-primary/50 hover:bg-cc-primary/20 focus:outline-none focus:ring-2 focus:ring-cc-primary/35 cursor-pointer"
             >
               <svg viewBox="0 0 24 24" className="h-4.5 w-4.5" fill="none" stroke="currentColor" strokeWidth="1.8" aria-hidden="true">

--- a/web/src/components/Playground.tsx
+++ b/web/src/components/Playground.tsx
@@ -1586,6 +1586,61 @@ export function Playground() {
         <Section title="Session Items" description="Sidebar session rows — status dot, backend badge, Docker indicator, archive on hover">
           <PlaygroundSessionItems />
         </Section>
+
+        {/* ─── Push-to-Talk Microphone Button ──────────────────── */}
+        <Section title="Push-to-Talk Microphone" description="Mic button states in the Composer toolbar — idle, recording, transcribing">
+          <div className="space-y-4 max-w-3xl">
+            <Card label="Idle">
+              <div className="flex items-center gap-3">
+                <button
+                  className="flex items-center justify-center w-8 h-8 rounded-md text-cc-muted hover:text-cc-fg hover:bg-cc-hover cursor-pointer transition-colors"
+                  title="Hold to record (Ctrl+Shift+M)"
+                  aria-label="Push-to-talk microphone"
+                >
+                  <svg viewBox="0 0 16 16" fill="none" stroke="currentColor" strokeWidth="1.5" className="w-4 h-4">
+                    <path d="M8 1.5a2 2 0 0 0-2 2v4a2 2 0 0 0 4 0v-4a2 2 0 0 0-2-2z" />
+                    <path d="M12 6.5v1a4 4 0 0 1-8 0v-1" strokeLinecap="round" />
+                    <path d="M8 11.5v2.5M6 14h4" strokeLinecap="round" />
+                  </svg>
+                </button>
+                <span className="text-xs text-cc-muted">Default idle state</span>
+              </div>
+            </Card>
+            <Card label="Recording">
+              <div className="flex items-center gap-3">
+                <button
+                  className="flex items-center justify-center w-8 h-8 rounded-md text-cc-error bg-cc-error/10 animate-pulse cursor-pointer transition-colors"
+                  title="Release to transcribe"
+                  aria-label="Recording - release to transcribe"
+                >
+                  <svg viewBox="0 0 16 16" fill="none" stroke="currentColor" strokeWidth="1.5" className="w-4 h-4">
+                    <path d="M8 1.5a2 2 0 0 0-2 2v4a2 2 0 0 0 4 0v-4a2 2 0 0 0-2-2z" fill="currentColor" />
+                    <path d="M12 6.5v1a4 4 0 0 1-8 0v-1" strokeLinecap="round" />
+                    <path d="M8 11.5v2.5M6 14h4" strokeLinecap="round" />
+                  </svg>
+                </button>
+                <span className="text-xs text-cc-muted">Active recording — pulsing red</span>
+              </div>
+            </Card>
+            <Card label="Transcribing">
+              <div className="flex items-center gap-3">
+                <button
+                  className="flex items-center justify-center w-8 h-8 rounded-md text-cc-muted opacity-50 cursor-wait transition-colors"
+                  title="Transcribing..."
+                  aria-label="Transcribing audio"
+                  disabled
+                >
+                  <svg viewBox="0 0 16 16" fill="none" stroke="currentColor" strokeWidth="1.5" className="w-4 h-4">
+                    <path d="M8 1.5a2 2 0 0 0-2 2v4a2 2 0 0 0 4 0v-4a2 2 0 0 0-2-2z" />
+                    <path d="M12 6.5v1a4 4 0 0 1-8 0v-1" strokeLinecap="round" />
+                    <path d="M8 11.5v2.5M6 14h4" strokeLinecap="round" />
+                  </svg>
+                </button>
+                <span className="text-xs text-cc-muted">Waiting for Deepgram transcription</span>
+              </div>
+            </Card>
+          </div>
+        </Section>
       </div>
     </div>
   );

--- a/web/src/utils/routing.test.ts
+++ b/web/src/utils/routing.test.ts
@@ -32,6 +32,10 @@ describe("parseHash", () => {
     expect(parseHash("#/integrations/linear")).toEqual({ page: "integration-linear" });
   });
 
+  it("parses deepgram integration route", () => {
+    expect(parseHash("#/integrations/deepgram")).toEqual({ page: "integration-deepgram" });
+  });
+
   it("parses terminal route", () => {
     expect(parseHash("#/terminal")).toEqual({ page: "terminal" });
   });

--- a/web/src/utils/routing.ts
+++ b/web/src/utils/routing.ts
@@ -6,6 +6,7 @@ export type Route =
   | { page: "settings" }
   | { page: "integrations" }
   | { page: "integration-linear" }
+  | { page: "integration-deepgram" }
   | { page: "prompts" }
   | { page: "terminal" }
   | { page: "environments" }
@@ -33,6 +34,7 @@ export function parseHash(hash: string): Route {
   if (hash === "#/settings") return { page: "settings" };
   if (hash === "#/integrations") return { page: "integrations" };
   if (hash === "#/integrations/linear") return { page: "integration-linear" };
+  if (hash === "#/integrations/deepgram") return { page: "integration-deepgram" };
   if (hash === "#/prompts") return { page: "prompts" };
   if (hash === "#/terminal") return { page: "terminal" };
   if (hash === "#/environments") return { page: "environments" };

--- a/web/src/utils/use-audio-recorder.test.ts
+++ b/web/src/utils/use-audio-recorder.test.ts
@@ -1,0 +1,814 @@
+// @vitest-environment jsdom
+import { renderHook, act, waitFor } from "@testing-library/react";
+
+/**
+ * Tests for the useAudioRecorder hook which manages browser microphone recording,
+ * MediaRecorder lifecycle, and Deepgram transcription via the api module.
+ *
+ * The hook transitions through these states:
+ *   idle -> requesting -> recording -> (stop) -> transcribing -> idle
+ *                                    -> (cancel) -> idle
+ *                                    -> (error) -> error -> idle (after 3s)
+ *
+ * We mock:
+ *   - navigator.mediaDevices.getUserMedia (returns a mock MediaStream)
+ *   - MediaRecorder (controllable mock that lets us trigger ondataavailable/onstop)
+ *   - api.transcribeAudio (the Deepgram transcription endpoint)
+ *
+ * Important: We use vi.useFakeTimers({ shouldAdvanceTime: true }) so that
+ * waitFor() polling still works (it relies on real setTimeout), while
+ * giving us vi.advanceTimersByTime() for testing the 60s max timeout
+ * and the 3s error-to-idle reset.
+ */
+
+// ---------------------------------------------------------------------------
+// Mock the api module
+// ---------------------------------------------------------------------------
+const mockTranscribeAudio = vi.fn();
+
+vi.mock("../api.js", () => ({
+  api: {
+    transcribeAudio: (...args: unknown[]) => mockTranscribeAudio(...args),
+  },
+}));
+
+import { useAudioRecorder } from "./use-audio-recorder.js";
+
+// ---------------------------------------------------------------------------
+// Mock MediaRecorder
+// ---------------------------------------------------------------------------
+
+// Holds the most recently constructed MockMediaRecorder instance so tests
+// can trigger ondataavailable/onstop on it after startRecording is called.
+let mockRecorderInstance: MockMediaRecorder | null = null;
+
+class MockMediaRecorder {
+  state = "inactive" as string;
+  mimeType: string;
+  ondataavailable: ((e: { data: Blob }) => void) | null = null;
+  onstop: (() => void) | null = null;
+
+  constructor(_stream: MediaStream, opts?: { mimeType?: string }) {
+    this.mimeType = opts?.mimeType ?? "audio/webm";
+    mockRecorderInstance = this;
+  }
+
+  start() {
+    this.state = "recording";
+  }
+
+  stop() {
+    this.state = "inactive";
+    // Simulate the browser firing ondataavailable then onstop synchronously.
+    // Tests can override ondataavailable before calling stop for custom behavior.
+    if (this.ondataavailable) {
+      this.ondataavailable({ data: new Blob(["audio-data"], { type: this.mimeType }) });
+    }
+    if (this.onstop) {
+      this.onstop();
+    }
+  }
+
+  static isTypeSupported = vi.fn().mockReturnValue(true);
+}
+
+// ---------------------------------------------------------------------------
+// Mock MediaStream
+// ---------------------------------------------------------------------------
+
+function createMockStream(): MediaStream & { _mockTrack: { stop: ReturnType<typeof vi.fn> } } {
+  const mockTrack = { stop: vi.fn(), kind: "audio" };
+  return {
+    getTracks: () => [mockTrack],
+    // Keep a reference so tests can assert tracks were stopped
+    _mockTrack: mockTrack,
+  } as unknown as MediaStream & { _mockTrack: { stop: ReturnType<typeof vi.fn> } };
+}
+
+// ---------------------------------------------------------------------------
+// Setup / teardown
+// ---------------------------------------------------------------------------
+
+let mockStream: ReturnType<typeof createMockStream>;
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  // shouldAdvanceTime: true lets waitFor() polling work normally while
+  // still allowing vi.advanceTimersByTime() for explicit timer control
+  vi.useFakeTimers({ shouldAdvanceTime: true });
+  mockRecorderInstance = null;
+
+  mockStream = createMockStream();
+
+  // Install the mock MediaRecorder globally
+  globalThis.MediaRecorder = MockMediaRecorder as unknown as typeof MediaRecorder;
+
+  // Mock getUserMedia to resolve with our mock stream
+  Object.defineProperty(navigator, "mediaDevices", {
+    value: {
+      getUserMedia: vi.fn().mockResolvedValue(mockStream),
+    },
+    writable: true,
+    configurable: true,
+  });
+
+  // Default: transcription succeeds with some text
+  mockTranscribeAudio.mockResolvedValue({ text: "hello world" });
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+// ---------------------------------------------------------------------------
+// Helper: start a recording and wait for state to become "recording"
+// ---------------------------------------------------------------------------
+async function startAndWaitForRecording(
+  result: { current: ReturnType<typeof useAudioRecorder> },
+) {
+  await act(async () => {
+    result.current.startRecording();
+  });
+  // startRecording is async internally (getUserMedia); flush microtask queue
+  await waitFor(() => {
+    expect(result.current.state).toBe("recording");
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("useAudioRecorder", () => {
+  // ─── Initial state ──────────────────────────────────────────────────
+
+  it("returns idle state on initial render", () => {
+    // The hook should start in the "idle" state with callable functions
+    const { result } = renderHook(() =>
+      useAudioRecorder({
+        onTranscript: vi.fn(),
+        onError: vi.fn(),
+      }),
+    );
+
+    expect(result.current.state).toBe("idle");
+    expect(typeof result.current.startRecording).toBe("function");
+    expect(typeof result.current.stopRecording).toBe("function");
+    expect(typeof result.current.cancelRecording).toBe("function");
+  });
+
+  // ─── startRecording: happy path ─────────────────────────────────────
+
+  it("transitions from idle -> requesting -> recording on startRecording", async () => {
+    // Validates the full state transition when microphone access is granted
+    // and MediaRecorder is created and started
+    const { result } = renderHook(() =>
+      useAudioRecorder({
+        onTranscript: vi.fn(),
+        onError: vi.fn(),
+      }),
+    );
+
+    expect(result.current.state).toBe("idle");
+
+    await startAndWaitForRecording(result);
+
+    // getUserMedia should have been called requesting audio
+    expect(navigator.mediaDevices.getUserMedia).toHaveBeenCalledWith({ audio: true });
+
+    // MediaRecorder should have been constructed and started
+    expect(mockRecorderInstance).not.toBeNull();
+    expect(mockRecorderInstance!.state).toBe("recording");
+  });
+
+  it("uses audio/webm;codecs=opus when isTypeSupported returns true", async () => {
+    // The hook checks MediaRecorder.isTypeSupported("audio/webm;codecs=opus")
+    // and uses that preferred MIME type when supported
+    MockMediaRecorder.isTypeSupported.mockReturnValue(true);
+
+    const { result } = renderHook(() =>
+      useAudioRecorder({ onTranscript: vi.fn(), onError: vi.fn() }),
+    );
+
+    await startAndWaitForRecording(result);
+
+    expect(mockRecorderInstance!.mimeType).toBe("audio/webm;codecs=opus");
+  });
+
+  it("falls back to audio/webm when isTypeSupported returns false", async () => {
+    // When the opus codec isn't supported, it should fall back to plain audio/webm
+    MockMediaRecorder.isTypeSupported.mockReturnValue(false);
+
+    const { result } = renderHook(() =>
+      useAudioRecorder({ onTranscript: vi.fn(), onError: vi.fn() }),
+    );
+
+    await startAndWaitForRecording(result);
+
+    expect(mockRecorderInstance!.mimeType).toBe("audio/webm");
+  });
+
+  // ─── stopRecording: successful transcription ────────────────────────
+
+  it("transitions recording -> transcribing -> idle on successful transcription", async () => {
+    // Full flow: start recording, stop, verify transcription is called,
+    // onTranscript receives the text, and state returns to idle
+    const onTranscript = vi.fn();
+    const onError = vi.fn();
+    mockTranscribeAudio.mockResolvedValue({ text: "transcribed text" });
+
+    const { result } = renderHook(() =>
+      useAudioRecorder({ onTranscript, onError }),
+    );
+
+    await startAndWaitForRecording(result);
+
+    // Stop the recording — this triggers onstop which calls transcribeAudio
+    await act(async () => {
+      result.current.stopRecording();
+    });
+
+    // Wait for the async transcription to complete
+    await waitFor(() => {
+      expect(result.current.state).toBe("idle");
+    });
+
+    // transcribeAudio should have been called with a Blob
+    expect(mockTranscribeAudio).toHaveBeenCalledTimes(1);
+    const callArgs = mockTranscribeAudio.mock.calls[0];
+    expect(callArgs[0]).toBeInstanceOf(Blob);
+
+    // onTranscript should have been called with the transcribed text
+    expect(onTranscript).toHaveBeenCalledWith("transcribed text");
+    expect(onError).not.toHaveBeenCalled();
+  });
+
+  it("passes keywords to api.transcribeAudio", async () => {
+    // When the hook is initialized with keywords, those should be forwarded
+    // to the transcription API call
+    const onTranscript = vi.fn();
+    mockTranscribeAudio.mockResolvedValue({ text: "result" });
+
+    const { result } = renderHook(() =>
+      useAudioRecorder({
+        onTranscript,
+        onError: vi.fn(),
+        keywords: "Claude,Anthropic",
+      }),
+    );
+
+    await startAndWaitForRecording(result);
+
+    await act(async () => {
+      result.current.stopRecording();
+    });
+
+    await waitFor(() => {
+      expect(result.current.state).toBe("idle");
+    });
+
+    expect(mockTranscribeAudio).toHaveBeenCalledWith(
+      expect.any(Blob),
+      "Claude,Anthropic",
+    );
+  });
+
+  it("does not call onTranscript when transcription returns empty/whitespace text", async () => {
+    // If the transcription result is empty or only whitespace, onTranscript
+    // should not be called, but the state should still return to idle
+    const onTranscript = vi.fn();
+    mockTranscribeAudio.mockResolvedValue({ text: "   " });
+
+    const { result } = renderHook(() =>
+      useAudioRecorder({ onTranscript, onError: vi.fn() }),
+    );
+
+    await startAndWaitForRecording(result);
+
+    await act(async () => {
+      result.current.stopRecording();
+    });
+
+    await waitFor(() => {
+      expect(result.current.state).toBe("idle");
+    });
+
+    // transcribeAudio was called, but onTranscript was NOT called because text was whitespace
+    expect(mockTranscribeAudio).toHaveBeenCalledTimes(1);
+    expect(onTranscript).not.toHaveBeenCalled();
+  });
+
+  // ─── stopRecording: transcription error ─────────────────────────────
+
+  it("calls onError and transitions to error state when transcription fails", async () => {
+    // When api.transcribeAudio rejects, onError should be called with the
+    // error message, state should go to "error", then auto-reset to "idle"
+    // after 3 seconds
+    const onError = vi.fn();
+    mockTranscribeAudio.mockRejectedValue(new Error("Transcription failed"));
+
+    const { result } = renderHook(() =>
+      useAudioRecorder({ onTranscript: vi.fn(), onError }),
+    );
+
+    await startAndWaitForRecording(result);
+
+    await act(async () => {
+      result.current.stopRecording();
+    });
+
+    await waitFor(() => {
+      expect(result.current.state).toBe("error");
+    });
+
+    expect(onError).toHaveBeenCalledWith("Transcription failed");
+
+    // After 3 seconds, state should auto-reset to idle
+    await act(async () => {
+      vi.advanceTimersByTime(3000);
+    });
+
+    expect(result.current.state).toBe("idle");
+  });
+
+  it("handles non-Error transcription failures by converting to string", async () => {
+    // When the transcription promise rejects with a non-Error value (e.g. a string),
+    // the hook should convert it to a string via String()
+    const onError = vi.fn();
+    mockTranscribeAudio.mockRejectedValue("string error");
+
+    const { result } = renderHook(() =>
+      useAudioRecorder({ onTranscript: vi.fn(), onError }),
+    );
+
+    await startAndWaitForRecording(result);
+
+    await act(async () => {
+      result.current.stopRecording();
+    });
+
+    await waitFor(() => {
+      expect(result.current.state).toBe("error");
+    });
+
+    expect(onError).toHaveBeenCalledWith("string error");
+  });
+
+  // ─── Empty blob (no audio data) ────────────────────────────────────
+
+  it("returns to idle without transcribing when blob is empty", async () => {
+    // If the MediaRecorder produces no data (blob.size === 0), the hook
+    // should skip transcription and go directly back to idle
+    const onTranscript = vi.fn();
+
+    const { result } = renderHook(() =>
+      useAudioRecorder({ onTranscript, onError: vi.fn() }),
+    );
+
+    await startAndWaitForRecording(result);
+
+    // Override the stop behavior to produce an empty blob (no ondataavailable call).
+    // When no chunks are collected, new Blob([], ...) produces a zero-size blob.
+    const recorder = mockRecorderInstance!;
+    const originalOnstop = recorder.onstop;
+    recorder.stop = function (this: MockMediaRecorder) {
+      this.state = "inactive";
+      // Do NOT call ondataavailable — simulates no audio data captured.
+      // Call onstop directly to trigger the transcription path.
+      if (originalOnstop) {
+        originalOnstop();
+      }
+    };
+
+    await act(async () => {
+      result.current.stopRecording();
+    });
+
+    await waitFor(() => {
+      expect(result.current.state).toBe("idle");
+    });
+
+    // transcribeAudio should NOT have been called since blob was empty
+    expect(mockTranscribeAudio).not.toHaveBeenCalled();
+    expect(onTranscript).not.toHaveBeenCalled();
+  });
+
+  // ─── cancelRecording ───────────────────────────────────────────────
+
+  it("cancels recording without transcribing and returns to idle", async () => {
+    // cancelRecording should nullify onstop (preventing transcription),
+    // stop the recorder, clean up streams, and set state to idle
+    const onTranscript = vi.fn();
+
+    const { result } = renderHook(() =>
+      useAudioRecorder({ onTranscript, onError: vi.fn() }),
+    );
+
+    await startAndWaitForRecording(result);
+
+    act(() => {
+      result.current.cancelRecording();
+    });
+
+    expect(result.current.state).toBe("idle");
+
+    // Transcription should never have been called
+    expect(mockTranscribeAudio).not.toHaveBeenCalled();
+    expect(onTranscript).not.toHaveBeenCalled();
+  });
+
+  // ─── getUserMedia errors ───────────────────────────────────────────
+
+  it("handles NotAllowedError with 'Microphone permission denied' message", async () => {
+    // When the user denies microphone permission, the hook should report
+    // a user-friendly error message
+    const onError = vi.fn();
+    const permissionError = new DOMException("Permission denied", "NotAllowedError");
+    (navigator.mediaDevices.getUserMedia as ReturnType<typeof vi.fn>).mockRejectedValue(
+      permissionError,
+    );
+
+    const { result } = renderHook(() =>
+      useAudioRecorder({ onTranscript: vi.fn(), onError }),
+    );
+
+    await act(async () => {
+      result.current.startRecording();
+    });
+
+    await waitFor(() => {
+      expect(result.current.state).toBe("error");
+    });
+
+    expect(onError).toHaveBeenCalledWith("Microphone permission denied");
+
+    // After 3 seconds, state should auto-reset to idle
+    await act(async () => {
+      vi.advanceTimersByTime(3000);
+    });
+
+    expect(result.current.state).toBe("idle");
+  });
+
+  it("handles NotFoundError with 'No microphone found' message", async () => {
+    // When no audio input device is available, the hook should report
+    // a user-friendly error
+    const onError = vi.fn();
+    const notFoundError = new DOMException("No devices found", "NotFoundError");
+    (navigator.mediaDevices.getUserMedia as ReturnType<typeof vi.fn>).mockRejectedValue(
+      notFoundError,
+    );
+
+    const { result } = renderHook(() =>
+      useAudioRecorder({ onTranscript: vi.fn(), onError }),
+    );
+
+    await act(async () => {
+      result.current.startRecording();
+    });
+
+    await waitFor(() => {
+      expect(result.current.state).toBe("error");
+    });
+
+    expect(onError).toHaveBeenCalledWith("No microphone found");
+  });
+
+  it("handles generic getUserMedia errors with the error message", async () => {
+    // For unexpected errors from getUserMedia (not NotAllowed/NotFound),
+    // the hook should pass through the error message directly
+    const onError = vi.fn();
+    (navigator.mediaDevices.getUserMedia as ReturnType<typeof vi.fn>).mockRejectedValue(
+      new Error("Something went wrong"),
+    );
+
+    const { result } = renderHook(() =>
+      useAudioRecorder({ onTranscript: vi.fn(), onError }),
+    );
+
+    await act(async () => {
+      result.current.startRecording();
+    });
+
+    await waitFor(() => {
+      expect(result.current.state).toBe("error");
+    });
+
+    expect(onError).toHaveBeenCalledWith("Something went wrong");
+  });
+
+  it("handles non-Error getUserMedia rejections by converting to string", async () => {
+    // If getUserMedia rejects with a non-Error (unlikely but defensive),
+    // the hook should convert it with String()
+    const onError = vi.fn();
+    (navigator.mediaDevices.getUserMedia as ReturnType<typeof vi.fn>).mockRejectedValue(
+      42,
+    );
+
+    const { result } = renderHook(() =>
+      useAudioRecorder({ onTranscript: vi.fn(), onError }),
+    );
+
+    await act(async () => {
+      result.current.startRecording();
+    });
+
+    await waitFor(() => {
+      expect(result.current.state).toBe("error");
+    });
+
+    expect(onError).toHaveBeenCalledWith("42");
+  });
+
+  // ─── Guards against double-start ───────────────────────────────────
+
+  it("does not start when already in recording state", async () => {
+    // Calling startRecording while already recording should be a no-op
+    const { result } = renderHook(() =>
+      useAudioRecorder({ onTranscript: vi.fn(), onError: vi.fn() }),
+    );
+
+    await startAndWaitForRecording(result);
+
+    // Reset the mock to track new calls
+    (navigator.mediaDevices.getUserMedia as ReturnType<typeof vi.fn>).mockClear();
+
+    await act(async () => {
+      result.current.startRecording();
+    });
+
+    // getUserMedia should NOT have been called a second time
+    expect(navigator.mediaDevices.getUserMedia).not.toHaveBeenCalled();
+    expect(result.current.state).toBe("recording");
+  });
+
+  it("does not start when in transcribing state", async () => {
+    // While audio is being transcribed, startRecording should be a no-op.
+    // We achieve the "transcribing" state by stopping the recorder with a
+    // transcribeAudio that never resolves during the test.
+    let resolveTranscription!: (val: { text: string }) => void;
+    mockTranscribeAudio.mockReturnValue(
+      new Promise((resolve) => {
+        resolveTranscription = resolve;
+      }),
+    );
+
+    const { result } = renderHook(() =>
+      useAudioRecorder({ onTranscript: vi.fn(), onError: vi.fn() }),
+    );
+
+    await startAndWaitForRecording(result);
+
+    // Stop recording to trigger onstop -> transcribing state
+    await act(async () => {
+      result.current.stopRecording();
+    });
+
+    await waitFor(() => {
+      expect(result.current.state).toBe("transcribing");
+    });
+
+    // Now try to start again — should be a no-op
+    (navigator.mediaDevices.getUserMedia as ReturnType<typeof vi.fn>).mockClear();
+
+    await act(async () => {
+      result.current.startRecording();
+    });
+
+    expect(navigator.mediaDevices.getUserMedia).not.toHaveBeenCalled();
+    expect(result.current.state).toBe("transcribing");
+
+    // Clean up by resolving the pending transcription
+    await act(async () => {
+      resolveTranscription({ text: "" });
+    });
+  });
+
+  // ─── stopRecording when not recording ──────────────────────────────
+
+  it("stopRecording is a no-op when not recording", () => {
+    // Calling stopRecording when idle should not throw or cause errors
+    const { result } = renderHook(() =>
+      useAudioRecorder({ onTranscript: vi.fn(), onError: vi.fn() }),
+    );
+
+    // Should not throw
+    act(() => {
+      result.current.stopRecording();
+    });
+
+    expect(result.current.state).toBe("idle");
+  });
+
+  // ─── cancelRecording when not recording ────────────────────────────
+
+  it("cancelRecording from idle is a safe no-op", () => {
+    // Calling cancelRecording when there's nothing to cancel should just
+    // ensure state remains idle without errors
+    const { result } = renderHook(() =>
+      useAudioRecorder({ onTranscript: vi.fn(), onError: vi.fn() }),
+    );
+
+    act(() => {
+      result.current.cancelRecording();
+    });
+
+    expect(result.current.state).toBe("idle");
+  });
+
+  // ─── Max recording duration auto-stop ──────────────────────────────
+
+  it("auto-stops recording after MAX_RECORDING_MS (60s)", async () => {
+    // The hook sets a 60-second timeout that auto-stops the MediaRecorder.
+    // We verify that advancing timers past 60s triggers recorder.stop().
+    const onTranscript = vi.fn();
+    mockTranscribeAudio.mockResolvedValue({ text: "auto-stopped" });
+
+    const { result } = renderHook(() =>
+      useAudioRecorder({ onTranscript, onError: vi.fn() }),
+    );
+
+    await startAndWaitForRecording(result);
+
+    // Advance time past the 60-second max duration
+    await act(async () => {
+      vi.advanceTimersByTime(60_000);
+    });
+
+    // The recorder should have been stopped and transcription should proceed
+    await waitFor(() => {
+      expect(result.current.state).toBe("idle");
+    });
+
+    expect(onTranscript).toHaveBeenCalledWith("auto-stopped");
+  });
+
+  // ─── Cleanup on unmount ────────────────────────────────────────────
+
+  it("stops recording and cleans up on unmount", async () => {
+    // When the component unmounts while recording, the hook should stop
+    // the MediaRecorder (with onstop nullified to prevent transcription)
+    // and release the media stream
+    const { result, unmount } = renderHook(() =>
+      useAudioRecorder({ onTranscript: vi.fn(), onError: vi.fn() }),
+    );
+
+    await startAndWaitForRecording(result);
+
+    const recorder = mockRecorderInstance!;
+    // Spy on the actual stop method
+    const stopSpy = vi.spyOn(recorder, "stop");
+
+    unmount();
+
+    // The recorder's stop should have been called during cleanup
+    expect(stopSpy).toHaveBeenCalled();
+
+    // The onstop handler should have been nullified before stopping
+    // (to prevent transcription during unmount)
+    expect(recorder.onstop).toBeNull();
+  });
+
+  it("cleans up stream tracks on unmount", async () => {
+    // Verify that the media stream tracks are stopped when the hook unmounts
+    const { result, unmount } = renderHook(() =>
+      useAudioRecorder({ onTranscript: vi.fn(), onError: vi.fn() }),
+    );
+
+    await startAndWaitForRecording(result);
+
+    unmount();
+
+    // Stream tracks should have been stopped during cleanup
+    expect(mockStream._mockTrack.stop).toHaveBeenCalled();
+  });
+
+  // ─── Callback ref updates ──────────────────────────────────────────
+
+  it("uses the latest onTranscript callback even if it changes between start and stop", async () => {
+    // The hook stores callbacks in refs so the onstop closure always uses
+    // the most current version. This test verifies that behavior.
+    const onTranscript1 = vi.fn();
+    const onTranscript2 = vi.fn();
+    mockTranscribeAudio.mockResolvedValue({ text: "result" });
+
+    const { result, rerender } = renderHook(
+      (props: { onTranscript: (text: string) => void }) =>
+        useAudioRecorder({
+          onTranscript: props.onTranscript,
+          onError: vi.fn(),
+        }),
+      { initialProps: { onTranscript: onTranscript1 } },
+    );
+
+    await startAndWaitForRecording(result);
+
+    // Change the onTranscript callback mid-recording
+    rerender({ onTranscript: onTranscript2 });
+
+    await act(async () => {
+      result.current.stopRecording();
+    });
+
+    await waitFor(() => {
+      expect(result.current.state).toBe("idle");
+    });
+
+    // The NEW callback (onTranscript2) should have been called, not the original
+    expect(onTranscript1).not.toHaveBeenCalled();
+    expect(onTranscript2).toHaveBeenCalledWith("result");
+  });
+
+  it("uses the latest onError callback even if it changes", async () => {
+    // Same ref-update pattern for onError
+    const onError1 = vi.fn();
+    const onError2 = vi.fn();
+    mockTranscribeAudio.mockRejectedValue(new Error("fail"));
+
+    const { result, rerender } = renderHook(
+      (props: { onError: (err: string) => void }) =>
+        useAudioRecorder({
+          onTranscript: vi.fn(),
+          onError: props.onError,
+        }),
+      { initialProps: { onError: onError1 } },
+    );
+
+    await startAndWaitForRecording(result);
+
+    // Change the onError callback mid-recording
+    rerender({ onError: onError2 });
+
+    await act(async () => {
+      result.current.stopRecording();
+    });
+
+    await waitFor(() => {
+      expect(result.current.state).toBe("error");
+    });
+
+    // The NEW callback should have been invoked
+    expect(onError1).not.toHaveBeenCalled();
+    expect(onError2).toHaveBeenCalledWith("fail");
+  });
+
+  it("uses the latest keywords ref value at transcription time", async () => {
+    // If keywords change between starting and stopping, the latest value
+    // should be passed to api.transcribeAudio
+    mockTranscribeAudio.mockResolvedValue({ text: "result" });
+
+    const { result, rerender } = renderHook(
+      (props: { keywords?: string }) =>
+        useAudioRecorder({
+          onTranscript: vi.fn(),
+          onError: vi.fn(),
+          keywords: props.keywords,
+        }),
+      { initialProps: { keywords: "initial" } },
+    );
+
+    await startAndWaitForRecording(result);
+
+    // Update keywords mid-recording
+    rerender({ keywords: "updated-keywords" });
+
+    await act(async () => {
+      result.current.stopRecording();
+    });
+
+    await waitFor(() => {
+      expect(result.current.state).toBe("idle");
+    });
+
+    // The updated keywords should have been used
+    expect(mockTranscribeAudio).toHaveBeenCalledWith(
+      expect.any(Blob),
+      "updated-keywords",
+    );
+  });
+
+  // ─── Stream track cleanup in onstop ─────────────────────────────────
+
+  it("stops media stream tracks in the onstop handler", async () => {
+    // When recording stops normally (not cancel), the onstop handler should
+    // stop all tracks on the original media stream
+    mockTranscribeAudio.mockResolvedValue({ text: "done" });
+
+    const { result } = renderHook(() =>
+      useAudioRecorder({ onTranscript: vi.fn(), onError: vi.fn() }),
+    );
+
+    await startAndWaitForRecording(result);
+
+    await act(async () => {
+      result.current.stopRecording();
+    });
+
+    await waitFor(() => {
+      expect(result.current.state).toBe("idle");
+    });
+
+    // Track stop should have been called in the onstop handler
+    expect(mockStream._mockTrack.stop).toHaveBeenCalled();
+  });
+});

--- a/web/src/utils/use-audio-recorder.ts
+++ b/web/src/utils/use-audio-recorder.ts
@@ -1,0 +1,143 @@
+import { useState, useRef, useCallback, useEffect } from "react";
+import { api } from "../api.js";
+
+export type RecordingState = "idle" | "requesting" | "recording" | "transcribing" | "error";
+
+const MAX_RECORDING_MS = 60_000;
+
+interface UseAudioRecorderOptions {
+  onTranscript: (text: string) => void;
+  onError: (error: string) => void;
+  keywords?: string;
+}
+
+export function useAudioRecorder({ onTranscript, onError, keywords }: UseAudioRecorderOptions) {
+  const [state, setState] = useState<RecordingState>("idle");
+  const mediaRecorderRef = useRef<MediaRecorder | null>(null);
+  const chunksRef = useRef<Blob[]>([]);
+  const streamRef = useRef<MediaStream | null>(null);
+  const maxTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  // Store latest callbacks in refs so the MediaRecorder.onstop closure always sees the current version
+  const onTranscriptRef = useRef(onTranscript);
+  onTranscriptRef.current = onTranscript;
+  const onErrorRef = useRef(onError);
+  onErrorRef.current = onError;
+  const keywordsRef = useRef(keywords);
+  keywordsRef.current = keywords;
+
+  const cleanup = useCallback(() => {
+    if (maxTimerRef.current) {
+      clearTimeout(maxTimerRef.current);
+      maxTimerRef.current = null;
+    }
+    if (streamRef.current) {
+      streamRef.current.getTracks().forEach((t) => t.stop());
+      streamRef.current = null;
+    }
+    mediaRecorderRef.current = null;
+    chunksRef.current = [];
+  }, []);
+
+  // Cleanup on unmount
+  useEffect(() => {
+    return () => {
+      if (mediaRecorderRef.current?.state === "recording") {
+        mediaRecorderRef.current.onstop = null;
+        mediaRecorderRef.current.stop();
+      }
+      cleanup();
+    };
+  }, [cleanup]);
+
+  const startRecording = useCallback(async () => {
+    if (state === "recording" || state === "requesting" || state === "transcribing") return;
+    setState("requesting");
+    try {
+      const stream = await navigator.mediaDevices.getUserMedia({ audio: true });
+      streamRef.current = stream;
+
+      const mimeType = typeof MediaRecorder !== "undefined" && MediaRecorder.isTypeSupported?.("audio/webm;codecs=opus")
+        ? "audio/webm;codecs=opus"
+        : "audio/webm";
+
+      const recorder = new MediaRecorder(stream, { mimeType });
+      chunksRef.current = [];
+
+      recorder.ondataavailable = (e) => {
+        if (e.data.size > 0) chunksRef.current.push(e.data);
+      };
+
+      recorder.onstop = async () => {
+        // Stop all mic tracks
+        stream.getTracks().forEach((t) => t.stop());
+        streamRef.current = null;
+        if (maxTimerRef.current) {
+          clearTimeout(maxTimerRef.current);
+          maxTimerRef.current = null;
+        }
+
+        const blob = new Blob(chunksRef.current, { type: recorder.mimeType });
+        chunksRef.current = [];
+        if (blob.size === 0) {
+          setState("idle");
+          return;
+        }
+
+        setState("transcribing");
+        try {
+          const result = await api.transcribeAudio(blob, keywordsRef.current);
+          if (result.text.trim()) {
+            onTranscriptRef.current(result.text);
+          }
+          setState("idle");
+        } catch (err) {
+          onErrorRef.current(err instanceof Error ? err.message : String(err));
+          setState("error");
+          setTimeout(() => setState("idle"), 3000);
+        }
+      };
+
+      mediaRecorderRef.current = recorder;
+      recorder.start();
+      setState("recording");
+
+      // Auto-stop after max duration
+      maxTimerRef.current = setTimeout(() => {
+        if (mediaRecorderRef.current?.state === "recording") {
+          mediaRecorderRef.current.stop();
+        }
+      }, MAX_RECORDING_MS);
+    } catch (err) {
+      cleanup();
+      if (err instanceof DOMException && err.name === "NotAllowedError") {
+        onErrorRef.current("Microphone permission denied");
+      } else if (err instanceof DOMException && err.name === "NotFoundError") {
+        onErrorRef.current("No microphone found");
+      } else {
+        onErrorRef.current(err instanceof Error ? err.message : String(err));
+      }
+      setState("error");
+      setTimeout(() => setState("idle"), 3000);
+    }
+  }, [state, cleanup]);
+
+  const stopRecording = useCallback(() => {
+    if (mediaRecorderRef.current?.state === "recording") {
+      mediaRecorderRef.current.stop();
+    }
+  }, []);
+
+  const cancelRecording = useCallback(() => {
+    if (mediaRecorderRef.current) {
+      mediaRecorderRef.current.onstop = null;
+      if (mediaRecorderRef.current.state === "recording") {
+        mediaRecorderRef.current.stop();
+      }
+    }
+    cleanup();
+    setState("idle");
+  }, [cleanup]);
+
+  return { state, startRecording, stopRecording, cancelRecording };
+}


### PR DESCRIPTION
## Summary
- Add push-to-talk speech-to-text dictation to the Composer using Deepgram
- Server-side transcription proxy ensures the API key never reaches the browser
- Full settings page (save/verify/disconnect) following the existing Linear integration pattern
- Mic button in both mobile and desktop Composer toolbars with hold-to-record and Ctrl+Shift+M keyboard shortcut

## What's New

### Backend
- `deepgramApiKey` added to settings persistence (only exposes `deepgramApiKeyConfigured` boolean)
- `POST /deepgram/transcribe` — accepts audio via FormData, proxies to Deepgram nova-3 model, supports keyword boosting
- `POST /deepgram/verify` — validates API key via Deepgram `/v1/projects` endpoint

### Frontend
- **DeepgramSettingsPage** — configure, verify, and disconnect Deepgram API key
- **IntegrationsPage** — Deepgram card with live connection status (teal gradient)
- **Composer** — mic button with visual states (idle/recording/transcribing), 60s auto-stop
- **useAudioRecorder hook** — encapsulates MediaRecorder (WebM/Opus), permission handling, cleanup
- **Playground** — mic button state demos

### Tests
- Server route tests (no key, no audio, success, errors, keyword passthrough, verify flows)
- DeepgramSettingsPage tests (load, save, verify, disconnect)
- IntegrationsPage tests updated for Deepgram card
- Composer tests updated for new `getSettings` dependency

## Test plan
- [x] `bun run typecheck` passes
- [x] `bun run test` passes (113 files, 2906 tests)
- [ ] Manual: save Deepgram API key at `#/integrations/deepgram`, verify shows "Connected" with project name
- [ ] Manual: hold mic button in Composer, speak, release — transcribed text appears in textarea
- [ ] Manual: confirm no API key appears in browser DevTools Network tab

## Review provenance
- Implemented by AI agent (Claude Opus 4.6)
- Human review: pending

Closes THE-194
