### PR TITLE
feat(linear): inject Linear context into CLI system prompt

### DIFF
--- a/web/server/cli-launcher.ts
+++ b/web/server/cli-launcher.ts
@@ -156,6 +156,8 @@ export interface LaunchOptions {
   resumeSessionAt?: string;
   /** Fork a new Claude session when resuming from prior context. */
   forkSession?: boolean;
+  /** Optional system prompt to inject into Codex sessions (e.g. Linear context). */
+  systemPrompt?: string;
 }
 
 /**
@@ -826,6 +828,7 @@ export class CliLauncher {
       threadId: info.cliSessionId,
       sandbox: options.codexSandbox,
       recorder: this.recorder ?? undefined,
+      systemPrompt: options.systemPrompt,
       killProcess: async () => {
         try {
           proxyProc.kill("SIGTERM");
@@ -1026,6 +1029,7 @@ export class CliLauncher {
       threadId: info.cliSessionId,
       sandbox: options.codexSandbox,
       recorder: this.recorder ?? undefined,
+      systemPrompt: options.systemPrompt,
     });
 
     // Handle init errors — mark session as exited so UI shows failure.

--- a/web/server/codex-adapter.ts
+++ b/web/server/codex-adapter.ts
@@ -175,6 +175,8 @@ export interface CodexAdapterOptions {
   recorder?: RecorderManager;
   /** Callback to kill the underlying process/connection on disconnect. */
   killProcess?: () => Promise<void> | void;
+  /** Optional system prompt injected into thread/start as instructions (e.g. Linear context). */
+  systemPrompt?: string;
 }
 
 // ─── Stdio JSON-RPC Transport ────────────────────────────────────────────────
@@ -776,6 +778,7 @@ export class CodexAdapter {
               cwd: this.getExecutionCwd(),
               approvalPolicy: this.mapApprovalPolicy(this.currentPermissionMode),
               sandbox: this.options.sandbox || this.mapSandboxPolicy(this.currentPermissionMode),
+              ...(this.options.systemPrompt ? { instructions: this.options.systemPrompt } : {}),
             }) as { thread: { id: string } };
             this.threadId = threadResult.thread.id;
           }

--- a/web/server/linear-prompt-builder.test.ts
+++ b/web/server/linear-prompt-builder.test.ts
@@ -1,0 +1,61 @@
+import { describe, it, expect } from "vitest";
+import { buildLinearSystemPrompt } from "./linear-prompt-builder.js";
+
+describe("buildLinearSystemPrompt", () => {
+  const connection = {
+    workspaceName: "Acme Corp",
+    viewerName: "Jane Doe",
+    viewerEmail: "jane@acme.com",
+  };
+
+  const issue = {
+    identifier: "ENG-42",
+    title: "Fix login redirect",
+    stateName: "In Progress",
+    teamName: "Engineering",
+    url: "https://linear.app/acme/issue/ENG-42",
+  };
+
+  it("includes workspace info and API instructions", () => {
+    // Verifies the core prompt contains workspace context and API usage guidance
+    const prompt = buildLinearSystemPrompt(connection);
+    expect(prompt).toContain("LINEAR_API_KEY");
+    expect(prompt).toContain("Acme Corp");
+    expect(prompt).toContain("Jane Doe");
+    expect(prompt).toContain("jane@acme.com");
+    expect(prompt).toContain("https://api.linear.app/graphql");
+    expect(prompt).toContain("Authorization: Bearer $LINEAR_API_KEY");
+  });
+
+  it("includes issue context when provided", () => {
+    // When a Linear issue is linked, the prompt should include issue details
+    const prompt = buildLinearSystemPrompt(connection, issue);
+    expect(prompt).toContain("ENG-42");
+    expect(prompt).toContain("Fix login redirect");
+    expect(prompt).toContain("In Progress");
+    expect(prompt).toContain("Engineering");
+    expect(prompt).toContain("https://linear.app/acme/issue/ENG-42");
+  });
+
+  it("omits issue section when no issue provided", () => {
+    // Without an issue, the prompt should only contain workspace + API info
+    const prompt = buildLinearSystemPrompt(connection);
+    expect(prompt).not.toContain("Linked issue:");
+    expect(prompt).not.toContain("Issue URL:");
+  });
+
+  it("includes common operations guidance", () => {
+    // The prompt should tell the agent what it can do with the Linear API
+    const prompt = buildLinearSystemPrompt(connection);
+    expect(prompt).toContain("add comments");
+    expect(prompt).toContain("transition issue status");
+    expect(prompt).toContain("read issue details");
+  });
+
+  it("returns a multi-line string with newlines", () => {
+    // The prompt must be multi-line for readability in the system prompt
+    const prompt = buildLinearSystemPrompt(connection, issue);
+    const lines = prompt.split("\n");
+    expect(lines.length).toBeGreaterThan(3);
+  });
+});

