### PR TITLE
docs: add functional Mintlify documentation for all features

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,6 +131,7 @@ Preview builds are **not** production-stable. Use `latest` / semver tags for sta
 In **Settings > Updates**, switch the update channel to **Prerelease** to receive preview builds. The default channel is **Stable** (semver releases only). Switching channels takes effect immediately on the next update check.
 
 ## Docs
+- **Full documentation**: [`docs/`](docs/) (Mintlify — run `cd docs && mint dev` to preview locally)
 - Protocol reverse engineering: [`WEBSOCKET_PROTOCOL_REVERSED.md`](WEBSOCKET_PROTOCOL_REVERSED.md)
 - Contributor and architecture guide: [`CLAUDE.md`](CLAUDE.md)
 

--- a/docs/agents/advanced-config.mdx
+++ b/docs/agents/advanced-config.mdx
@@ -1,0 +1,63 @@
+---
+title: Advanced Configuration
+description: MCP servers, skills, allowed tools, and environment variables
+---
+
+# Advanced Configuration
+
+The agent editor has an **Advanced** section (click to expand) with additional configuration options.
+
+## MCP servers
+
+Add [Model Context Protocol](https://modelcontextprotocol.io/) servers to give the agent access to external tools and data sources.
+
+### Add an MCP server
+
+1. In the agent editor, expand **Advanced**
+2. Under **MCP Servers**, click **Add Server**
+3. Fill in:
+   - **Name**: Identifier for the server (e.g., `github`, `database`)
+   - **Type**: `stdio` (command-line process), `sse` (server-sent events), or `http`
+   - **Command + Args** (stdio): The command to run (e.g., `npx -y @modelcontextprotocol/server-github`)
+   - **URL** (sse/http): The server URL
+   - **Environment variables** (optional): JSON key-value pairs passed to the server process
+
+### Example: GitHub MCP server
+
+```
+Name: github
+Type: stdio
+Command: npx
+Args: -y @modelcontextprotocol/server-github
+Env: {"GITHUB_TOKEN": "ghp_..."}
+```
+
+## Skills
+
+Toggle available skills from `~/.claude/skills/`. Skills are discovered at runtime and provide additional capabilities to the agent. Check the skills you want to enable for this agent.
+
+## Allowed tools
+
+Restrict which tools the agent can use by adding tool names to the allowlist. Type a tool name and press Enter. Leave empty to allow all tools.
+
+Common tool names: `Read`, `Write`, `Edit`, `Bash`, `Grep`, `Glob`, `WebFetch`, `WebSearch`.
+
+## Per-agent environment variables
+
+Add key-value environment variables specific to this agent. These are merged with (and override) variables from the selected environment profile.
+
+Click **Add Variable**, enter a key and value, and save. These variables are injected into the CLI subprocess when the agent runs.
+
+## Git configuration
+
+| Option | Description |
+|---|---|
+| **Branch** | Git branch to check out when the session starts |
+| **Create branch** | If checked, creates the branch if it doesn't exist |
+| **Use worktree** | Creates an isolated [git worktree](/git/branches-and-worktrees) for the session |
+
+## Codex-specific
+
+| Option | Description |
+|---|---|
+| **Internet access** | Toggle network access for Codex sessions (off by default) |

--- a/docs/agents/creating-agents.mdx
+++ b/docs/agents/creating-agents.mdx
@@ -1,0 +1,53 @@
+---
+title: Creating Agents
+description: Build reusable agent configurations with custom prompts and settings
+---
+
+# Creating Agents
+
+Agents are reusable configurations that spawn sessions with specific settings, prompts, and triggers. Navigate to **Agents** in the sidebar (or go to `#/agents`).
+
+## Create an agent
+
+1. Click **+ New Agent**
+2. Fill in the **identity** section:
+   - **Name**: A descriptive name (e.g., "PR Reviewer", "Test Runner")
+   - **Description**: What this agent does
+   - **Icon**: Choose from 18 icons (bot, terminal, pencil, search, shield, rocket, wrench, etc.)
+
+3. Write the **system prompt**:
+   - This is the instruction the agent receives when it starts
+   - Use `{{input}}` as a placeholder for dynamic input provided at run time
+   - Example: `Review the following pull request and provide feedback: {{input}}`
+
+4. Configure the **controls row**:
+   - **Backend**: Claude Code or Codex
+   - **Model**: Which model to use (e.g., Claude Sonnet 4, Claude Opus)
+   - **Permission mode**: Default, Accept Edits, or Bypass
+   - **Working directory**: The folder the agent operates in (or "temp" for auto-created)
+   - **Branch** (optional): Git branch to check out
+   - **Environment profile** (optional): Apply an [environment profile](/environments/environment-profiles)
+   - **Internet access** (Codex only): Toggle network access
+
+5. Click **Save**
+
+## Run an agent manually
+
+Click the **Run** button on an agent card. If the agent's prompt contains `{{input}}`, a modal appears asking for the input value. The agent creates a new session and starts executing.
+
+## Enable and disable
+
+Toggle agents on/off with the **switch** on each agent card. Disabled agents won't execute scheduled or webhook triggers, but can still be run manually.
+
+## Agent cards
+
+Each agent card shows:
+- Name, description, and icon
+- Backend type and model
+- Trigger badges (Manual, Webhook, Schedule)
+- Stats: total runs, last run time, next scheduled run
+- Action buttons: Run, Edit, Export, Toggle, Delete
+
+## Storage
+
+Agents are stored as individual JSON files in `~/.companion/agents/`. The agent ID is a slug derived from the name (e.g., "PR Reviewer" becomes `pr-reviewer`).

--- a/docs/agents/import-export.mdx
+++ b/docs/agents/import-export.mdx
@@ -1,0 +1,48 @@
+---
+title: Import & Export
+description: Share agent configurations across teams
+---
+
+# Import & Export
+
+## Export an agent
+
+1. On the **Agents** page, find the agent you want to export
+2. Click the **download icon** on the agent card
+3. A `.agent.json` file is downloaded to your machine
+
+The exported file contains the agent's full configuration: name, description, prompt, backend settings, triggers, MCP servers, environment variables, and more.
+
+Tracking fields (ID, creation date, run count, etc.) are excluded from the export so the agent starts fresh when imported.
+
+## Import an agent
+
+1. On the **Agents** page, click **Import**
+2. Select a `.agent.json` file
+3. The agent is created in a **disabled** state for safety — review its configuration before enabling it
+
+<Warning>
+Imported agents start disabled. Review the agent's prompt, environment variables, and permissions before enabling it, especially if the file came from an external source.
+</Warning>
+
+## REST API
+
+```bash
+# Export
+curl http://localhost:3456/api/agents/pr-reviewer/export \
+  -H "Authorization: Bearer YOUR_TOKEN" \
+  -o pr-reviewer.agent.json
+
+# Import
+curl -X POST http://localhost:3456/api/agents/import \
+  -H "Authorization: Bearer YOUR_TOKEN" \
+  -H "Content-Type: application/json" \
+  -d @pr-reviewer.agent.json
+```
+
+## Use cases
+
+- Share agent configurations across your team
+- Version control agent definitions alongside your code
+- Back up agent configurations before making changes
+- Create template agents that others can customize

--- a/docs/agents/triggers.mdx
+++ b/docs/agents/triggers.mdx
@@ -1,0 +1,92 @@
+---
+title: Triggers
+description: Automate agent execution with webhooks and schedules
+---
+
+# Triggers
+
+Agents can be triggered in three ways: manually, via webhook, or on a schedule.
+
+## Manual trigger
+
+Always available. Click the **Run** button on the agent card. If the prompt uses `{{input}}`, a modal asks for the input value.
+
+## Webhook trigger
+
+Expose your agent as an HTTP endpoint that external services can call.
+
+### Setup
+
+1. Open the agent editor
+2. In the **Triggers** section, toggle **Webhook** on
+3. A unique URL and secret are generated automatically
+4. Copy the webhook URL
+
+### Calling the webhook
+
+Send a POST request to the webhook URL:
+
+```bash
+curl -X POST https://your-companion:3456/api/agents/pr-reviewer/webhook/YOUR_SECRET \
+  -H "Content-Type: application/json" \
+  -d '{"input": "Review PR #42 on the main branch"}'
+```
+
+The `input` field is optional. If provided, it replaces `{{input}}` in the agent's prompt.
+
+### Regenerate secret
+
+Click **Regenerate Secret** in the agent editor to invalidate the old URL and generate a new one.
+
+### Use cases
+
+- Trigger a code review agent from a GitHub webhook on PR creation
+- Run a deployment agent from your CI/CD pipeline
+- Start a test runner from a Slack bot
+
+## Schedule trigger
+
+Run agents automatically on a recurring schedule or at a specific time.
+
+### Recurring (cron)
+
+1. In the agent editor, toggle **Schedule** on
+2. Choose a **preset** or enter a custom cron expression:
+
+| Preset | Cron expression |
+|---|---|
+| Every hour | `0 * * * *` |
+| Daily at 8am | `0 8 * * *` |
+| Weekdays at 9am | `0 9 * * 1-5` |
+| Weekly on Monday | `0 9 * * 1` |
+
+3. The agent card shows the next scheduled run time
+
+### One-time (datetime)
+
+1. Toggle **Schedule** on
+2. Switch to **One-time** mode
+3. Pick a date and time using the datetime picker
+4. The agent runs once at the specified time
+
+### Schedule display
+
+Agent cards show:
+- A **Schedule** badge when scheduling is enabled
+- The **next run** timestamp
+- A humanized description (e.g., "Every weekday at 9:00 AM")
+
+## Execution history
+
+Each agent tracks:
+- **Total runs**: Number of times the agent has executed
+- **Last run**: Timestamp of the most recent execution
+- **Last session**: Link to the session created by the last run
+- **Consecutive failures**: Count resets on success
+
+View execution history via the API:
+
+```bash
+curl http://localhost:3456/api/agents/pr-reviewer/executions \
+  -H "Authorization: Bearer YOUR_TOKEN"
+```

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -1,0 +1,87 @@
+{
+  "$schema": "https://mintlify.com/docs.json",
+  "theme": "maple",
+  "name": "The Companion",
+  "description": "Web UI for Claude Code and Codex sessions. Run multiple agents, inspect tool calls, and gate risky actions with explicit approvals.",
+  "colors": {
+    "primary": "#6366F1",
+    "light": "#818CF8",
+    "dark": "#4F46E5"
+  },
+  "navigation": [
+    {
+      "group": "Getting Started",
+      "pages": [
+        "index",
+        "getting-started/installation",
+        "getting-started/quickstart",
+        "getting-started/cli-reference"
+      ]
+    },
+    {
+      "group": "Saved Prompts",
+      "pages": [
+        "prompts/creating-prompts",
+        "prompts/using-prompts"
+      ]
+    },
+    {
+      "group": "Agents",
+      "pages": [
+        "agents/creating-agents",
+        "agents/triggers",
+        "agents/advanced-config",
+        "agents/import-export"
+      ]
+    },
+    {
+      "group": "Environments & Docker",
+      "pages": [
+        "environments/environment-profiles",
+        "environments/docker-sessions",
+        "environments/init-scripts-ports"
+      ]
+    },
+    {
+      "group": "Sessions & Permissions",
+      "pages": [
+        "sessions/creating-sessions",
+        "sessions/managing-sessions",
+        "sessions/permissions",
+        "sessions/session-recovery"
+      ]
+    },
+    {
+      "group": "Git Workflows",
+      "pages": [
+        "git/branches-and-worktrees"
+      ]
+    },
+    {
+      "group": "Integrations",
+      "pages": [
+        "integrations/linear"
+      ]
+    },
+    {
+      "group": "Troubleshooting",
+      "pages": [
+        "troubleshooting/common-issues",
+        "troubleshooting/recordings"
+      ]
+    }
+  ],
+  "navbar": {
+    "links": [
+      {
+        "label": "GitHub",
+        "url": "https://github.com/thevibecompany/the-companion"
+      }
+    ]
+  },
+  "footer": {
+    "socials": {
+      "github": "https://github.com/thevibecompany/the-companion"
+    }
+  }
+}

--- a/docs/environments/docker-sessions.mdx
+++ b/docs/environments/docker-sessions.mdx
@@ -1,0 +1,97 @@
+---
+title: Docker Sessions
+description: Run agent sessions in isolated Docker containers
+---
+
+# Docker Sessions
+
+Docker sessions run the agent CLI inside a container, providing an isolated filesystem, pre-installed toolchains, and port forwarding. This is useful for untrusted workloads, reproducible environments, and projects with specific system dependencies.
+
+## Prerequisites
+
+- Docker must be installed and running on your machine
+- The Environments page shows a **Docker** badge (green if available, amber if not detected)
+
+## The container image
+
+The default image (`the-companion:latest`) is based on Ubuntu 24.04 and includes:
+
+| Tool | Version |
+|---|---|
+| Node.js | 22 LTS (via nvm, with pnpm) |
+| Bun | Latest |
+| Deno | Latest |
+| Go | 1.23 |
+| Rust | Latest (via rustup) |
+| Python | System + poetry + uv |
+| Docker CLI | Latest (for nested Docker) |
+| GitHub CLI (gh) | Latest |
+| Claude Code CLI | Latest |
+| Codex CLI | Latest |
+| VS Code Server | code-server |
+
+Plus system tools: git, curl, wget, make, jq, cmake, sqlite3, ffmpeg, imagemagick.
+
+## Set up a Docker environment
+
+1. Go to **Environments** and create a new profile (or edit an existing one)
+2. Open the **Docker** tab
+3. Select a **base image** from the dropdown (e.g., `the-companion:latest`) or enter a custom image name
+4. Click **Pull** to download the image — progress is shown in real time
+
+### Custom Dockerfile
+
+If you need additional dependencies:
+
+1. In the Docker tab, write a custom **Dockerfile**:
+
+```dockerfile
+FROM the-companion:latest
+
+# Add project-specific dependencies
+RUN apt-get update && apt-get install -y postgresql-client
+RUN pip install pandas numpy
+
+WORKDIR /workspace
+CMD ["sleep", "infinity"]
+```
+
+2. Click **Build Image** to build and tag the custom image
+3. The build status (idle, building, success, error) is shown on the profile card
+
+## What happens when a Docker session starts
+
+1. A container is created with an isolated named volume
+2. Your **working directory** is copied into `/workspace` inside the container
+3. **Auth files** are seeded from your host machine:
+   - Claude Code credentials (`~/.claude`)
+   - Codex auth and config
+   - Git identity and GitHub token (SSH remotes are rewritten to HTTPS)
+4. The **init script** runs (if configured)
+5. The CLI subprocess starts inside the container
+
+## Port forwarding
+
+Ports defined in the environment profile are automatically mapped to random available host ports. This prevents conflicts when running multiple Docker sessions.
+
+The container always exposes port 13337 (VS Code Server). Codex sessions also expose port 4502 for WebSocket.
+
+Check the mapped ports in the session terminal.
+
+## Volume mounts
+
+Add volume mounts in the environment profile to share directories between host and container. Volumes are specified as `host_path:container_path` pairs.
+
+## Auth and Git inside containers
+
+The Companion automatically:
+- Copies your Claude Code / Codex credentials into the container
+- Sets up `gh` as the git credential helper for GitHub authentication
+- Copies your git identity (`user.name`, `user.email`)
+- Disables GPG signing (unavailable in containers)
+- Marks `/workspace` as a safe directory
+- Rewrites SSH git remotes to HTTPS (containers lack SSH keys)
+
+<Note>
+Docker sessions and [git worktrees](/git/branches-and-worktrees) are mutually exclusive. Containers already provide filesystem isolation, so worktrees are not needed.
+</Note>

--- a/docs/environments/environment-profiles.mdx
+++ b/docs/environments/environment-profiles.mdx
@@ -1,0 +1,77 @@
+---
+title: Environment Profiles
+description: Define reusable sets of environment variables and Docker configurations
+---
+
+# Environment Profiles
+
+Environment profiles let you define reusable configurations — environment variables, Docker settings, init scripts, and port mappings — that are applied when launching sessions or agents.
+
+Navigate to **Environments** in the sidebar, or access from **Settings > Environments**.
+
+## Create a profile
+
+1. Click **New Environment**
+2. Enter a **name** (e.g., "Production API", "GLM v5 Setup")
+3. The profile editor has four tabs:
+
+### Variables tab
+
+Add key-value environment variables. Click **Add Variable**, enter the key and value, repeat as needed.
+
+These variables are injected into the CLI subprocess when a session starts with this profile.
+
+### Docker tab
+
+Configure a Docker container for isolated sessions. See [Docker Sessions](/environments/docker-sessions) for full details.
+
+### Ports tab
+
+Define container ports to expose. See [Init Scripts & Ports](/environments/init-scripts-ports).
+
+### Init Script tab
+
+Write a shell script that runs before the session starts. See [Init Scripts & Ports](/environments/init-scripts-ports).
+
+## Apply a profile
+
+### To a session
+
+When creating a new session on the Home page, select an environment profile from the **Environment** dropdown. The profile's variables are injected into the CLI subprocess.
+
+### To an agent
+
+In the agent editor, select an environment profile from the **Env Profile** dropdown in the controls row. The profile is applied every time the agent runs.
+
+## Use case: alternative model providers
+
+You can use environment variables to configure alternative model providers. For example, to use GLM v5 instead of the default Claude model:
+
+1. Create a new environment profile named "GLM v5"
+2. In the **Variables** tab, set the environment variables that your CLI uses for model configuration:
+
+| Variable | Value |
+|---|---|
+| `ANTHROPIC_BASE_URL` | `https://your-glm-endpoint.example.com/v1` |
+| `ANTHROPIC_API_KEY` | `your-glm-api-key` |
+| `ANTHROPIC_MODEL` | `glm-v5` |
+
+3. Select this profile when creating sessions or configuring agents
+
+<Tip>
+The exact variables depend on your model provider's compatibility layer. Many providers offer OpenAI- or Anthropic-compatible APIs that accept the same environment variables.
+</Tip>
+
+## Storage
+
+Profiles are stored as individual JSON files in `~/.companion/envs/`, named by slug (e.g., `glm-v5.json`).
+
+## REST API
+
+| Method | Endpoint | Description |
+|---|---|---|
+| `GET` | `/api/envs` | List all profiles |
+| `GET` | `/api/envs/:slug` | Get a single profile |
+| `POST` | `/api/envs` | Create a profile |
+| `PUT` | `/api/envs/:slug` | Update a profile |
+| `DELETE` | `/api/envs/:slug` | Delete a profile |

--- a/docs/environments/init-scripts-ports.mdx
+++ b/docs/environments/init-scripts-ports.mdx
@@ -1,0 +1,78 @@
+---
+title: Init Scripts & Ports
+description: Run setup commands and expose container ports
+---
+
+# Init Scripts & Ports
+
+## Init scripts
+
+The **Init Script** tab in the environment profile editor lets you write a shell script that runs before the session starts. This is useful for installing dependencies, seeding data, or running setup commands.
+
+### How it works
+
+- The script runs via `sh -lc` (login shell)
+- In Docker sessions: runs inside the container as root
+- Timeout: **120 seconds** (configurable via `COMPANION_INIT_SCRIPT_TIMEOUT` env var)
+- If the script fails (non-zero exit code), the session creation is aborted
+
+### Examples
+
+Install project dependencies:
+
+```bash
+cd /workspace
+bun install
+```
+
+Set up a Python environment:
+
+```bash
+cd /workspace
+pip install -r requirements.txt
+python manage.py migrate
+```
+
+Install system packages (Docker sessions only):
+
+```bash
+apt-get update && apt-get install -y redis-tools
+redis-cli ping
+```
+
+Seed a database:
+
+```bash
+cd /workspace
+createdb myapp_dev 2>/dev/null || true
+psql myapp_dev < db/seed.sql
+```
+
+### Syntax highlighting
+
+The init script editor supports shell syntax highlighting in the UI.
+
+## Ports
+
+The **Ports** tab lets you define container ports to expose. Each port you add is automatically mapped to a random available host port when the container starts.
+
+### Add ports
+
+1. Open the environment profile editor
+2. Go to the **Ports** tab
+3. Enter a port number and click **Add**
+4. Repeat for each port you need
+
+### Common ports
+
+| Port | Service |
+|---|---|
+| 3000 | Node.js / React dev server |
+| 5432 | PostgreSQL |
+| 6379 | Redis |
+| 8000 | Python / Django |
+| 8080 | General web server |
+
+### Port mapping
+
+Ports are mapped with `-p 0:PORT` so the host port is automatically assigned (preventing conflicts across multiple sessions). Check the actual mapped port in the session terminal after the container starts.

--- a/docs/getting-started/cli-reference.mdx
+++ b/docs/getting-started/cli-reference.mdx
@@ -1,0 +1,52 @@
+---
+title: CLI Reference
+description: Complete reference for The Companion CLI
+---
+
+# CLI Reference
+
+## Commands
+
+| Command | Description |
+|---|---|
+| `the-companion` | Start server in foreground (default) |
+| `the-companion serve` | Start server in foreground (explicit) |
+| `the-companion install` | Register as a background service (launchd/systemd) |
+| `the-companion start` | Start the background service |
+| `the-companion stop` | Stop the background service |
+| `the-companion restart` | Restart the background service |
+| `the-companion uninstall` | Remove the background service |
+| `the-companion status` | Show service status |
+| `the-companion logs` | Tail service log files |
+
+## Options
+
+| Option | Description | Default |
+|---|---|---|
+| `--port <n>` | Override the server port | `3456` |
+
+## Environment variables
+
+| Variable | Description |
+|---|---|
+| `COMPANION_AUTH_TOKEN` | Auth token (overrides `~/.companion/auth.json`) |
+| `COMPANION_RECORD` | Set to `0` or `false` to disable protocol recording |
+| `COMPANION_RECORDINGS_DIR` | Override recordings directory (default: `~/.companion/recordings/`) |
+| `COMPANION_RECORDINGS_MAX_LINES` | Max total lines before recording rotation (default: 1,000,000) |
+| `COMPANION_INIT_SCRIPT_TIMEOUT` | Init script timeout in seconds (default: 120) |
+
+## Examples
+
+```bash
+# Custom port
+the-companion --port 8080
+
+# Custom auth token
+COMPANION_AUTH_TOKEN="my-token" the-companion
+
+# Install and run as service
+the-companion install && the-companion start && the-companion status
+
+# View logs
+the-companion logs
+```

--- a/docs/getting-started/installation.mdx
+++ b/docs/getting-started/installation.mdx
@@ -1,0 +1,73 @@
+---
+title: Installation
+description: How to install and run The Companion
+---
+
+# Installation
+
+## Requirements
+
+- [Bun](https://bun.sh) runtime
+- [Claude Code](https://docs.anthropic.com/en/docs/claude-code) CLI and/or [Codex](https://github.com/openai/codex) CLI
+
+## Try it instantly
+
+```bash
+bunx the-companion
+```
+
+Open [http://localhost:3456](http://localhost:3456).
+
+## Install globally
+
+```bash
+bun install -g the-companion
+```
+
+### Background service
+
+Register as a background service so it starts automatically and survives reboots:
+
+```bash
+# Register (launchd on macOS, systemd on Linux)
+the-companion install
+
+# Start the service
+the-companion start
+```
+
+### Custom port
+
+```bash
+the-companion --port 8080
+```
+
+## Authentication
+
+The server auto-generates an auth token on first start, stored at `~/.companion/auth.json`.
+
+```bash
+# Show the current token
+cd web && bun run generate-token
+
+# Force-regenerate
+cd web && bun run generate-token --force
+```
+
+Or set via environment variable:
+
+```bash
+COMPANION_AUTH_TOKEN="my-secret-token" bunx the-companion
+```
+
+## Preview / prerelease builds
+
+Every push to `main` publishes preview artifacts:
+
+| Artifact | Tag | Example |
+|---|---|---|
+| Docker image (moving) | `preview-main` | `docker.io/stangirard/the-companion:preview-main` |
+| Docker image (immutable) | `preview-<sha>` | `docker.io/stangirard/the-companion:preview-abc1234` |
+| npm package | `next` | `bunx the-companion@next` |
+
+In **Settings > Updates**, switch to **Prerelease** channel to receive preview builds.

--- a/docs/getting-started/quickstart.mdx
+++ b/docs/getting-started/quickstart.mdx
@@ -1,0 +1,70 @@
+---
+title: Quickstart
+description: Go from zero to your first session in under a minute
+---
+
+# Quickstart
+
+## Prerequisites
+
+Install [Bun](https://bun.sh) and at least one agent CLI:
+
+```bash
+# Bun
+curl -fsSL https://bun.sh/install | bash
+
+# Claude Code
+npm install -g @anthropic-ai/claude-code
+
+# Codex (optional)
+npm install -g @openai/codex
+```
+
+Make sure your CLI is authenticated before proceeding (run `claude` or `codex` once in your terminal to set up credentials).
+
+## 1. Start the server
+
+```bash
+bunx the-companion
+```
+
+Open [http://localhost:3456](http://localhost:3456).
+
+## 2. Create a session
+
+Click **New Session** on the home page. Choose:
+
+- **Backend**: Claude Code or Codex
+- **Working directory**: The project folder the agent will operate in
+- **Model** (Claude Code): Which Claude model to use
+- **Branch** (optional): Select or create a git branch
+- **Environment** (optional): Apply an [environment profile](/environments/environment-profiles)
+
+Click **Start** to launch the session.
+
+## 3. Chat with the agent
+
+Type a prompt in the composer and press Enter. You'll see:
+
+- **Streaming responses** as the agent thinks
+- **Tool call blocks** showing each action (file reads, writes, bash commands)
+- **Task items** extracted from the agent's work plan
+
+## 4. Handle permissions
+
+When the agent wants to write a file or run a command, a permission banner appears:
+
+<img src="/screenshots/readme-permissions.png" alt="Permission approval UI" />
+
+- **Allow**: Execute this tool call
+- **Deny**: Skip this action
+- **Allow all**: Auto-approve for the rest of the session
+
+See [Permissions](/sessions/permissions) for more control options.
+
+## Next steps
+
+- [Create saved prompts](/prompts/creating-prompts) for reusable instructions
+- [Build agents](/agents/creating-agents) for automated workflows
+- [Set up Docker environments](/environments/docker-sessions) for isolated sessions
+- [Connect Linear](/integrations/linear) for issue-driven development

--- a/docs/git/branches-and-worktrees.mdx
+++ b/docs/git/branches-and-worktrees.mdx
@@ -1,0 +1,83 @@
+---
+title: Branches & Worktrees
+description: Use git branches and worktrees to isolate agent sessions
+---
+
+# Branches & Worktrees
+
+The Companion lets you select a git branch when creating a session and optionally create an isolated git worktree so multiple agents can work on the same repo without interfering with each other.
+
+## Branch picker
+
+On the home page, when creating a session in a git repository:
+
+1. A **branch dropdown** appears showing all local and remote branches
+2. Each branch shows status indicators:
+   - Green up/down arrows with counts (commits ahead/behind upstream)
+   - Blue **wt** badge if a worktree already exists for that branch
+   - Green **current** badge for the currently checked-out branch
+3. Type to **filter** branches by name
+4. If your search doesn't match an existing branch, an option to **create a new branch** appears
+
+### What happens when you select a branch
+
+Without worktrees: the server runs `git fetch` and `git checkout` in the project directory, then `git pull`. This is a simple branch switch — the same as doing it manually in the terminal.
+
+## Worktree toggle
+
+Click the **Worktree** button (git branch icon) next to the branch picker to enable worktree isolation.
+
+### What worktrees do
+
+A git worktree is an independent working tree with its own branch, staging area, and files. When you enable worktrees:
+
+1. The Companion creates a new working directory at `~/.companion/worktrees/{repo-name}/{branch}/`
+2. The session uses this worktree as its working directory instead of the original repo
+3. Your original checkout is untouched
+4. Multiple sessions can work on the same branch — each gets its own worktree with a unique branch name (e.g., `main-wt-5391`)
+
+### When to use worktrees
+
+- **Parallel sessions on the same branch**: Two agents working on `main` simultaneously
+- **Protecting your checkout**: Keep your own work in the original repo while an agent works in a worktree
+- **Isolated experiments**: Let the agent make changes without affecting your local state
+
+### How naming works
+
+| Scenario | Worktree path | Actual branch |
+|---|---|---|
+| First session on `feature/login` | `~/.companion/worktrees/my-repo/feature--login/` | `feature/login` |
+| Second session on `feature/login` | `~/.companion/worktrees/my-repo/feature--login-wt-8374/` | `feature/login-wt-8374` |
+| First session on `main` | `~/.companion/worktrees/my-repo/main/` | `main` |
+
+Branch name collisions are resolved by appending a random 4-digit suffix. The user-selected branch is tracked separately from the actual git branch name.
+
+## Worktrees in agents
+
+The agent editor has the same branch and worktree controls. When an agent runs:
+
+- **Branch**: The branch to check out
+- **Create branch**: Creates the branch if it doesn't exist
+- **Use worktree**: Isolates the session in a worktree
+
+## Cleanup
+
+Worktrees are tracked in `~/.companion/worktrees.json`. When you archive a session, its worktree can be cleaned up. Worktrees with uncommitted changes are flagged before deletion.
+
+## Docker sessions
+
+<Note>
+Worktrees are not used with Docker sessions. Containers already provide full filesystem isolation — the host workspace is copied into `/workspace` inside the container.
+</Note>
+
+## REST API
+
+| Method | Endpoint | Description |
+|---|---|---|
+| `GET` | `/git/repo-info?path=` | Check if a path is a git repo |
+| `GET` | `/git/branches?repoRoot=` | List all branches with metadata |
+| `POST` | `/git/fetch` | Run `git fetch --prune` |
+| `GET` | `/git/worktrees?repoRoot=` | List all worktrees |
+| `POST` | `/git/worktree` | Create or reuse a worktree |
+| `DELETE` | `/git/worktree` | Remove a worktree |
+| `POST` | `/git/pull` | Run `git pull` |

--- a/docs/index.mdx
+++ b/docs/index.mdx
@@ -1,0 +1,50 @@
+---
+title: The Companion
+description: Web UI for Claude Code and Codex sessions
+---
+
+# The Companion
+
+A browser-based interface for running multiple [Claude Code](https://docs.anthropic.com/en/docs/claude-code) and [Codex](https://github.com/openai/codex) sessions with streaming output, tool call visibility, and permission control.
+
+<img src="/screenshots/readme-main-workspace.png" alt="The Companion main workspace" />
+
+## Quick start
+
+```bash
+bunx the-companion
+```
+
+Open [http://localhost:3456](http://localhost:3456). See the [Installation](/getting-started/installation) guide for more options.
+
+## Subscription and authentication
+
+The Companion is a local UI layer that runs on your machine. It does not have its own account system or billing.
+
+- **Claude Code** requires an Anthropic API key or a Claude Pro/Team/Enterprise subscription with Claude Code enabled.
+- **Codex** requires an OpenAI account with Codex CLI access.
+
+All model inference happens through your own subscriptions. The Companion bridges your browser to these CLI tools over a local WebSocket connection.
+
+## Features
+
+<CardGroup cols={2}>
+  <Card title="Saved Prompts" icon="bookmark" href="/prompts/creating-prompts">
+    Create reusable prompts scoped globally or to specific projects. Insert them in any session with @mentions.
+  </Card>
+  <Card title="Agents" icon="robot" href="/agents/creating-agents">
+    Build reusable agent configurations with custom prompts, triggers (webhook, schedule), and Docker/git support.
+  </Card>
+  <Card title="Environments & Docker" icon="docker" href="/environments/environment-profiles">
+    Define environment profiles with variables, Docker containers, init scripts, and port forwarding.
+  </Card>
+  <Card title="Sessions & Permissions" icon="shield-check" href="/sessions/creating-sessions">
+    Run parallel sessions, approve tool calls, and recover work after restarts.
+  </Card>
+  <Card title="Git Worktrees" icon="code-branch" href="/git/branches-and-worktrees">
+    Isolate sessions with git worktrees so multiple agents can work on the same repo without conflicts.
+  </Card>
+  <Card title="Linear Integration" icon="list-check" href="/integrations/linear">
+    Search and create Linear issues, link them to sessions, and auto-transition issue status.
+  </Card>
+</CardGroup>

--- a/docs/integrations/linear.mdx
+++ b/docs/integrations/linear.mdx
@@ -1,0 +1,99 @@
+---
+title: Linear Integration
+description: Connect Linear for issue-driven development workflows
+---
+
+# Linear Integration
+
+The Companion integrates with [Linear](https://linear.app) to let you search issues, create new ones, link them to sessions, and automatically transition issue status as you work.
+
+## Setup
+
+1. Navigate to **Integrations** in the sidebar, then click **Linear Settings**
+2. Enter your **Linear API key** (starts with `lin_api_`)
+   - Get one from [Linear Settings > API](https://linear.app/settings/api)
+3. Click **Verify** to test the connection
+4. On success, you'll see your name, email, and connected workspace
+
+## Search and browse issues
+
+On the **Home page**, the Linear section lets you:
+
+- **Search issues**: Type an issue key (e.g., `ENG-123`) or title to find issues across your workspace. Results exclude completed issues and are sorted with active issues first.
+- **Browse project issues**: If you've attached a Linear project to the current repository, recent issues from that project are shown automatically.
+
+Toggle between project-scoped and global search with the search button.
+
+## Create issues
+
+Click **Create Issue** on the Home page to create a new Linear issue:
+
+| Field | Description |
+|---|---|
+| **Title** | Issue title (required) |
+| **Description** | Markdown description |
+| **Team** | Which Linear team to assign to (required) |
+| **Priority** | None, Urgent, High, Medium, or Low |
+| **Assign to me** | Self-assign the issue |
+
+If you have a project attached to the current repo, the issue is automatically added to that project.
+
+## Link issues to sessions
+
+1. On the Home page, search for or create an issue
+2. Select the issue — it appears as a **Context** badge
+3. Create the session — the issue details (identifier, title, state, description, labels, assignees, URL) are prepended to your first message as context
+4. The **branch name** is auto-populated from the issue (e.g., `ENG-123` + "Fix auth flow" becomes `eng-123-fix-auth-flow`)
+
+You can also link or unlink issues after a session is created.
+
+## Auto-transition
+
+Automatically move a linked issue to a specific status when a session starts.
+
+### Configure
+
+1. Go to **Linear Settings**
+2. Toggle **Auto-transition** on
+3. Select the **team** (if you have multiple teams)
+4. Choose the **target status** from the team's workflow states (e.g., "In Progress")
+
+Now, every time you create a session with a linked Linear issue, the issue automatically moves to the configured status.
+
+## Archive transition
+
+When you archive a session that has a linked Linear issue (and the issue isn't already "done"), a modal asks what to do:
+
+- **Keep current status**: Leave the issue as-is
+- **Move to backlog**: Transition to the team's backlog state
+- **Move to configured status**: Transition to a status you've pre-configured in settings
+
+### Configure archive transition
+
+1. Go to **Linear Settings**
+2. Toggle **Archive transition** on
+3. Select the target status for archived sessions
+
+## Project-repo mapping
+
+Associate git repositories with Linear projects so that project-scoped issue search works automatically:
+
+1. On the Home page, click the **attach project** icon in the Linear section
+2. Select a Linear project from the dropdown
+3. The mapping is saved — when you open the Home page in that repo, project issues are shown automatically
+
+Mappings are stored in `~/.companion/linear-projects.json`.
+
+## Rate limiting
+
+Linear has a 5,000 requests/hour rate limit. The Companion manages this with built-in caching:
+
+| Data | Cache TTL |
+|---|---|
+| Connection info | 5 minutes |
+| Workflow states | 5 minutes |
+| Issue searches | 30 seconds |
+| Project issues | 60 seconds |
+| Projects list | 5 minutes |
+
+Concurrent duplicate requests are deduplicated to a single API call.

--- a/docs/prompts/creating-prompts.mdx
+++ b/docs/prompts/creating-prompts.mdx
@@ -1,0 +1,55 @@
+---
+title: Creating Prompts
+description: Create, edit, and organize reusable saved prompts
+---
+
+# Creating Prompts
+
+Saved prompts let you store reusable instructions that can be inserted into any session. Navigate to **Prompts** in the sidebar (or go to `#/prompts`).
+
+## Create a prompt
+
+1. Click **New Prompt**
+2. Enter a **name** (e.g., `review-pr`, `fix-tests`, `explain-code`)
+3. Write the **prompt content** — the actual instructions the agent will receive
+4. Choose a **scope**:
+   - **Global**: Available in all sessions regardless of working directory
+   - **Project**: Only appears in sessions whose working directory matches one of the associated folders
+5. For project-scoped prompts, click **Add Folder** to associate one or more project paths
+6. Click **Save**
+
+## Edit and delete
+
+- Click the **pencil icon** on any prompt card to edit its name, content, scope, or associated folders
+- Click the **trash icon** to delete a prompt
+- Use the **search bar** at the top to filter prompts by name or content
+
+## Scope: global vs project
+
+| Scope | Visible in | Use case |
+|---|---|---|
+| Global | All sessions | General instructions like "review this PR" or "explain this code" |
+| Project | Sessions whose cwd matches an associated folder | Project-specific instructions like "use our ESLint config" or "follow our API conventions" |
+
+A single prompt can be associated with multiple project folders. For example, a "run tests" prompt could be linked to both your frontend and backend repos with different test commands.
+
+## Grouped view
+
+The Prompts page groups prompts by scope:
+
+- **Global** section at the top with all global prompts
+- **Per-folder** sections below, one for each unique project path
+
+## Storage
+
+Prompts are stored at `~/.companion/prompts.json` as a JSON array. Each prompt has a unique ID, name, content, scope, and timestamps.
+
+## REST API
+
+| Method | Endpoint | Description |
+|---|---|---|
+| `GET` | `/api/prompts` | List all prompts (optional `?cwd=` and `?scope=` filters) |
+| `GET` | `/api/prompts/:id` | Get a single prompt |
+| `POST` | `/api/prompts` | Create a prompt |
+| `PUT` | `/api/prompts/:id` | Update a prompt |
+| `DELETE` | `/api/prompts/:id` | Delete a prompt |

--- a/docs/prompts/using-prompts.mdx
+++ b/docs/prompts/using-prompts.mdx
@@ -1,0 +1,63 @@
+---
+title: Using Prompts
+description: Insert saved prompts into conversations with @mentions
+---
+
+# Using Prompts
+
+Once you've [created prompts](/prompts/creating-prompts), you can insert them into any session using the `@` mention syntax.
+
+## How to use
+
+1. Open a session and click in the **composer** (message input)
+2. Type `@` followed by the prompt name (e.g., `@review-pr`)
+3. A **mention menu** appears with matching prompts
+4. Select the prompt — its content is inserted inline into your message
+5. Press Enter to send
+
+## How filtering works
+
+- The mention menu shows prompts matching your text using fuzzy search on the prompt title
+- **Global prompts** always appear
+- **Project-scoped prompts** only appear when the session's working directory matches one of the prompt's associated folders
+
+## Example workflow
+
+### 1. Create a "review-pr" prompt
+
+Go to **Prompts** and create:
+
+- **Name**: `review-pr`
+- **Content**: `Review this pull request. Check for bugs, security issues, and code style. Suggest improvements. Run the test suite and report any failures.`
+- **Scope**: Global
+
+### 2. Use it in a session
+
+Open a session in your project directory and type:
+
+```
+@review-pr
+```
+
+The composer expands to:
+
+```
+Review this pull request. Check for bugs, security issues, and code style.
+Suggest improvements. Run the test suite and report any failures.
+```
+
+You can add extra context before sending:
+
+```
+@review-pr Focus especially on the authentication changes in auth.ts.
+```
+
+### 3. Project-specific variant
+
+Create another prompt scoped to your backend project:
+
+- **Name**: `review-pr`
+- **Content**: `Review this pull request. Run "bun run test" and "bun run typecheck". Check that all API routes have input validation. Ensure SQL queries use parameterized statements.`
+- **Scope**: Project (`/home/user/backend`)
+
+When you're in a session with cwd `/home/user/backend`, the project-scoped version appears first in the mention menu. In other sessions, only the global version appears.

--- a/docs/sessions/creating-sessions.mdx
+++ b/docs/sessions/creating-sessions.mdx
@@ -1,0 +1,62 @@
+---
+title: Creating Sessions
+description: How to create and configure agent sessions
+---
+
+# Creating Sessions
+
+A session is a conversation with an agent backed by a CLI subprocess. Each session has its own message history, tool call log, task list, and permission state.
+
+## From the UI
+
+Click **New Session** on the home page. Configure:
+
+| Option | Description |
+|---|---|
+| **Backend** | Claude Code or Codex |
+| **Working directory** | The folder the agent operates in |
+| **Model** (Claude Code) | Which Claude model to use |
+| **Branch** (optional) | Git branch to check out or create |
+| **Use worktree** (optional) | Create an isolated [git worktree](/git/branches-and-worktrees) |
+| **Environment** (optional) | Apply an [environment profile](/environments/environment-profiles) |
+| **Linear issue** (optional) | Link a [Linear issue](/integrations/linear) for context |
+
+Click **Start** to launch the session.
+
+## What happens at creation
+
+1. The server spawns a CLI subprocess (Claude Code or Codex) with `--sdk-url` pointing back to the server
+2. The CLI connects to the server over WebSocket
+3. The server bridges messages between the CLI and your browser
+4. If a branch is selected, the server checks it out (or creates a worktree)
+5. If a Docker environment is configured, the session runs inside a container
+
+## Backend differences
+
+### Claude Code
+- Uses the NDJSON WebSocket protocol
+- Supports model selection, permission modes, and session resumption via `--resume`
+- Requires an Anthropic API key or Claude Pro/Team/Enterprise subscription
+
+### Codex
+- Uses a JSON-RPC WebSocket protocol
+- Has its own authentication (OpenAI account)
+- Supports an internet access toggle
+- Some features like permission modes may work differently
+
+The UI adapts to show only the options available for the selected backend.
+
+## Via the REST API
+
+```bash
+curl -X POST http://localhost:3456/api/sessions \
+  -H "Content-Type: application/json" \
+  -H "Authorization: Bearer YOUR_TOKEN" \
+  -d '{
+    "cwd": "/path/to/project",
+    "backendType": "claude",
+    "branch": "feature/my-branch",
+    "useWorktree": true,
+    "envSlug": "my-env-profile"
+  }'
+```

--- a/docs/sessions/managing-sessions.mdx
+++ b/docs/sessions/managing-sessions.mdx
@@ -1,0 +1,52 @@
+---
+title: Managing Sessions
+description: Switch between, monitor, and control active sessions
+---
+
+# Managing Sessions
+
+## Sidebar
+
+The sidebar lists all active and recent sessions. Each entry shows the session name, backend type, connection status, and working directory. Click a session to switch to it.
+
+## Chat view
+
+The chat view displays messages in a timeline:
+
+- **User messages**: Your prompts
+- **Assistant messages**: Streaming agent responses
+- **Tool call blocks**: Expandable blocks showing the tool name, input, and output
+- **Permission banners**: Inline approve/deny buttons for sensitive actions
+
+## Task panel
+
+The right-side panel shows a structured breakdown of the agent's work. Tasks are automatically extracted from `TodoWrite`, `TaskCreate`, and `TaskUpdate` tool calls. Each task shows its status: pending, in progress, or completed.
+
+## Interrupting the agent
+
+Click the **stop button** in the composer area to interrupt a running agent. This sends an interrupt signal to the CLI subprocess.
+
+## Archiving sessions
+
+Remove sessions from the sidebar by archiving them. This:
+
+- Stops the CLI subprocess
+- Removes the session file from disk
+- If a Docker container is running, removes the container and its volume
+- If a [Linear issue](/integrations/linear) is linked, prompts you to choose what happens to the issue status
+
+<Warning>
+Archiving a Docker session removes the container and all uncommitted changes inside it. Make sure you've committed or pushed any work before archiving.
+</Warning>
+
+## Session tabs
+
+Sessions may have additional tabs beyond the chat:
+
+| Tab | Description |
+|---|---|
+| **Chat** | Main conversation view |
+| **Diff** | File changes made during the session |
+| **Editor** | In-app code editor (CodeMirror) |
+| **Terminal** | Terminal access to the session's environment |
+| **Process** | Raw CLI process output |

--- a/docs/sessions/permissions.mdx
+++ b/docs/sessions/permissions.mdx
@@ -1,0 +1,58 @@
+---
+title: Permissions
+description: Control what the agent can do with permission modes and AI validation
+---
+
+# Permissions
+
+When an agent wants to perform a sensitive action — writing files, running commands, accessing the network — The Companion intercepts the request and presents it for your approval.
+
+<img src="/screenshots/readme-permissions.png" alt="Permission approval UI" />
+
+## How it works
+
+1. The CLI sends a permission request (e.g., "can I run `rm -rf node_modules`?")
+2. A **permission banner** appears inline in the chat with the tool name and input
+3. You click **Allow** or **Deny**
+4. Your response is sent back to the CLI, which proceeds or skips accordingly
+
+If you don't respond, the agent waits indefinitely — it will never act without your explicit consent.
+
+## Permission modes
+
+You can set the permission mode per session to control how much approval is required.
+
+| Mode | Behavior |
+|---|---|
+| **Default** | Every sensitive tool call requires individual approval |
+| **Accept Edits** | File edits are auto-approved; commands and network access still need approval |
+| **Bypass** | All tool calls are auto-approved without prompting |
+
+<Warning>
+Bypass mode removes all safety gates. Only use this in isolated environments or when you fully trust the agent's task.
+</Warning>
+
+### Change the mode
+
+You can change the permission mode at any time during a session. The change takes effect immediately for all subsequent tool calls.
+
+## AI validation
+
+AI validation uses a separate model to evaluate tool calls before execution. It categorizes each request as safe, dangerous, or uncertain.
+
+### Setup
+
+1. Go to **Settings** and enter your **Anthropic API key**
+2. Toggle **AI Validation** on
+
+### How it works
+
+| Category | Behavior |
+|---|---|
+| **Safe** (read-only, benign commands) | Auto-approved if "auto-approve safe" is enabled |
+| **Dangerous** (destructive commands like `rm -rf`) | Auto-denied if "auto-deny dangerous" is enabled |
+| **Uncertain** | Shown to you with the AI's recommendation |
+
+### Per-session override
+
+Click the **shield icon** in the session header to toggle AI validation on or off for that specific session, overriding the global setting.

--- a/docs/sessions/session-recovery.mdx
+++ b/docs/sessions/session-recovery.mdx
@@ -1,0 +1,25 @@
+---
+title: Session Recovery
+description: How sessions persist and recover across restarts
+---
+
+# Session Recovery
+
+## Automatic persistence
+
+Sessions are saved to disk as JSON files in `$TMPDIR/vibe-sessions/`. Writes are debounced to minimize I/O during streaming. The saved state includes the session configuration, message history, task list, permission state, and CLI process PID.
+
+## What happens on server restart
+
+1. The server reads all persisted session files
+2. For each session with a recorded PID, it checks if the CLI process is still running
+3. If alive, it gives a grace period for the CLI to reconnect its WebSocket
+4. If gone (or no reconnection), the server relaunches the CLI with `--resume` using the session's internal ID
+
+This means you can restart The Companion without losing your work. The agent picks up where it left off.
+
+## Limitations
+
+- If both the server and CLI crash at the same time, the last few messages may not be persisted (due to write debouncing)
+- Runtime state in the CLI process is lost on restart, though conversation history is preserved
+- Docker sessions: the container persists across server restarts, but the CLI inside it is relaunched

--- a/docs/troubleshooting/common-issues.mdx
+++ b/docs/troubleshooting/common-issues.mdx
@@ -1,0 +1,128 @@
+---
+title: Common Issues
+description: Solutions to frequently encountered problems
+---
+
+# Common Issues
+
+## CLI not found
+
+**Symptom**: Error when creating a session — `claude` or `codex` command not found.
+
+**Fix**: Install the CLI globally and ensure it's on your `PATH`:
+
+```bash
+# Claude Code
+npm install -g @anthropic-ai/claude-code
+which claude
+
+# Codex
+npm install -g @openai/codex
+which codex
+```
+
+## Port already in use
+
+**Symptom**: Server fails to start with "address already in use" on port 3456.
+
+**Fix**: Find what's using the port or choose another:
+
+```bash
+lsof -i :3456
+the-companion --port 8080
+```
+
+## Authentication errors
+
+**Symptom**: Browser shows auth error or can't connect.
+
+**Fix**: Regenerate the token:
+
+```bash
+cd web && bun run generate-token --force
+```
+
+Or set explicitly:
+
+```bash
+COMPANION_AUTH_TOKEN="my-token" the-companion
+```
+
+## CLI disconnects immediately
+
+**Symptom**: Session is created but the CLI exits right away.
+
+**Causes**:
+- CLI not authenticated (missing API key or subscription)
+- Working directory doesn't exist
+- Incompatible CLI version
+
+Check server logs: `the-companion logs`
+
+## Docker not detected
+
+**Symptom**: Environments page shows amber "No Docker" badge. Docker sessions fail to create.
+
+**Fix**:
+- Ensure Docker is installed and the daemon is running: `docker ps`
+- On Linux, make sure your user is in the `docker` group: `sudo usermod -aG docker $USER`
+- On macOS, ensure Docker Desktop is running
+
+## Docker image pull fails
+
+**Symptom**: Image pull shows error state in the Environments Docker tab.
+
+**Fix**:
+- Check your internet connection
+- Verify the image name is correct
+- Try pulling manually: `docker pull the-companion:latest`
+- Check Docker Hub rate limits if pulling many images
+
+## Worktree conflicts
+
+**Symptom**: Error creating a worktree for a branch.
+
+**Causes**:
+- The branch is already checked out in the main working tree (git doesn't allow a branch in two worktrees)
+- The worktree path already exists on disk
+
+**Fix**: The Companion handles this automatically by creating a unique branch name (e.g., `main-wt-5391`). If you see persistent errors, check `~/.companion/worktrees.json` and remove stale entries.
+
+## Linear connection fails
+
+**Symptom**: "Verify" button shows an error in Linear Settings.
+
+**Fix**:
+- Ensure your API key starts with `lin_api_`
+- Check that the key hasn't been revoked in [Linear Settings > API](https://linear.app/settings/api)
+- Try generating a new API key
+
+## Session not recovering after restart
+
+**Symptom**: Sessions appear after restart but the agent doesn't resume.
+
+**Fix**:
+- Check that the CLI is still installed and on `PATH`
+- Verify your authentication is still valid
+- Check that the working directory still exists
+- View server logs for relaunch errors: `the-companion logs`
+
+## Browser WebSocket not connecting
+
+**Symptom**: UI loads but shows disconnected state.
+
+**Fix**:
+- Check the server is running
+- Refresh the page
+- Check for proxy or firewall blocking WebSocket connections
+- Verify the auth token matches (check browser console for 401 errors)
+
+## Server logs
+
+When running as a background service:
+
+```bash
+the-companion logs
+```
+
+When running in foreground, logs print to stdout. Check the session files directly at `$TMPDIR/vibe-sessions/` for raw state inspection.

--- a/docs/troubleshooting/recordings.mdx
+++ b/docs/troubleshooting/recordings.mdx
@@ -1,0 +1,82 @@
+---
+title: Protocol Recordings
+description: Debug issues with automatic WebSocket message recordings
+---
+
+# Protocol Recordings
+
+The Companion automatically records all WebSocket messages to JSONL files. Use recordings to debug issues, understand agent behavior, or build test fixtures.
+
+## Where recordings are stored
+
+- **Directory**: `~/.companion/recordings/`
+- **Override**: Set `COMPANION_RECORDINGS_DIR` env var
+- **File naming**: `{sessionId}_{backendType}_{ISO-timestamp}_{randomSuffix}.jsonl`
+
+## Recording format
+
+Each file is JSONL (one JSON object per line). The first line is a header with session metadata. Subsequent lines are message entries:
+
+```json
+{"ts": 1771153996875, "dir": "in", "raw": "{\"type\":\"system\",...}", "ch": "cli"}
+```
+
+| Field | Description |
+|---|---|
+| `ts` | Timestamp (milliseconds since epoch) |
+| `dir` | `"in"` (received by server) or `"out"` (sent by server) |
+| `ch` | `"cli"` (agent process) or `"browser"` (frontend) |
+| `raw` | The exact original message — never re-serialized |
+
+## Inspecting recordings
+
+```bash
+# View the first 20 messages
+head -20 ~/.companion/recordings/SESSION_*.jsonl
+
+# Filter for CLI messages only
+grep '"ch":"cli"' ~/.companion/recordings/SESSION_*.jsonl
+
+# Find permission requests
+grep 'can_use_tool' ~/.companion/recordings/SESSION_*.jsonl
+
+# Pretty-print a single entry
+sed -n '5p' ~/.companion/recordings/SESSION_*.jsonl | python3 -m json.tool
+```
+
+## Enable and disable
+
+Recording is enabled by default. Disable it with:
+
+```bash
+COMPANION_RECORD=0 the-companion
+```
+
+## Per-session control
+
+Use the REST API to start/stop recording for individual sessions:
+
+```bash
+# Check recording status
+curl http://localhost:3456/api/sessions/SESSION_ID/recording/status \
+  -H "Authorization: Bearer YOUR_TOKEN"
+
+# Stop recording
+curl -X POST http://localhost:3456/api/sessions/SESSION_ID/recording/stop \
+  -H "Authorization: Bearer YOUR_TOKEN"
+
+# Start recording
+curl -X POST http://localhost:3456/api/sessions/SESSION_ID/recording/start \
+  -H "Authorization: Bearer YOUR_TOKEN"
+```
+
+## List all recordings
+
+```bash
+curl http://localhost:3456/api/recordings \
+  -H "Authorization: Bearer YOUR_TOKEN"
+```
+
+## Rotation
+
+Automatic cleanup triggers when total lines across all recordings exceed 1,000,000 (configurable with `COMPANION_RECORDINGS_MAX_LINES`).


### PR DESCRIPTION
## Summary
- Adds complete Mintlify documentation scaffold with 21 functional how-to pages
- Covers all major features: Saved Prompts, Agents, Environments & Docker, Sessions & Permissions, Git Worktrees, Linear Integration
- Includes `docs.json` config with 8 navigation groups
- Updates README.md with link to new docs

## Details
Replaces the previous architecture-focused documentation with practical, task-oriented pages:

- **Saved Prompts**: How to create, scope, and use prompts via @mentions
- **Agents**: Creating agents, webhook/schedule triggers, MCP servers, import/export
- **Environments & Docker**: Environment profiles, Docker sessions, init scripts, GLM v5 via env vars
- **Sessions & Permissions**: Session lifecycle, permission modes, AI validation
- **Git Workflows**: Branch picker, worktree isolation
- **Linear Integration**: Issue search/create, session linking, auto-transition
- **Troubleshooting**: Common issues, protocol recordings

## Test plan
- [x] All 21 nav entries resolve to existing `.mdx` files
- [x] All image references point to existing screenshots
- [x] `docs.json` is valid JSON with required Mintlify fields
- [ ] Run `cd docs && npx mint dev` to verify local preview

## Review provenance
- Implemented by AI agent
- Human review: no

Closes THE-214
