### PR TITLE
fix(ui): limit auto-approve notifications to one with dismiss button

### DIFF
--- a/web/src/components/AiValidationBadge.test.tsx
+++ b/web/src/components/AiValidationBadge.test.tsx
@@ -1,6 +1,6 @@
 // @vitest-environment jsdom
-import { describe, it, expect } from "vitest";
-import { render, screen } from "@testing-library/react";
+import { describe, it, expect, vi } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/react";
 import "@testing-library/jest-dom";
 import { AiValidationBadge } from "./AiValidationBadge.js";
 import type { PermissionRequest } from "../types.js";
@@ -69,6 +69,36 @@ describe("AiValidationBadge", () => {
   it("passes accessibility scan", async () => {
     const { axe } = await import("vitest-axe");
     const { container } = render(<AiValidationBadge entry={mockEntry()} />);
+    const results = await axe(container);
+    expect(results).toHaveNoViolations();
+  });
+
+  it("renders dismiss button when onDismiss is provided", () => {
+    const onDismiss = vi.fn();
+    render(<AiValidationBadge entry={mockEntry()} onDismiss={onDismiss} />);
+    const btn = screen.getByRole("button", { name: /dismiss/i });
+    expect(btn).toBeInTheDocument();
+  });
+
+  it("calls onDismiss when dismiss button is clicked", () => {
+    const onDismiss = vi.fn();
+    render(<AiValidationBadge entry={mockEntry()} onDismiss={onDismiss} />);
+    fireEvent.click(screen.getByRole("button", { name: /dismiss/i }));
+    expect(onDismiss).toHaveBeenCalledOnce();
+  });
+
+  it("does not render dismiss button when onDismiss is omitted", () => {
+    // Verifies the dismiss button is optional and not shown by default
+    render(<AiValidationBadge entry={mockEntry()} />);
+    expect(screen.queryByRole("button", { name: /dismiss/i })).not.toBeInTheDocument();
+  });
+
+  it("passes accessibility scan with dismiss button", async () => {
+    // Ensures the dismiss button meets accessibility standards (has aria-label, etc.)
+    const { axe } = await import("vitest-axe");
+    const { container } = render(
+      <AiValidationBadge entry={mockEntry()} onDismiss={() => {}} />
+    );
     const results = await axe(container);
     expect(results).toHaveNoViolations();
   });

--- a/web/src/components/AiValidationBadge.tsx
+++ b/web/src/components/AiValidationBadge.tsx
@@ -7,10 +7,11 @@ interface AiValidationBadgeProps {
     reason: string;
     timestamp: number;
   };
+  onDismiss?: () => void;
 }
 
 /** Compact inline notification for AI auto-resolved permissions. */
-export function AiValidationBadge({ entry }: AiValidationBadgeProps) {
+export function AiValidationBadge({ entry, onDismiss }: AiValidationBadgeProps) {
   const { request, behavior, reason } = entry;
   const isAllow = behavior === "allow";
 
@@ -35,7 +36,7 @@ export function AiValidationBadge({ entry }: AiValidationBadgeProps) {
       <svg viewBox="0 0 16 16" fill="currentColor" className="w-3.5 h-3.5 shrink-0 opacity-70">
         <path fillRule="evenodd" d="M8 1.246l.542.228c1.926.812 3.732.95 5.408.435l.61-.187v6.528a5.75 5.75 0 01-2.863 4.973L8 15.5l-3.697-2.277A5.75 5.75 0 011.44 8.25V1.722l.61.187c1.676.515 3.482.377 5.408-.435L8 1.246z" clipRule="evenodd" />
       </svg>
-      <span>
+      <span className="flex-1">
         AI auto-{isAllow ? "approved" : "denied"}:
         {" "}
         <span className="font-mono-code opacity-80">{toolDesc}</span>
@@ -43,6 +44,17 @@ export function AiValidationBadge({ entry }: AiValidationBadgeProps) {
           <span className="text-cc-muted ml-1">({reason})</span>
         )}
       </span>
+      {onDismiss && (
+        <button
+          onClick={onDismiss}
+          className="opacity-50 hover:opacity-100 transition-opacity cursor-pointer flex-shrink-0"
+          aria-label="Dismiss notification"
+        >
+          <svg viewBox="0 0 16 16" fill="currentColor" className="w-3.5 h-3.5">
+            <path d="M4.646 4.646a.5.5 0 01.708 0L8 7.293l2.646-2.647a.5.5 0 01.708.708L8.707 8l2.647 2.646a.5.5 0 01-.708.708L8 8.707l-2.646 2.647a.5.5 0 01-.708-.708L7.293 8 4.646 5.354a.5.5 0 010-.708z" />
+          </svg>
+        </button>
+      )}
     </div>
   );
 }

--- a/web/src/components/ChatView.tsx
+++ b/web/src/components/ChatView.tsx
@@ -10,6 +10,7 @@ import { AiValidationBadge } from "./AiValidationBadge.js";
 export function ChatView({ sessionId }: { sessionId: string }) {
   const sessionPerms = useStore((s) => s.pendingPermissions.get(sessionId));
   const aiResolved = useStore((s) => s.aiResolvedPermissions.get(sessionId));
+  const clearAiResolvedPermissions = useStore((s) => s.clearAiResolvedPermissions);
   const connStatus = useStore(
     (s) => s.connectionStatus.get(sessionId) ?? "disconnected"
   );
@@ -49,12 +50,13 @@ export function ChatView({ sessionId }: { sessionId: string }) {
       {/* Message feed */}
       <MessageFeed sessionId={sessionId} />
 
-      {/* AI auto-resolved notifications */}
+      {/* AI auto-resolved notification (most recent only) */}
       {aiResolved && aiResolved.length > 0 && (
         <div className="shrink-0 border-t border-cc-border bg-cc-card">
-          {aiResolved.slice(-5).map((entry, i) => (
-            <AiValidationBadge key={`${entry.request.request_id}-${i}`} entry={entry} />
-          ))}
+          <AiValidationBadge
+            entry={aiResolved[aiResolved.length - 1]}
+            onDismiss={() => clearAiResolvedPermissions(sessionId)}
+          />
         </div>
       )}
 

--- a/web/src/components/Playground.tsx
+++ b/web/src/components/Playground.tsx
@@ -937,8 +937,8 @@ export function Playground() {
             <Card label="Per-session toggle (enabled)">
               <PlaygroundAiValidationToggle enabled={true} />
             </Card>
-            <Card label="Auto-resolved badges">
-              <div className="border border-cc-border rounded-xl overflow-hidden bg-cc-card divide-y divide-cc-border">
+            <Card label="Auto-resolved badge (with dismiss)">
+              <div className="border border-cc-border rounded-xl overflow-hidden bg-cc-card">
                 <AiValidationBadge
                   entry={{
                     request: mockPermission({
@@ -949,7 +949,12 @@ export function Playground() {
                     reason: "Read is a read-only tool",
                     timestamp: Date.now(),
                   }}
+                  onDismiss={() => alert("Dismissed!")}
                 />
+              </div>
+            </Card>
+            <Card label="Auto-resolved badge (denied, with dismiss)">
+              <div className="border border-cc-border rounded-xl overflow-hidden bg-cc-card">
                 <AiValidationBadge
                   entry={{
                     request: mockPermission({
@@ -960,7 +965,12 @@ export function Playground() {
                     reason: "Recursive delete of root directory",
                     timestamp: Date.now(),
                   }}
+                  onDismiss={() => alert("Dismissed!")}
                 />
+              </div>
+            </Card>
+            <Card label="Auto-resolved badge (no dismiss)">
+              <div className="border border-cc-border rounded-xl overflow-hidden bg-cc-card">
                 <AiValidationBadge
                   entry={{
                     request: mockPermission({

--- a/web/src/store.test.ts
+++ b/web/src/store.test.ts
@@ -400,6 +400,31 @@ describe("Permissions", () => {
   });
 });
 
+// ─── AI Resolved Permissions ────────────────────────────────────────────────
+
+describe("AI Resolved Permissions", () => {
+  it("clearAiResolvedPermissions: clears AI-resolved entries for a session", () => {
+    const entry = {
+      request: makePermission({ request_id: "r1", tool_name: "Read" }),
+      behavior: "allow" as const,
+      reason: "read-only",
+      timestamp: Date.now(),
+    };
+    useStore.getState().addAiResolvedPermission("s1", entry);
+    expect(useStore.getState().aiResolvedPermissions.get("s1")).toHaveLength(1);
+
+    // Clear should remove the session key entirely
+    useStore.getState().clearAiResolvedPermissions("s1");
+    expect(useStore.getState().aiResolvedPermissions.get("s1")).toBeUndefined();
+  });
+
+  it("clearAiResolvedPermissions: no-op when session has no entries", () => {
+    // Should not throw when clearing a session with no AI-resolved permissions
+    useStore.getState().clearAiResolvedPermissions("nonexistent");
+    expect(useStore.getState().aiResolvedPermissions.has("nonexistent")).toBe(false);
+  });
+});
+
 // ─── Tasks ──────────────────────────────────────────────────────────────────
 
 describe("Tasks", () => {

--- a/web/src/store.ts
+++ b/web/src/store.ts
@@ -174,6 +174,7 @@ interface AppState {
   addPermission: (sessionId: string, perm: PermissionRequest) => void;
   removePermission: (sessionId: string, requestId: string) => void;
   addAiResolvedPermission: (sessionId: string, entry: { request: PermissionRequest; behavior: "allow" | "deny"; reason: string; timestamp: number }) => void;
+  clearAiResolvedPermissions: (sessionId: string) => void;
   setSessionAiValidation: (sessionId: string, settings: { aiValidationEnabled?: boolean | null; aiValidationAutoApprove?: boolean | null; aiValidationAutoDeny?: boolean | null }) => void;
 
   // Task actions
@@ -638,6 +639,13 @@ export const useStore = create<AppState>((set) => ({
       // Keep only the last 50 entries per session to avoid unbounded growth
       if (sessionEntries.length > 50) sessionEntries.splice(0, sessionEntries.length - 50);
       aiResolvedPermissions.set(sessionId, sessionEntries);
+      return { aiResolvedPermissions };
+    }),
+
+  clearAiResolvedPermissions: (sessionId) =>
+    set((s) => {
+      const aiResolvedPermissions = new Map(s.aiResolvedPermissions);
+      aiResolvedPermissions.delete(sessionId);
       return { aiResolvedPermissions };
     }),
 


### PR DESCRIPTION
## Summary
- Show only the most recent AI auto-resolved notification (instead of stacking up to 5)
- Add a dismiss (X) button to close the notification
- Clearing notifications allows new ones to appear when the next auto-resolve happens

## Why
Auto-approve notifications were stacking up at the bottom of the chat, taking up too much vertical space with no way to dismiss them.

## Testing
- `bun run typecheck` passes
- `bun run test` passes (3539 tests, including 6 new tests)
- Playground updated with dismiss/no-dismiss variants at `#/playground`

## Review provenance
- Implemented by AI agent
- Human review: no