--- a/web/server/linear-prompt-builder.ts
+++ b/web/server/linear-prompt-builder.ts
@@ -1,0 +1,47 @@
+// ─── Linear System Prompt Builder ─────────────────────────────────────────────
+//
+// Builds a system prompt snippet that tells Claude Code / Codex about the
+// LINEAR_API_KEY environment variable and the linked Linear issue context.
+// This is injected via the `initialize` control request's `appendSystemPrompt`
+// field (Claude Code) or the `instructions` field in `thread/start` (Codex).
+
+interface LinearConnectionContext {
+  workspaceName: string;
+  viewerName: string;
+  viewerEmail: string;
+}
+
+interface LinearIssueContext {
+  identifier: string;
+  title: string;
+  stateName: string;
+  teamName: string;
+  url: string;
+}
+
+export function buildLinearSystemPrompt(
+  connection: LinearConnectionContext,
+  issue?: LinearIssueContext,
+): string {
+  const lines = [
+    "You have access to the Linear API via the LINEAR_API_KEY environment variable.",
+    `Connected workspace: "${connection.workspaceName}" (viewer: ${connection.viewerName}, ${connection.viewerEmail})`,
+  ];
+  if (issue) {
+    lines.push(
+      `Linked issue: ${issue.identifier} — "${issue.title}" (status: ${issue.stateName}, team: ${issue.teamName})`,
+    );
+    lines.push(`Issue URL: ${issue.url}`);
+  }
+  lines.push("");
+  lines.push(
+    "You can use this key to call the Linear GraphQL API at https://api.linear.app/graphql.",
+  );
+  lines.push(
+    "Use the Authorization header: `Authorization: Bearer $LINEAR_API_KEY`",
+  );
+  lines.push(
+    "Common operations: add comments, transition issue status, read issue details, update issue fields.",
+  );
+  return lines.join("\n");
+}

--- a/web/server/routes.ts
+++ b/web/server/routes.ts
@@ -35,6 +35,7 @@ import { registerSystemRoutes } from "./routes/system-routes.js";
 import { registerLinearRoutes, transitionLinearIssue, fetchLinearTeamStates } from "./routes/linear-routes.js";
 import { registerLinearConnectionRoutes } from "./routes/linear-connection-routes.js";
 import { getConnection, listConnections, resolveApiKey } from "./linear-connections.js";
+import { buildLinearSystemPrompt } from "./linear-prompt-builder.js";
 import { getSettings } from "./settings-manager.js";
 import { discoverClaudeSessions } from "./claude-session-discovery.js";
 import { getClaudeSessionHistoryPage } from "./claude-session-history.js";
@@ -211,10 +212,12 @@ export function createRoutes(
       }
 
       // Inject LINEAR_API_KEY if a Linear connection is specified
+      let linearSystemPrompt: string | undefined;
       if (body.linearConnectionId) {
         const conn = getConnection(body.linearConnectionId);
         if (conn?.apiKey) {
           envVars = { ...envVars, LINEAR_API_KEY: conn.apiKey };
+          linearSystemPrompt = buildLinearSystemPrompt(conn, body.linearIssue);
         }
       }
 
@@ -437,6 +440,7 @@ export function createRoutes(
         containerCwd: containerInfo?.containerCwd,
         resumeSessionAt,
         forkSession,
+        systemPrompt: backend === "codex" ? linearSystemPrompt : undefined,
       });
 
       // Re-track container with real session ID and mark session as containerized
@@ -456,6 +460,11 @@ export function createRoutes(
           worktreePath: worktreeInfo.worktreePath,
           createdAt: Date.now(),
         });
+      }
+
+      // Inject Linear context into the CLI's system prompt (must happen before first user message)
+      if (linearSystemPrompt && backend === "claude") {
+        wsBridge.injectSystemPrompt(session.sessionId, linearSystemPrompt);
       }
 
       return c.json(session);
@@ -508,10 +517,12 @@ export function createRoutes(
         }
 
         // Inject LINEAR_API_KEY if a Linear connection is specified
+        let linearSystemPrompt: string | undefined;
         if (body.linearConnectionId) {
           const conn = getConnection(body.linearConnectionId);
           if (conn?.apiKey) {
             envVars = { ...envVars, LINEAR_API_KEY: conn.apiKey };
+            linearSystemPrompt = buildLinearSystemPrompt(conn, body.linearIssue);
           }
         }
 
