### PR TITLE
fix(ci): use bun run test instead of bun test in preview workflow

### DIFF
--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -36,7 +36,7 @@ jobs:
 
       - name: Run tests
         working-directory: web
-        run: bun test
+        run: bun run test
 
   preview-docker:
     name: deploy/preview


### PR DESCRIPTION
## Summary
- Fixes the preview workflow `test-gate` job which was using `bun test` (Bun's native test runner) instead of `bun run test` (which invokes Vitest via `package.json` scripts)
- This caused 878 test failures on the first preview run after merging #451

## Why
- `bun test` uses Bun's built-in test runner which is incompatible with the project's Vitest test suite
- `bun run test` correctly invokes `vitest run` as defined in `package.json`

## Testing
- One-line change, verified locally

## Review provenance
- Implemented by AI agent (Claude Opus 4.6)
- Human review: no

🤖 Generated with [Claude Code](https://claude.com/claude-code)