### PR TITLE
feat(web): add voice input with microphone button and Ctrl+Shift+M shortcut

### DIFF
--- a/web/src/components/Composer.test.tsx
+++ b/web/src/components/Composer.test.tsx
@@ -41,6 +41,19 @@ vi.mock("../store.js", () => {
   return { useStore };
 });
 
+const mockSpeechToggle = vi.fn();
+const mockSpeechStop = vi.fn();
+vi.mock("../utils/use-speech-to-text.js", () => ({
+  useSpeechToText: () => ({
+    isListening: false,
+    isSupported: true,
+    interimText: "",
+    startListening: vi.fn(),
+    stopListening: mockSpeechStop,
+    toggleListening: mockSpeechToggle,
+  }),
+}));
+
 import { Composer } from "./Composer.js";
 
 function makeSession(overrides: Partial<SessionState> = {}): SessionState {
@@ -571,5 +584,22 @@ describe("Composer save prompt", () => {
     const { container } = render(<Composer sessionId="s1" />);
     const results = await axe(container);
     expect(results).toHaveNoViolations();
+  });
+
+  describe("voice input", () => {
+    it("renders microphone button when connected", () => {
+      setupMockStore({ isConnected: true });
+      render(<Composer sessionId="s1" />);
+      // MicButton renders on both mobile and desktop toolbars
+      const buttons = screen.getAllByRole("button", { name: /toggle voice input/i });
+      expect(buttons.length).toBeGreaterThan(0);
+    });
+
+    it("microphone button has keyboard shortcut in title", () => {
+      setupMockStore({ isConnected: true });
+      render(<Composer sessionId="s1" />);
+      const buttons = screen.getAllByRole("button", { name: /toggle voice input/i });
+      expect(buttons[0].getAttribute("title")).toBe("Voice input (Ctrl+Shift+M)");
+    });
   });
 });

--- a/web/src/components/Composer.tsx
+++ b/web/src/components/Composer.tsx
@@ -7,6 +7,8 @@ import type { ModeOption } from "../utils/backends.js";
 import { ModelSwitcher } from "./ModelSwitcher.js";
 import { MentionMenu } from "./MentionMenu.js";
 import { useMentionMenu } from "../utils/use-mention-menu.js";
+import { useSpeechToText } from "../utils/use-speech-to-text.js";
+import { MicButton } from "./MicButton.js";
 
 import { readFileAsBase64, type ImageAttachment } from "../utils/image.js";
 
@@ -46,6 +48,19 @@ export function Composer({ sessionId }: { sessionId: string }) {
     caretPos,
     cwd: sessionData?.cwd,
     enabled: !slashMenuOpen,
+  });
+
+  const speech = useSpeechToText({
+    onTranscript: useCallback((transcript: string) => {
+      setText((prev) => {
+        const separator = prev.length > 0 && !prev.endsWith(" ") ? " " : "";
+        return prev + separator + transcript;
+      });
+      if (textareaRef.current) {
+        textareaRef.current.style.height = "auto";
+        textareaRef.current.style.height = Math.min(textareaRef.current.scrollHeight, 200) + "px";
+      }
+    }, []),
   });
 
   // Build command list from session data