@@ -817,6 +828,7 @@ export function createRoutes(
           containerCwd: containerInfo?.containerCwd,
           resumeSessionAt,
           forkSession,
+          systemPrompt: backend === "codex" ? linearSystemPrompt : undefined,
         });
 
         // Re-track container and mark session as containerized
@@ -835,6 +847,11 @@ export function createRoutes(
             worktreePath: worktreeInfo.worktreePath,
             createdAt: Date.now(),
           });
+        }
+
+        // Inject Linear context into the CLI's system prompt (must happen before first user message)
+        if (linearSystemPrompt && backend === "claude") {
+          wsBridge.injectSystemPrompt(session.sessionId, linearSystemPrompt);
         }
 
         await emitProgress(stream, "launching_cli", "Session started", "done");

--- a/web/server/ws-bridge.ts
+++ b/web/server/ws-bridge.ts
@@ -536,6 +536,22 @@ export class WsBridge {
     this.routeBrowserMessage(session, { type: "mcp_set_servers", servers });
   }
 
+  /** Send an initialize control request with context appended to the system prompt.
+   *  Must be called before the first user message. If CLI isn't connected yet,
+   *  the message is queued and sent when CLI connects (before any queued user messages). */
+  injectSystemPrompt(sessionId: string, appendSystemPrompt: string): void {
+    const session = this.sessions.get(sessionId);
+    if (!session) {
+      console.error(`[ws-bridge] Cannot inject system prompt: session ${sessionId} not found`);
+      return;
+    }
+    sendControlRequest(
+      session,
+      { subtype: "initialize", appendSystemPrompt },
+      this.sendToCLI.bind(this),
+    );
+  }
+
   handleBrowserClose(ws: ServerWebSocket<SocketData>) {
     const sessionId = (ws.data as BrowserSocketData).sessionId;
     const session = this.sessions.get(sessionId);

--- a/web/src/api.ts
+++ b/web/src/api.ts
@@ -226,6 +226,13 @@ export interface CreateSessionOpts {
   resumeSessionAt?: string;
   forkSession?: boolean;
   linearConnectionId?: string;
+  linearIssue?: {
+    identifier: string;
+    title: string;
+    stateName: string;
+    teamName: string;
+    url: string;
+  };
 }
 
 export interface BackendInfo {

--- a/web/src/components/HomePage.tsx
+++ b/web/src/components/HomePage.tsx
@@ -631,6 +631,13 @@ export function HomePage() {
           resumeSessionAt: effectiveResumeSessionAt,
           forkSession: effectiveForkSession,
           linearConnectionId: selectedLinearIssue ? (selectedLinearConnectionId || undefined) : undefined,
+          linearIssue: selectedLinearIssue ? {
+            identifier: selectedLinearIssue.identifier,
+            title: selectedLinearIssue.title,
+            stateName: selectedLinearIssue.stateName,
+            teamName: selectedLinearIssue.teamName,
+            url: selectedLinearIssue.url,
+          } : undefined,
         },
         (progress) => {
           useStore.getState().addCreationProgress(progress);


### PR DESCRIPTION
## Summary
- Injects Linear workspace and issue context into the CLI agent's system prompt when a session is linked to a Linear issue
- Uses `appendSystemPrompt` via the `initialize` control request (Claude Code) and `instructions` in `thread/start` (Codex)
- The agent now knows about `LINEAR_API_KEY`, the connected workspace, and the linked issue — enabling it to call the Linear GraphQL API directly

## How it works
1. **Session creation**: When `linearConnectionId` is provided, builds a system prompt with workspace info + issue details
2. **Claude Code**: Sends an `initialize` control request with `appendSystemPrompt` before the first user message (queued via the existing FIFO pending message mechanism)
3. **Codex**: Passes `instructions` in the `thread/start` JSON-RPC call via a new `systemPrompt` option on `CodexAdapterOptions`

## New files
- `web/server/linear-prompt-builder.ts` — `buildLinearSystemPrompt()` utility
- `web/server/linear-prompt-builder.test.ts` — 5 tests

## Modified files
- `web/server/ws-bridge.ts` — New `injectSystemPrompt()` method
- `web/server/routes.ts` — Build + inject prompt in both session creation endpoints
- `web/server/cli-launcher.ts` — Pass `systemPrompt` to CodexAdapter
- `web/server/codex-adapter.ts` — Accept `systemPrompt`, pass as `instructions` in `thread/start`
- `web/src/api.ts` — Add `linearIssue` to session creation request type
- `web/src/components/HomePage.tsx` — Pass issue details in session creation body

## Testing
- All 3509 tests pass
- TypeScript type check passes
- New `linear-prompt-builder.test.ts` covers: workspace info, issue context, omission without issue, API guidance, multi-line output

## Review provenance
- Implemented by AI agent
- Human review: no
