### PR TITLE
feat(ui): add compacting context indicator in message feed

### DIFF
--- a/web/src/components/MessageFeed.test.tsx
+++ b/web/src/components/MessageFeed.test.tsx
@@ -14,7 +14,9 @@ const { getClaudeSessionHistoryMock } = vi.hoisted(() => ({
 
 // Mock react-markdown to avoid ESM issues in tests
 vi.mock("react-markdown", () => ({
-  default: ({ children }: { children: string }) => <div data-testid="markdown">{children}</div>,
+  default: ({ children }: { children: string }) => (
+    <div data-testid="markdown">{children}</div>
+  ),
 }));
 
 vi.mock("remark-gfm", () => ({
@@ -39,7 +41,8 @@ vi.mock("../store.js", () => ({
       streamingOutputTokens: mockStoreValues.streamingOutputTokens ?? new Map(),
       sessionStatus: mockStoreValues.sessionStatus ?? new Map(),
       toolProgress: mockStoreValues.toolProgress ?? new Map(),
-      chatTabReentryTickBySession: mockStoreValues.chatTabReentryTickBySession ?? new Map(),
+      chatTabReentryTickBySession:
+        mockStoreValues.chatTabReentryTickBySession ?? new Map(),
       sdkSessions: mockStoreValues.sdkSessions ?? [],
     };
     return selector(state);
@@ -48,7 +51,9 @@ vi.mock("../store.js", () => ({
 
 import { MessageFeed } from "./MessageFeed.js";
 
-function makeMessage(overrides: Partial<ChatMessage> & { role: ChatMessage["role"] }): ChatMessage {
+function makeMessage(
+  overrides: Partial<ChatMessage> & { role: ChatMessage["role"] },
+): ChatMessage {
   return {
     id: `msg-${Math.random().toString(36).slice(2, 8)}`,
     content: "",
@@ -75,13 +80,19 @@ function setStoreStatus(sessionId: string, status: string | null) {
   mockStoreValues.sessionStatus = statusMap;
 }
 
-function setStoreStreamingStartedAt(sessionId: string, startedAt: number | undefined) {
+function setStoreStreamingStartedAt(
+  sessionId: string,
+  startedAt: number | undefined,
+) {
   const map = new Map();
   if (startedAt !== undefined) map.set(sessionId, startedAt);
   mockStoreValues.streamingStartedAt = map;
 }
 
-function setStoreStreamingOutputTokens(sessionId: string, tokens: number | undefined) {
+function setStoreStreamingOutputTokens(
+  sessionId: string,
+  tokens: number | undefined,
+) {
   const map = new Map();
   if (tokens !== undefined) map.set(sessionId, tokens);
   mockStoreValues.streamingOutputTokens = map;
@@ -184,9 +195,7 @@ describe("MessageFeed - empty state", () => {
 
   it("does not show empty state when there are messages", () => {
     const sid = "test-not-empty";
-    setStoreMessages(sid, [
-      makeMessage({ role: "user", content: "Hello" }),
-    ]);
+    setStoreMessages(sid, [makeMessage({ role: "user", content: "Hello" })]);
 
     render(<MessageFeed sessionId={sid} />);
 
@@ -232,7 +241,12 @@ describe("MessageFeed - streaming assistant bubble", () => {
     const sid = "test-streaming";
     setStoreMessages(sid, [
       makeMessage({ id: "u1", role: "user", content: "Hello" }),
-      makeMessage({ id: "a1", role: "assistant", content: "I am currently thinking about", isStreaming: true }),
+      makeMessage({
+        id: "a1",
+        role: "assistant",
+        content: "I am currently thinking about",
+        isStreaming: true,
+      }),
     ]);
 
     render(<MessageFeed sessionId={sid} />);
@@ -331,13 +345,18 @@ describe("MessageFeed - lazy resume transcript", () => {
 
     render(<MessageFeed sessionId={sid} />);
 
-    fireEvent.click(screen.getByRole("button", { name: /load previous history/i }));
+    fireEvent.click(
+      screen.getByRole("button", { name: /load previous history/i }),
+    );
 
     await waitFor(() => {
-      expect(getClaudeSessionHistoryMock).toHaveBeenCalledWith("prior-session-123", {
-        cursor: 0,
-        limit: 40,
-      });
+      expect(getClaudeSessionHistoryMock).toHaveBeenCalledWith(
+        "prior-session-123",
+        {
+          cursor: 0,
+          limit: 40,
+        },
+      );
     });
     expect(await screen.findByText("Earlier question")).toBeTruthy();
     expect(await screen.findByText("Earlier answer")).toBeTruthy();
@@ -345,7 +364,9 @@ describe("MessageFeed - lazy resume transcript", () => {
 
   it("shows inline resume banner for active chats and updates loaded transcript status", async () => {
     const sid = "test-resume-inline";
-    setStoreMessages(sid, [makeMessage({ id: "u1", role: "user", content: "Continue from here" })]);
+    setStoreMessages(sid, [
+      makeMessage({ id: "u1", role: "user", content: "Continue from here" }),
+    ]);
     setSdkSessions([
       {
         sessionId: sid,
@@ -376,28 +397,75 @@ describe("MessageFeed - lazy resume transcript", () => {
 
     expect(screen.getByText("Forked from existing Claude thread")).toBeTruthy();
 
-    fireEvent.click(screen.getByRole("button", { name: /load previous history/i }));
+    fireEvent.click(
+      screen.getByRole("button", { name: /load previous history/i }),
+    );
 
     await waitFor(() => {
-      expect(getClaudeSessionHistoryMock).toHaveBeenCalledWith("prior-inline-456", {
-        cursor: 0,
-        limit: 40,
-      });
+      expect(getClaudeSessionHistoryMock).toHaveBeenCalledWith(
+        "prior-inline-456",
+        {
+          cursor: 0,
+          limit: 40,
+        },
+      );
     });
 
-    expect(await screen.findByText("Loaded all available prior transcript")).toBeTruthy();
+    expect(
+      await screen.findByText("Loaded all available prior transcript"),
+    ).toBeTruthy();
+  });
+});
+
+// ─── Compacting context indicator ─────────────────────────────────────────────
+
+describe("MessageFeed - compacting indicator", () => {
+  it("renders compacting spinner when session status is 'compacting'", () => {
+    const sid = "test-compacting";
+    setStoreMessages(sid, [makeMessage({ role: "user", content: "hi" })]);
+    setStoreStatus(sid, "compacting");
+
+    render(<MessageFeed sessionId={sid} />);
+
+    expect(screen.getByText("Compacting context...")).toBeTruthy();
+  });
+
+  it("does not render compacting spinner when session is running", () => {
+    const sid = "test-not-compacting";
+    setStoreMessages(sid, [makeMessage({ role: "user", content: "hi" })]);
+    setStoreStatus(sid, "running");
+    setStoreStreamingStartedAt(sid, Date.now() - 3000);
+
+    render(<MessageFeed sessionId={sid} />);
+
+    expect(screen.queryByText("Compacting context...")).toBeNull();
+  });
+
+  it("does not render compacting spinner when session is idle", () => {
+    const sid = "test-idle-no-compact";
+    setStoreMessages(sid, [makeMessage({ role: "user", content: "hi" })]);
+    setStoreStatus(sid, "idle");
+
+    render(<MessageFeed sessionId={sid} />);
+
+    expect(screen.queryByText("Compacting context...")).toBeNull();
   });
 });
 
 describe("MessageFeed - tool progress indicator", () => {
   it("renders tool progress while tools are running", () => {
     const sid = "test-tool-progress";
-    setStoreMessages(sid, [makeMessage({ role: "user", content: "run checks" })]);
+    setStoreMessages(sid, [
+      makeMessage({ role: "user", content: "run checks" }),
+    ]);
     const progressBySession = new Map();
-    progressBySession.set(sid, new Map([
-      ["bash-1", { toolName: "Bash", elapsedSeconds: 7 }],
-      ["read-1", { toolName: "Read", elapsedSeconds: 2 }],
-    ]));
+    progressBySession.set(
+      sid,
+      new Map([
+        ["bash-1", { toolName: "Bash", elapsedSeconds: 7 }],
+        ["read-1", { toolName: "Read", elapsedSeconds: 2 }],
+      ]),
+    );
     mockStoreValues.toolProgress = progressBySession;
 
     render(<MessageFeed sessionId={sid} />);
@@ -420,7 +488,12 @@ describe("MessageFeed - tool-only message detection", () => {
         role: "assistant",
         content: "",
         contentBlocks: [
-          { type: "tool_use", id: "tu-1", name: "Read", input: { file_path: "/a.ts" } },
+          {
+            type: "tool_use",
+            id: "tu-1",
+            name: "Read",
+            input: { file_path: "/a.ts" },
+          },
         ],
       }),
       makeMessage({
@@ -428,7 +501,12 @@ describe("MessageFeed - tool-only message detection", () => {
         role: "assistant",
         content: "",
         contentBlocks: [
-          { type: "tool_use", id: "tu-2", name: "Read", input: { file_path: "/b.ts" } },
+          {
+            type: "tool_use",
+            id: "tu-2",
+            name: "Read",
+            input: { file_path: "/b.ts" },
+          },
         ],
       }),
     ]);
@@ -450,7 +528,12 @@ describe("MessageFeed - tool-only message detection", () => {
         role: "assistant",
         content: "",
         contentBlocks: [
-          { type: "tool_use", id: "tu-1", name: "Read", input: { file_path: "/a.ts" } },
+          {
+            type: "tool_use",
+            id: "tu-1",
+            name: "Read",
+            input: { file_path: "/a.ts" },
+          },
         ],
       }),
       makeMessage({
@@ -458,7 +541,12 @@ describe("MessageFeed - tool-only message detection", () => {
         role: "assistant",
         content: "",
         contentBlocks: [
-          { type: "tool_use", id: "tu-2", name: "Bash", input: { command: "ls" } },
+          {
+            type: "tool_use",
+            id: "tu-2",
+            name: "Bash",
+            input: { command: "ls" },
+          },
         ],
       }),
     ]);
@@ -478,7 +566,12 @@ describe("MessageFeed - tool-only message detection", () => {
         content: "",
         contentBlocks: [
           { type: "text", text: "Let me check something" },
-          { type: "tool_use", id: "tu-1", name: "Read", input: { file_path: "/a.ts" } },
+          {
+            type: "tool_use",
+            id: "tu-1",
+            name: "Read",
+            input: { file_path: "/a.ts" },
+          },
         ],
       }),
     ]);
@@ -506,7 +599,10 @@ describe("MessageFeed - subagent grouping", () => {
             type: "tool_use",
             id: "task-1",
             name: "Task",
-            input: { description: "Research the problem", subagent_type: "researcher" },
+            input: {
+              description: "Research the problem",
+              subagent_type: "researcher",
+            },
           },
         ],
       }),
@@ -521,7 +617,9 @@ describe("MessageFeed - subagent grouping", () => {
     render(<MessageFeed sessionId={sid} />);
 
     // The description appears in both the tool preview and the subagent container label
-    expect(screen.getAllByText("Research the problem").length).toBeGreaterThanOrEqual(1);
+    expect(
+      screen.getAllByText("Research the problem").length,
+    ).toBeGreaterThanOrEqual(1);
     // The agent type badge should be shown
     expect(screen.getByText("researcher")).toBeTruthy();
   });

--- a/web/src/components/MessageFeed.tsx
+++ b/web/src/components/MessageFeed.tsx
@@ -2,7 +2,12 @@ import { useEffect, useRef, useMemo, useState, useCallback } from "react";
 import { useStore } from "../store.js";
 import { api } from "../api.js";
 import { MessageBubble } from "./MessageBubble.js";
-import { getToolIcon, getToolLabel, getPreview, ToolIcon } from "./ToolBlock.js";
+import {
+  getToolIcon,
+  getToolLabel,
+  getPreview,
+  ToolIcon,
+} from "./ToolBlock.js";
 import type { ChatMessage, ContentBlock, SdkSessionInfo } from "../types.js";
 import { formatElapsed, formatTokenCount } from "../utils/format.js";
 
@@ -22,7 +27,11 @@ function formatResumeSourcePath(path: string): string {
 
 // ─── Message-level grouping ─────────────────────────────────────────────────
 
-interface ToolItem { id: string; name: string; input: Record<string, unknown> }
+interface ToolItem {
+  id: string;
+  name: string;
+  input: Record<string, unknown>;
+}
 
 interface ToolMsgGroup {
   kind: "tool_msg_group";
@@ -74,7 +83,16 @@ function getToolOnlyName(msg: ChatMessage): string | null {
 function extractToolItems(msg: ChatMessage): ToolItem[] {
   const blocks = msg.contentBlocks || [];
   return blocks
-    .filter((b): b is ContentBlock & { type: "tool_use"; id: string; name: string; input: Record<string, unknown> } => b.type === "tool_use")
+    .filter(
+      (
+        b,
+      ): b is ContentBlock & {
+        type: "tool_use";
+        id: string;
+        name: string;
+        input: Record<string, unknown>;
+      } => b.type === "tool_use",
+    )
     .map((b) => ({ id: b.id, name: b.name, input: b.input }));
 }
 
@@ -83,12 +101,15 @@ function getTaskIdsFromEntry(entry: FeedEntry): string[] {
   if (entry.kind === "message") {
     const blocks = entry.msg.contentBlocks || [];
     return blocks
-      .filter((b): b is Extract<ContentBlock, { type: "tool_use" }> => b.type === "tool_use")
-      .filter(b => b.name === "Task")
-      .map(b => b.id);
+      .filter(
+        (b): b is Extract<ContentBlock, { type: "tool_use" }> =>
+          b.type === "tool_use",
+      )
+      .filter((b) => b.name === "Task")
+      .map((b) => b.id);
   }
   if (entry.kind === "tool_msg_group" && entry.toolName === "Task") {
-    return entry.items.map(item => item.id);
+    return entry.items.map((item) => item.id);
   }
   return [];
 }
@@ -123,15 +144,18 @@ function groupToolMessages(messages: ChatMessage[]): FeedEntry[] {
 /** Build feed entries with subagent nesting */
 function buildEntries(
   messages: ChatMessage[],
-  taskInfo: Map<string, {
-    description: string;
-    agentType: string;
-    backend?: "claude" | "codex";
-    status?: string;
-    receiverCount?: number;
-    senderThreadId?: string;
-    receiverThreadIds?: string[];
-  }>,
+  taskInfo: Map<
+    string,
+    {
+      description: string;
+      agentType: string;
+      backend?: "claude" | "codex";
+      status?: string;
+      receiverCount?: number;
+      senderThreadId?: string;
+      receiverThreadIds?: string[];
+    }
+  >,
   childrenByParent: Map<string, ChatMessage[]>,
 ): FeedEntry[] {
   const grouped = groupToolMessages(messages);
@@ -145,7 +169,10 @@ function buildEntries(
     for (const taskId of taskIds) {
       const children = childrenByParent.get(taskId);
       if (children && children.length > 0) {
-        const info = taskInfo.get(taskId) || { description: "Subagent", agentType: "" };
+        const info = taskInfo.get(taskId) || {
+          description: "Subagent",
+          agentType: "",
+        };
         const childEntries = buildEntries(children, taskInfo, childrenByParent);
         result.push({
           kind: "subagent",
@@ -168,37 +195,50 @@ function buildEntries(
 
 function groupMessages(messages: ChatMessage[]): FeedEntry[] {
   // Phase 1: Find all Task tool_use IDs across all messages
-  const taskInfo = new Map<string, {
-    description: string;
-    agentType: string;
-    backend?: "claude" | "codex";
-    status?: string;
-    receiverCount?: number;
-    senderThreadId?: string;
-    receiverThreadIds?: string[];
-  }>();
+  const taskInfo = new Map<
+    string,
+    {
+      description: string;
+      agentType: string;
+      backend?: "claude" | "codex";
+      status?: string;
+      receiverCount?: number;
+      senderThreadId?: string;
+      receiverThreadIds?: string[];
+    }
+  >();
   for (const msg of messages) {
     if (!msg.contentBlocks) continue;
     for (const b of msg.contentBlocks) {
       if (b.type === "tool_use" && b.name === "Task") {
         const { input, id } = b;
         const receiverThreadIds = Array.isArray(input?.receiver_thread_ids)
-          ? input.receiver_thread_ids.filter((threadId): threadId is string => typeof threadId === "string" && threadId.length > 0)
+          ? input.receiver_thread_ids.filter(
+              (threadId): threadId is string =>
+                typeof threadId === "string" && threadId.length > 0,
+            )
           : undefined;
-        const receiverCount = receiverThreadIds && receiverThreadIds.length > 0
-          ? receiverThreadIds.length
-          : undefined;
-        const senderThreadId = typeof input?.sender_thread_id === "string" && input.sender_thread_id.length > 0
-          ? input.sender_thread_id
-          : undefined;
-        const hasCodexMetadata = typeof input?.codex_status === "string"
-          || senderThreadId !== undefined
-          || receiverCount !== undefined;
+        const receiverCount =
+          receiverThreadIds && receiverThreadIds.length > 0
+            ? receiverThreadIds.length
+            : undefined;
+        const senderThreadId =
+          typeof input?.sender_thread_id === "string" &&
+          input.sender_thread_id.length > 0
+            ? input.sender_thread_id
+            : undefined;
+        const hasCodexMetadata =
+          typeof input?.codex_status === "string" ||
+          senderThreadId !== undefined ||
+          receiverCount !== undefined;
         taskInfo.set(id, {
           description: String(input?.description || "Subagent"),
           agentType: String(input?.subagent_type || ""),
           backend: hasCodexMetadata ? "codex" : "claude",
-          status: typeof input?.codex_status === "string" ? input.codex_status : undefined,
+          status:
+            typeof input?.codex_status === "string"
+              ? input.codex_status
+              : undefined,
           receiverCount,
           senderThreadId,
           receiverThreadIds,
@@ -219,7 +259,10 @@ function groupMessages(messages: ChatMessage[]): FeedEntry[] {
   for (const msg of messages) {
     if (msg.parentToolUseId && taskInfo.has(msg.parentToolUseId)) {
       let arr = childrenByParent.get(msg.parentToolUseId);
-      if (!arr) { arr = []; childrenByParent.set(msg.parentToolUseId, arr); }
+      if (!arr) {
+        arr = [];
+        childrenByParent.set(msg.parentToolUseId, arr);
+      }
       arr.push(msg);
     } else {
       topLevel.push(msg);
@@ -251,7 +294,11 @@ function ToolMessageGroup({ group }: { group: ToolMsgGroup }) {
                 onClick={() => setOpen(!open)}
                 className="w-full flex items-center gap-2.5 px-3 py-2 text-left hover:bg-cc-hover transition-colors cursor-pointer"
               >
-                <svg viewBox="0 0 16 16" fill="currentColor" className={`w-3 h-3 text-cc-muted transition-transform shrink-0 ${open ? "rotate-90" : ""}`}>
+                <svg
+                  viewBox="0 0 16 16"
+                  fill="currentColor"
+                  className={`w-3 h-3 text-cc-muted transition-transform shrink-0 ${open ? "rotate-90" : ""}`}
+                >
                   <path d="M6 4l4 4-4 4" />
                 </svg>
                 <ToolIcon type={iconType} />
@@ -285,7 +332,11 @@ function ToolMessageGroup({ group }: { group: ToolMsgGroup }) {
               onClick={() => setOpen(!open)}
               className="w-full flex items-center gap-2.5 px-3 py-2 text-left hover:bg-cc-hover transition-colors cursor-pointer"
             >
-              <svg viewBox="0 0 16 16" fill="currentColor" className={`w-3 h-3 text-cc-muted transition-transform shrink-0 ${open ? "rotate-90" : ""}`}>
+              <svg
+                viewBox="0 0 16 16"
+                fill="currentColor"
+                className={`w-3 h-3 text-cc-muted transition-transform shrink-0 ${open ? "rotate-90" : ""}`}
+              >
                 <path d="M6 4l4 4-4 4" />
               </svg>
               <ToolIcon type={iconType} />
@@ -300,9 +351,14 @@ function ToolMessageGroup({ group }: { group: ToolMsgGroup }) {
                 {group.items.map((item, i) => {
                   const preview = getPreview(item.name, item.input);
                   return (
-                    <div key={item.id || i} className="flex items-center gap-2 py-1 text-xs text-cc-muted font-mono-code truncate">
+                    <div
+                      key={item.id || i}
+                      className="flex items-center gap-2 py-1 text-xs text-cc-muted font-mono-code truncate"
+                    >
                       <span className="w-1 h-1 rounded-full bg-cc-muted/40 shrink-0" />
-                      <span className="truncate">{preview || JSON.stringify(item.input).slice(0, 80)}</span>
+                      <span className="truncate">
+                        {preview || JSON.stringify(item.input).slice(0, 80)}
+                      </span>
                     </div>
                   );
                 })}
@@ -346,21 +402,34 @@ function normalizeSubagentStatus(status?: string): {
       className: "text-green-600 bg-green-500/15",
     };
   }
-  if (normalized === "failed" || normalized === "error" || normalized === "errored") {
+  if (
+    normalized === "failed" ||
+    normalized === "error" ||
+    normalized === "errored"
+  ) {
     return {
       label: "failed",
       summaryLabel: "failed",
       className: "text-cc-error bg-cc-error/10",
     };
   }
-  if (normalized === "pending" || normalized === "pendinginit" || normalized === "pending_init") {
+  if (
+    normalized === "pending" ||
+    normalized === "pendinginit" ||
+    normalized === "pending_init"
+  ) {
     return {
       label: "pending",
       summaryLabel: "pending",
       className: "text-amber-700 bg-amber-500/15",
     };
   }
-  if (normalized === "running" || normalized === "inprogress" || normalized === "in_progress" || normalized === "started") {
+  if (
+    normalized === "running" ||
+    normalized === "inprogress" ||
+    normalized === "in_progress" ||
+    normalized === "started"
+  ) {
     return {
       label: "running",
       summaryLabel: "running",
@@ -384,7 +453,8 @@ function SubagentContainer({ group }: { group: SubagentGroup }) {
   const senderThreadId = group.senderThreadId;
   const receiverThreadIds = group.receiverThreadIds || [];
   const backend = group.backend || "claude";
-  const statusSummaryCount = receiverCount !== undefined ? receiverCount : childCount;
+  const statusSummaryCount =
+    receiverCount !== undefined ? receiverCount : childCount;
 
   // Get the last visible entry for a compact preview
   const lastEntry = group.children[group.children.length - 1];
@@ -398,7 +468,8 @@ function SubagentContainer({ group }: { group: SubagentGroup }) {
       const text = lastEntry.msg.content?.trim();
       if (text) return text.length > 60 ? text.slice(0, 60) + "..." : text;
       const toolBlock = lastEntry.msg.contentBlocks?.find(
-        (b): b is Extract<ContentBlock, { type: "tool_use" }> => b.type === "tool_use"
+        (b): b is Extract<ContentBlock, { type: "tool_use" }> =>
+          b.type === "tool_use",
       );
       if (toolBlock) return getToolLabel(toolBlock.name);
     }
@@ -412,14 +483,26 @@ function SubagentContainer({ group }: { group: SubagentGroup }) {
           onClick={() => setOpen(!open)}
           className="w-full flex items-center gap-2 py-1.5 text-left cursor-pointer mb-1"
         >
-          <svg viewBox="0 0 16 16" fill="currentColor" className={`w-3 h-3 text-cc-muted transition-transform shrink-0 ${open ? "rotate-90" : ""}`}>
+          <svg
+            viewBox="0 0 16 16"
+            fill="currentColor"
+            className={`w-3 h-3 text-cc-muted transition-transform shrink-0 ${open ? "rotate-90" : ""}`}
+          >
             <path d="M6 4l4 4-4 4" />
           </svg>
-          <svg viewBox="0 0 16 16" fill="none" stroke="currentColor" strokeWidth="1.5" className="w-3.5 h-3.5 text-cc-primary shrink-0">
+          <svg
+            viewBox="0 0 16 16"
+            fill="none"
+            stroke="currentColor"
+            strokeWidth="1.5"
+            className="w-3.5 h-3.5 text-cc-primary shrink-0"
+          >
             <circle cx="8" cy="8" r="5" />
             <path d="M8 5v3l2 1" strokeLinecap="round" />
           </svg>
-          <span className="text-xs font-medium text-cc-fg truncate">{label}</span>
+          <span className="text-xs font-medium text-cc-fg truncate">
+            {label}
+          </span>
           {agentType && (
             <span className="text-[10px] text-cc-muted bg-cc-hover rounded-full px-1.5 py-0.5 shrink-0">
               {agentType}
@@ -429,7 +512,9 @@ function SubagentContainer({ group }: { group: SubagentGroup }) {
             {backend === "codex" ? "Codex" : "Claude"}
           </span>
           {status && (
-            <span className={`text-[10px] rounded-full px-1.5 py-0.5 shrink-0 ${status.className}`}>
+            <span
+              className={`text-[10px] rounded-full px-1.5 py-0.5 shrink-0 ${status.className}`}
+            >
               {status.label}
             </span>
           )}
@@ -454,7 +539,9 @@ function SubagentContainer({ group }: { group: SubagentGroup }) {
               <div className="rounded-lg border border-cc-border bg-cc-card px-2.5 py-2 space-y-1.5">
                 <div className="flex flex-wrap items-center gap-1.5 text-[10px]">
                   {status && (
-                    <span className={`rounded-full px-1.5 py-0.5 ${status.className}`}>
+                    <span
+                      className={`rounded-full px-1.5 py-0.5 ${status.className}`}
+                    >
                       {statusSummaryCount} {status.summaryLabel}
                     </span>
                   )}
@@ -494,7 +581,11 @@ function SubagentContainer({ group }: { group: SubagentGroup }) {
 function AssistantAvatar() {
   return (
     <div className="w-7 h-7 rounded-full bg-cc-primary/10 flex items-center justify-center shrink-0 mt-0.5">
-      <svg viewBox="0 0 16 16" fill="currentColor" className="w-3.5 h-3.5 text-cc-primary">
+      <svg
+        viewBox="0 0 16 16"
+        fill="currentColor"
+        className="w-3.5 h-3.5 text-cc-primary"
+      >
         <circle cx="8" cy="8" r="3" />
       </svg>
     </div>
@@ -505,9 +596,17 @@ function AssistantAvatar() {
 
 export function MessageFeed({ sessionId }: { sessionId: string }) {
   const messages = useStore((s) => s.messages.get(sessionId) ?? EMPTY_MESSAGES);
-  const sdkSession = useStore((s) => (s.sdkSessions || EMPTY_SDK_SESSIONS).find((session) => session.sessionId === sessionId));
-  const streamingStartedAt = useStore((s) => s.streamingStartedAt.get(sessionId));
-  const streamingOutputTokens = useStore((s) => s.streamingOutputTokens.get(sessionId));
+  const sdkSession = useStore((s) =>
+    (s.sdkSessions || EMPTY_SDK_SESSIONS).find(
+      (session) => session.sessionId === sessionId,
+    ),
+  );
+  const streamingStartedAt = useStore((s) =>
+    s.streamingStartedAt.get(sessionId),
+  );
+  const streamingOutputTokens = useStore((s) =>
+    s.streamingOutputTokens.get(sessionId),
+  );
   const sessionStatus = useStore((s) => s.sessionStatus.get(sessionId));
   const toolProgress = useStore((s) => s.toolProgress.get(sessionId));
   const bottomRef = useRef<HTMLDivElement>(null);
@@ -515,14 +614,18 @@ export function MessageFeed({ sessionId }: { sessionId: string }) {
   const isNearBottom = useRef(true);
   const [elapsed, setElapsed] = useState(0);
   const [visibleCount, setVisibleCount] = useState(FEED_PAGE_SIZE);
-  const [resumeHistoryMessages, setResumeHistoryMessages] = useState<ChatMessage[]>([]);
+  const [resumeHistoryMessages, setResumeHistoryMessages] = useState<
+    ChatMessage[]
+  >([]);
   const [resumeHistoryCursor, setResumeHistoryCursor] = useState(0);
   const [resumeHistoryHasMore, setResumeHistoryHasMore] = useState(false);
   const [resumeHistoryLoaded, setResumeHistoryLoaded] = useState(false);
   const [resumeHistoryLoading, setResumeHistoryLoading] = useState(false);
   const [resumeHistoryError, setResumeHistoryError] = useState("");
   const resumeHistoryMessageIdsRef = useRef<Set<string>>(new Set());
-  const chatTabReentryTick = useStore((s) => s.chatTabReentryTickBySession.get(sessionId) ?? 0);
+  const chatTabReentryTick = useStore(
+    (s) => s.chatTabReentryTickBySession.get(sessionId) ?? 0,
+  );
   const hasStreamingAssistant = useMemo(
     () => messages.some((m) => m.role === "assistant" && m.isStreaming),
     [messages],
@@ -532,7 +635,9 @@ export function MessageFeed({ sessionId }: { sessionId: string }) {
     return (sdkSession?.resumeSessionAt || "").trim();
   }, [sdkSession?.backendType, sdkSession?.resumeSessionAt]);
   const canLoadResumeHistory = resumeSourceSessionId.length > 0;
-  const resumeModeLabel = sdkSession?.forkSession ? "Forked from" : "Continuing from";
+  const resumeModeLabel = sdkSession?.forkSession
+    ? "Forked from"
+    : "Continuing from";
   const mergedMessages = useMemo(() => {
     if (resumeHistoryMessages.length === 0) return messages;
     const deduped: ChatMessage[] = [];
@@ -550,7 +655,10 @@ export function MessageFeed({ sessionId }: { sessionId: string }) {
     return deduped;
   }, [resumeHistoryMessages, messages]);
 
-  const grouped = useMemo(() => groupMessages(mergedMessages), [mergedMessages]);
+  const grouped = useMemo(
+    () => groupMessages(mergedMessages),
+    [mergedMessages],
+  );
 
   // Reset paging/transcript state when switching sessions.
   useEffect(() => {
@@ -566,7 +674,9 @@ export function MessageFeed({ sessionId }: { sessionId: string }) {
 
   const totalEntries = grouped.length;
   const hasMore = totalEntries > visibleCount;
-  const visibleEntries = hasMore ? grouped.slice(totalEntries - visibleCount) : grouped;
+  const visibleEntries = hasMore
+    ? grouped.slice(totalEntries - visibleCount)
+    : grouped;
   const hiddenCount = totalEntries - visibleEntries.length;
 
   const handleLoadMore = useCallback(() => {
@@ -582,73 +692,82 @@ export function MessageFeed({ sessionId }: { sessionId: string }) {
     });
   }, []);
 
-  const loadResumeHistoryPage = useCallback(async (
-    options: { preserveScroll?: boolean } = {},
-  ) => {
-    if (!canLoadResumeHistory || !resumeSourceSessionId || resumeHistoryLoading) return;
+  const loadResumeHistoryPage = useCallback(
+    async (options: { preserveScroll?: boolean } = {}) => {
+      if (
+        !canLoadResumeHistory ||
+        !resumeSourceSessionId ||
+        resumeHistoryLoading
+      )
+        return;
 
-    const container = containerRef.current;
-    const previousHeight = container?.scrollHeight ?? 0;
-    const cursor = resumeHistoryLoaded ? resumeHistoryCursor : 0;
+      const container = containerRef.current;
+      const previousHeight = container?.scrollHeight ?? 0;
+      const cursor = resumeHistoryLoaded ? resumeHistoryCursor : 0;
 
-    setResumeHistoryLoading(true);
-    setResumeHistoryError("");
-    try {
-      const page = await api.getClaudeSessionHistory(resumeSourceSessionId, {
-        cursor,
-        limit: RESUME_HISTORY_PAGE_SIZE,
-      });
-
-      const incoming = page.messages.map((msg): ChatMessage => ({
-        id: msg.id,
-        role: msg.role,
-        content: msg.content,
-        contentBlocks: msg.role === "assistant" ? msg.contentBlocks : undefined,
-        timestamp: msg.timestamp || Date.now(),
-        model: msg.role === "assistant" ? msg.model : undefined,
-        stopReason: msg.role === "assistant" ? msg.stopReason : undefined,
-      }));
-
-      const uniqueIncoming: ChatMessage[] = [];
-      for (const msg of incoming) {
-        if (resumeHistoryMessageIdsRef.current.has(msg.id)) continue;
-        resumeHistoryMessageIdsRef.current.add(msg.id);
-        uniqueIncoming.push(msg);
-      }
-
-      setResumeHistoryMessages((prev) => [...uniqueIncoming, ...prev]);
-      setResumeHistoryCursor(page.nextCursor);
-      setResumeHistoryHasMore(page.hasMore);
-      setResumeHistoryLoaded(true);
-
-      if (uniqueIncoming.length > 0) {
-        setVisibleCount((count) => count + uniqueIncoming.length);
-      }
-
-      if (options.preserveScroll !== false && container) {
-        requestAnimationFrame(() => {
-          const newHeight = container.scrollHeight;
-          container.scrollTop += newHeight - previousHeight;
+      setResumeHistoryLoading(true);
+      setResumeHistoryError("");
+      try {
+        const page = await api.getClaudeSessionHistory(resumeSourceSessionId, {
+          cursor,
+          limit: RESUME_HISTORY_PAGE_SIZE,
         });
+
+        const incoming = page.messages.map(
+          (msg): ChatMessage => ({
+            id: msg.id,
+            role: msg.role,
+            content: msg.content,
+            contentBlocks:
+              msg.role === "assistant" ? msg.contentBlocks : undefined,
+            timestamp: msg.timestamp || Date.now(),
+            model: msg.role === "assistant" ? msg.model : undefined,
+            stopReason: msg.role === "assistant" ? msg.stopReason : undefined,
+          }),
+        );
+
+        const uniqueIncoming: ChatMessage[] = [];
+        for (const msg of incoming) {
+          if (resumeHistoryMessageIdsRef.current.has(msg.id)) continue;
+          resumeHistoryMessageIdsRef.current.add(msg.id);
+          uniqueIncoming.push(msg);
+        }
+
+        setResumeHistoryMessages((prev) => [...uniqueIncoming, ...prev]);
+        setResumeHistoryCursor(page.nextCursor);
+        setResumeHistoryHasMore(page.hasMore);
+        setResumeHistoryLoaded(true);
+
+        if (uniqueIncoming.length > 0) {
+          setVisibleCount((count) => count + uniqueIncoming.length);
+        }
+
+        if (options.preserveScroll !== false && container) {
+          requestAnimationFrame(() => {
+            const newHeight = container.scrollHeight;
+            container.scrollTop += newHeight - previousHeight;
+          });
+        }
+      } catch (error) {
+        const message = error instanceof Error ? error.message : String(error);
+        setResumeHistoryError(message || "Failed to load previous history");
+        if (!resumeHistoryLoaded) {
+          setResumeHistoryMessages([]);
+          setResumeHistoryCursor(0);
+          setResumeHistoryHasMore(false);
+        }
+      } finally {
+        setResumeHistoryLoading(false);
       }
-    } catch (error) {
-      const message = error instanceof Error ? error.message : String(error);
-      setResumeHistoryError(message || "Failed to load previous history");
-      if (!resumeHistoryLoaded) {
-        setResumeHistoryMessages([]);
-        setResumeHistoryCursor(0);
-        setResumeHistoryHasMore(false);
-      }
-    } finally {
-      setResumeHistoryLoading(false);
-    }
-  }, [
-    canLoadResumeHistory,
-    resumeSourceSessionId,
-    resumeHistoryLoading,
-    resumeHistoryLoaded,
-    resumeHistoryCursor,
-  ]);
+    },
+    [
+      canLoadResumeHistory,
+      resumeSourceSessionId,
+      resumeHistoryLoading,
+      resumeHistoryLoaded,
+      resumeHistoryCursor,
+    ],
+  );
 
   // Tick elapsed time every second while generating
   useEffect(() => {
@@ -667,15 +786,18 @@ export function MessageFeed({ sessionId }: { sessionId: string }) {
     if (!el) return;
     isNearBottom.current =
       el.scrollHeight - el.scrollTop - el.clientHeight < 120;
-    const distanceFromBottom = Math.max(0, el.scrollHeight - el.clientHeight - el.scrollTop);
+    const distanceFromBottom = Math.max(
+      0,
+      el.scrollHeight - el.clientHeight - el.scrollTop,
+    );
     savedDistanceFromBottomBySession.set(sessionId, distanceFromBottom);
 
     if (
-      canLoadResumeHistory
-      && resumeHistoryLoaded
-      && resumeHistoryHasMore
-      && !resumeHistoryLoading
-      && el.scrollTop <= SCROLL_TOP_PREFETCH_PX
+      canLoadResumeHistory &&
+      resumeHistoryLoaded &&
+      resumeHistoryHasMore &&
+      !resumeHistoryLoading &&
+      el.scrollTop <= SCROLL_TOP_PREFETCH_PX
     ) {
       void loadResumeHistoryPage({ preserveScroll: true });
     }
@@ -697,7 +819,10 @@ export function MessageFeed({ sessionId }: { sessionId: string }) {
     el.style.scrollBehavior = "auto";
     const savedDistance = savedDistanceFromBottomBySession.get(sessionId);
     if (typeof savedDistance === "number") {
-      el.scrollTop = Math.max(0, el.scrollHeight - el.clientHeight - savedDistance);
+      el.scrollTop = Math.max(
+        0,
+        el.scrollHeight - el.clientHeight - savedDistance,
+      );
     } else {
       el.scrollTop = el.scrollHeight;
     }
@@ -714,7 +839,10 @@ export function MessageFeed({ sessionId }: { sessionId: string }) {
     return () => {
       const el = containerRef.current;
       if (!el) return;
-      const distanceFromBottom = Math.max(0, el.scrollHeight - el.clientHeight - el.scrollTop);
+      const distanceFromBottom = Math.max(
+        0,
+        el.scrollHeight - el.clientHeight - el.scrollTop,
+      );
       savedDistanceFromBottomBySession.set(sessionId, distanceFromBottom);
     };
   }, [sessionId]);
@@ -735,7 +863,13 @@ export function MessageFeed({ sessionId }: { sessionId: string }) {
     return (
       <div className="flex-1 flex flex-col items-center justify-center gap-4 select-none px-6">
         <div className="w-14 h-14 rounded-2xl bg-cc-card border border-cc-border flex items-center justify-center">
-          <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.5" className="w-7 h-7 text-cc-muted">
+          <svg
+            viewBox="0 0 24 24"
+            fill="none"
+            stroke="currentColor"
+            strokeWidth="1.5"
+            className="w-7 h-7 text-cc-muted"
+          >
             <polyline points="4 17 10 11 4 5" />
             <line x1="12" y1="19" x2="20" y2="19" />
           </svg>
@@ -743,24 +877,33 @@ export function MessageFeed({ sessionId }: { sessionId: string }) {
         <div className="text-center">
           {canLoadResumeHistory ? (
             <>
-              <p className="text-sm text-cc-fg font-medium mb-1">This session has prior Claude context</p>
+              <p className="text-sm text-cc-fg font-medium mb-1">
+                This session has prior Claude context
+              </p>
               <p className="text-xs text-cc-muted leading-relaxed mb-3">
-                {resumeModeLabel} {resumeSourceSessionId.slice(0, 8)}. Load earlier messages into this chat when needed.
+                {resumeModeLabel} {resumeSourceSessionId.slice(0, 8)}. Load
+                earlier messages into this chat when needed.
               </p>
               <button
-                onClick={() => void loadResumeHistoryPage({ preserveScroll: false })}
+                onClick={() =>
+                  void loadResumeHistoryPage({ preserveScroll: false })
+                }
                 disabled={resumeHistoryLoading}
                 className="inline-flex items-center gap-1.5 px-3 py-1.5 text-xs font-medium text-cc-fg bg-cc-card border border-cc-border rounded-lg hover:bg-cc-hover transition-colors disabled:opacity-60 disabled:cursor-not-allowed cursor-pointer"
               >
                 {resumeHistoryLoading ? "Loading..." : "Load previous history"}
               </button>
               {resumeHistoryError && (
-                <p className="text-xs text-cc-error mt-2">{resumeHistoryError}</p>
+                <p className="text-xs text-cc-error mt-2">
+                  {resumeHistoryError}
+                </p>
               )}
             </>
           ) : (
             <>
-              <p className="text-sm text-cc-fg font-medium mb-1">Start a conversation</p>
+              <p className="text-sm text-cc-fg font-medium mb-1">
+                Start a conversation
+              </p>
               <p className="text-xs text-cc-muted leading-relaxed">
                 Send a message to begin working with The Companion.
               </p>
@@ -785,21 +928,32 @@ export function MessageFeed({ sessionId }: { sessionId: string }) {
             <div className="rounded-xl border border-cc-border bg-cc-card p-3">
               <div className="flex items-center justify-between gap-3">
                 <div>
-                  <p className="text-xs font-medium text-cc-fg">{resumeModeLabel} existing Claude thread</p>
+                  <p className="text-xs font-medium text-cc-fg">
+                    {resumeModeLabel} existing Claude thread
+                  </p>
                   <p className="text-[11px] text-cc-muted mt-1">
-                    {resumeSourceSessionId} {sdkSession?.cwd ? `· ${formatResumeSourcePath(sdkSession.cwd)}` : ""}
+                    {resumeSourceSessionId}{" "}
+                    {sdkSession?.cwd
+                      ? `· ${formatResumeSourcePath(sdkSession.cwd)}`
+                      : ""}
                   </p>
                 </div>
                 <button
-                  onClick={() => void loadResumeHistoryPage({ preserveScroll: true })}
+                  onClick={() =>
+                    void loadResumeHistoryPage({ preserveScroll: true })
+                  }
                   disabled={resumeHistoryLoading}
                   className="shrink-0 inline-flex items-center gap-1.5 px-3 py-1.5 text-xs font-medium text-cc-fg bg-cc-card border border-cc-border rounded-lg hover:bg-cc-hover transition-colors disabled:opacity-60 disabled:cursor-not-allowed cursor-pointer"
                 >
-                  {resumeHistoryLoading ? "Loading..." : "Load previous history"}
+                  {resumeHistoryLoading
+                    ? "Loading..."
+                    : "Load previous history"}
                 </button>
               </div>
               {resumeHistoryError && (
-                <p className="text-xs text-cc-error mt-2">{resumeHistoryError}</p>
+                <p className="text-xs text-cc-error mt-2">
+                  {resumeHistoryError}
+                </p>
               )}
             </div>
           )}
@@ -808,9 +962,9 @@ export function MessageFeed({ sessionId }: { sessionId: string }) {
             <div className="flex justify-center">
               <p className="text-[11px] text-cc-muted">
                 {resumeHistoryHasMore
-                  ? (resumeHistoryLoading
+                  ? resumeHistoryLoading
                     ? "Loading older transcript..."
-                    : "Scroll to top to load older transcript")
+                    : "Scroll to top to load older transcript"
                   : "Loaded all available prior transcript"}
               </p>
             </div>
@@ -822,10 +976,15 @@ export function MessageFeed({ sessionId }: { sessionId: string }) {
                 onClick={handleLoadMore}
                 className="flex items-center gap-1.5 px-3 py-1.5 text-xs font-medium text-cc-muted hover:text-cc-fg bg-cc-card border border-cc-border rounded-lg hover:bg-cc-hover transition-colors cursor-pointer"
               >
-                <svg viewBox="0 0 16 16" fill="currentColor" className="w-3 h-3">
+                <svg
+                  viewBox="0 0 16 16"
+                  fill="currentColor"
+                  className="w-3 h-3"
+                >
                   <path d="M8 2a.75.75 0 01.75.75v4.5h4.5a.75.75 0 010 1.5h-4.5v4.5a.75.75 0 01-1.5 0v-4.5h-4.5a.75.75 0 010-1.5h4.5v-4.5A.75.75 0 018 2z" />
                 </svg>
-                Load {Math.min(FEED_PAGE_SIZE, hiddenCount)} more ({hiddenCount} hidden)
+                Load {Math.min(FEED_PAGE_SIZE, hiddenCount)} more ({hiddenCount}{" "}
+                hidden)
               </button>
             </div>
           )}
@@ -842,6 +1001,23 @@ export function MessageFeed({ sessionId }: { sessionId: string }) {
                   <span className="text-cc-muted/60">{p.elapsedSeconds}s</span>
                 </span>
               ))}
+            </div>
+          )}
+
+          {/* Compacting context indicator */}
+          {sessionStatus === "compacting" && (
+            <div className="flex items-center gap-1.5 text-[11px] text-cc-warning font-mono-code pl-10">
+              <svg
+                className="w-3 h-3 animate-spin shrink-0"
+                viewBox="0 0 16 16"
+                fill="none"
+                stroke="currentColor"
+                strokeWidth="2"
+              >
+                <circle cx="8" cy="8" r="6" opacity="0.25" />
+                <path d="M8 2a6 6 0 0 1 6 6" strokeLinecap="round" />
+              </svg>
+              <span>Compacting context...</span>
             </div>
           )}
 

--- a/web/src/components/Playground.tsx
+++ b/web/src/components/Playground.tsx
@@ -1,7 +1,13 @@
 import { useState, useEffect, useMemo } from "react";
 import { PermissionBanner } from "./PermissionBanner.js";
 import { MessageBubble } from "./MessageBubble.js";
-import { ToolBlock, getToolIcon, getToolLabel, getPreview, ToolIcon } from "./ToolBlock.js";
+import {
+  ToolBlock,
+  getToolIcon,
+  getToolLabel,
+  getPreview,
+  ToolIcon,
+} from "./ToolBlock.js";
 import { DiffViewer } from "./DiffViewer.js";
 import { useStore } from "../store.js";
 import { navigateToSession, navigateHome } from "../utils/routing.js";
@@ -9,12 +15,27 @@ import { UpdateBanner } from "./UpdateBanner.js";
 import { ClaudeMdEditor } from "./ClaudeMdEditor.js";
 import { ChatView } from "./ChatView.js";
 import { api } from "../api.js";
-import type { PermissionRequest, ChatMessage, ContentBlock, SessionState, McpServerDetail } from "../types.js";
+import type {
+  PermissionRequest,
+  ChatMessage,
+  ContentBlock,
+  SessionState,
+  McpServerDetail,
+} from "../types.js";
 import { AiValidationBadge } from "./AiValidationBadge.js";
 import { AiValidationToggle } from "./AiValidationToggle.js";
 import type { TaskItem } from "../types.js";
-import type { UpdateInfo, GitHubPRInfo, LinearIssue, LinearComment } from "../api.js";
-import { GitHubPRDisplay, CodexRateLimitsSection, CodexTokenDetailsSection } from "./TaskPanel.js";
+import type {
+  UpdateInfo,
+  GitHubPRInfo,
+  LinearIssue,
+  LinearComment,
+} from "../api.js";
+import {
+  GitHubPRDisplay,
+  CodexRateLimitsSection,
+  CodexTokenDetailsSection,
+} from "./TaskPanel.js";
 import { LinearLogo } from "./LinearLogo.js";
 import { SessionCreationProgress } from "./SessionCreationProgress.js";
 import { SessionLaunchOverlay } from "./SessionLaunchOverlay.js";
@@ -27,7 +48,12 @@ import type { SessionItem as SessionItemType } from "../utils/project-grouping.j
 
 const MOCK_SESSION_ID = "playground-session";
 
-function mockPermission(overrides: Partial<PermissionRequest> & { tool_name: string; input: Record<string, unknown> }): PermissionRequest {
+function mockPermission(
+  overrides: Partial<PermissionRequest> & {
+    tool_name: string;
+    input: Record<string, unknown>;
+  },
+): PermissionRequest {
   return {
     request_id: `perm-${Math.random().toString(36).slice(2, 8)}`,
     tool_use_id: `tu-${Math.random().toString(36).slice(2, 8)}`,
@@ -45,13 +71,23 @@ const PERM_BASH = mockPermission({
   permission_suggestions: [
     {
       type: "addRules" as const,
-      rules: [{ toolName: "Bash", ruleContent: "git log --oneline -20 && npm run build" }],
+      rules: [
+        {
+          toolName: "Bash",
+          ruleContent: "git log --oneline -20 && npm run build",
+        },
+      ],
       behavior: "allow" as const,
       destination: "session" as const,
     },
     {
       type: "addRules" as const,
-      rules: [{ toolName: "Bash", ruleContent: "git log --oneline -20 && npm run build" }],
+      rules: [
+        {
+          toolName: "Bash",
+          ruleContent: "git log --oneline -20 && npm run build",
+        },
+      ],
       behavior: "allow" as const,
       destination: "projectSettings" as const,
     },
@@ -62,8 +98,10 @@ const PERM_EDIT = mockPermission({
   tool_name: "Edit",
   input: {
     file_path: "/Users/stan/Dev/project/src/utils/format.ts",
-    old_string: 'export function formatDate(d: Date) {\n  return d.toISOString();\n}',
-    new_string: 'export function formatDate(d: Date, locale = "en-US") {\n  return d.toLocaleDateString(locale, {\n    year: "numeric",\n    month: "short",\n    day: "numeric",\n  });\n}',
+    old_string:
+      "export function formatDate(d: Date) {\n  return d.toISOString();\n}",
+    new_string:
+      'export function formatDate(d: Date, locale = "en-US") {\n  return d.toLocaleDateString(locale, {\n    year: "numeric",\n    month: "short",\n    day: "numeric",\n  });\n}',
   },
   permission_suggestions: [
     {
@@ -79,7 +117,8 @@ const PERM_WRITE = mockPermission({
   tool_name: "Write",
   input: {
     file_path: "/Users/stan/Dev/project/src/config.ts",
-    content: 'export const config = {\n  apiUrl: "https://api.example.com",\n  timeout: 5000,\n  retries: 3,\n  debug: process.env.NODE_ENV !== "production",\n};\n',
+    content:
+      'export const config = {\n  apiUrl: "https://api.example.com",\n  timeout: 5000,\n  retries: 3,\n  debug: process.env.NODE_ENV !== "production",\n};\n',
   },
 });
 
@@ -109,7 +148,11 @@ const PERM_GLOB = mockPermission({
 
 const PERM_GREP = mockPermission({
   tool_name: "Grep",
-  input: { pattern: "TODO|FIXME|HACK", path: "/Users/stan/Dev/project/src", glob: "*.ts" },
+  input: {
+    pattern: "TODO|FIXME|HACK",
+    path: "/Users/stan/Dev/project/src",
+    glob: "*.ts",
+  },
 });
 
 const PERM_EXIT_PLAN = mockPermission({
@@ -125,7 +168,10 @@ const PERM_EXIT_PLAN = mockPermission({
 
 const PERM_GENERIC = mockPermission({
   tool_name: "WebSearch",
-  input: { query: "TypeScript 5.5 new features", allowed_domains: ["typescriptlang.org", "github.com"] },
+  input: {
+    query: "TypeScript 5.5 new features",
+    allowed_domains: ["typescriptlang.org", "github.com"],
+  },
   description: "Search the web for TypeScript 5.5 features",
 });
 
@@ -139,21 +185,33 @@ const PERM_DYNAMIC = mockPermission({
 const PERM_AI_UNCERTAIN = mockPermission({
   tool_name: "Bash",
   input: { command: "npm install --save-dev @types/react" },
-  ai_validation: { verdict: "uncertain", reason: "Package installation modifies node_modules", ruleBasedOnly: false },
+  ai_validation: {
+    verdict: "uncertain",
+    reason: "Package installation modifies node_modules",
+    ruleBasedOnly: false,
+  },
 });
 
 // AI Validation mock: safe recommendation (shown when auto-approve is off)
 const PERM_AI_SAFE = mockPermission({
   tool_name: "Bash",
   input: { command: "git status" },
-  ai_validation: { verdict: "safe", reason: "Read-only git command", ruleBasedOnly: false },
+  ai_validation: {
+    verdict: "safe",
+    reason: "Read-only git command",
+    ruleBasedOnly: false,
+  },
 });
 
 // AI Validation mock: dangerous recommendation (shown when auto-deny is off)
 const PERM_AI_DANGEROUS = mockPermission({
   tool_name: "Bash",
   input: { command: "rm -rf node_modules && rm -rf .git" },
-  ai_validation: { verdict: "dangerous", reason: "Recursive delete of project files", ruleBasedOnly: false },
+  ai_validation: {
+    verdict: "dangerous",
+    reason: "Recursive delete of project files",
+    ruleBasedOnly: false,
+  },
 });
 
 const PERM_ASK_SINGLE = mockPermission({
@@ -164,9 +222,19 @@ const PERM_ASK_SINGLE = mockPermission({
         header: "Auth method",
         question: "Which authentication method should we use for the API?",
         options: [
-          { label: "JWT tokens (Recommended)", description: "Stateless, scalable, works well with microservices" },
-          { label: "Session cookies", description: "Traditional approach, simpler but requires session storage" },
-          { label: "OAuth 2.0", description: "Delegated auth, best for third-party integrations" },
+          {
+            label: "JWT tokens (Recommended)",
+            description: "Stateless, scalable, works well with microservices",
+          },
+          {
+            label: "Session cookies",
+            description:
+              "Traditional approach, simpler but requires session storage",
+          },
+          {
+            label: "OAuth 2.0",
+            description: "Delegated auth, best for third-party integrations",
+          },
         ],
         multiSelect: false,
       },
@@ -182,7 +250,10 @@ const PERM_ASK_MULTI = mockPermission({
         header: "Database",
         question: "Which database should we use?",
         options: [
-          { label: "PostgreSQL", description: "Relational, strong consistency" },
+          {
+            label: "PostgreSQL",
+            description: "Relational, strong consistency",
+          },
           { label: "MongoDB", description: "Document store, flexible schema" },
         ],
         multiSelect: false,
@@ -204,7 +275,8 @@ const PERM_ASK_MULTI = mockPermission({
 const MSG_USER: ChatMessage = {
   id: "msg-1",
   role: "user",
-  content: "Can you help me refactor the authentication module to use JWT tokens?",
+  content:
+    "Can you help me refactor the authentication module to use JWT tokens?",
   timestamp: Date.now() - 60000,
 };
 
@@ -260,9 +332,13 @@ const MSG_ASSISTANT_TOOLS: ChatMessage = {
     {
       type: "tool_result",
       tool_use_id: "tu-2",
-      content: 'export function authMiddleware(req, res, next) {\n  if (!req.session.userId) {\n    return res.status(401).json({ error: "Unauthorized" });\n  }\n  next();\n}',
+      content:
+        'export function authMiddleware(req, res, next) {\n  if (!req.session.userId) {\n    return res.status(401).json({ error: "Unauthorized" });\n  }\n  next();\n}',
     },
-    { type: "text", text: "Now I understand the current structure. Let me create the JWT utility." },
+    {
+      type: "text",
+      text: "Now I understand the current structure. Let me create the JWT utility.",
+    },
   ],
   timestamp: Date.now() - 45000,
 };
@@ -274,9 +350,13 @@ const MSG_ASSISTANT_THINKING: ChatMessage = {
   contentBlocks: [
     {
       type: "thinking",
-      thinking: "Let me think about the best approach here. The user wants to migrate from session cookies to JWT. I need to:\n1. Create a JWT sign/verify utility\n2. Update the middleware to read Authorization header\n3. Change the login endpoint to return a token\n4. Update all tests\n\nI should use jsonwebtoken package for signing and jose for verification in edge environments. But since this is a Node.js server, jsonwebtoken is fine.\n\nThe token should contain: userId, role, iat, exp. Expiry should be configurable. I'll also add a refresh token mechanism.",
+      thinking:
+        "Let me think about the best approach here. The user wants to migrate from session cookies to JWT. I need to:\n1. Create a JWT sign/verify utility\n2. Update the middleware to read Authorization header\n3. Change the login endpoint to return a token\n4. Update all tests\n\nI should use jsonwebtoken package for signing and jose for verification in edge environments. But since this is a Node.js server, jsonwebtoken is fine.\n\nThe token should contain: userId, role, iat, exp. Expiry should be configurable. I'll also add a refresh token mechanism.",
     },
-    { type: "text", text: "I've analyzed the codebase and have a clear plan. Let me start implementing." },
+    {
+      type: "text",
+      text: "I've analyzed the codebase and have a clear plan. Let me start implementing.",
+    },
   ],
   timestamp: Date.now() - 40000,
 };
@@ -312,7 +392,8 @@ const MSG_TOOL_ERROR: ChatMessage = {
     {
       type: "tool_result",
       tool_use_id: "tu-3",
-      content: "FAIL src/auth/__tests__/middleware.test.ts\n  ● Auth Middleware › should reject expired tokens\n    Expected: 401\n    Received: 500\n\n    TypeError: Cannot read property 'verify' of undefined",
+      content:
+        "FAIL src/auth/__tests__/middleware.test.ts\n  ● Auth Middleware › should reject expired tokens\n    Expected: 401\n    Received: 500\n\n    TypeError: Cannot read property 'verify' of undefined",
       is_error: true,
     },
     { type: "text", text: "There's a test failure. Let me fix the issue." },
@@ -322,12 +403,46 @@ const MSG_TOOL_ERROR: ChatMessage = {
 
 // Tasks
 const MOCK_TASKS: TaskItem[] = [
-  { id: "1", subject: "Create JWT utility module", description: "", status: "completed" },
-  { id: "2", subject: "Update auth middleware", description: "", status: "completed", activeForm: "Updating auth middleware" },
-  { id: "3", subject: "Migrate login endpoint", description: "", status: "in_progress", activeForm: "Refactoring login to return JWT" },
-  { id: "4", subject: "Add refresh token support", description: "", status: "pending" },
-  { id: "5", subject: "Update all auth tests", description: "", status: "pending", blockedBy: ["3"] },
-  { id: "6", subject: "Run full test suite and fix failures", description: "", status: "pending", blockedBy: ["5"] },
+  {
+    id: "1",
+    subject: "Create JWT utility module",
+    description: "",
+    status: "completed",
+  },
+  {
+    id: "2",
+    subject: "Update auth middleware",
+    description: "",
+    status: "completed",
+    activeForm: "Updating auth middleware",
+  },
+  {
+    id: "3",
+    subject: "Migrate login endpoint",
+    description: "",
+    status: "in_progress",
+    activeForm: "Refactoring login to return JWT",
+  },
+  {
+    id: "4",
+    subject: "Add refresh token support",
+    description: "",
+    status: "pending",
+  },
+  {
+    id: "5",
+    subject: "Update all auth tests",
+    description: "",
+    status: "pending",
+    blockedBy: ["3"],
+  },
+  {
+    id: "6",
+    subject: "Run full test suite and fix failures",
+    description: "",
+    status: "pending",
+    blockedBy: ["5"],
+  },
 ];
 
 // Tool group items (for ToolMessageGroup mock)
@@ -340,7 +455,11 @@ const MOCK_TOOL_GROUP_ITEMS = [
 
 const MOCK_SUBAGENT_TOOL_ITEMS = [
   { id: "sa-1", name: "Grep", input: { pattern: "useAuth", path: "src/" } },
-  { id: "sa-2", name: "Grep", input: { pattern: "session.userId", path: "src/" } },
+  {
+    id: "sa-2",
+    name: "Grep",
+    input: { pattern: "session.userId", path: "src/" },
+  },
 ];
 
 // GitHub PR mock data
@@ -423,7 +542,11 @@ const MOCK_MCP_SERVERS: McpServerDetail[] = [
   {
     name: "filesystem",
     status: "connected",
-    config: { type: "stdio", command: "npx", args: ["-y", "@anthropic/mcp-fs"] },
+    config: {
+      type: "stdio",
+      command: "npx",
+      args: ["-y", "@anthropic/mcp-fs"],
+    },
     scope: "project",
     tools: [
       { name: "read_file", annotations: { readOnly: true } },
@@ -434,7 +557,11 @@ const MOCK_MCP_SERVERS: McpServerDetail[] = [
   {
     name: "github",
     status: "connected",
-    config: { type: "stdio", command: "npx", args: ["-y", "@anthropic/mcp-github"] },
+    config: {
+      type: "stdio",
+      command: "npx",
+      args: ["-y", "@anthropic/mcp-github"],
+    },
     scope: "user",
     tools: [
       { name: "create_issue" },
@@ -446,7 +573,11 @@ const MOCK_MCP_SERVERS: McpServerDetail[] = [
     name: "postgres",
     status: "failed",
     error: "Connection refused: ECONNREFUSED 127.0.0.1:5432",
-    config: { type: "stdio", command: "npx", args: ["-y", "@anthropic/mcp-postgres"] },
+    config: {
+      type: "stdio",
+      command: "npx",
+      args: ["-y", "@anthropic/mcp-postgres"],
+    },
     scope: "project",
     tools: [],
   },
@@ -455,7 +586,9 @@ const MOCK_MCP_SERVERS: McpServerDetail[] = [
     status: "disabled",
     config: { type: "sse", url: "http://localhost:8080/sse" },
     scope: "user",
-    tools: [{ name: "search", annotations: { readOnly: true, openWorld: true } }],
+    tools: [
+      { name: "search", annotations: { readOnly: true, openWorld: true } },
+    ],
   },
   {
     name: "docker",
@@ -470,7 +603,8 @@ const MOCK_MCP_SERVERS: McpServerDetail[] = [
 const MOCK_LINEAR_ISSUE_ACTIVE: LinearIssue = {
   id: "issue-1",
   identifier: "THE-147",
-  title: "Associer un ticket Linear a une session dans le panneau lateral droit",
+  title:
+    "Associer un ticket Linear a une session dans le panneau lateral droit",
   description: "Pouvoir associer un ticket Linear a une session.",
   url: "https://linear.app/thevibecompany/issue/THE-147",
   branchName: "the-147-associer-un-ticket-linear",
@@ -498,16 +632,31 @@ const MOCK_LINEAR_ISSUE_DONE: LinearIssue = {
 };
 
 const MOCK_LINEAR_COMMENTS: LinearComment[] = [
-  { id: "c1", body: "Started working on the sidebar integration", createdAt: new Date(Date.now() - 3600_000).toISOString(), userName: "Alice" },
-  { id: "c2", body: "Added the search component, LGTM", createdAt: new Date(Date.now() - 1800_000).toISOString(), userName: "Bob" },
-  { id: "c3", body: "Testing the polling flow now", createdAt: new Date(Date.now() - 300_000).toISOString(), userName: "Alice" },
+  {
+    id: "c1",
+    body: "Started working on the sidebar integration",
+    createdAt: new Date(Date.now() - 3600_000).toISOString(),
+    userName: "Alice",
+  },
+  {
+    id: "c2",
+    body: "Added the search component, LGTM",
+    createdAt: new Date(Date.now() - 1800_000).toISOString(),
+    userName: "Bob",
+  },
+  {
+    id: "c3",
+    body: "Testing the polling flow now",
+    createdAt: new Date(Date.now() - 300_000).toISOString(),
+    userName: "Alice",
+  },
 ];
 
 // ─── Playground Component ───────────────────────────────────────────────────
 
 export function Playground() {
-  const [darkMode, setDarkMode] = useState(
-    () => document.documentElement.classList.contains("dark")
+  const [darkMode, setDarkMode] = useState(() =>
+    document.documentElement.classList.contains("dark"),
   );
 
   useEffect(() => {
@@ -527,7 +676,8 @@ export function Playground() {
     const prevStatus = snapshot.sessionStatus.get(sessionId);
     const prevStreaming = snapshot.streaming.get(sessionId);
     const prevStreamingStartedAt = snapshot.streamingStartedAt.get(sessionId);
-    const prevStreamingOutputTokens = snapshot.streamingOutputTokens.get(sessionId);
+    const prevStreamingOutputTokens =
+      snapshot.streamingOutputTokens.get(sessionId);
 
     const session: SessionState = {
       session_id: sessionId,
@@ -559,16 +709,26 @@ export function Playground() {
     store.setConnectionStatus(sessionId, "connected");
     store.setCliConnected(sessionId, true);
     store.setSessionStatus(sessionId, "running");
-    const streamingText = "I'm updating tests and then I'll run the full suite.";
+    const streamingText =
+      "I'm updating tests and then I'll run the full suite.";
     store.setMessages(sessionId, [
       MSG_USER,
       MSG_ASSISTANT,
       MSG_ASSISTANT_TOOLS,
       MSG_TOOL_ERROR,
-      { id: "stream-draft", role: "assistant", content: streamingText, timestamp: Date.now(), isStreaming: true },
+      {
+        id: "stream-draft",
+        role: "assistant",
+        content: streamingText,
+        timestamp: Date.now(),
+        isStreaming: true,
+      },
     ]);
     store.setStreaming(sessionId, streamingText);
-    store.setStreamingStats(sessionId, { startedAt: Date.now() - 12000, outputTokens: 1200 });
+    store.setStreamingStats(sessionId, {
+      startedAt: Date.now() - 12000,
+      outputTokens: 1200,
+    });
     store.addPermission(sessionId, PERM_BASH);
     store.addPermission(sessionId, PERM_DYNAMIC);
 
@@ -584,15 +744,27 @@ export function Playground() {
         const streamingStartedAt = new Map(s.streamingStartedAt);
         const streamingOutputTokens = new Map(s.streamingOutputTokens);
 
-        if (prevSession) sessions.set(sessionId, prevSession); else sessions.delete(sessionId);
-        if (prevMessages) messages.set(sessionId, prevMessages); else messages.delete(sessionId);
-        if (prevPerms) pendingPermissions.set(sessionId, prevPerms); else pendingPermissions.delete(sessionId);
-        if (prevConn) connectionStatus.set(sessionId, prevConn); else connectionStatus.delete(sessionId);
-        if (typeof prevCli === "boolean") cliConnected.set(sessionId, prevCli); else cliConnected.delete(sessionId);
-        if (prevStatus) sessionStatus.set(sessionId, prevStatus); else sessionStatus.delete(sessionId);
-        if (typeof prevStreaming === "string") streaming.set(sessionId, prevStreaming); else streaming.delete(sessionId);
-        if (typeof prevStreamingStartedAt === "number") streamingStartedAt.set(sessionId, prevStreamingStartedAt); else streamingStartedAt.delete(sessionId);
-        if (typeof prevStreamingOutputTokens === "number") streamingOutputTokens.set(sessionId, prevStreamingOutputTokens); else streamingOutputTokens.delete(sessionId);
+        if (prevSession) sessions.set(sessionId, prevSession);
+        else sessions.delete(sessionId);
+        if (prevMessages) messages.set(sessionId, prevMessages);
+        else messages.delete(sessionId);
+        if (prevPerms) pendingPermissions.set(sessionId, prevPerms);
+        else pendingPermissions.delete(sessionId);
+        if (prevConn) connectionStatus.set(sessionId, prevConn);
+        else connectionStatus.delete(sessionId);
+        if (typeof prevCli === "boolean") cliConnected.set(sessionId, prevCli);
+        else cliConnected.delete(sessionId);
+        if (prevStatus) sessionStatus.set(sessionId, prevStatus);
+        else sessionStatus.delete(sessionId);
+        if (typeof prevStreaming === "string")
+          streaming.set(sessionId, prevStreaming);
+        else streaming.delete(sessionId);
+        if (typeof prevStreamingStartedAt === "number")
+          streamingStartedAt.set(sessionId, prevStreamingStartedAt);
+        else streamingStartedAt.delete(sessionId);
+        if (typeof prevStreamingOutputTokens === "number")
+          streamingOutputTokens.set(sessionId, prevStreamingOutputTokens);
+        else streamingOutputTokens.delete(sessionId);
 
         return {
           sessions,
@@ -615,8 +787,12 @@ export function Playground() {
       <header className="sticky top-0 z-50 bg-cc-sidebar border-b border-cc-border">
         <div className="max-w-5xl mx-auto px-6 py-4 flex items-center justify-between">
           <div>
-            <h1 className="text-lg font-semibold text-cc-fg tracking-tight">Component Playground</h1>
-            <p className="text-xs text-cc-muted mt-0.5">Visual catalog of all UI components</p>
+            <h1 className="text-lg font-semibold text-cc-fg tracking-tight">
+              Component Playground
+            </h1>
+            <p className="text-xs text-cc-muted mt-0.5">
+              Visual catalog of all UI components
+            </p>
           </div>
           <div className="flex items-center gap-3">
             <button
@@ -644,56 +820,116 @@ export function Playground() {
 
       <div className="max-w-5xl mx-auto px-6 py-8 space-y-12">
         {/* ─── Permission Banners ──────────────────────────────── */}
-        <Section title="Permission Banners" description="Tool approval requests shown above the composer">
+        <Section
+          title="Permission Banners"
+          description="Tool approval requests shown above the composer"
+        >
           <div className="border border-cc-border rounded-xl overflow-hidden bg-cc-card divide-y divide-cc-border">
-            <PermissionBanner permission={PERM_BASH} sessionId={MOCK_SESSION_ID} />
-            <PermissionBanner permission={PERM_EDIT} sessionId={MOCK_SESSION_ID} />
-            <PermissionBanner permission={PERM_WRITE} sessionId={MOCK_SESSION_ID} />
-            <PermissionBanner permission={PERM_READ} sessionId={MOCK_SESSION_ID} />
-            <PermissionBanner permission={PERM_GLOB} sessionId={MOCK_SESSION_ID} />
-            <PermissionBanner permission={PERM_GREP} sessionId={MOCK_SESSION_ID} />
-            <PermissionBanner permission={PERM_GENERIC} sessionId={MOCK_SESSION_ID} />
-            <PermissionBanner permission={PERM_DYNAMIC} sessionId={MOCK_SESSION_ID} />
+            <PermissionBanner
+              permission={PERM_BASH}
+              sessionId={MOCK_SESSION_ID}
+            />
+            <PermissionBanner
+              permission={PERM_EDIT}
+              sessionId={MOCK_SESSION_ID}
+            />
+            <PermissionBanner
+              permission={PERM_WRITE}
+              sessionId={MOCK_SESSION_ID}
+            />
+            <PermissionBanner
+              permission={PERM_READ}
+              sessionId={MOCK_SESSION_ID}
+            />
+            <PermissionBanner
+              permission={PERM_GLOB}
+              sessionId={MOCK_SESSION_ID}
+            />
+            <PermissionBanner
+              permission={PERM_GREP}
+              sessionId={MOCK_SESSION_ID}
+            />
+            <PermissionBanner
+              permission={PERM_GENERIC}
+              sessionId={MOCK_SESSION_ID}
+            />
+            <PermissionBanner
+              permission={PERM_DYNAMIC}
+              sessionId={MOCK_SESSION_ID}
+            />
           </div>
         </Section>
 
         {/* ─── Real Chat Stack ──────────────────────────────── */}
-        <Section title="Real Chat Stack" description="Integrated ChatView using real MessageFeed + PermissionBanner + Composer components">
-          <div data-testid="playground-real-chat-stack" className="max-w-3xl border border-cc-border rounded-xl overflow-hidden bg-cc-card h-[620px]">
+        <Section
+          title="Real Chat Stack"
+          description="Integrated ChatView using real MessageFeed + PermissionBanner + Composer components"
+        >
+          <div
+            data-testid="playground-real-chat-stack"
+            className="max-w-3xl border border-cc-border rounded-xl overflow-hidden bg-cc-card h-[620px]"
+          >
             <ChatView sessionId={MOCK_SESSION_ID} />
           </div>
         </Section>
 
         {/* ─── ExitPlanMode (the fix) ──────────────────────────── */}
-        <Section title="ExitPlanMode" description="Plan approval request — previously rendered as raw JSON, now shows formatted markdown">
+        <Section
+          title="ExitPlanMode"
+          description="Plan approval request — previously rendered as raw JSON, now shows formatted markdown"
+        >
           <div className="border border-cc-border rounded-xl overflow-hidden bg-cc-card">
-            <PermissionBanner permission={PERM_EXIT_PLAN} sessionId={MOCK_SESSION_ID} />
+            <PermissionBanner
+              permission={PERM_EXIT_PLAN}
+              sessionId={MOCK_SESSION_ID}
+            />
           </div>
         </Section>
 
         {/* ─── AskUserQuestion ──────────────────────────────── */}
-        <Section title="AskUserQuestion" description="Interactive questions with selectable options">
+        <Section
+          title="AskUserQuestion"
+          description="Interactive questions with selectable options"
+        >
           <div className="space-y-4">
             <Card label="Single question">
-              <PermissionBanner permission={PERM_ASK_SINGLE} sessionId={MOCK_SESSION_ID} />
+              <PermissionBanner
+                permission={PERM_ASK_SINGLE}
+                sessionId={MOCK_SESSION_ID}
+              />
             </Card>
             <Card label="Multi-question">
-              <PermissionBanner permission={PERM_ASK_MULTI} sessionId={MOCK_SESSION_ID} />
+              <PermissionBanner
+                permission={PERM_ASK_MULTI}
+                sessionId={MOCK_SESSION_ID}
+              />
             </Card>
           </div>
         </Section>
 
         {/* ─── AI Validation ──────────────────────────────── */}
-        <Section title="AI Validation" description="AI-powered permission validation badges and recommendations">
+        <Section
+          title="AI Validation"
+          description="AI-powered permission validation badges and recommendations"
+        >
           <div className="space-y-4">
             <Card label="Permission with AI recommendation (uncertain)">
-              <PermissionBanner permission={PERM_AI_UNCERTAIN} sessionId={MOCK_SESSION_ID} />
+              <PermissionBanner
+                permission={PERM_AI_UNCERTAIN}
+                sessionId={MOCK_SESSION_ID}
+              />
             </Card>
             <Card label="Permission with AI recommendation (safe)">
-              <PermissionBanner permission={PERM_AI_SAFE} sessionId={MOCK_SESSION_ID} />
+              <PermissionBanner
+                permission={PERM_AI_SAFE}
+                sessionId={MOCK_SESSION_ID}
+              />
             </Card>
             <Card label="Permission with AI recommendation (dangerous)">
-              <PermissionBanner permission={PERM_AI_DANGEROUS} sessionId={MOCK_SESSION_ID} />
+              <PermissionBanner
+                permission={PERM_AI_DANGEROUS}
+                sessionId={MOCK_SESSION_ID}
+              />
             </Card>
             <Card label="Per-session toggle (disabled)">
               <PlaygroundAiValidationToggle enabled={false} />
@@ -703,31 +939,49 @@ export function Playground() {
             </Card>
             <Card label="Auto-resolved badges">
               <div className="border border-cc-border rounded-xl overflow-hidden bg-cc-card divide-y divide-cc-border">
-                <AiValidationBadge entry={{
-                  request: mockPermission({ tool_name: "Read", input: { file_path: "/src/index.ts" } }),
-                  behavior: "allow",
-                  reason: "Read is a read-only tool",
-                  timestamp: Date.now(),
-                }} />
-                <AiValidationBadge entry={{
-                  request: mockPermission({ tool_name: "Bash", input: { command: "rm -rf /" } }),
-                  behavior: "deny",
-                  reason: "Recursive delete of root directory",
-                  timestamp: Date.now(),
-                }} />
-                <AiValidationBadge entry={{
-                  request: mockPermission({ tool_name: "Grep", input: { pattern: "TODO", path: "/src" } }),
-                  behavior: "allow",
-                  reason: "Grep is a read-only tool",
-                  timestamp: Date.now(),
-                }} />
+                <AiValidationBadge
+                  entry={{
+                    request: mockPermission({
+                      tool_name: "Read",
+                      input: { file_path: "/src/index.ts" },
+                    }),
+                    behavior: "allow",
+                    reason: "Read is a read-only tool",
+                    timestamp: Date.now(),
+                  }}
+                />
+                <AiValidationBadge
+                  entry={{
+                    request: mockPermission({
+                      tool_name: "Bash",
+                      input: { command: "rm -rf /" },
+                    }),
+                    behavior: "deny",
+                    reason: "Recursive delete of root directory",
+                    timestamp: Date.now(),
+                  }}
+                />
+                <AiValidationBadge
+                  entry={{
+                    request: mockPermission({
+                      tool_name: "Grep",
+                      input: { pattern: "TODO", path: "/src" },
+                    }),
+                    behavior: "allow",
+                    reason: "Grep is a read-only tool",
+                    timestamp: Date.now(),
+                  }}
+                />
               </div>
             </Card>
           </div>
         </Section>
 
         {/* ─── Messages ──────────────────────────────── */}
-        <Section title="Messages" description="Chat message bubbles for all roles">
+        <Section
+          title="Messages"
+          description="Chat message bubbles for all roles"
+        >
           <div className="space-y-4 max-w-3xl">
             <Card label="User message">
               <MessageBubble message={MSG_USER} />
@@ -757,41 +1011,165 @@ export function Playground() {
         </Section>
 
         {/* ─── Tool Blocks (standalone) ──────────────────────── */}
-        <Section title="Tool Blocks" description="Expandable tool call visualization">
+        <Section
+          title="Tool Blocks"
+          description="Expandable tool call visualization"
+        >
           <div className="space-y-2 max-w-3xl">
-            <ToolBlock name="Bash" input={{ command: "git status && npm run lint", description: "Check git status and lint" }} toolUseId="tb-1" />
-            <ToolBlock name="Read" input={{ file_path: "/Users/stan/Dev/project/src/index.ts", offset: 10, limit: 50 }} toolUseId="tb-2" />
-            <ToolBlock name="Edit" input={{ file_path: "src/utils.ts", old_string: "const x = 1;", new_string: "const x = 2;", replace_all: true }} toolUseId="tb-3" />
+            <ToolBlock
+              name="Bash"
+              input={{
+                command: "git status && npm run lint",
+                description: "Check git status and lint",
+              }}
+              toolUseId="tb-1"
+            />
+            <ToolBlock
+              name="Read"
+              input={{
+                file_path: "/Users/stan/Dev/project/src/index.ts",
+                offset: 10,
+                limit: 50,
+              }}
+              toolUseId="tb-2"
+            />
+            <ToolBlock
+              name="Edit"
+              input={{
+                file_path: "src/utils.ts",
+                old_string: "const x = 1;",
+                new_string: "const x = 2;",
+                replace_all: true,
+              }}
+              toolUseId="tb-3"
+            />
             <ToolBlock
               name="Edit"
               input={{
                 file_path: "/Users/stan/Dev/project/src/store.ts",
                 changes: [
-                  { path: "/Users/stan/Dev/project/src/store.ts", kind: "update" },
+                  {
+                    path: "/Users/stan/Dev/project/src/store.ts",
+                    kind: "update",
+                  },
                   { path: "/Users/stan/Dev/project/src/ws.ts", kind: "update" },
                 ],
               }}
               toolUseId="tb-3b"
             />
-            <ToolBlock name="Write" input={{ file_path: "src/new-file.ts", content: 'export const hello = "world";\n' }} toolUseId="tb-4" />
-            <ToolBlock name="Glob" input={{ pattern: "**/*.tsx", path: "/Users/stan/Dev/project/src" }} toolUseId="tb-5" />
-            <ToolBlock name="Grep" input={{ pattern: "useEffect", path: "src/", glob: "*.tsx", output_mode: "content", context: 3, head_limit: 20 }} toolUseId="tb-6" />
-            <ToolBlock name="WebSearch" input={{ query: "React 19 new features", allowed_domains: ["react.dev", "github.com"] }} toolUseId="tb-7" />
-            <ToolBlock name="WebFetch" input={{ url: "https://react.dev/blog/2024/12/05/react-19", prompt: "Summarize the key changes in React 19" }} toolUseId="tb-8" />
-            <ToolBlock name="Task" input={{ description: "Search for auth patterns", subagent_type: "Explore", prompt: "Find all files related to authentication and authorization in the codebase. Look for middleware, guards, and token handling." }} toolUseId="tb-9" />
-            <ToolBlock name="TodoWrite" input={{ todos: [
-              { content: "Create JWT utility module", status: "completed", activeForm: "Creating JWT module" },
-              { content: "Update auth middleware", status: "in_progress", activeForm: "Updating middleware" },
-              { content: "Migrate login endpoint", status: "pending", activeForm: "Migrating login" },
-              { content: "Run full test suite", status: "pending", activeForm: "Running tests" },
-            ]}} toolUseId="tb-10" />
-            <ToolBlock name="NotebookEdit" input={{ notebook_path: "/Users/stan/Dev/project/analysis.ipynb", cell_type: "code", edit_mode: "replace", cell_number: 3, new_source: "import pandas as pd\ndf = pd.read_csv('data.csv')\ndf.describe()" }} toolUseId="tb-11" />
-            <ToolBlock name="SendMessage" input={{ type: "message", recipient: "researcher", content: "Please investigate the auth module structure and report back.", summary: "Requesting auth module investigation" }} toolUseId="tb-12" />
+            <ToolBlock
+              name="Write"
+              input={{
+                file_path: "src/new-file.ts",
+                content: 'export const hello = "world";\n',
+              }}
+              toolUseId="tb-4"
+            />
+            <ToolBlock
+              name="Glob"
+              input={{
+                pattern: "**/*.tsx",
+                path: "/Users/stan/Dev/project/src",
+              }}
+              toolUseId="tb-5"
+            />
+            <ToolBlock
+              name="Grep"
+              input={{
+                pattern: "useEffect",
+                path: "src/",
+                glob: "*.tsx",
+                output_mode: "content",
+                context: 3,
+                head_limit: 20,
+              }}
+              toolUseId="tb-6"
+            />
+            <ToolBlock
+              name="WebSearch"
+              input={{
+                query: "React 19 new features",
+                allowed_domains: ["react.dev", "github.com"],
+              }}
+              toolUseId="tb-7"
+            />
+            <ToolBlock
+              name="WebFetch"
+              input={{
+                url: "https://react.dev/blog/2024/12/05/react-19",
+                prompt: "Summarize the key changes in React 19",
+              }}
+              toolUseId="tb-8"
+            />
+            <ToolBlock
+              name="Task"
+              input={{
+                description: "Search for auth patterns",
+                subagent_type: "Explore",
+                prompt:
+                  "Find all files related to authentication and authorization in the codebase. Look for middleware, guards, and token handling.",
+              }}
+              toolUseId="tb-9"
+            />
+            <ToolBlock
+              name="TodoWrite"
+              input={{
+                todos: [
+                  {
+                    content: "Create JWT utility module",
+                    status: "completed",
+                    activeForm: "Creating JWT module",
+                  },
+                  {
+                    content: "Update auth middleware",
+                    status: "in_progress",
+                    activeForm: "Updating middleware",
+                  },
+                  {
+                    content: "Migrate login endpoint",
+                    status: "pending",
+                    activeForm: "Migrating login",
+                  },
+                  {
+                    content: "Run full test suite",
+                    status: "pending",
+                    activeForm: "Running tests",
+                  },
+                ],
+              }}
+              toolUseId="tb-10"
+            />
+            <ToolBlock
+              name="NotebookEdit"
+              input={{
+                notebook_path: "/Users/stan/Dev/project/analysis.ipynb",
+                cell_type: "code",
+                edit_mode: "replace",
+                cell_number: 3,
+                new_source:
+                  "import pandas as pd\ndf = pd.read_csv('data.csv')\ndf.describe()",
+              }}
+              toolUseId="tb-11"
+            />
+            <ToolBlock
+              name="SendMessage"
+              input={{
+                type: "message",
+                recipient: "researcher",
+                content:
+                  "Please investigate the auth module structure and report back.",
+                summary: "Requesting auth module investigation",
+              }}
+              toolUseId="tb-12"
+            />
           </div>
         </Section>
 
         {/* ─── Tool Progress Indicator ──────────────────────── */}
-        <Section title="Tool Progress" description="Real-time progress indicator shown while tools are running">
+        <Section
+          title="Tool Progress"
+          description="Real-time progress indicator shown while tools are running"
+        >
           <div className="space-y-4 max-w-3xl">
             <Card label="Single tool running">
               <div className="flex items-center gap-1.5 text-[11px] text-cc-muted font-mono-code pl-9">
@@ -813,47 +1191,99 @@ export function Playground() {
           </div>
         </Section>
 
+        {/* ─── Compacting Context Indicator ─────────────────── */}
+        <Section
+          title="Compacting Context"
+          description="Spinner shown in the message feed when Claude Code is compacting context"
+        >
+          <div className="space-y-4 max-w-3xl">
+            <Card label="Compacting indicator">
+              <div className="flex items-center gap-1.5 text-[11px] text-cc-warning font-mono-code pl-9">
+                <svg
+                  className="w-3 h-3 animate-spin shrink-0"
+                  viewBox="0 0 16 16"
+                  fill="none"
+                  stroke="currentColor"
+                  strokeWidth="2"
+                >
+                  <circle cx="8" cy="8" r="6" opacity="0.25" />
+                  <path d="M8 2a6 6 0 0 1 6 6" strokeLinecap="round" />
+                </svg>
+                <span>Compacting context...</span>
+              </div>
+            </Card>
+          </div>
+        </Section>
+
         {/* ─── Tool Use Summary ──────────────────────────────── */}
-        <Section title="Tool Use Summary" description="System message summarizing batch tool execution">
+        <Section
+          title="Tool Use Summary"
+          description="System message summarizing batch tool execution"
+        >
           <div className="space-y-4 max-w-3xl">
             <Card label="Summary as system message">
-              <MessageBubble message={{
-                id: "summary-1",
-                role: "system",
-                content: "Read 4 files, searched 12 matches across 3 directories",
-                timestamp: Date.now(),
-              }} />
+              <MessageBubble
+                message={{
+                  id: "summary-1",
+                  role: "system",
+                  content:
+                    "Read 4 files, searched 12 matches across 3 directories",
+                  timestamp: Date.now(),
+                }}
+              />
             </Card>
           </div>
         </Section>
 
         {/* ─── Task Panel ──────────────────────────────── */}
-        <Section title="Tasks" description="Task list states: pending, in progress, completed, blocked">
+        <Section
+          title="Tasks"
+          description="Task list states: pending, in progress, completed, blocked"
+        >
           <div className="w-[280px] border border-cc-border rounded-xl overflow-hidden bg-cc-card">
             {/* Session stats mock */}
             <div className="px-4 py-3 border-b border-cc-border space-y-2.5">
               <div className="flex items-center justify-between">
-                <span className="text-[11px] text-cc-muted uppercase tracking-wider">Cost</span>
-                <span className="text-[13px] font-medium text-cc-fg tabular-nums">$0.1847</span>
+                <span className="text-[11px] text-cc-muted uppercase tracking-wider">
+                  Cost
+                </span>
+                <span className="text-[13px] font-medium text-cc-fg tabular-nums">
+                  $0.1847
+                </span>
               </div>
               <div className="space-y-1">
                 <div className="flex items-center justify-between">
-                  <span className="text-[11px] text-cc-muted uppercase tracking-wider">Context</span>
-                  <span className="text-[11px] text-cc-muted tabular-nums">62%</span>
+                  <span className="text-[11px] text-cc-muted uppercase tracking-wider">
+                    Context
+                  </span>
+                  <span className="text-[11px] text-cc-muted tabular-nums">
+                    62%
+                  </span>
                 </div>
                 <div className="w-full h-1.5 rounded-full bg-cc-hover overflow-hidden">
-                  <div className="h-full rounded-full bg-cc-warning transition-all duration-500" style={{ width: "62%" }} />
+                  <div
+                    className="h-full rounded-full bg-cc-warning transition-all duration-500"
+                    style={{ width: "62%" }}
+                  />
                 </div>
               </div>
               <div className="flex items-center justify-between">
-                <span className="text-[11px] text-cc-muted uppercase tracking-wider">Turns</span>
-                <span className="text-[13px] font-medium text-cc-fg tabular-nums">14</span>
+                <span className="text-[11px] text-cc-muted uppercase tracking-wider">
+                  Turns
+                </span>
+                <span className="text-[13px] font-medium text-cc-fg tabular-nums">
+                  14
+                </span>
               </div>
             </div>
             {/* Task header */}
             <div className="px-4 py-2.5 border-b border-cc-border flex items-center justify-between">
-              <span className="text-[12px] font-semibold text-cc-fg">Tasks</span>
-              <span className="text-[11px] text-cc-muted tabular-nums">2/{MOCK_TASKS.length}</span>
+              <span className="text-[12px] font-semibold text-cc-fg">
+                Tasks
+              </span>
+              <span className="text-[11px] text-cc-muted tabular-nums">
+                2/{MOCK_TASKS.length}
+              </span>
             </div>
             {/* Task list */}
             <div className="px-3 py-2 space-y-0.5">
@@ -865,7 +1295,10 @@ export function Playground() {
         </Section>
 
         {/* ─── GitHub PR Status ──────────────────────────────── */}
-        <Section title="GitHub PR Status" description="PR health shown in the TaskPanel — checks, reviews, unresolved comments">
+        <Section
+          title="GitHub PR Status"
+          description="PR health shown in the TaskPanel — checks, reviews, unresolved comments"
+        >
           <div className="space-y-4">
             <Card label="Open PR — failing checks + changes requested">
               <div className="w-[280px] border border-cc-border rounded-xl overflow-hidden bg-cc-card">
@@ -891,22 +1324,40 @@ export function Playground() {
         </Section>
 
         {/* ─── Linear Issue (TaskPanel) ────────────────── */}
-        <Section title="Linear Issue (TaskPanel)" description="Linear issue linked to a session — displayed in TaskPanel with status, comments, and actions">
+        <Section
+          title="Linear Issue (TaskPanel)"
+          description="Linear issue linked to a session — displayed in TaskPanel with status, comments, and actions"
+        >
           <div className="space-y-4">
             <Card label="Active issue — In Progress with comments">
               <div className="w-[280px] border border-cc-border rounded-xl overflow-hidden bg-cc-card">
                 <div className="px-4 py-3 space-y-2">
                   <div className="flex items-center gap-1.5">
                     <LinearLogo className="w-3.5 h-3.5 text-cc-muted shrink-0" />
-                    <span className="text-[12px] font-semibold text-cc-fg font-mono-code">{MOCK_LINEAR_ISSUE_ACTIVE.identifier}</span>
+                    <span className="text-[12px] font-semibold text-cc-fg font-mono-code">
+                      {MOCK_LINEAR_ISSUE_ACTIVE.identifier}
+                    </span>
                     <span className="text-[9px] font-medium px-1.5 rounded-full leading-[16px] text-blue-400 bg-blue-400/10">
                       {MOCK_LINEAR_ISSUE_ACTIVE.stateName}
                     </span>
-                    <button className="ml-auto flex items-center justify-center w-5 h-5 rounded text-cc-muted hover:text-cc-fg hover:bg-cc-hover transition-colors cursor-pointer" title="Unlink">
-                      <svg viewBox="0 0 16 16" fill="none" stroke="currentColor" strokeWidth="1.5" className="w-3 h-3"><path d="M4 4l8 8M12 4l-8 8" /></svg>
+                    <button
+                      className="ml-auto flex items-center justify-center w-5 h-5 rounded text-cc-muted hover:text-cc-fg hover:bg-cc-hover transition-colors cursor-pointer"
+                      title="Unlink"
+                    >
+                      <svg
+                        viewBox="0 0 16 16"
+                        fill="none"
+                        stroke="currentColor"
+                        strokeWidth="1.5"
+                        className="w-3 h-3"
+                      >
+                        <path d="M4 4l8 8M12 4l-8 8" />
+                      </svg>
                     </button>
                   </div>
-                  <p className="text-[11px] text-cc-muted truncate">{MOCK_LINEAR_ISSUE_ACTIVE.title}</p>
+                  <p className="text-[11px] text-cc-muted truncate">
+                    {MOCK_LINEAR_ISSUE_ACTIVE.title}
+                  </p>
                   <div className="flex items-center gap-2 text-[10px] text-cc-muted">
                     <span>{MOCK_LINEAR_ISSUE_ACTIVE.priorityLabel}</span>
                     <span>&middot;</span>
@@ -915,18 +1366,34 @@ export function Playground() {
                     <span>@ Alice</span>
                   </div>
                   <div className="flex flex-wrap gap-1">
-                    <span className="text-[9px] px-1.5 py-0.5 rounded-full" style={{ backgroundColor: "#bb87fc20", color: "#bb87fc" }}>feature</span>
-                    <span className="text-[9px] px-1.5 py-0.5 rounded-full" style={{ backgroundColor: "#f2994a20", color: "#f2994a" }}>frontend</span>
+                    <span
+                      className="text-[9px] px-1.5 py-0.5 rounded-full"
+                      style={{ backgroundColor: "#bb87fc20", color: "#bb87fc" }}
+                    >
+                      feature
+                    </span>
+                    <span
+                      className="text-[9px] px-1.5 py-0.5 rounded-full"
+                      style={{ backgroundColor: "#f2994a20", color: "#f2994a" }}
+                    >
+                      frontend
+                    </span>
                   </div>
                 </div>
                 {/* Comments */}
                 <div className="px-4 py-2 border-t border-cc-border space-y-1.5 max-h-36 overflow-y-auto">
-                  <span className="text-[10px] text-cc-muted uppercase tracking-wider">Comments</span>
+                  <span className="text-[10px] text-cc-muted uppercase tracking-wider">
+                    Comments
+                  </span>
                   {MOCK_LINEAR_COMMENTS.map((c) => (
                     <div key={c.id} className="text-[11px]">
                       <div className="flex items-center gap-1">
-                        <span className="font-medium text-cc-fg">{c.userName}</span>
-                        <span className="text-[9px] text-cc-muted">just now</span>
+                        <span className="font-medium text-cc-fg">
+                          {c.userName}
+                        </span>
+                        <span className="text-[9px] text-cc-muted">
+                          just now
+                        </span>
                       </div>
                       <p className="text-cc-muted line-clamp-2">{c.body}</p>
                     </div>
@@ -934,9 +1401,19 @@ export function Playground() {
                 </div>
                 {/* Comment input */}
                 <div className="px-4 py-2 border-t border-cc-border flex items-center gap-1.5">
-                  <input type="text" placeholder="Add a comment..." className="flex-1 text-[11px] bg-transparent border border-cc-border rounded-md px-2 py-1.5 text-cc-fg placeholder:text-cc-muted focus:outline-none focus:border-cc-primary/50" />
+                  <input
+                    type="text"
+                    placeholder="Add a comment..."
+                    className="flex-1 text-[11px] bg-transparent border border-cc-border rounded-md px-2 py-1.5 text-cc-fg placeholder:text-cc-muted focus:outline-none focus:border-cc-primary/50"
+                  />
                   <button className="flex items-center justify-center w-6 h-6 rounded text-cc-primary cursor-pointer">
-                    <svg viewBox="0 0 16 16" fill="currentColor" className="w-3.5 h-3.5"><path d="M1.724 1.053a.5.5 0 0 0-.714.545l1.403 4.85a.5.5 0 0 0 .397.354l5.19.736-5.19.737a.5.5 0 0 0-.397.353L1.01 13.48a.5.5 0 0 0 .714.545l13-6.5a.5.5 0 0 0 0-.894l-13-6.5z" /></svg>
+                    <svg
+                      viewBox="0 0 16 16"
+                      fill="currentColor"
+                      className="w-3.5 h-3.5"
+                    >
+                      <path d="M1.724 1.053a.5.5 0 0 0-.714.545l1.403 4.85a.5.5 0 0 0 .397.354l5.19.736-5.19.737a.5.5 0 0 0-.397.353L1.01 13.48a.5.5 0 0 0 .714.545l13-6.5a.5.5 0 0 0 0-.894l-13-6.5z" />
+                    </svg>
                   </button>
                 </div>
               </div>
@@ -947,12 +1424,16 @@ export function Playground() {
                 <div className="px-4 py-3 space-y-2">
                   <div className="flex items-center gap-1.5">
                     <LinearLogo className="w-3.5 h-3.5 text-cc-muted shrink-0" />
-                    <span className="text-[12px] font-semibold text-cc-fg font-mono-code">{MOCK_LINEAR_ISSUE_DONE.identifier}</span>
+                    <span className="text-[12px] font-semibold text-cc-fg font-mono-code">
+                      {MOCK_LINEAR_ISSUE_DONE.identifier}
+                    </span>
                     <span className="text-[9px] font-medium px-1.5 rounded-full leading-[16px] text-cc-success bg-cc-success/10">
                       {MOCK_LINEAR_ISSUE_DONE.stateName}
                     </span>
                   </div>
-                  <p className="text-[11px] text-cc-muted truncate">{MOCK_LINEAR_ISSUE_DONE.title}</p>
+                  <p className="text-[11px] text-cc-muted truncate">
+                    {MOCK_LINEAR_ISSUE_DONE.title}
+                  </p>
                   <div className="flex items-center gap-2 text-[10px] text-cc-muted">
                     <span>{MOCK_LINEAR_ISSUE_DONE.priorityLabel}</span>
                     <span>&middot;</span>
@@ -962,12 +1443,20 @@ export function Playground() {
                 {/* Done warning */}
                 <div className="px-4 py-2 bg-cc-success/10 border-t border-cc-success/20 flex items-center justify-between gap-2">
                   <div className="min-w-0">
-                    <p className="text-[11px] text-cc-success font-medium">Issue completed</p>
-                    <p className="text-[10px] text-cc-success/80">Ticket moved to done.</p>
+                    <p className="text-[11px] text-cc-success font-medium">
+                      Issue completed
+                    </p>
+                    <p className="text-[10px] text-cc-success/80">
+                      Ticket moved to done.
+                    </p>
                   </div>
                   <div className="flex items-center gap-1.5 shrink-0">
-                    <button className="text-[10px] text-cc-muted hover:text-cc-fg px-1.5 py-0.5 rounded cursor-pointer">Dismiss</button>
-                    <button className="text-[10px] text-cc-success font-medium px-2 py-0.5 rounded bg-cc-success/20 hover:bg-cc-success/30 cursor-pointer">Close session</button>
+                    <button className="text-[10px] text-cc-muted hover:text-cc-fg px-1.5 py-0.5 rounded cursor-pointer">
+                      Dismiss
+                    </button>
+                    <button className="text-[10px] text-cc-success font-medium px-2 py-0.5 rounded bg-cc-success/20 hover:bg-cc-success/30 cursor-pointer">
+                      Close session
+                    </button>
                   </div>
                 </div>
               </div>
@@ -987,22 +1476,42 @@ export function Playground() {
         </Section>
 
         {/* ─── MCP Servers ──────────────────────────────── */}
-        <Section title="MCP Servers" description="MCP server status display with toggle, reconnect, and tool listing">
+        <Section
+          title="MCP Servers"
+          description="MCP server status display with toggle, reconnect, and tool listing"
+        >
           <div className="space-y-4">
             <Card label="All server states (connected, failed, disabled, connecting)">
               <div className="w-[280px] border border-cc-border rounded-xl overflow-hidden bg-cc-card">
                 {/* MCP section header */}
                 <div className="shrink-0 px-4 py-2.5 border-b border-cc-border flex items-center justify-between">
                   <span className="text-[12px] font-semibold text-cc-fg flex items-center gap-1.5">
-                    <svg viewBox="0 0 16 16" fill="currentColor" className="w-3.5 h-3.5 text-cc-muted">
+                    <svg
+                      viewBox="0 0 16 16"
+                      fill="currentColor"
+                      className="w-3.5 h-3.5 text-cc-muted"
+                    >
                       <path d="M1.5 3A1.5 1.5 0 013 1.5h10A1.5 1.5 0 0114.5 3v1A1.5 1.5 0 0113 5.5H3A1.5 1.5 0 011.5 4V3zm0 5A1.5 1.5 0 013 6.5h10A1.5 1.5 0 0114.5 8v1A1.5 1.5 0 0113 10.5H3A1.5 1.5 0 011.5 9V8zm0 5A1.5 1.5 0 013 11.5h10a1.5 1.5 0 011.5 1.5v1a1.5 1.5 0 01-1.5 1.5H3A1.5 1.5 0 011.5 14v-1z" />
                     </svg>
                     MCP Servers
                   </span>
                   <span className="text-[11px] text-cc-muted">
-                    <svg viewBox="0 0 16 16" fill="none" stroke="currentColor" strokeWidth="1.5" className="w-3.5 h-3.5">
-                      <path d="M2.5 8a5.5 5.5 0 019.78-3.5M13.5 8a5.5 5.5 0 01-9.78 3.5" strokeLinecap="round" />
-                      <path d="M12.5 2v3h-3M3.5 14v-3h3" strokeLinecap="round" strokeLinejoin="round" />
+                    <svg
+                      viewBox="0 0 16 16"
+                      fill="none"
+                      stroke="currentColor"
+                      strokeWidth="1.5"
+                      className="w-3.5 h-3.5"
+                    >
+                      <path
+                        d="M2.5 8a5.5 5.5 0 019.78-3.5M13.5 8a5.5 5.5 0 01-9.78 3.5"
+                        strokeLinecap="round"
+                      />
+                      <path
+                        d="M12.5 2v3h-3M3.5 14v-3h3"
+                        strokeLinecap="round"
+                        strokeLinejoin="round"
+                      />
                     </svg>
                   </span>
                 </div>
@@ -1018,15 +1527,26 @@ export function Playground() {
         </Section>
 
         {/* ─── Panel Config View ──────────────────────────── */}
-        <Section title="Panel Config View" description="Inline configuration for the right sidebar — toggle sections on/off and reorder them">
+        <Section
+          title="Panel Config View"
+          description="Inline configuration for the right sidebar — toggle sections on/off and reorder them"
+        >
           <div className="space-y-4">
             <Card label="Config mode with mixed enabled/disabled sections">
               <div className="w-[320px] border border-cc-border rounded-xl overflow-hidden bg-cc-card">
                 {/* Header */}
                 <div className="shrink-0 flex items-center justify-between px-4 py-3 border-b border-cc-border">
-                  <span className="text-sm font-semibold text-cc-fg tracking-tight">Panel Settings</span>
+                  <span className="text-sm font-semibold text-cc-fg tracking-tight">
+                    Panel Settings
+                  </span>
                   <button className="flex items-center justify-center w-6 h-6 rounded-lg text-cc-muted hover:text-cc-fg hover:bg-cc-hover transition-colors cursor-pointer">
-                    <svg viewBox="0 0 16 16" fill="none" stroke="currentColor" strokeWidth="1.5" className="w-3.5 h-3.5">
+                    <svg
+                      viewBox="0 0 16 16"
+                      fill="none"
+                      stroke="currentColor"
+                      strokeWidth="1.5"
+                      className="w-3.5 h-3.5"
+                    >
                       <path d="M4 4l8 8M12 4l-8 8" />
                     </svg>
                   </button>
@@ -1034,12 +1554,42 @@ export function Playground() {
                 {/* Section rows */}
                 <div className="px-3 py-3 space-y-1">
                   {[
-                    { id: "git-branch", label: "Git Branch", desc: "Current branch, ahead/behind, and line changes", enabled: true },
-                    { id: "usage-limits", label: "Usage Limits", desc: "API usage and rate limit meters", enabled: true },
-                    { id: "github-pr", label: "GitHub PR", desc: "Pull request status, CI checks, and reviews", enabled: false },
-                    { id: "linear-issue", label: "Linear Issue", desc: "Linked Linear ticket and comments", enabled: true },
-                    { id: "mcp-servers", label: "MCP Servers", desc: "Model Context Protocol server connections", enabled: false },
-                    { id: "tasks", label: "Tasks", desc: "Agent task list and progress", enabled: true },
+                    {
+                      id: "git-branch",
+                      label: "Git Branch",
+                      desc: "Current branch, ahead/behind, and line changes",
+                      enabled: true,
+                    },
+                    {
+                      id: "usage-limits",
+                      label: "Usage Limits",
+                      desc: "API usage and rate limit meters",
+                      enabled: true,
+                    },
+                    {
+                      id: "github-pr",
+                      label: "GitHub PR",
+                      desc: "Pull request status, CI checks, and reviews",
+                      enabled: false,
+                    },
+                    {
+                      id: "linear-issue",
+                      label: "Linear Issue",
+                      desc: "Linked Linear ticket and comments",
+                      enabled: true,
+                    },
+                    {
+                      id: "mcp-servers",
+                      label: "MCP Servers",
+                      desc: "Model Context Protocol server connections",
+                      enabled: false,
+                    },
+                    {
+                      id: "tasks",
+                      label: "Tasks",
+                      desc: "Agent task list and progress",
+                      enabled: true,
+                    },
                   ].map((s, i, arr) => (
                     <div
                       key={s.id}
@@ -1048,16 +1598,38 @@ export function Playground() {
                       }`}
                     >
                       <div className="flex flex-col gap-0.5 shrink-0">
-                        <button disabled={i === 0} className="w-5 h-4 flex items-center justify-center text-cc-muted hover:text-cc-fg disabled:opacity-20 disabled:cursor-not-allowed cursor-pointer transition-colors">
-                          <svg viewBox="0 0 16 16" fill="currentColor" className="w-3 h-3"><path d="M8 4l4 4H4l4-4z" /></svg>
+                        <button
+                          disabled={i === 0}
+                          className="w-5 h-4 flex items-center justify-center text-cc-muted hover:text-cc-fg disabled:opacity-20 disabled:cursor-not-allowed cursor-pointer transition-colors"
+                        >
+                          <svg
+                            viewBox="0 0 16 16"
+                            fill="currentColor"
+                            className="w-3 h-3"
+                          >
+                            <path d="M8 4l4 4H4l4-4z" />
+                          </svg>
                         </button>
-                        <button disabled={i === arr.length - 1} className="w-5 h-4 flex items-center justify-center text-cc-muted hover:text-cc-fg disabled:opacity-20 disabled:cursor-not-allowed cursor-pointer transition-colors">
-                          <svg viewBox="0 0 16 16" fill="currentColor" className="w-3 h-3"><path d="M8 12l4-4H4l4 4z" /></svg>
+                        <button
+                          disabled={i === arr.length - 1}
+                          className="w-5 h-4 flex items-center justify-center text-cc-muted hover:text-cc-fg disabled:opacity-20 disabled:cursor-not-allowed cursor-pointer transition-colors"
+                        >
+                          <svg
+                            viewBox="0 0 16 16"
+                            fill="currentColor"
+                            className="w-3 h-3"
+                          >
+                            <path d="M8 12l4-4H4l4 4z" />
+                          </svg>
                         </button>
                       </div>
                       <div className="flex-1 min-w-0">
-                        <span className="text-[12px] font-medium text-cc-fg block">{s.label}</span>
-                        <span className="text-[10px] text-cc-muted block truncate">{s.desc}</span>
+                        <span className="text-[12px] font-medium text-cc-fg block">
+                          {s.label}
+                        </span>
+                        <span className="text-[10px] text-cc-muted block truncate">
+                          {s.desc}
+                        </span>
                       </div>
                       <button
                         className={`shrink-0 w-8 h-[18px] rounded-full transition-colors cursor-pointer relative ${
@@ -1066,17 +1638,25 @@ export function Playground() {
                         role="switch"
                         aria-checked={s.enabled}
                       >
-                        <span className={`absolute top-[2px] w-[14px] h-[14px] rounded-full bg-white shadow transition-transform ${
-                          s.enabled ? "translate-x-[16px]" : "translate-x-[2px]"
-                        }`} />
+                        <span
+                          className={`absolute top-[2px] w-[14px] h-[14px] rounded-full bg-white shadow transition-transform ${
+                            s.enabled
+                              ? "translate-x-[16px]"
+                              : "translate-x-[2px]"
+                          }`}
+                        />
                       </button>
                     </div>
                   ))}
                 </div>
                 {/* Footer */}
                 <div className="shrink-0 border-t border-cc-border px-3 py-2.5 flex items-center justify-between">
-                  <button className="text-[11px] text-cc-muted hover:text-cc-fg transition-colors cursor-pointer">Reset to defaults</button>
-                  <button className="text-[11px] font-medium text-cc-primary hover:text-cc-primary-hover transition-colors cursor-pointer">Done</button>
+                  <button className="text-[11px] text-cc-muted hover:text-cc-fg transition-colors cursor-pointer">
+                    Reset to defaults
+                  </button>
+                  <button className="text-[11px] font-medium text-cc-primary hover:text-cc-primary-hover transition-colors cursor-pointer">
+                    Done
+                  </button>
                 </div>
               </div>
             </Card>
@@ -1084,7 +1664,10 @@ export function Playground() {
         </Section>
 
         {/* ─── Codex Session Details ──────────────────────── */}
-        <Section title="Codex Session Details" description="Rate limits and token details for Codex (OpenAI) sessions — streamed via session_update">
+        <Section
+          title="Codex Session Details"
+          description="Rate limits and token details for Codex (OpenAI) sessions — streamed via session_update"
+        >
           <div className="space-y-4">
             <Card label="Rate limits with token breakdown">
               <CodexPlaygroundDemo />
@@ -1093,7 +1676,10 @@ export function Playground() {
         </Section>
 
         {/* ─── Update Banner ──────────────────────────────── */}
-        <Section title="Update Banner" description="Notification banner for available updates">
+        <Section
+          title="Update Banner"
+          description="Notification banner for available updates"
+        >
           <div className="space-y-4 max-w-3xl">
             <Card label="Service mode (auto-update)">
               <PlaygroundUpdateBanner
@@ -1151,18 +1737,27 @@ export function Playground() {
         </Section>
 
         {/* ─── Status Indicators ──────────────────────────────── */}
-        <Section title="Status Indicators" description="Connection and session status banners">
+        <Section
+          title="Status Indicators"
+          description="Connection and session status banners"
+        >
           <div className="space-y-3 max-w-3xl">
             <Card label="Disconnected warning">
               <div className="px-4 py-2 bg-cc-warning/10 border border-cc-warning/20 rounded-lg text-center">
-                <span className="text-xs text-cc-warning font-medium">Reconnecting to session...</span>
+                <span className="text-xs text-cc-warning font-medium">
+                  Reconnecting to session...
+                </span>
               </div>
             </Card>
             <Card label="Connected">
               <div className="flex items-center gap-2 px-3 py-2 bg-cc-card border border-cc-border rounded-lg">
                 <span className="w-2 h-2 rounded-full bg-cc-success" />
-                <span className="text-xs text-cc-fg font-medium">Connected</span>
-                <span className="text-[11px] text-cc-muted ml-auto">claude-opus-4-6</span>
+                <span className="text-xs text-cc-fg font-medium">
+                  Connected
+                </span>
+                <span className="text-[11px] text-cc-muted ml-auto">
+                  claude-opus-4-6
+                </span>
               </div>
             </Card>
             <Card label="Running / Thinking">
@@ -1173,26 +1768,62 @@ export function Playground() {
             </Card>
             <Card label="Compacting">
               <div className="flex items-center gap-2 px-3 py-2 bg-cc-card border border-cc-border rounded-lg">
-                <svg className="w-3.5 h-3.5 text-cc-muted animate-spin" viewBox="0 0 16 16" fill="none">
-                  <circle cx="8" cy="8" r="6" stroke="currentColor" strokeWidth="1.5" strokeDasharray="28" strokeDashoffset="8" strokeLinecap="round" />
+                <svg
+                  className="w-3.5 h-3.5 text-cc-muted animate-spin"
+                  viewBox="0 0 16 16"
+                  fill="none"
+                >
+                  <circle
+                    cx="8"
+                    cy="8"
+                    r="6"
+                    stroke="currentColor"
+                    strokeWidth="1.5"
+                    strokeDasharray="28"
+                    strokeDashoffset="8"
+                    strokeLinecap="round"
+                  />
                 </svg>
-                <span className="text-xs text-cc-muted font-medium">Compacting context...</span>
+                <span className="text-xs text-cc-muted font-medium">
+                  Compacting context...
+                </span>
               </div>
             </Card>
           </div>
         </Section>
 
         {/* ─── Composer ──────────────────────────────── */}
-        <Section title="Composer" description="Message input bar with mode toggle, image upload, saved prompts (@), and send/stop buttons">
+        <Section
+          title="Composer"
+          description="Message input bar with mode toggle, image upload, saved prompts (@), and send/stop buttons"
+        >
           <div className="max-w-3xl">
             <Card label="Connected — code mode">
               <div className="border-t border-cc-border bg-cc-card px-4 py-3">
                 <div className="relative bg-cc-input-bg/95 border border-cc-border rounded-[14px] shadow-[0_10px_30px_rgba(0,0,0,0.10)] overflow-visible">
                   <div className="flex items-end gap-2 px-2.5 py-2">
                     <div className="mb-0.5 flex items-center gap-1.5 px-2.5 py-1.5 rounded-md border border-cc-border text-[12px] font-semibold text-cc-muted">
-                      <svg viewBox="0 0 16 16" fill="currentColor" className="w-3.5 h-3.5">
-                        <path d="M2.5 4l4 4-4 4" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" fill="none" />
-                        <path d="M8.5 4l4 4-4 4" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" fill="none" />
+                      <svg
+                        viewBox="0 0 16 16"
+                        fill="currentColor"
+                        className="w-3.5 h-3.5"
+                      >
+                        <path
+                          d="M2.5 4l4 4-4 4"
+                          stroke="currentColor"
+                          strokeWidth="2"
+                          strokeLinecap="round"
+                          strokeLinejoin="round"
+                          fill="none"
+                        />
+                        <path
+                          d="M8.5 4l4 4-4 4"
+                          stroke="currentColor"
+                          strokeWidth="2"
+                          strokeLinecap="round"
+                          strokeLinejoin="round"
+                          fill="none"
+                        />
                       </svg>
                       <span>code</span>
                     </div>
@@ -1205,14 +1836,34 @@ export function Playground() {
                     />
                     <div className="mb-0.5 flex items-center gap-1.5">
                       <div className="flex items-center justify-center w-9 h-9 rounded-lg border border-cc-border text-cc-muted">
-                        <svg viewBox="0 0 16 16" fill="none" stroke="currentColor" strokeWidth="1.5" className="w-4 h-4">
+                        <svg
+                          viewBox="0 0 16 16"
+                          fill="none"
+                          stroke="currentColor"
+                          strokeWidth="1.5"
+                          className="w-4 h-4"
+                        >
                           <rect x="2" y="2" width="12" height="12" rx="2" />
-                          <circle cx="5.5" cy="5.5" r="1" fill="currentColor" stroke="none" />
-                          <path d="M2 11l3-3 2 2 3-4 4 5" strokeLinecap="round" strokeLinejoin="round" />
+                          <circle
+                            cx="5.5"
+                            cy="5.5"
+                            r="1"
+                            fill="currentColor"
+                            stroke="none"
+                          />
+                          <path
+                            d="M2 11l3-3 2 2 3-4 4 5"
+                            strokeLinecap="round"
+                            strokeLinejoin="round"
+                          />
                         </svg>
                       </div>
                       <div className="flex items-center justify-center w-9 h-9 rounded-full bg-cc-primary text-white shadow-[0_6px_20px_rgba(0,0,0,0.18)]">
-                        <svg viewBox="0 0 16 16" fill="currentColor" className="w-3.5 h-3.5">
+                        <svg
+                          viewBox="0 0 16 16"
+                          fill="currentColor"
+                          className="w-3.5 h-3.5"
+                        >
                           <path d="M3 2l11 6-11 6V9.5l7-1.5-7-1.5V2z" />
                         </svg>
                       </div>
@@ -1227,12 +1878,21 @@ export function Playground() {
                 <div className="relative bg-cc-input-bg/95 border border-cc-border rounded-[14px] shadow-[0_10px_30px_rgba(0,0,0,0.10)] overflow-visible">
                   <div className="absolute left-2 right-2 bottom-full mb-1 max-h-[180px] overflow-y-auto bg-cc-card border border-cc-border rounded-[10px] shadow-lg z-20 py-1">
                     <div className="px-3 py-2 flex items-center gap-2.5 bg-cc-hover">
-                      <span className="flex items-center justify-center w-6 h-6 rounded-md bg-cc-hover text-cc-muted shrink-0">@</span>
+                      <span className="flex items-center justify-center w-6 h-6 rounded-md bg-cc-hover text-cc-muted shrink-0">
+                        @
+                      </span>
                       <div className="flex-1 min-w-0">
-                        <div className="text-[13px] font-medium text-cc-fg truncate">@review-pr</div>
-                        <div className="text-[11px] text-cc-muted truncate">Review this PR and list risks, regressions, and missing tests.</div>
+                        <div className="text-[13px] font-medium text-cc-fg truncate">
+                          @review-pr
+                        </div>
+                        <div className="text-[11px] text-cc-muted truncate">
+                          Review this PR and list risks, regressions, and
+                          missing tests.
+                        </div>
                       </div>
-                      <span className="text-[10px] text-cc-muted shrink-0">project</span>
+                      <span className="text-[10px] text-cc-muted shrink-0">
+                        project
+                      </span>
                     </div>
                   </div>
                   <div className="flex items-end gap-2 px-2.5 py-2">
@@ -1245,7 +1905,13 @@ export function Playground() {
                     />
                     <div className="mb-0.5 flex items-center gap-1.5">
                       <div className="flex items-center justify-center w-9 h-9 rounded-lg border border-cc-border text-cc-muted">
-                        <svg viewBox="0 0 16 16" fill="none" stroke="currentColor" strokeWidth="1.5" className="w-4 h-4">
+                        <svg
+                          viewBox="0 0 16 16"
+                          fill="none"
+                          stroke="currentColor"
+                          strokeWidth="1.5"
+                          className="w-4 h-4"
+                        >
                           <path d="M4 2.75h8A1.25 1.25 0 0113.25 4v9.25L8 10.5l-5.25 2.75V4A1.25 1.25 0 014 2.75z" />
                         </svg>
                       </div>
@@ -1260,7 +1926,11 @@ export function Playground() {
                 <div className="relative bg-cc-input-bg/95 border border-cc-primary/40 rounded-[14px] shadow-[0_10px_30px_rgba(0,0,0,0.10)] overflow-visible">
                   <div className="flex items-end gap-2 px-2.5 py-2">
                     <div className="mb-0.5 flex items-center gap-1.5 px-2.5 py-1.5 rounded-md border border-cc-primary/40 text-[12px] font-semibold text-cc-primary bg-cc-primary/8">
-                      <svg viewBox="0 0 16 16" fill="currentColor" className="w-3.5 h-3.5">
+                      <svg
+                        viewBox="0 0 16 16"
+                        fill="currentColor"
+                        className="w-3.5 h-3.5"
+                      >
                         <rect x="3" y="3" width="3.5" height="10" rx="0.75" />
                         <rect x="9.5" y="3" width="3.5" height="10" rx="0.75" />
                       </svg>
@@ -1276,14 +1946,34 @@ export function Playground() {
                     />
                     <div className="mb-0.5 flex items-center gap-1.5">
                       <div className="flex items-center justify-center w-9 h-9 rounded-lg border border-cc-border text-cc-muted">
-                        <svg viewBox="0 0 16 16" fill="none" stroke="currentColor" strokeWidth="1.5" className="w-4 h-4">
+                        <svg
+                          viewBox="0 0 16 16"
+                          fill="none"
+                          stroke="currentColor"
+                          strokeWidth="1.5"
+                          className="w-4 h-4"
+                        >
                           <rect x="2" y="2" width="12" height="12" rx="2" />
-                          <circle cx="5.5" cy="5.5" r="1" fill="currentColor" stroke="none" />
-                          <path d="M2 11l3-3 2 2 3-4 4 5" strokeLinecap="round" strokeLinejoin="round" />
+                          <circle
+                            cx="5.5"
+                            cy="5.5"
+                            r="1"
+                            fill="currentColor"
+                            stroke="none"
+                          />
+                          <path
+                            d="M2 11l3-3 2 2 3-4 4 5"
+                            strokeLinecap="round"
+                            strokeLinejoin="round"
+                          />
                         </svg>
                       </div>
                       <div className="flex items-center justify-center w-9 h-9 rounded-full bg-cc-hover text-cc-muted">
-                        <svg viewBox="0 0 16 16" fill="currentColor" className="w-3.5 h-3.5">
+                        <svg
+                          viewBox="0 0 16 16"
+                          fill="currentColor"
+                          className="w-3.5 h-3.5"
+                        >
                           <path d="M3 2l11 6-11 6V9.5l7-1.5-7-1.5V2z" />
                         </svg>
                       </div>
@@ -1298,9 +1988,27 @@ export function Playground() {
                 <div className="relative bg-cc-input-bg/95 border border-cc-border rounded-[14px] shadow-[0_10px_30px_rgba(0,0,0,0.10)] overflow-visible">
                   <div className="flex items-end gap-2 px-2.5 py-2">
                     <div className="mb-0.5 flex items-center gap-1.5 px-2.5 py-1.5 rounded-md border border-cc-border text-[12px] font-semibold text-cc-muted">
-                      <svg viewBox="0 0 16 16" fill="currentColor" className="w-3.5 h-3.5">
-                        <path d="M2.5 4l4 4-4 4" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" fill="none" />
-                        <path d="M8.5 4l4 4-4 4" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" fill="none" />
+                      <svg
+                        viewBox="0 0 16 16"
+                        fill="currentColor"
+                        className="w-3.5 h-3.5"
+                      >
+                        <path
+                          d="M2.5 4l4 4-4 4"
+                          stroke="currentColor"
+                          strokeWidth="2"
+                          strokeLinecap="round"
+                          strokeLinejoin="round"
+                          fill="none"
+                        />
+                        <path
+                          d="M8.5 4l4 4-4 4"
+                          stroke="currentColor"
+                          strokeWidth="2"
+                          strokeLinecap="round"
+                          strokeLinejoin="round"
+                          fill="none"
+                        />
                       </svg>
                       <span>code</span>
                     </div>
@@ -1314,14 +2022,34 @@ export function Playground() {
                     />
                     <div className="mb-0.5 flex items-center gap-1.5">
                       <div className="flex items-center justify-center w-9 h-9 rounded-lg border border-cc-border text-cc-muted">
-                        <svg viewBox="0 0 16 16" fill="none" stroke="currentColor" strokeWidth="1.5" className="w-4 h-4">
+                        <svg
+                          viewBox="0 0 16 16"
+                          fill="none"
+                          stroke="currentColor"
+                          strokeWidth="1.5"
+                          className="w-4 h-4"
+                        >
                           <rect x="2" y="2" width="12" height="12" rx="2" />
-                          <circle cx="5.5" cy="5.5" r="1" fill="currentColor" stroke="none" />
-                          <path d="M2 11l3-3 2 2 3-4 4 5" strokeLinecap="round" strokeLinejoin="round" />
+                          <circle
+                            cx="5.5"
+                            cy="5.5"
+                            r="1"
+                            fill="currentColor"
+                            stroke="none"
+                          />
+                          <path
+                            d="M2 11l3-3 2 2 3-4 4 5"
+                            strokeLinecap="round"
+                            strokeLinejoin="round"
+                          />
                         </svg>
                       </div>
                       <div className="flex items-center justify-center w-9 h-9 rounded-lg bg-cc-error/10 text-cc-error">
-                        <svg viewBox="0 0 16 16" fill="currentColor" className="w-3.5 h-3.5">
+                        <svg
+                          viewBox="0 0 16 16"
+                          fill="currentColor"
+                          className="w-3.5 h-3.5"
+                        >
                           <rect x="3" y="3" width="10" height="10" rx="1" />
                         </svg>
                       </div>
@@ -1334,18 +2062,32 @@ export function Playground() {
         </Section>
 
         {/* ─── Streaming Indicator ──────────────────────────────── */}
-        <Section title="Streaming Indicator" description="Live typing animation shown while the assistant is generating">
+        <Section
+          title="Streaming Indicator"
+          description="Live typing animation shown while the assistant is generating"
+        >
           <div className="space-y-4 max-w-3xl">
             <Card label="Streaming with cursor">
               <div className="flex items-start gap-3">
                 <div className="w-6 h-6 rounded-full bg-cc-primary/10 flex items-center justify-center shrink-0 mt-0.5">
-                  <svg viewBox="0 0 16 16" fill="none" className="w-3.5 h-3.5 text-cc-primary">
-                    <path d="M8 1v14M1 8h14" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" />
+                  <svg
+                    viewBox="0 0 16 16"
+                    fill="none"
+                    className="w-3.5 h-3.5 text-cc-primary"
+                  >
+                    <path
+                      d="M8 1v14M1 8h14"
+                      stroke="currentColor"
+                      strokeWidth="1.5"
+                      strokeLinecap="round"
+                    />
                   </svg>
                 </div>
                 <div className="flex-1 min-w-0">
                   <pre className="font-serif-assistant text-[15px] text-cc-fg whitespace-pre-wrap break-words leading-relaxed">
-                    I'll start by creating the JWT utility module with sign and verify helpers. Let me first check what dependencies are already installed...
+                    I'll start by creating the JWT utility module with sign and
+                    verify helpers. Let me first check what dependencies are
+                    already installed...
                     <span className="inline-block w-0.5 h-4 bg-cc-primary ml-0.5 align-middle animate-[pulse-dot_0.8s_ease-in-out_infinite]" />
                   </pre>
                 </div>
@@ -1366,19 +2108,37 @@ export function Playground() {
         </Section>
 
         {/* ─── Tool Message Groups ──────────────────────────────── */}
-        <Section title="Tool Message Groups" description="Consecutive same-tool calls collapsed into a single expandable row">
+        <Section
+          title="Tool Message Groups"
+          description="Consecutive same-tool calls collapsed into a single expandable row"
+        >
           <div className="space-y-4 max-w-3xl">
             <Card label="Multi-item group (4 Reads)">
-              <PlaygroundToolGroup toolName="Read" items={MOCK_TOOL_GROUP_ITEMS} />
+              <PlaygroundToolGroup
+                toolName="Read"
+                items={MOCK_TOOL_GROUP_ITEMS}
+              />
             </Card>
             <Card label="Single-item group">
-              <PlaygroundToolGroup toolName="Glob" items={[{ id: "sg-1", name: "Glob", input: { pattern: "src/auth/**/*.ts" } }]} />
+              <PlaygroundToolGroup
+                toolName="Glob"
+                items={[
+                  {
+                    id: "sg-1",
+                    name: "Glob",
+                    input: { pattern: "src/auth/**/*.ts" },
+                  },
+                ]}
+              />
             </Card>
           </div>
         </Section>
 
         {/* ─── Subagent Groups ──────────────────────────────── */}
-        <Section title="Subagent Groups" description="Nested messages from Task tool subagents shown in a collapsible indent">
+        <Section
+          title="Subagent Groups"
+          description="Nested messages from Task tool subagents shown in a collapsible indent"
+        >
           <div className="space-y-4 max-w-3xl">
             <Card label="Subagent with nested tool calls">
               <PlaygroundSubagentGroup
@@ -1395,19 +2155,28 @@ export function Playground() {
         </Section>
 
         {/* ─── Diff Viewer ──────────────────────────────── */}
-        <Section title="Diff Viewer" description="Unified diff rendering with word-level highlighting — used in ToolBlock, PermissionBanner, and DiffPanel">
+        <Section
+          title="Diff Viewer"
+          description="Unified diff rendering with word-level highlighting — used in ToolBlock, PermissionBanner, and DiffPanel"
+        >
           <div className="space-y-4 max-w-3xl">
             <Card label="Edit diff (compact mode)">
               <DiffViewer
-                oldText={'export function formatDate(d: Date) {\n  return d.toISOString();\n}'}
-                newText={'export function formatDate(d: Date, locale = "en-US") {\n  return d.toLocaleDateString(locale, {\n    year: "numeric",\n    month: "short",\n    day: "numeric",\n  });\n}'}
+                oldText={
+                  "export function formatDate(d: Date) {\n  return d.toISOString();\n}"
+                }
+                newText={
+                  'export function formatDate(d: Date, locale = "en-US") {\n  return d.toLocaleDateString(locale, {\n    year: "numeric",\n    month: "short",\n    day: "numeric",\n  });\n}'
+                }
                 fileName="src/utils/format.ts"
                 mode="compact"
               />
             </Card>
             <Card label="New file diff (compact mode)">
               <DiffViewer
-                newText={'export const config = {\n  apiUrl: "https://api.example.com",\n  timeout: 5000,\n  retries: 3,\n  debug: process.env.NODE_ENV !== "production",\n};\n'}
+                newText={
+                  'export const config = {\n  apiUrl: "https://api.example.com",\n  timeout: 5000,\n  retries: 3,\n  debug: process.env.NODE_ENV !== "production",\n};\n'
+                }
                 fileName="src/config.ts"
                 mode="compact"
               />
@@ -1446,81 +2215,205 @@ export function Playground() {
           </div>
         </Section>
         {/* ─── Session Creation Progress ─────────────────────── */}
-        <Section title="Session Creation Progress" description="Step-by-step progress indicator shown during session creation (SSE streaming)">
+        <Section
+          title="Session Creation Progress"
+          description="Step-by-step progress indicator shown during session creation (SSE streaming)"
+        >
           <div className="space-y-4 max-w-md">
             <Card label="In progress (container session)">
               <SessionCreationProgress
-                steps={[
-                  { step: "resolving_env", label: "Resolving environment...", status: "done" },
-                  { step: "pulling_image", label: "Pulling Docker image...", status: "done" },
-                  { step: "creating_container", label: "Starting container...", status: "in_progress" },
-                  { step: "launching_cli", label: "Launching Claude Code...", status: "in_progress" },
-                ] satisfies CreationProgressEvent[]}
+                steps={
+                  [
+                    {
+                      step: "resolving_env",
+                      label: "Resolving environment...",
+                      status: "done",
+                    },
+                    {
+                      step: "pulling_image",
+                      label: "Pulling Docker image...",
+                      status: "done",
+                    },
+                    {
+                      step: "creating_container",
+                      label: "Starting container...",
+                      status: "in_progress",
+                    },
+                    {
+                      step: "launching_cli",
+                      label: "Launching Claude Code...",
+                      status: "in_progress",
+                    },
+                  ] satisfies CreationProgressEvent[]
+                }
               />
             </Card>
             <Card label="Completed (worktree session)">
               <SessionCreationProgress
-                steps={[
-                  { step: "resolving_env", label: "Resolving environment...", status: "done" },
-                  { step: "fetching_git", label: "Fetching from remote...", status: "done" },
-                  { step: "checkout_branch", label: "Checking out feat/auth...", status: "done" },
-                  { step: "creating_worktree", label: "Creating worktree...", status: "done" },
-                  { step: "launching_cli", label: "Launching Claude Code...", status: "done" },
-                ] satisfies CreationProgressEvent[]}
+                steps={
+                  [
+                    {
+                      step: "resolving_env",
+                      label: "Resolving environment...",
+                      status: "done",
+                    },
+                    {
+                      step: "fetching_git",
+                      label: "Fetching from remote...",
+                      status: "done",
+                    },
+                    {
+                      step: "checkout_branch",
+                      label: "Checking out feat/auth...",
+                      status: "done",
+                    },
+                    {
+                      step: "creating_worktree",
+                      label: "Creating worktree...",
+                      status: "done",
+                    },
+                    {
+                      step: "launching_cli",
+                      label: "Launching Claude Code...",
+                      status: "done",
+                    },
+                  ] satisfies CreationProgressEvent[]
+                }
               />
             </Card>
             <Card label="Error during image pull">
               <SessionCreationProgress
-                steps={[
-                  { step: "resolving_env", label: "Resolving environment...", status: "done" },
-                  { step: "pulling_image", label: "Pulling Docker image...", status: "error" },
-                ] satisfies CreationProgressEvent[]}
+                steps={
+                  [
+                    {
+                      step: "resolving_env",
+                      label: "Resolving environment...",
+                      status: "done",
+                    },
+                    {
+                      step: "pulling_image",
+                      label: "Pulling Docker image...",
+                      status: "error",
+                    },
+                  ] satisfies CreationProgressEvent[]
+                }
                 error="Failed to pull docker.io/stangirard/the-companion:latest — connection timed out after 30s"
               />
             </Card>
             <Card label="With streaming init script logs">
               <SessionCreationProgress
-                steps={[
-                  { step: "resolving_env", label: "Resolving environment...", status: "done" },
-                  { step: "pulling_image", label: "Image ready", status: "done" },
-                  { step: "creating_container", label: "Container running", status: "done" },
-                  { step: "running_init_script", label: "Running init script...", status: "in_progress", detail: "Installing dependencies..." },
-                ] satisfies CreationProgressEvent[]}
+                steps={
+                  [
+                    {
+                      step: "resolving_env",
+                      label: "Resolving environment...",
+                      status: "done",
+                    },
+                    {
+                      step: "pulling_image",
+                      label: "Image ready",
+                      status: "done",
+                    },
+                    {
+                      step: "creating_container",
+                      label: "Container running",
+                      status: "done",
+                    },
+                    {
+                      step: "running_init_script",
+                      label: "Running init script...",
+                      status: "in_progress",
+                      detail: "Installing dependencies...",
+                    },
+                  ] satisfies CreationProgressEvent[]
+                }
               />
             </Card>
             <Card label="With streaming image pull logs">
               <SessionCreationProgress
-                steps={[
-                  { step: "resolving_env", label: "Resolving environment...", status: "done" },
-                  { step: "pulling_image", label: "Pulling Docker image...", status: "in_progress", detail: "Downloading layer 3/7 [=====>    ] 45%" },
-                ] satisfies CreationProgressEvent[]}
+                steps={
+                  [
+                    {
+                      step: "resolving_env",
+                      label: "Resolving environment...",
+                      status: "done",
+                    },
+                    {
+                      step: "pulling_image",
+                      label: "Pulling Docker image...",
+                      status: "in_progress",
+                      detail: "Downloading layer 3/7 [=====>    ] 45%",
+                    },
+                  ] satisfies CreationProgressEvent[]
+                }
               />
             </Card>
             <Card label="Error during init script">
               <SessionCreationProgress
-                steps={[
-                  { step: "resolving_env", label: "Resolving environment...", status: "done" },
-                  { step: "pulling_image", label: "Pulling Docker image...", status: "done" },
-                  { step: "creating_container", label: "Starting container...", status: "done" },
-                  { step: "running_init_script", label: "Running init script...", status: "error" },
-                ] satisfies CreationProgressEvent[]}
-                error={"npm ERR! code ENOENT\nnpm ERR! syscall open\nnpm ERR! path /app/package.json"}
+                steps={
+                  [
+                    {
+                      step: "resolving_env",
+                      label: "Resolving environment...",
+                      status: "done",
+                    },
+                    {
+                      step: "pulling_image",
+                      label: "Pulling Docker image...",
+                      status: "done",
+                    },
+                    {
+                      step: "creating_container",
+                      label: "Starting container...",
+                      status: "done",
+                    },
+                    {
+                      step: "running_init_script",
+                      label: "Running init script...",
+                      status: "error",
+                    },
+                  ] satisfies CreationProgressEvent[]
+                }
+                error={
+                  "npm ERR! code ENOENT\nnpm ERR! syscall open\nnpm ERR! path /app/package.json"
+                }
               />
             </Card>
           </div>
         </Section>
         {/* ─── Session Launch Overlay ──────────────────────────── */}
-        <Section title="Session Launch Overlay" description="Full-screen overlay shown during session creation, replacing the inline progress list">
+        <Section
+          title="Session Launch Overlay"
+          description="Full-screen overlay shown during session creation, replacing the inline progress list"
+        >
           <div className="space-y-4">
             <Card label="In progress (container session)">
               <div className="relative h-[360px] bg-cc-bg rounded-lg overflow-hidden border border-cc-border">
                 <SessionLaunchOverlay
-                  steps={[
-                    { step: "resolving_env", label: "Environment resolved", status: "done" },
-                    { step: "pulling_image", label: "Pulling Docker image...", status: "done" },
-                    { step: "creating_container", label: "Starting container...", status: "in_progress" },
-                    { step: "launching_cli", label: "Launching Claude Code...", status: "in_progress" },
-                  ] satisfies CreationProgressEvent[]}
+                  steps={
+                    [
+                      {
+                        step: "resolving_env",
+                        label: "Environment resolved",
+                        status: "done",
+                      },
+                      {
+                        step: "pulling_image",
+                        label: "Pulling Docker image...",
+                        status: "done",
+                      },
+                      {
+                        step: "creating_container",
+                        label: "Starting container...",
+                        status: "in_progress",
+                      },
+                      {
+                        step: "launching_cli",
+                        label: "Launching Claude Code...",
+                        status: "in_progress",
+                      },
+                    ] satisfies CreationProgressEvent[]
+                  }
                   backend="claude"
                   onCancel={() => {}}
                 />
@@ -1529,12 +2422,30 @@ export function Playground() {
             <Card label="All steps done (launching)">
               <div className="relative h-[360px] bg-cc-bg rounded-lg overflow-hidden border border-cc-border">
                 <SessionLaunchOverlay
-                  steps={[
-                    { step: "resolving_env", label: "Environment resolved", status: "done" },
-                    { step: "fetching_git", label: "Fetch complete", status: "done" },
-                    { step: "creating_worktree", label: "Worktree created", status: "done" },
-                    { step: "launching_cli", label: "CLI launched", status: "done" },
-                  ] satisfies CreationProgressEvent[]}
+                  steps={
+                    [
+                      {
+                        step: "resolving_env",
+                        label: "Environment resolved",
+                        status: "done",
+                      },
+                      {
+                        step: "fetching_git",
+                        label: "Fetch complete",
+                        status: "done",
+                      },
+                      {
+                        step: "creating_worktree",
+                        label: "Worktree created",
+                        status: "done",
+                      },
+                      {
+                        step: "launching_cli",
+                        label: "CLI launched",
+                        status: "done",
+                      },
+                    ] satisfies CreationProgressEvent[]
+                  }
                   backend="claude"
                 />
               </div>
@@ -1542,10 +2453,20 @@ export function Playground() {
             <Card label="Error state">
               <div className="relative h-[400px] bg-cc-bg rounded-lg overflow-hidden border border-cc-border">
                 <SessionLaunchOverlay
-                  steps={[
-                    { step: "resolving_env", label: "Environment resolved", status: "done" },
-                    { step: "pulling_image", label: "Pulling Docker image...", status: "error" },
-                  ] satisfies CreationProgressEvent[]}
+                  steps={
+                    [
+                      {
+                        step: "resolving_env",
+                        label: "Environment resolved",
+                        status: "done",
+                      },
+                      {
+                        step: "pulling_image",
+                        label: "Pulling Docker image...",
+                        status: "error",
+                      },
+                    ] satisfies CreationProgressEvent[]
+                  }
                   error="Failed to pull docker.io/stangirard/the-companion:latest — connection timed out after 30s"
                   backend="claude"
                   onCancel={() => {}}
@@ -1555,10 +2476,20 @@ export function Playground() {
             <Card label="Codex backend">
               <div className="relative h-[320px] bg-cc-bg rounded-lg overflow-hidden border border-cc-border">
                 <SessionLaunchOverlay
-                  steps={[
-                    { step: "resolving_env", label: "Environment resolved", status: "done" },
-                    { step: "launching_cli", label: "Launching Codex...", status: "in_progress" },
-                  ] satisfies CreationProgressEvent[]}
+                  steps={
+                    [
+                      {
+                        step: "resolving_env",
+                        label: "Environment resolved",
+                        status: "done",
+                      },
+                      {
+                        step: "launching_cli",
+                        label: "Launching Codex...",
+                        status: "in_progress",
+                      },
+                    ] satisfies CreationProgressEvent[]
+                  }
                   backend="codex"
                   onCancel={() => {}}
                 />
@@ -1567,7 +2498,10 @@ export function Playground() {
           </div>
         </Section>
         {/* ─── Update Overlay ──────────────────────────── */}
-        <Section title="Update Overlay" description="Full-screen overlay shown when auto-update is in progress, polls server and reloads when ready">
+        <Section
+          title="Update Overlay"
+          description="Full-screen overlay shown when auto-update is in progress, polls server and reloads when ready"
+        >
           <div className="space-y-4">
             <Card label="Installing phase">
               <div className="relative h-[360px] bg-cc-bg rounded-lg overflow-hidden border border-cc-border">
@@ -1592,7 +2526,10 @@ export function Playground() {
           </div>
         </Section>
         {/* ─── CLAUDE.md Editor ──────────────────────────────── */}
-        <Section title="CLAUDE.md Editor" description="Modal for viewing and editing project CLAUDE.md instructions">
+        <Section
+          title="CLAUDE.md Editor"
+          description="Modal for viewing and editing project CLAUDE.md instructions"
+        >
           <div className="space-y-4 max-w-3xl">
             <Card label="Open editor button (from TopBar)">
               <PlaygroundClaudeMdButton />
@@ -1603,7 +2540,10 @@ export function Playground() {
           </div>
         </Section>
         {/* ─── Session Items ──────────────────────────────────── */}
-        <Section title="Session Items" description="Sidebar session rows — status dot, backend badge, Docker indicator, archive on hover">
+        <Section
+          title="Session Items"
+          description="Sidebar session rows — status dot, backend badge, Docker indicator, archive on hover"
+        >
           <PlaygroundSessionItems />
         </Section>
       </div>
@@ -1659,7 +2599,11 @@ function PlaygroundSessionItems() {
       <Card label="Running — Claude Code">
         <div className="bg-cc-sidebar rounded-lg p-1">
           <SessionItem
-            session={mockSession({ isConnected: true, status: "running", backendType: "claude" })}
+            session={mockSession({
+              isConnected: true,
+              status: "running",
+              backendType: "claude",
+            })}
             isActive={false}
             sessionName="Refactor auth module"
             permCount={0}
@@ -1673,7 +2617,12 @@ function PlaygroundSessionItems() {
       <Card label="Running — Codex + Docker">
         <div className="bg-cc-sidebar rounded-lg p-1">
           <SessionItem
-            session={mockSession({ isConnected: true, status: "running", backendType: "codex", isContainerized: true })}
+            session={mockSession({
+              isConnected: true,
+              status: "running",
+              backendType: "codex",
+              isContainerized: true,
+            })}
             isActive={false}
             sessionName="Add payment flow"
             permCount={0}
@@ -1687,7 +2636,12 @@ function PlaygroundSessionItems() {
       <Card label="Awaiting Input — 2 permissions pending">
         <div className="bg-cc-sidebar rounded-lg p-1">
           <SessionItem
-            session={mockSession({ isConnected: true, status: "running", backendType: "claude", permCount: 2 })}
+            session={mockSession({
+              isConnected: true,
+              status: "running",
+              backendType: "claude",
+              permCount: 2,
+            })}
             isActive={false}
             sessionName="Fix login bug"
             permCount={2}
@@ -1701,7 +2655,11 @@ function PlaygroundSessionItems() {
       <Card label="Idle — connected, not running">
         <div className="bg-cc-sidebar rounded-lg p-1">
           <SessionItem
-            session={mockSession({ isConnected: true, status: "idle", backendType: "claude" })}
+            session={mockSession({
+              isConnected: true,
+              status: "idle",
+              backendType: "claude",
+            })}
             isActive={false}
             sessionName="Review PR #42"
             permCount={0}
@@ -1729,7 +2687,12 @@ function PlaygroundSessionItems() {
       <Card label="Active (selected session)">
         <div className="bg-cc-sidebar rounded-lg p-1">
           <SessionItem
-            session={mockSession({ isConnected: true, status: "running", backendType: "claude", isContainerized: true })}
+            session={mockSession({
+              isConnected: true,
+              status: "running",
+              backendType: "claude",
+              isContainerized: true,
+            })}
             isActive={true}
             sessionName="Build new dashboard"
             permCount={0}
@@ -1759,7 +2722,15 @@ function PlaygroundSessionItems() {
 
 // ─── Shared Layout Helpers ──────────────────────────────────────────────────
 
-function Section({ title, description, children }: { title: string; description: string; children: React.ReactNode }) {
+function Section({
+  title,
+  description,
+  children,
+}: {
+  title: string;
+  description: string;
+  children: React.ReactNode;
+}) {
   return (
     <section>
       <div className="mb-4">
@@ -1771,11 +2742,19 @@ function Section({ title, description, children }: { title: string; description:
   );
 }
 
-function Card({ label, children }: { label: string; children: React.ReactNode }) {
+function Card({
+  label,
+  children,
+}: {
+  label: string;
+  children: React.ReactNode;
+}) {
   return (
     <div className="border border-cc-border rounded-xl overflow-hidden bg-cc-card">
       <div className="px-3 py-1.5 bg-cc-hover/50 border-b border-cc-border">
-        <span className="text-[10px] text-cc-muted font-mono-code uppercase tracking-wider">{label}</span>
+        <span className="text-[10px] text-cc-muted font-mono-code uppercase tracking-wider">
+          {label}
+        </span>
       </div>
       <div className="p-4">{children}</div>
     </div>
@@ -1788,7 +2767,9 @@ function PlaygroundTerminalTabsMock() {
     { id: "docker", label: "Docker", cwd: "/workspace" },
   ];
   const [active, setActive] = useState("host");
-  const [placement, setPlacement] = useState<"top" | "right" | "bottom" | "left">("bottom");
+  const [placement, setPlacement] = useState<
+    "top" | "right" | "bottom" | "left"
+  >("bottom");
 
   return (
     <div className="rounded-xl border border-cc-border bg-cc-card overflow-hidden">
@@ -1802,7 +2783,8 @@ function PlaygroundTerminalTabsMock() {
                 placement === p ? "bg-cc-card text-cc-fg" : "text-cc-muted"
               }`}
             >
-              {p[0]?.toUpperCase()}{p.slice(1)}
+              {p[0]?.toUpperCase()}
+              {p.slice(1)}
             </button>
           ))}
         </div>
@@ -1824,9 +2806,13 @@ function PlaygroundTerminalTabsMock() {
         </span>
       </div>
       <div className="h-32 p-3 bg-cc-bg">
-        <div className={`h-full min-h-0 rounded-lg border border-cc-border bg-cc-card flex ${placement === "left" || placement === "right" ? "flex-row" : "flex-col"}`}>
+        <div
+          className={`h-full min-h-0 rounded-lg border border-cc-border bg-cc-card flex ${placement === "left" || placement === "right" ? "flex-row" : "flex-col"}`}
+        >
           {(placement === "top" || placement === "left") && (
-            <div className={`${placement === "left" ? "w-2/5 border-r" : "h-2/5 border-b"} border-cc-border bg-cc-sidebar/40 flex items-center justify-center text-[10px] text-cc-muted font-mono-code`}>
+            <div
+              className={`${placement === "left" ? "w-2/5 border-r" : "h-2/5 border-b"} border-cc-border bg-cc-sidebar/40 flex items-center justify-center text-[10px] text-cc-muted font-mono-code`}
+            >
               Terminal docked
             </div>
           )}
@@ -1834,7 +2820,9 @@ function PlaygroundTerminalTabsMock() {
             Session content
           </div>
           {(placement === "right" || placement === "bottom") && (
-            <div className={`${placement === "right" ? "w-2/5 border-l" : "h-2/5 border-t"} border-cc-border bg-cc-sidebar/40 flex items-center justify-center text-[10px] text-cc-muted font-mono-code`}>
+            <div
+              className={`${placement === "right" ? "w-2/5 border-l" : "h-2/5 border-t"} border-cc-border bg-cc-sidebar/40 flex items-center justify-center text-[10px] text-cc-muted font-mono-code`}
+            >
               Terminal docked
             </div>
           )}
@@ -1846,9 +2834,19 @@ function PlaygroundTerminalTabsMock() {
 
 // ─── Inline Tool Group (mirrors MessageFeed's ToolMessageGroup) ─────────────
 
-interface ToolItem { id: string; name: string; input: Record<string, unknown> }
+interface ToolItem {
+  id: string;
+  name: string;
+  input: Record<string, unknown>;
+}
 
-function PlaygroundToolGroup({ toolName, items }: { toolName: string; items: ToolItem[] }) {
+function PlaygroundToolGroup({
+  toolName,
+  items,
+}: {
+  toolName: string;
+  items: ToolItem[];
+}) {
   const [open, setOpen] = useState(false);
   const iconType = getToolIcon(toolName);
   const label = getToolLabel(toolName);
@@ -1859,7 +2857,13 @@ function PlaygroundToolGroup({ toolName, items }: { toolName: string; items: Too
     return (
       <div className="flex items-start gap-3">
         <div className="w-6 h-6 rounded-full bg-cc-primary/10 flex items-center justify-center shrink-0 mt-0.5">
-          <svg viewBox="0 0 16 16" fill="currentColor" className="w-3 h-3 text-cc-primary"><circle cx="8" cy="8" r="3" /></svg>
+          <svg
+            viewBox="0 0 16 16"
+            fill="currentColor"
+            className="w-3 h-3 text-cc-primary"
+          >
+            <circle cx="8" cy="8" r="3" />
+          </svg>
         </div>
         <div className="flex-1 min-w-0">
           <div className="border border-cc-border rounded-[10px] overflow-hidden bg-cc-card">
@@ -1867,7 +2871,11 @@ function PlaygroundToolGroup({ toolName, items }: { toolName: string; items: Too
               onClick={() => setOpen(!open)}
               className="w-full flex items-center gap-2.5 px-3 py-2 text-left hover:bg-cc-hover transition-colors cursor-pointer"
             >
-              <svg viewBox="0 0 16 16" fill="currentColor" className={`w-3 h-3 text-cc-muted transition-transform shrink-0 ${open ? "rotate-90" : ""}`}>
+              <svg
+                viewBox="0 0 16 16"
+                fill="currentColor"
+                className={`w-3 h-3 text-cc-muted transition-transform shrink-0 ${open ? "rotate-90" : ""}`}
+              >
                 <path d="M6 4l4 4-4 4" />
               </svg>
               <ToolIcon type={iconType} />
@@ -1892,7 +2900,13 @@ function PlaygroundToolGroup({ toolName, items }: { toolName: string; items: Too
   return (
     <div className="flex items-start gap-3">
       <div className="w-6 h-6 rounded-full bg-cc-primary/10 flex items-center justify-center shrink-0 mt-0.5">
-        <svg viewBox="0 0 16 16" fill="currentColor" className="w-3 h-3 text-cc-primary"><circle cx="8" cy="8" r="3" /></svg>
+        <svg
+          viewBox="0 0 16 16"
+          fill="currentColor"
+          className="w-3 h-3 text-cc-primary"
+        >
+          <circle cx="8" cy="8" r="3" />
+        </svg>
       </div>
       <div className="flex-1 min-w-0">
         <div className="border border-cc-border rounded-[10px] overflow-hidden bg-cc-card">
@@ -1900,7 +2914,11 @@ function PlaygroundToolGroup({ toolName, items }: { toolName: string; items: Too
             onClick={() => setOpen(!open)}
             className="w-full flex items-center gap-2.5 px-3 py-2 text-left hover:bg-cc-hover transition-colors cursor-pointer"
           >
-            <svg viewBox="0 0 16 16" fill="currentColor" className={`w-3 h-3 text-cc-muted transition-transform shrink-0 ${open ? "rotate-90" : ""}`}>
+            <svg
+              viewBox="0 0 16 16"
+              fill="currentColor"
+              className={`w-3 h-3 text-cc-muted transition-transform shrink-0 ${open ? "rotate-90" : ""}`}
+            >
               <path d="M6 4l4 4-4 4" />
             </svg>
             <ToolIcon type={iconType} />
@@ -1914,9 +2932,14 @@ function PlaygroundToolGroup({ toolName, items }: { toolName: string; items: Too
               {items.map((item, i) => {
                 const preview = getPreview(item.name, item.input);
                 return (
-                  <div key={item.id || i} className="flex items-center gap-2 py-1 text-xs text-cc-muted font-mono-code truncate">
+                  <div
+                    key={item.id || i}
+                    className="flex items-center gap-2 py-1 text-xs text-cc-muted font-mono-code truncate"
+                  >
                     <span className="w-1 h-1 rounded-full bg-cc-muted/40 shrink-0" />
-                    <span className="truncate">{preview || JSON.stringify(item.input).slice(0, 80)}</span>
+                    <span className="truncate">
+                      {preview || JSON.stringify(item.input).slice(0, 80)}
+                    </span>
                   </div>
                 );
               })}
@@ -1954,13 +2977,43 @@ function PlaygroundSubagentGroup({
     if (!status) return null;
     const raw = status.trim().toLowerCase();
     if (!raw) return null;
-    if (raw === "completed") return { label: "completed", className: "text-green-600 bg-green-500/15", summary: "completed" };
-    if (raw === "failed" || raw === "error" || raw === "errored") return { label: "failed", className: "text-cc-error bg-cc-error/10", summary: "failed" };
-    if (raw === "pending" || raw === "pendinginit" || raw === "pending_init") return { label: "pending", className: "text-amber-700 bg-amber-500/15", summary: "pending" };
-    if (raw === "running" || raw === "inprogress" || raw === "in_progress" || raw === "started") return { label: "running", className: "text-blue-600 bg-blue-500/15", summary: "running" };
-    return { label: status, className: "text-amber-700 bg-amber-500/15", summary: "running" };
+    if (raw === "completed")
+      return {
+        label: "completed",
+        className: "text-green-600 bg-green-500/15",
+        summary: "completed",
+      };
+    if (raw === "failed" || raw === "error" || raw === "errored")
+      return {
+        label: "failed",
+        className: "text-cc-error bg-cc-error/10",
+        summary: "failed",
+      };
+    if (raw === "pending" || raw === "pendinginit" || raw === "pending_init")
+      return {
+        label: "pending",
+        className: "text-amber-700 bg-amber-500/15",
+        summary: "pending",
+      };
+    if (
+      raw === "running" ||
+      raw === "inprogress" ||
+      raw === "in_progress" ||
+      raw === "started"
+    )
+      return {
+        label: "running",
+        className: "text-blue-600 bg-blue-500/15",
+        summary: "running",
+      };
+    return {
+      label: status,
+      className: "text-amber-700 bg-amber-500/15",
+      summary: "running",
+    };
   }, [status]);
-  const statusSummaryCount = receiverCount !== undefined ? receiverCount : items.length;
+  const statusSummaryCount =
+    receiverCount !== undefined ? receiverCount : items.length;
 
   return (
     <div className="ml-9 border-l-2 border-cc-primary/20 pl-4">
@@ -1968,14 +3021,26 @@ function PlaygroundSubagentGroup({
         onClick={() => setOpen(!open)}
         className="w-full flex items-center gap-2 py-1.5 text-left cursor-pointer mb-1"
       >
-        <svg viewBox="0 0 16 16" fill="currentColor" className={`w-3 h-3 text-cc-muted transition-transform shrink-0 ${open ? "rotate-90" : ""}`}>
+        <svg
+          viewBox="0 0 16 16"
+          fill="currentColor"
+          className={`w-3 h-3 text-cc-muted transition-transform shrink-0 ${open ? "rotate-90" : ""}`}
+        >
           <path d="M6 4l4 4-4 4" />
         </svg>
-        <svg viewBox="0 0 16 16" fill="none" stroke="currentColor" strokeWidth="1.5" className="w-3.5 h-3.5 text-cc-primary shrink-0">
+        <svg
+          viewBox="0 0 16 16"
+          fill="none"
+          stroke="currentColor"
+          strokeWidth="1.5"
+          className="w-3.5 h-3.5 text-cc-primary shrink-0"
+        >
           <circle cx="8" cy="8" r="5" />
           <path d="M8 5v3l2 1" strokeLinecap="round" />
         </svg>
-        <span className="text-xs font-medium text-cc-fg truncate">{description}</span>
+        <span className="text-xs font-medium text-cc-fg truncate">
+          {description}
+        </span>
         {agentType && (
           <span className="text-[10px] text-cc-muted bg-cc-hover rounded-full px-1.5 py-0.5 shrink-0">
             {agentType}
@@ -1985,7 +3050,9 @@ function PlaygroundSubagentGroup({
           {backend === "codex" ? "Codex" : "Claude"}
         </span>
         {normalizedStatus && (
-          <span className={`text-[10px] rounded-full px-1.5 py-0.5 shrink-0 ${normalizedStatus.className}`}>
+          <span
+            className={`text-[10px] rounded-full px-1.5 py-0.5 shrink-0 ${normalizedStatus.className}`}
+          >
             {normalizedStatus.label}
           </span>
         )}
@@ -2000,11 +3067,15 @@ function PlaygroundSubagentGroup({
       </button>
       {open && (
         <div className="space-y-3 pb-2">
-          {(normalizedStatus || senderThreadId || receiverThreadIds.length > 0) && (
+          {(normalizedStatus ||
+            senderThreadId ||
+            receiverThreadIds.length > 0) && (
             <div className="rounded-lg border border-cc-border bg-cc-card px-2.5 py-2 space-y-1.5">
               <div className="flex flex-wrap items-center gap-1.5 text-[10px]">
                 {normalizedStatus && (
-                  <span className={`rounded-full px-1.5 py-0.5 ${normalizedStatus.className}`}>
+                  <span
+                    className={`rounded-full px-1.5 py-0.5 ${normalizedStatus.className}`}
+                  >
                     {statusSummaryCount} {normalizedStatus.summary}
                   </span>
                 )}
@@ -2033,7 +3104,10 @@ function PlaygroundSubagentGroup({
               )}
             </div>
           )}
-          <PlaygroundToolGroup toolName={items[0]?.name || "Grep"} items={items} />
+          <PlaygroundToolGroup
+            toolName={items[0]?.name || "Grep"}
+            items={items}
+          />
         </div>
       )}
     </div>
@@ -2075,8 +3149,16 @@ function CodexPlaygroundDemo() {
       total_lines_added: 0,
       total_lines_removed: 0,
       codex_rate_limits: {
-        primary: { usedPercent: 62, windowDurationMins: 300, resetsAt: Date.now() + 2 * 3_600_000 },
-        secondary: { usedPercent: 18, windowDurationMins: 10080, resetsAt: Date.now() + 5 * 86_400_000 },
+        primary: {
+          usedPercent: 62,
+          windowDurationMins: 300,
+          resetsAt: Date.now() + 2 * 3_600_000,
+        },
+        secondary: {
+          usedPercent: 18,
+          windowDurationMins: 10080,
+          resetsAt: Date.now() + 5 * 86_400_000,
+        },
       },
       codex_token_details: {
         inputTokens: 84_230,
@@ -2134,7 +3216,10 @@ function PlaygroundClaudeMdButton() {
   const [cwd, setCwd] = useState("/tmp");
 
   useEffect(() => {
-    api.getHome().then((res) => setCwd(res.cwd)).catch(() => {});
+    api
+      .getHome()
+      .then((res) => setCwd(res.cwd))
+      .catch(() => {});
   }, []);
 
   return (
@@ -2143,7 +3228,11 @@ function PlaygroundClaudeMdButton() {
         onClick={() => setOpen(true)}
         className="flex items-center gap-2 px-3 py-2 rounded-lg bg-cc-hover border border-cc-border hover:bg-cc-active transition-colors cursor-pointer"
       >
-        <svg viewBox="0 0 16 16" fill="currentColor" className="w-4 h-4 text-cc-primary">
+        <svg
+          viewBox="0 0 16 16"
+          fill="currentColor"
+          className="w-4 h-4 text-cc-primary"
+        >
           <path d="M4 1.5a.5.5 0 01.5-.5h7a.5.5 0 01.354.146l2 2A.5.5 0 0114 3.5v11a.5.5 0 01-.5.5h-11a.5.5 0 01-.5-.5v-13zm1 .5v12h8V4h-1.5a.5.5 0 01-.5-.5V2H5zm6 0v1h1l-1-1zM6.5 7a.5.5 0 000 1h5a.5.5 0 000-1h-5zm0 2a.5.5 0 000 1h5a.5.5 0 000-1h-5zm0 2a.5.5 0 000 1h3a.5.5 0 000-1h-3z" />
         </svg>
         <span className="text-xs font-medium text-cc-fg">Edit CLAUDE.md</span>
@@ -2151,11 +3240,7 @@ function PlaygroundClaudeMdButton() {
       <span className="text-[11px] text-cc-muted">
         Click to open the editor modal (uses server working directory)
       </span>
-      <ClaudeMdEditor
-        cwd={cwd}
-        open={open}
-        onClose={() => setOpen(false)}
-      />
+      <ClaudeMdEditor cwd={cwd} open={open} onClose={() => setOpen(false)} />
     </div>
   );
 }
@@ -2164,22 +3249,46 @@ function PlaygroundClaudeMdButton() {
 
 function PlaygroundMcpRow({ server }: { server: McpServerDetail }) {
   const [expanded, setExpanded] = useState(false);
-  const statusMap: Record<string, { label: string; cls: string; dot: string }> = {
-    connected: { label: "Connected", cls: "text-cc-success bg-cc-success/10", dot: "bg-cc-success" },
-    connecting: { label: "Connecting", cls: "text-cc-warning bg-cc-warning/10", dot: "bg-cc-warning animate-pulse" },
-    failed: { label: "Failed", cls: "text-cc-error bg-cc-error/10", dot: "bg-cc-error" },
-    disabled: { label: "Disabled", cls: "text-cc-muted bg-cc-hover", dot: "bg-cc-muted opacity-40" },
-  };
+  const statusMap: Record<string, { label: string; cls: string; dot: string }> =
+    {
+      connected: {
+        label: "Connected",
+        cls: "text-cc-success bg-cc-success/10",
+        dot: "bg-cc-success",
+      },
+      connecting: {
+        label: "Connecting",
+        cls: "text-cc-warning bg-cc-warning/10",
+        dot: "bg-cc-warning animate-pulse",
+      },
+      failed: {
+        label: "Failed",
+        cls: "text-cc-error bg-cc-error/10",
+        dot: "bg-cc-error",
+      },
+      disabled: {
+        label: "Disabled",
+        cls: "text-cc-muted bg-cc-hover",
+        dot: "bg-cc-muted opacity-40",
+      },
+    };
   const badge = statusMap[server.status] || statusMap.disabled;
 
   return (
     <div className="rounded-lg border border-cc-border bg-cc-bg">
       <div className="flex items-center gap-2 px-2.5 py-2">
         <span className={`w-1.5 h-1.5 rounded-full shrink-0 ${badge.dot}`} />
-        <button onClick={() => setExpanded(!expanded)} className="flex-1 min-w-0 text-left cursor-pointer">
-          <span className="text-[12px] font-medium text-cc-fg truncate block">{server.name}</span>
+        <button
+          onClick={() => setExpanded(!expanded)}
+          className="flex-1 min-w-0 text-left cursor-pointer"
+        >
+          <span className="text-[12px] font-medium text-cc-fg truncate block">
+            {server.name}
+          </span>
         </button>
-        <span className={`text-[9px] font-medium px-1.5 rounded-full leading-[16px] shrink-0 ${badge.cls}`}>
+        <span
+          className={`text-[9px] font-medium px-1.5 rounded-full leading-[16px] shrink-0 ${badge.cls}`}
+        >
           {badge.label}
         </span>
       </div>
@@ -2194,14 +3303,19 @@ function PlaygroundMcpRow({ server }: { server: McpServerDetail }) {
               <div className="flex items-start gap-1">
                 <span className="text-cc-muted/60 shrink-0">Cmd:</span>
                 <span className="font-mono text-[10px] break-all">
-                  {server.config.command}{server.config.args?.length ? ` ${server.config.args.join(" ")}` : ""}
+                  {server.config.command}
+                  {server.config.args?.length
+                    ? ` ${server.config.args.join(" ")}`
+                    : ""}
                 </span>
               </div>
             )}
             {server.config.url && (
               <div className="flex items-start gap-1">
                 <span className="text-cc-muted/60 shrink-0">URL:</span>
-                <span className="font-mono text-[10px] break-all">{server.config.url}</span>
+                <span className="font-mono text-[10px] break-all">
+                  {server.config.url}
+                </span>
               </div>
             )}
             <div className="flex items-center gap-1">
@@ -2210,14 +3324,21 @@ function PlaygroundMcpRow({ server }: { server: McpServerDetail }) {
             </div>
           </div>
           {server.error && (
-            <div className="text-[11px] text-cc-error bg-cc-error/5 rounded px-2 py-1">{server.error}</div>
+            <div className="text-[11px] text-cc-error bg-cc-error/5 rounded px-2 py-1">
+              {server.error}
+            </div>
           )}
           {server.tools && server.tools.length > 0 && (
             <div className="space-y-1">
-              <span className="text-[10px] text-cc-muted uppercase tracking-wider">Tools ({server.tools.length})</span>
+              <span className="text-[10px] text-cc-muted uppercase tracking-wider">
+                Tools ({server.tools.length})
+              </span>
               <div className="flex flex-wrap gap-1">
                 {server.tools.map((tool) => (
-                  <span key={tool.name} className="text-[10px] font-mono px-1.5 py-0.5 rounded bg-cc-hover text-cc-fg">
+                  <span
+                    key={tool.name}
+                    className="text-[10px] font-mono px-1.5 py-0.5 rounded bg-cc-hover text-cc-fg"
+                  >
                     {tool.name}
                   </span>
                 ))}
@@ -2237,37 +3358,87 @@ function TaskRow({ task }: { task: TaskItem }) {
   const isInProgress = task.status === "in_progress";
 
   return (
-    <div className={`px-2.5 py-2 rounded-lg ${isCompleted ? "opacity-50" : ""}`}>
+    <div
+      className={`px-2.5 py-2 rounded-lg ${isCompleted ? "opacity-50" : ""}`}
+    >
       <div className="flex items-start gap-2">
         <span className="shrink-0 flex items-center justify-center w-4 h-4 mt-px">
           {isInProgress ? (
-            <svg className="w-4 h-4 text-cc-primary animate-spin" viewBox="0 0 16 16" fill="none">
-              <circle cx="8" cy="8" r="6" stroke="currentColor" strokeWidth="1.5" strokeDasharray="28" strokeDashoffset="8" strokeLinecap="round" />
+            <svg
+              className="w-4 h-4 text-cc-primary animate-spin"
+              viewBox="0 0 16 16"
+              fill="none"
+            >
+              <circle
+                cx="8"
+                cy="8"
+                r="6"
+                stroke="currentColor"
+                strokeWidth="1.5"
+                strokeDasharray="28"
+                strokeDashoffset="8"
+                strokeLinecap="round"
+              />
             </svg>
           ) : isCompleted ? (
-            <svg viewBox="0 0 16 16" fill="currentColor" className="w-4 h-4 text-cc-success">
-              <path fillRule="evenodd" d="M8 15A7 7 0 108 1a7 7 0 000 14zm3.354-9.354a.5.5 0 00-.708-.708L7 8.586 5.354 6.94a.5.5 0 10-.708.708l2 2a.5.5 0 00.708 0l4-4z" clipRule="evenodd" />
+            <svg
+              viewBox="0 0 16 16"
+              fill="currentColor"
+              className="w-4 h-4 text-cc-success"
+            >
+              <path
+                fillRule="evenodd"
+                d="M8 15A7 7 0 108 1a7 7 0 000 14zm3.354-9.354a.5.5 0 00-.708-.708L7 8.586 5.354 6.94a.5.5 0 10-.708.708l2 2a.5.5 0 00.708 0l4-4z"
+                clipRule="evenodd"
+              />
             </svg>
           ) : (
-            <svg viewBox="0 0 16 16" fill="none" className="w-4 h-4 text-cc-muted">
-              <circle cx="8" cy="8" r="6" stroke="currentColor" strokeWidth="1.5" />
+            <svg
+              viewBox="0 0 16 16"
+              fill="none"
+              className="w-4 h-4 text-cc-muted"
+            >
+              <circle
+                cx="8"
+                cy="8"
+                r="6"
+                stroke="currentColor"
+                strokeWidth="1.5"
+              />
             </svg>
           )}
         </span>
-        <span className={`text-[13px] leading-snug flex-1 ${isCompleted ? "text-cc-muted line-through" : "text-cc-fg"}`}>
+        <span
+          className={`text-[13px] leading-snug flex-1 ${isCompleted ? "text-cc-muted line-through" : "text-cc-fg"}`}
+        >
           {task.subject}
         </span>
       </div>
       {isInProgress && task.activeForm && (
-        <p className="mt-1 ml-6 text-[11px] text-cc-muted italic truncate">{task.activeForm}</p>
+        <p className="mt-1 ml-6 text-[11px] text-cc-muted italic truncate">
+          {task.activeForm}
+        </p>
       )}
       {task.blockedBy && task.blockedBy.length > 0 && (
         <p className="mt-1 ml-6 text-[11px] text-cc-muted flex items-center gap-1">
           <svg viewBox="0 0 16 16" fill="none" className="w-3 h-3 shrink-0">
-            <circle cx="8" cy="8" r="6" stroke="currentColor" strokeWidth="1.5" />
-            <path d="M5 8h6" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" />
+            <circle
+              cx="8"
+              cy="8"
+              r="6"
+              stroke="currentColor"
+              strokeWidth="1.5"
+            />
+            <path
+              d="M5 8h6"
+              stroke="currentColor"
+              strokeWidth="1.5"
+              strokeLinecap="round"
+            />
           </svg>
-          <span>blocked by {task.blockedBy.map((b) => `#${b}`).join(", ")}</span>
+          <span>
+            blocked by {task.blockedBy.map((b) => `#${b}`).join(", ")}
+          </span>
         </p>
       )}
     </div>
@@ -2312,16 +3483,20 @@ function PlaygroundAiValidationToggle({ enabled }: { enabled: boolean }) {
     });
     return () => {
       if (prev) {
-        useStore.getState().updateSession(PLAYGROUND_AI_VALIDATION_SESSION, prev);
+        useStore
+          .getState()
+          .updateSession(PLAYGROUND_AI_VALIDATION_SESSION, prev);
       }
     };
   }, [enabled]);
 
   // Force the enabled state each render to match the prop
   useEffect(() => {
-    useStore.getState().setSessionAiValidation(PLAYGROUND_AI_VALIDATION_SESSION, {
-      aiValidationEnabled: enabled,
-    });
+    useStore
+      .getState()
+      .setSessionAiValidation(PLAYGROUND_AI_VALIDATION_SESSION, {
+        aiValidationEnabled: enabled,
+      });
   }, [enabled]);
 
   return (


### PR DESCRIPTION
## Summary
- Add a spinning "Compacting context..." indicator in the message feed when Claude Code is compacting context
- Uses the existing `sessionStatus === "compacting"` state already wired in the store/websocket layer
- Includes 3 new tests (compacting shown, not shown when running, not shown when idle)
- Adds a Playground mock for the new indicator

## Why
Part of #129 — split from the original PR #362 which was too large. This is the first of 2 smaller PRs:
1. **This PR**: compacting indicator in message feed
2. **Next PR**: context window usage display (claude_token_details + ClaudeContextSection)

## Testing
- `bun run typecheck` — passes
- `bun run test` — 3090 tests pass (26 in MessageFeed.test.tsx including 3 new ones)

## Review provenance
- Implemented by AI agent (Claude Opus 4.6)
- Human review: no