@@ -153,6 +168,7 @@ export function Composer({ sessionId }: { sessionId: string }) {
     setImages([]);
     setSlashMenuOpen(false);
     mention.setMentionMenuOpen(false);
+    if (speech.isListening) speech.stopListening();
 
     if (textareaRef.current) {
       textareaRef.current.style.height = "auto";
@@ -225,6 +241,11 @@ export function Composer({ sessionId }: { sessionId: string }) {
       return;
     }
 
+    if ((e.ctrlKey || e.metaKey) && e.shiftKey && e.key.toLowerCase() === "m") {
+      e.preventDefault();
+      speech.toggleListening();
+      return;
+    }
     if (e.key === "Tab" && e.shiftKey) {
       e.preventDefault();
       toggleMode();
@@ -492,6 +513,13 @@ export function Composer({ sessionId }: { sessionId: string }) {
 
             <div className="flex-1" />
 
+            <MicButton
+              isListening={speech.isListening}
+              isSupported={speech.isSupported}
+              onClick={speech.toggleListening}
+              disabled={!isConnected}
+            />
+
             <button
               onClick={() => {
                 const defaultName = text.trim().slice(0, 32);
@@ -551,6 +579,14 @@ export function Composer({ sessionId }: { sessionId: string }) {
             />
           </div>
 
+          {/* Voice input indicator */}
+          {speech.isListening && (
+            <div className="px-4 pb-1 text-xs text-cc-muted flex items-center gap-1.5">
+              <span className="w-1.5 h-1.5 rounded-full bg-cc-error animate-pulse" />
+              <span>Listening{speech.interimText ? `: "${speech.interimText}"` : "..."}</span>
+            </div>
+          )}
+
           {/* Mobile action row (hidden on sm+) */}
           <div className="flex items-center justify-end gap-1 px-3 pb-1 sm:hidden">
             {/* Send/stop */}
@@ -599,6 +635,14 @@ export function Composer({ sessionId }: { sessionId: string }) {
                 <path d="M8 3v10M3 8h10" strokeLinecap="round" />
               </svg>
             </button>
+
+            {/* Voice input */}
+            <MicButton
+              isListening={speech.isListening}
+              isSupported={speech.isSupported}
+              onClick={speech.toggleListening}
+              disabled={!isConnected}
+            />
 
             {/* Save prompt (bookmark) */}
             <button

--- a/web/src/components/HomePage.test.tsx
+++ b/web/src/components/HomePage.test.tsx
@@ -77,6 +77,18 @@ vi.mock("../utils/routing.js", () => ({
   navigateToSession: vi.fn(),
 }));
 
+const mockSpeechToggle = vi.fn();
+vi.mock("../utils/use-speech-to-text.js", () => ({
+  useSpeechToText: () => ({
+    isListening: false,
+    isSupported: true,
+    interimText: "",
+    startListening: vi.fn(),
+    stopListening: vi.fn(),
+    toggleListening: mockSpeechToggle,
+  }),
+}));
+
 import { HomePage } from "./HomePage.js";
 
 /** Helper to build a default store mock with overridable fields. */
@@ -1292,6 +1304,23 @@ describe("HomePage", () => {
 
       // Should replace @rev with the prompt content, keeping the prefix
       expect(textarea.value).toBe("Please Please review this code ");
+    });
+  });
+
+  describe("voice input", () => {
+    it("renders microphone button on home page", async () => {
+      render(<HomePage />);
+      await waitFor(() => {
+        expect(screen.getByRole("button", { name: /toggle voice input/i })).toBeInTheDocument();
+      });
+    });
+
+    it("microphone button has keyboard shortcut in title", async () => {
+      render(<HomePage />);
+      await waitFor(() => {
+        const btn = screen.getByRole("button", { name: /toggle voice input/i });
+        expect(btn).toHaveAttribute("title", "Voice input (Ctrl+Shift+M)");
+      });
     });
   });
 });

--- a/web/src/components/HomePage.tsx
+++ b/web/src/components/HomePage.tsx
@@ -25,6 +25,8 @@ import { LinearSection } from "./home/LinearSection.js";
 import { BranchPicker } from "./home/BranchPicker.js";
 import { MentionMenu } from "./MentionMenu.js";
 import { useMentionMenu } from "../utils/use-mention-menu.js";
+import { useSpeechToText } from "../utils/use-speech-to-text.js";
+import { MicButton } from "./MicButton.js";
 import type { SavedPrompt } from "../api.js";
 import type { SdkSessionInfo } from "../types.js";
 
@@ -167,6 +169,19 @@ export function HomePage() {
     text,
     caretPos,
     cwd: cwd || undefined,
+  });
+
+  const speech = useSpeechToText({
+    onTranscript: useCallback((transcript: string) => {
+      setText((prev) => {
+        const separator = prev.length > 0 && !prev.endsWith(" ") ? " " : "";
+        return prev + separator + transcript;
+      });
+      if (textareaRef.current) {
+        textareaRef.current.style.height = "auto";
+        textareaRef.current.style.height = Math.min(textareaRef.current.scrollHeight, 200) + "px";
+      }
+    }, []),
   });
 
   // Restore cursor position after prompt insertion
@@ -530,6 +545,11 @@ export function HomePage() {
       return;
     }
 
+    if ((e.ctrlKey || e.metaKey) && e.shiftKey && e.key.toLowerCase() === "m") {
+      e.preventDefault();
+      speech.toggleListening();
+      return;
+    }
     if (e.key === "Tab" && e.shiftKey) {
       e.preventDefault();
       const currentModes = getModesForBackend(backend);
@@ -895,6 +915,14 @@ export function HomePage() {
                 style={{ minHeight: "100px", maxHeight: "200px" }}
               />
 
+              {/* Voice input indicator */}
+              {speech.isListening && (
+                <div className="px-4 pb-1 text-xs text-cc-muted flex items-center gap-1.5">
+                  <span className="w-1.5 h-1.5 rounded-full bg-cc-error animate-pulse" />
+                  <span>Listening{speech.interimText ? `: "${speech.interimText}"` : "..."}</span>
+                </div>
+              )}
+
               {/* Bottom toolbar */}
               <div className="flex items-center justify-between px-3 pb-3">
                 {/* Left: mode dropdown */}
@@ -929,8 +957,15 @@ export function HomePage() {
                   )}
                 </div>
 
-                {/* Right: image placeholder + send */}
+                {/* Right: mic + image + send */}
                 <div className="flex items-center gap-1.5">
+                  {/* Voice input */}
+                  <MicButton
+                    isListening={speech.isListening}
+                    isSupported={speech.isSupported}
+                    onClick={speech.toggleListening}
+                  />
+
                   {/* Image upload */}
                   <button
                     onClick={() => fileInputRef.current?.click()}

--- a/web/src/components/MicButton.test.tsx
+++ b/web/src/components/MicButton.test.tsx
@@ -1,0 +1,104 @@
+// @vitest-environment jsdom
+/**
+ * Tests for the MicButton component.
+ * Validates rendering states (idle, listening, unsupported, disabled),
+ * click handling, and accessibility attributes.
+ */
+import { describe, it, expect, vi } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/react";
+import "@testing-library/jest-dom";
+import { MicButton } from "./MicButton.js";
+
+describe("MicButton", () => {
+  // -- Render tests --
+
+  it("renders a button when isSupported is true", () => {
+    render(<MicButton isListening={false} isSupported={true} onClick={vi.fn()} />);
+    expect(screen.getByRole("button", { name: /toggle voice input/i })).toBeInTheDocument();
+  });
+
+  it("renders nothing when isSupported is false", () => {
+    const { container } = render(
+      <MicButton isListening={false} isSupported={false} onClick={vi.fn()} />,
+    );
+    expect(container.firstChild).toBeNull();
+  });
+
+  // -- Click handling --
+
+  it("calls onClick when clicked", () => {
+    const onClick = vi.fn();
+    render(<MicButton isListening={false} isSupported={true} onClick={onClick} />);
+    fireEvent.click(screen.getByRole("button"));
+    expect(onClick).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not fire onClick when disabled", () => {
+    const onClick = vi.fn();
+    render(<MicButton isListening={false} isSupported={true} onClick={onClick} disabled />);
+    fireEvent.click(screen.getByRole("button"));
+    expect(onClick).not.toHaveBeenCalled();
+  });
+
+  // -- Accessibility --
+
+  it("has aria-pressed=false when not listening", () => {
+    render(<MicButton isListening={false} isSupported={true} onClick={vi.fn()} />);
+    expect(screen.getByRole("button")).toHaveAttribute("aria-pressed", "false");
+  });
+
+  it("has aria-pressed=true when listening", () => {
+    render(<MicButton isListening={true} isSupported={true} onClick={vi.fn()} />);
+    expect(screen.getByRole("button")).toHaveAttribute("aria-pressed", "true");
+  });
+
+  it("has descriptive title with keyboard shortcut", () => {
+    render(<MicButton isListening={false} isSupported={true} onClick={vi.fn()} />);
+    expect(screen.getByRole("button")).toHaveAttribute("title", "Voice input (Ctrl+Shift+M)");
+  });
+
+  it("passes axe accessibility checks", async () => {
+    const { axe } = await import("vitest-axe");
+    const { container } = render(
+      <MicButton isListening={false} isSupported={true} onClick={vi.fn()} />,
+    );
+    const results = await axe(container);
+    expect(results).toHaveNoViolations();
+  });
+
+  it("passes axe accessibility checks in listening state", async () => {
+    const { axe } = await import("vitest-axe");
+    const { container } = render(
+      <MicButton isListening={true} isSupported={true} onClick={vi.fn()} />,
+    );
+    const results = await axe(container);
+    expect(results).toHaveNoViolations();
+  });
+
+  // -- Visual states --
+
+  it("shows pulsing dot when listening", () => {
+    const { container } = render(
+      <MicButton isListening={true} isSupported={true} onClick={vi.fn()} />,
+    );
+    // The pulsing dot is a span with animate-pulse class
+    const dots = container.querySelectorAll(".animate-pulse");
+    expect(dots.length).toBeGreaterThan(0);
+  });
+
+  it("does not show pulsing dot when idle", () => {
+    const { container } = render(
+      <MicButton isListening={false} isSupported={true} onClick={vi.fn()} />,
+    );
+    const dots = container.querySelectorAll(".animate-pulse");
+    expect(dots.length).toBe(0);
+  });
+
+  it("does not show pulsing dot when listening but disabled", () => {
+    const { container } = render(
+      <MicButton isListening={true} isSupported={true} onClick={vi.fn()} disabled />,
+    );
+    const dots = container.querySelectorAll(".animate-pulse");
+    expect(dots.length).toBe(0);
+  });
+});

--- a/web/src/components/MicButton.tsx
+++ b/web/src/components/MicButton.tsx
@@ -1,0 +1,37 @@
+interface MicButtonProps {
+  isListening: boolean;
+  isSupported: boolean;
+  onClick: () => void;
+  disabled?: boolean;
+}
+
+export function MicButton({ isListening, isSupported, onClick, disabled }: MicButtonProps) {
+  if (!isSupported) return null;
+
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      disabled={disabled}
+      aria-label="Toggle voice input"
+      aria-pressed={isListening}
+      title="Voice input (Ctrl+Shift+M)"
+      className={`relative flex items-center justify-center w-8 h-8 rounded-lg transition-colors ${
+        disabled
+          ? "text-cc-muted opacity-30 cursor-not-allowed"
+          : isListening
+            ? "text-cc-error hover:bg-cc-error/10 cursor-pointer"
+            : "text-cc-muted hover:text-cc-fg hover:bg-cc-hover cursor-pointer"
+      }`}
+    >
+      <svg viewBox="0 0 16 16" fill="none" stroke="currentColor" strokeWidth="1.5" className="w-4 h-4">
+        <rect x="5.5" y="1.5" width="5" height="8" rx="2.5" />
+        <path d="M3.5 7a4.5 4.5 0 009 0" strokeLinecap="round" />
+        <path d="M8 12.5v2M6 14.5h4" strokeLinecap="round" />
+      </svg>
+      {isListening && !disabled && (
+        <span className="absolute top-0.5 right-0.5 w-2 h-2 rounded-full bg-cc-error animate-pulse" />
+      )}
+    </button>
+  );
+}

--- a/web/src/components/Playground.tsx
+++ b/web/src/components/Playground.tsx
@@ -20,6 +20,7 @@ import { SessionCreationProgress } from "./SessionCreationProgress.js";
 import { SessionLaunchOverlay } from "./SessionLaunchOverlay.js";
 import { PlaygroundUpdateOverlay } from "./UpdateOverlay.js";
 import { SessionItem } from "./SessionItem.js";
+import { MicButton } from "./MicButton.js";
 import type { CreationProgressEvent } from "../types.js";
 import type { SessionItem as SessionItemType } from "../utils/project-grouping.js";
 
@@ -752,6 +753,36 @@ export function Playground() {
             </Card>
             <Card label="System message">
               <MessageBubble message={MSG_SYSTEM} />
+            </Card>
+          </div>
+        </Section>
+
+        {/* ─── Voice Input ──────────────────────────────────── */}
+        <Section title="Voice Input" description="Microphone button states for speech-to-text dictation (Ctrl+Shift+M)">
+          <div className="flex flex-wrap gap-6">
+            <Card label="Idle (supported)">
+              <div className="flex items-center gap-3">
+                <MicButton isListening={false} isSupported={true} onClick={() => {}} />
+                <span className="text-xs text-cc-muted">Click to start</span>
+              </div>
+            </Card>
+            <Card label="Listening (active)">
+              <div className="flex items-center gap-3">
+                <MicButton isListening={true} isSupported={true} onClick={() => {}} />
+                <span className="text-xs text-cc-muted">Recording...</span>
+              </div>
+            </Card>
+            <Card label="Not supported">
+              <div className="flex items-center gap-3">
+                <MicButton isListening={false} isSupported={false} onClick={() => {}} />
+                <span className="text-xs text-cc-muted">(button hidden)</span>
+              </div>
+            </Card>
+            <Card label="Disabled">
+              <div className="flex items-center gap-3">
+                <MicButton isListening={false} isSupported={true} onClick={() => {}} disabled />
+                <span className="text-xs text-cc-muted">Disconnected</span>
+              </div>
             </Card>
           </div>
         </Section>

--- a/web/src/utils/use-speech-to-text.test.ts
+++ b/web/src/utils/use-speech-to-text.test.ts
@@ -1,0 +1,167 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { renderHook, act } from "@testing-library/react";
+import { useSpeechToText } from "./use-speech-to-text.js";
+
+// Mock SpeechRecognition API
+class MockSpeechRecognition {
+  continuous = false;
+  interimResults = false;
+  lang = "";
+  onresult: ((event: unknown) => void) | null = null;
+  onend: (() => void) | null = null;
+  onerror: ((event: unknown) => void) | null = null;
+  start = vi.fn();
+  stop = vi.fn();
+  abort = vi.fn();
+}
+
+let savedSpeechRecognition: unknown;
+
+beforeEach(() => {
+  savedSpeechRecognition = (window as unknown as Record<string, unknown>).SpeechRecognition;
+  (window as unknown as Record<string, unknown>).SpeechRecognition = MockSpeechRecognition;
+});
+
+afterEach(() => {
+  if (savedSpeechRecognition !== undefined) {
+    (window as unknown as Record<string, unknown>).SpeechRecognition = savedSpeechRecognition;
+  } else {
+    delete (window as unknown as Record<string, unknown>).SpeechRecognition;
+  }
+  vi.restoreAllMocks();
+});
+
+describe("useSpeechToText", () => {
+  it("reports isSupported=true when SpeechRecognition is available", () => {
+    const { result } = renderHook(() =>
+      useSpeechToText({ onTranscript: vi.fn() }),
+    );
+    expect(result.current.isSupported).toBe(true);
+  });
+
+  it("reports isSupported=false when SpeechRecognition is not available", () => {
+    delete (window as unknown as Record<string, unknown>).SpeechRecognition;
+    delete (window as unknown as Record<string, unknown>).webkitSpeechRecognition;
+
+    const { result } = renderHook(() =>
+      useSpeechToText({ onTranscript: vi.fn() }),
+    );
+    expect(result.current.isSupported).toBe(false);
+    expect(result.current.isListening).toBe(false);
+  });
+
+  it("starts listening when startListening is called", () => {
+    const { result } = renderHook(() =>
+      useSpeechToText({ onTranscript: vi.fn() }),
+    );
+
+    act(() => {
+      result.current.startListening();
+    });
+
+    expect(result.current.isListening).toBe(true);
+  });
+
+  it("stops listening when stopListening is called", () => {
+    const { result } = renderHook(() =>
+      useSpeechToText({ onTranscript: vi.fn() }),
+    );
+
+    act(() => {
+      result.current.startListening();
+    });
+    expect(result.current.isListening).toBe(true);
+
+    act(() => {
+      result.current.stopListening();
+    });
+    expect(result.current.isListening).toBe(false);
+  });
+
+  it("toggles listening state with toggleListening", () => {
+    const { result } = renderHook(() =>
+      useSpeechToText({ onTranscript: vi.fn() }),
+    );
+
+    // Toggle on
+    act(() => {
+      result.current.toggleListening();
+    });
+    expect(result.current.isListening).toBe(true);
+
+    // Toggle off
+    act(() => {
+      result.current.toggleListening();
+    });
+    expect(result.current.isListening).toBe(false);
+  });
+
+  it("does not double-start when already listening", () => {
+    const { result } = renderHook(() =>
+      useSpeechToText({ onTranscript: vi.fn() }),
+    );
+
+    act(() => {
+      result.current.startListening();
+    });
+
+    // Second start should be no-op
+    act(() => {
+      result.current.startListening();
+    });
+
+    expect(result.current.isListening).toBe(true);
+  });
+
+  it("does not throw when stopListening called while not listening", () => {
+    const { result } = renderHook(() =>
+      useSpeechToText({ onTranscript: vi.fn() }),
+    );
+
+    // Should not throw
+    act(() => {
+      result.current.stopListening();
+    });
+
+    expect(result.current.isListening).toBe(false);
+  });
+
+  it("initializes with default state", () => {
+    const { result } = renderHook(() =>
+      useSpeechToText({ onTranscript: vi.fn() }),
+    );
+
+    expect(result.current.isListening).toBe(false);
+    expect(result.current.interimText).toBe("");
+  });
+
+  it("cleans up recognition on unmount", () => {
+    const { unmount } = renderHook(() =>
+      useSpeechToText({ onTranscript: vi.fn() }),
+    );
+
+    // Should not throw during unmount
+    unmount();
+  });
+
+  it("handles startListening gracefully when not supported", () => {
+    delete (window as unknown as Record<string, unknown>).SpeechRecognition;
+    delete (window as unknown as Record<string, unknown>).webkitSpeechRecognition;
+
+    const { result } = renderHook(() =>
+      useSpeechToText({ onTranscript: vi.fn() }),
+    );
+
+    // Should be no-op, not throw
+    act(() => {
+      result.current.startListening();
+    });
+    expect(result.current.isListening).toBe(false);
+
+    act(() => {
+      result.current.toggleListening();
+    });
+    expect(result.current.isListening).toBe(false);
+  });
+});

--- a/web/src/utils/use-speech-to-text.ts
+++ b/web/src/utils/use-speech-to-text.ts
@@ -1,0 +1,174 @@
+import { useState, useRef, useEffect, useCallback } from "react";
+
+// Web Speech API type declarations (not in standard lib.dom.d.ts)
+interface SpeechRecognitionEvent extends Event {
+  resultIndex: number;
+  results: SpeechRecognitionResultList;
+}
+
+interface SpeechRecognitionResultList {
+  length: number;
+  [index: number]: SpeechRecognitionResult;
+}
+
+interface SpeechRecognitionResult {
+  length: number;
+  [index: number]: SpeechRecognitionAlternative;
+  isFinal: boolean;
+}
+
+interface SpeechRecognitionAlternative {
+  transcript: string;
+  confidence: number;
+}
+
+interface SpeechRecognitionInstance extends EventTarget {
+  continuous: boolean;
+  interimResults: boolean;
+  lang: string;
+  start(): void;
+  stop(): void;
+  abort(): void;
+  onresult: ((event: SpeechRecognitionEvent) => void) | null;
+  onend: (() => void) | null;
+  onerror: ((event: Event & { error: string }) => void) | null;
+}
+
+type SpeechRecognitionConstructor = new () => SpeechRecognitionInstance;
+
+const getSpeechRecognition = (): SpeechRecognitionConstructor | null => {
+  if (typeof window === "undefined") return null;
+  return (
+    (window as unknown as Record<string, unknown>).SpeechRecognition as SpeechRecognitionConstructor ??
+    (window as unknown as Record<string, unknown>).webkitSpeechRecognition as SpeechRecognitionConstructor ??
+    null
+  );
+};
+
+export interface UseSpeechToTextOptions {
+  onTranscript: (text: string) => void;
+  lang?: string;
+}
+
+export interface UseSpeechToTextReturn {
+  isListening: boolean;
+  isSupported: boolean;
+  interimText: string;
+  startListening: () => void;
+  stopListening: () => void;
+  toggleListening: () => void;
+}
+
+export function useSpeechToText({ onTranscript, lang }: UseSpeechToTextOptions): UseSpeechToTextReturn {
+  const SpeechRecognition = getSpeechRecognition();
+  const isSupported = SpeechRecognition !== null;
+
+  const [isListening, setIsListening] = useState(false);
+  const [interimText, setInterimText] = useState("");
+
+  const recognitionRef = useRef<SpeechRecognitionInstance | null>(null);
+  const listeningRef = useRef(false);
+  const onTranscriptRef = useRef(onTranscript);
+  onTranscriptRef.current = onTranscript;
+
+  useEffect(() => {
+    if (!SpeechRecognition) return;
+
+    const recognition = new SpeechRecognition();
+    recognition.continuous = true;
+    recognition.interimResults = true;
+    if (lang) recognition.lang = lang;
+
+    recognition.onresult = (event: SpeechRecognitionEvent) => {
+      let interim = "";
+      for (let i = event.resultIndex; i < event.results.length; i++) {
+        const result = event.results[i];
+        if (result.isFinal) {
+          onTranscriptRef.current(result[0].transcript);
+        } else {
+          interim += result[0].transcript;
+        }
+      }
+      setInterimText(interim);
+    };
+
+    recognition.onend = () => {
+      if (listeningRef.current) {
+        // Browser auto-stopped (e.g., after silence); restart
+        try {
+          recognition.start();
+        } catch {
+          // Already started or other error — stop gracefully
+          listeningRef.current = false;
+          setIsListening(false);
+          setInterimText("");
+        }
+      } else {
+        setInterimText("");
+      }
+    };
+
+    recognition.onerror = (event: Event & { error: string }) => {
+      // "aborted" is expected when we call stop() while listening
+      if (event.error === "aborted") return;
+      console.warn("[speech-to-text] error:", event.error);
+      listeningRef.current = false;
+      setIsListening(false);
+      setInterimText("");
+    };
+
+    recognitionRef.current = recognition;
+
+    return () => {
+      listeningRef.current = false;
+      try {
+        recognition.abort();
+      } catch {
+        // Ignore
+      }
+      recognitionRef.current = null;
+    };
+  }, [SpeechRecognition, lang]);
+
+  const startListening = useCallback(() => {
+    if (!recognitionRef.current || listeningRef.current) return;
+    listeningRef.current = true;
+    setIsListening(true);
+    setInterimText("");
+    try {
+      recognitionRef.current.start();
+    } catch {
+      listeningRef.current = false;
+      setIsListening(false);
+    }
+  }, []);
+
+  const stopListening = useCallback(() => {
+    if (!recognitionRef.current || !listeningRef.current) return;
+    listeningRef.current = false;
+    setIsListening(false);
+    setInterimText("");
+    try {
+      recognitionRef.current.stop();
+    } catch {
+      // Ignore
+    }
+  }, []);
+
+  const toggleListening = useCallback(() => {
+    if (listeningRef.current) {
+      stopListening();
+    } else {
+      startListening();
+    }
+  }, [startListening, stopListening]);
+
+  return {
+    isListening,
+    isSupported,
+    interimText,
+    startListening,
+    stopListening,
+    toggleListening,
+  };
+}


### PR DESCRIPTION
## Summary
- Add speech-to-text voice input to both the HomePage composer and in-session Composer
- New `useSpeechToText` hook wrapping the Web Speech API with feature detection, auto-restart on silence, and graceful error handling
- New `MicButton` component with idle/listening/unsupported/disabled states and pulsing red indicator
- `Ctrl+Shift+M` (or `Cmd+Shift+M` on Mac) keyboard shortcut to toggle voice input
- "Listening..." indicator with real-time interim transcription displayed below the textarea
- Button hidden automatically in browsers without Speech API support (Firefox)
- Playground updated with MicButton state showcase

## Why
- Users want to dictate their prompts by voice instead of typing — the microphone button was missing from both the home page and the in-session composer
- The `Ctrl+Shift+M` shortcut was expected to work but wasn't implemented

## Testing
- `bun run typecheck` — passes
- `bun run test` — all 2912 tests pass (113 test files)
- New test files: `use-speech-to-text.test.ts` (10 tests), `MicButton.test.tsx` (12 tests)
- Updated: `HomePage.test.tsx` (+2 voice input tests), `Composer.test.tsx` (+2 voice input tests)
- Manual: click mic → pulsing indicator + "Listening..." → speak → text appears in textarea → click again to stop

## Review provenance
- Implemented by AI agent
- Human review: no
