### PR TITLE
fix(codex): preserve parent id in task tool-use backfill

### DIFF
--- a/web/server/codex-adapter.ts
+++ b/web/server/codex-adapter.ts
@@ -2055,7 +2055,7 @@ export class CodexAdapter {
           codex_status: collab.status,
           sender_thread_id: collab.senderThreadId || null,
           receiver_thread_ids: receiverThreadIds,
-        });
+        }, parentToolUseId);
         const isError = collab.status === "failed";
         const summary = this.summarizeCollabCall(collab);
         this.emitToolResult(item.id, summary, isError);
@@ -2314,10 +2314,15 @@ export class CodexAdapter {
   }
 
   /** Emit tool_use only if item/started was never received for this ID. */
-  private ensureToolUseEmitted(toolUseId: string, toolName: string, input: Record<string, unknown>): void {
+  private ensureToolUseEmitted(
+    toolUseId: string,
+    toolName: string,
+    input: Record<string, unknown>,
+    parentToolUseId: string | null = null,
+  ): void {
     if (!this.emittedToolUseIds.has(toolUseId)) {
       console.log(`[codex-adapter] Backfilling tool_use for ${toolName} (id=${toolUseId}) — item/started was missing`);
-      this.emitToolUseTracked(toolUseId, toolName, input);
+      this.emitToolUseTracked(toolUseId, toolName, input, parentToolUseId);
     }
   }
 


### PR DESCRIPTION
## Summary
- fix codex adapter backfill path so nested `collabAgentToolCall` keeps `parentToolUseId`
- pass `parentToolUseId` from `handleItemCompleted` into `ensureToolUseEmitted`
- add regression test for completed-only nested collab call (`item/completed` without `item/started`)

## Why
- without this, backfilled Task tool_use is emitted top-level (`parent_tool_use_id: null`) and nested collab grouping breaks in the frontend

## Testing
- `cd web && bun run test server/codex-adapter.test.ts`
- `cd web && bun run typecheck`

## Review provenance
- Implemented by AI agent
- Human review: no
