### PR TITLE
fix(linear): thread connectionId through CreateIssueModal for multi-connection support

### DIFF
--- a/web/src/components/home/CreateIssueModal.test.tsx
+++ b/web/src/components/home/CreateIssueModal.test.tsx
@@ -161,10 +161,43 @@ describe("CreateIssueModal", () => {
         projectId: "proj-1",
         assigneeId: "viewer-123",
         stateId: "state-backlog",
+        connectionId: undefined,
       });
     });
 
     expect(onCreated).toHaveBeenCalledWith(sampleCreatedIssue.issue);
+  });
+
+  it("threads connectionId through all API calls when provided", async () => {
+    // Verifies that when a connectionId is passed, it's forwarded to getLinearStates,
+    // getLinearConnection, and createLinearIssue so the correct Linear workspace is used.
+    const connId = "conn-abc-123";
+    const onCreated = vi.fn();
+    render(
+      <CreateIssueModal
+        connectionId={connId}
+        onCreated={onCreated}
+        onClose={vi.fn()}
+      />,
+    );
+
+    // Wait for teams to load — connectionId should be passed to both fetch calls
+    await waitFor(() => {
+      expect(screen.getByLabelText("Title *")).toBeInTheDocument();
+    });
+
+    expect(mockGetLinearStates).toHaveBeenCalledWith(connId);
+    expect(mockGetLinearConnection).toHaveBeenCalledWith(connId);
+
+    // Fill and submit the form
+    fireEvent.change(screen.getByLabelText("Title *"), { target: { value: "Multi-conn issue" } });
+    fireEvent.click(screen.getByText("Create Issue"));
+
+    await waitFor(() => {
+      expect(mockCreateLinearIssue).toHaveBeenCalledWith(
+        expect.objectContaining({ connectionId: connId }),
+      );
+    });
   });
 
   it("shows error message when creation fails", async () => {

--- a/web/src/components/home/CreateIssueModal.tsx
+++ b/web/src/components/home/CreateIssueModal.tsx
@@ -5,13 +5,15 @@ import { api, type LinearIssue, type LinearTeamStates } from "../../api.js";
 interface CreateIssueModalProps {
   /** Pre-selected project ID from the linearMapping, if available */
   defaultProjectId?: string;
+  /** Which Linear connection to use (for multi-connection support) */
+  connectionId?: string;
   /** Called on successful creation with the new issue */
   onCreated: (issue: LinearIssue) => void;
   /** Called when the modal is closed without creating */
   onClose: () => void;
 }
 
-export function CreateIssueModal({ defaultProjectId, onCreated, onClose }: CreateIssueModalProps) {
+export function CreateIssueModal({ defaultProjectId, connectionId, onCreated, onClose }: CreateIssueModalProps) {
   // Form fields
   const [title, setTitle] = useState("");
   const [description, setDescription] = useState("");
@@ -33,8 +35,8 @@ export function CreateIssueModal({ defaultProjectId, onCreated, onClose }: Creat
   useEffect(() => {
     let active = true;
     Promise.all([
-      api.getLinearStates(),
-      api.getLinearConnection(),
+      api.getLinearStates(connectionId),
+      api.getLinearConnection(connectionId),
     ]).then(([statesRes, connRes]) => {
       if (!active) return;
       setTeams(statesRes.teams);
@@ -48,7 +50,7 @@ export function CreateIssueModal({ defaultProjectId, onCreated, onClose }: Creat
       if (active) setLoading(false);
     });
     return () => { active = false; };
-  }, []);
+  }, [connectionId]);
 
   // Derive backlog state ID when team changes
   useEffect(() => {
@@ -74,6 +76,7 @@ export function CreateIssueModal({ defaultProjectId, onCreated, onClose }: Creat
         projectId: defaultProjectId || undefined,
         assigneeId: assignToSelf && viewerId ? viewerId : undefined,
         stateId: backlogStateId || undefined,
+        connectionId,
       });
       onCreated(result.issue);
     } catch (e: unknown) {

--- a/web/src/components/home/LinearSection.tsx
+++ b/web/src/components/home/LinearSection.tsx
@@ -675,6 +675,7 @@ export function LinearSection({
       {showCreateIssueModal && (
         <CreateIssueModal
           defaultProjectId={linearMapping?.projectId}
+          connectionId={selectedConnectionId ?? undefined}
           onCreated={handleIssueCreated}
           onClose={() => setShowCreateIssueModal(false)}
         />


### PR DESCRIPTION
## Summary
- `CreateIssueModal` was not receiving the selected `connectionId` when multiple Linear connections are configured
- Teams were loaded from the default (first) connection, and issues were created in the wrong workspace
- Now threads `connectionId` through `getLinearStates`, `getLinearConnection`, and `createLinearIssue`

## Why
When users have multiple Linear workspaces connected and select a non-default connection, clicking "Create issue" would fetch teams from and create issues in the wrong workspace.

## Testing
- Added test: `threads connectionId through all API calls when provided`
- Updated existing payload test to include `connectionId: undefined` for the no-connection case
- All 11 tests pass, typecheck passes

## Review provenance
- Implemented by AI agent
- Human review: no
