### PR TITLE
fix: add Windows compatibility for binary resolution and process spawning

### DIFF
--- a/web/server/cli-launcher.ts
+++ b/web/server/cli-launcher.ts
@@ -543,7 +543,10 @@ export class CliLauncher {
       spawnCwd = undefined; // cwd is set inside the container via -w at creation
     } else {
       // Host-based spawn (original behavior)
-      spawnCmd = [binary, ...args];
+      // On Windows, .cmd/.bat files cannot be spawned directly by Bun.spawn;
+      // they must be invoked via cmd.exe /c.
+      const isCmdScript = binary.endsWith(".cmd") || binary.endsWith(".bat");
+      spawnCmd = isCmdScript ? ["cmd.exe", "/c", binary, ...args] : [binary, ...args];
       spawnEnv = {
         ...process.env,
         CLAUDECODE: undefined,
@@ -743,7 +746,8 @@ export class CliLauncher {
       const binaryDir = resolve(binary, "..");
       const siblingNode = join(binaryDir, "node");
       const enrichedPath = getEnrichedPath();
-      const spawnPath = [binaryDir, ...enrichedPath.split(":")].filter(Boolean).join(":");
+      const pathSep = process.platform === "win32" ? ";" : ":";
+      const spawnPath = [binaryDir, ...enrichedPath.split(pathSep)].filter(Boolean).join(pathSep);
 
       if (existsSync(siblingNode)) {
         let codexScript: string;
@@ -754,7 +758,9 @@ export class CliLauncher {
         }
         spawnCmd = [siblingNode, codexScript, ...args];
       } else {
-        spawnCmd = [binary, ...args];
+        // On Windows, .cmd/.bat files cannot be spawned directly by Bun.spawn
+        const isCmdScript = binary.endsWith(".cmd") || binary.endsWith(".bat");
+        spawnCmd = isCmdScript ? ["cmd.exe", "/c", binary, ...args] : [binary, ...args];
       }
 
       spawnEnv = {
@@ -969,7 +975,8 @@ export class CliLauncher {
       const binaryDir = resolve(binary, "..");
       const siblingNode = join(binaryDir, "node");
       const enrichedPath = getEnrichedPath();
-      const spawnPath = [binaryDir, ...enrichedPath.split(":")].filter(Boolean).join(":");
+      const pathSep = process.platform === "win32" ? ";" : ":";
+      const spawnPath = [binaryDir, ...enrichedPath.split(pathSep)].filter(Boolean).join(pathSep);
 
       if (existsSync(siblingNode)) {
         let codexScript: string;
@@ -980,7 +987,9 @@ export class CliLauncher {
         }
         spawnCmd = [siblingNode, codexScript, ...args];
       } else {
-        spawnCmd = [binary, ...args];
+        // On Windows, .cmd/.bat files cannot be spawned directly by Bun.spawn
+        const isCmdScript = binary.endsWith(".cmd") || binary.endsWith(".bat");
+        spawnCmd = isCmdScript ? ["cmd.exe", "/c", binary, ...args] : [binary, ...args];
       }
 
       spawnEnv = {

--- a/web/server/path-resolver.ts
+++ b/web/server/path-resolver.ts
@@ -96,7 +96,8 @@ export function buildFallbackPath(): string {
     } catch { /* ignore */ }
   }
 
-  return [...new Set(candidates.filter((dir) => existsSync(dir)))].join(":");
+  const pathSep = process.platform === "win32" ? ";" : ":";
+  return [...new Set(candidates.filter((dir) => existsSync(dir)))].join(pathSep);
 }
 
 // ─── Enriched PATH (cached) ───────────────────────────────────────────────────
@@ -113,9 +114,10 @@ export function getEnrichedPath(): string {
 
   const currentPath = process.env.PATH || "";
   const userPath = captureUserShellPath();
+  const pathSep = process.platform === "win32" ? ";" : ":";
 
   // Merge: user shell PATH first (takes precedence), then current process PATH
-  const allDirs = [...userPath.split(":"), ...currentPath.split(":")];
+  const allDirs = [...userPath.split(pathSep), ...currentPath.split(pathSep)];
   const seen = new Set<string>();
   const deduped: string[] = [];
   for (const dir of allDirs) {
@@ -125,7 +127,7 @@ export function getEnrichedPath(): string {
     }
   }
 
-  _cachedPath = deduped.join(":");
+  _cachedPath = deduped.join(pathSep);
   return _cachedPath;
 }
 
@@ -144,19 +146,34 @@ export function resolveBinary(name: string): string | null {
   if (name.startsWith("/")) {
     return existsSync(name) ? name : null;
   }
-
-  const enrichedPath = getEnrichedPath();
-  try {
-    const resolved = execSync(`which ${name.replace(/[^a-zA-Z0-9._@/-]/g, "")}`, {
-
-      encoding: "utf-8",
-      timeout: 5_000,
-      env: { ...process.env, PATH: enrichedPath },
-    }).trim();
-    return resolved || null;
-  } catch {
-    return null;
+  // On Windows, also accept absolute paths like C:\... or D:\...
+  if (process.platform === "win32" && /^[a-zA-Z]:[/\\]/.test(name)) {
+    return existsSync(name) ? name : null;
   }
+
+  const sanitized = name.replace(/[^a-zA-Z0-9._@/-]/g, "");
+  const enrichedPath = getEnrichedPath();
+
+  // Try `which` (Unix/Git Bash), then `where` (Windows CMD/PowerShell)
+  for (const cmd of ["which", "where"]) {
+    try {
+      const result = execSync(`${cmd} ${sanitized}`, {
+        encoding: "utf-8",
+        timeout: 5_000,
+        env: { ...process.env, PATH: enrichedPath },
+      }).trim();
+      if (!result) continue;
+      // `where` on Windows may return multiple lines; prefer .cmd for Node/Bun spawn compatibility
+      if (cmd === "where") {
+        const lines = result.split(/\r?\n/).filter(Boolean);
+        return lines.find(l => l.endsWith(".cmd")) || lines[0];
+      }
+      return result;
+    } catch {
+      continue;
+    }
+  }
+  return null;
 }
 
 /**


### PR DESCRIPTION
## Summary

- **`path-resolver.ts`**: `resolveBinary()` uses `which` to locate binaries, which doesn't exist on Windows CMD/PowerShell. Added fallback to `where` command, with preference for `.cmd` results (needed for `Bun.spawn` compatibility). Also fixed PATH separator from hardcoded `:` to platform-aware (`;` on Windows).
- **`cli-launcher.ts`**: `Bun.spawn` cannot directly execute `.cmd`/`.bat` files on Windows (causes `ENOENT: uv_spawn` error). Added `cmd.exe /c` wrapper when spawning `.cmd`/`.bat` binaries. Also fixed hardcoded `:` PATH separator in codex spawn paths.

## Context

On Windows, `claude` and `codex` are installed as `.cmd` shim files (e.g., `claude.cmd`). Three issues prevented the companion from working:

1. `which` command doesn't exist in Windows CMD → binary resolution fails silently → `Bun.spawn("claude")` fails with ENOENT
2. Even when resolved to full path like `C:\...\claude.cmd`, `Bun.spawn` cannot execute `.cmd` files directly — they must go through `cmd.exe /c`
3. PATH separator on Windows is `;`, not `:` — causes PATH merging/splitting to break

## Test plan

- [x] Tested on Windows 11 with Git Bash + CMD, Claude Code installed via npm
- [ ] Verify no regression on macOS/Linux (changes are behind `process.platform === "win32"` checks)

🤖 Generated with [Claude Code](https://claude.com/claude-code)