### PR TITLE
fix: move WebSocket idleTimeout into websocket config object

### DIFF
--- a/web/server/index.ts
+++ b/web/server/index.ts
@@ -200,7 +200,6 @@ if (process.env.NODE_ENV === "production") {
 
 const server = Bun.serve<SocketData>({
   port,
-  idleTimeout: idleTimeoutSeconds,
   async fetch(req, server) {
     const url = new URL(req.url);
 
@@ -254,6 +253,7 @@ const server = Bun.serve<SocketData>({
     return app.fetch(req, server);
   },
   websocket: {
+    idleTimeout: idleTimeoutSeconds,
     open(ws: ServerWebSocket<SocketData>) {
       const data = ws.data;
       if (data.kind === "cli") {


### PR DESCRIPTION
## Summary

- `idleTimeout` was placed at the `Bun.serve()` top level, but Bun only reads it from inside the `websocket: {}` object ([docs](https://bun.sh/docs/api/websockets#timeouts-and-limits))
- This meant `COMPANION_IDLE_TIMEOUT_SECONDS` was parsed correctly but silently ignored — Bun always used its default 120s timeout
- Idle CLI sessions had their WebSocket connections dropped every ~120s then immediately reconnected, creating a connect/disconnect flapping cycle

## Before (broken)

```ts
const server = Bun.serve<SocketData>({
  port,
  idleTimeout: idleTimeoutSeconds,  // ← Bun ignores this here
  async fetch(req, server) { ... },
  websocket: {
    open(ws) { ... },
    ...
  },
});
```

## After (fixed)

```ts
const server = Bun.serve<SocketData>({
  port,
  async fetch(req, server) { ... },
  websocket: {
    idleTimeout: idleTimeoutSeconds,  // ← Bun reads it here
    open(ws) { ... },
    ...
  },
});
```

## Log symptoms (before fix)

```
[ws-bridge] CLI disconnected for session ba2d5daf-...
[ws-bridge] CLI disconnected for session 977ebb5d-...
[ws-bridge] CLI disconnected for session e9b7084c-...
[ws-bridge] CLI disconnected for session dbb34504-...
[ws-bridge] CLI connected for session e9b7084c-...
[ws-bridge] CLI connected for session dbb34504-...
[ws-bridge] CLI connected for session 977ebb5d-...
[ws-bridge] CLI connected for session ba2d5daf-...
(repeats every ~120s)
```

## Test plan

- [x] Verified 0 CLI disconnects after 130+ seconds with `COMPANION_IDLE_TIMEOUT_SECONDS=0`
- [ ] Confirm default 120s timeout still works when env var is not set

🤖 Generated with [Claude Code](https://claude.com/claude-code)