### PR TITLE
fix(codex): normalize non-string reasoning payloads

### DIFF
--- a/web/server/codex-adapter.test.ts
+++ b/web/server/codex-adapter.test.ts
@@ -1104,6 +1104,44 @@ describe("CodexAdapter", () => {
     expect(blockStops.length).toBeGreaterThanOrEqual(1);
   });
 
+  it("ignores non-string reasoning payloads (arrays) without crashing", async () => {
+    const messages: BrowserIncomingMessage[] = [];
+    const adapter = new CodexAdapter(proc as never, "test-session", { model: "o4-mini" });
+    adapter.onBrowserMessage((msg) => messages.push(msg));
+
+    await new Promise((r) => setTimeout(r, 50));
+    stdout.push(JSON.stringify({ id: 1, result: { userAgent: "codex" } }) + "\n");
+    await new Promise((r) => setTimeout(r, 20));
+    stdout.push(JSON.stringify({ id: 2, result: { thread: { id: "thr_123" } } }) + "\n");
+    await new Promise((r) => setTimeout(r, 50));
+
+    // Regression case: the last protocol can emit arrays for reasoning summary/content.
+    stdout.push(JSON.stringify({
+      method: "item/started",
+      params: { item: { type: "reasoning", id: "r_arr", summary: [], content: [] } },
+    }) + "\n");
+    await new Promise((r) => setTimeout(r, 20));
+
+    stdout.push(JSON.stringify({
+      method: "item/completed",
+      params: { item: { type: "reasoning", id: "r_arr", summary: [], content: [] } },
+    }) + "\n");
+    await new Promise((r) => setTimeout(r, 50));
+
+    const blockStops = messages.filter(
+      (m) => m.type === "stream_event" && (m as { event: { type: string } }).event?.type === "content_block_stop",
+    );
+    expect(blockStops.length).toBeGreaterThanOrEqual(1);
+
+    const thinkingMessages = messages.filter((m) =>
+      m.type === "assistant"
+      && (m as { message: { content: Array<{ type: string; thinking?: string }> } }).message.content.some(
+        (block) => block.type === "thinking",
+      ),
+    );
+    expect(thinkingMessages.length).toBe(0);
+  });
+
   // ── Codex CLI enum values must be kebab-case (v0.99+) ─────────────────
   // Valid sandbox values: "read-only", "workspace-write", "danger-full-access"
   // Valid approvalPolicy values: "never", "untrusted", "on-failure", "on-request"

--- a/web/server/codex-adapter.ts
+++ b/web/server/codex-adapter.ts
@@ -61,6 +61,24 @@ function safeKind(kind: unknown): string {
   return "modify";
 }
 
+/** Normalize a reasoning summary/content field into a displayable string.
+ * Codex payloads may (regressively) send arrays or objects instead of plain strings.
+ */
+function normalizeReasoningText(value: unknown): string {
+  if (typeof value === "string") return value;
+  if (typeof value === "number" || typeof value === "boolean") return String(value);
+  if (Array.isArray(value)) {
+    return value.map((entry) => normalizeReasoningText(entry)).join("");
+  }
+  if (value && typeof value === "object") {
+    const record = value as Record<string, unknown>;
+    if (typeof record.text === "string") return record.text;
+    if (typeof record.content === "string") return record.content;
+    if (typeof record.summary === "string") return record.summary;
+  }
+  return "";
+}
+
 interface CodexAgentMessageItem extends CodexItem {
   type: "agentMessage";
   text?: string;
@@ -99,8 +117,8 @@ interface CodexWebSearchItem extends CodexItem {
 
 interface CodexReasoningItem extends CodexItem {
   type: "reasoning";
-  summary?: string;
-  content?: string;
+  summary?: unknown;
+  content?: unknown;
 }
 
 interface CodexContextCompactionItem extends CodexItem {
@@ -1674,15 +1692,16 @@ export class CodexAdapter {
 
       case "reasoning": {
         const r = item as CodexReasoningItem;
-        this.reasoningTextByItemId.set(item.id, r.summary || r.content || "");
+        const initialReasoningText = normalizeReasoningText(r.summary) || normalizeReasoningText(r.content);
+        this.reasoningTextByItemId.set(item.id, initialReasoningText);
         // Emit as thinking content block
-        if (r.summary || r.content) {
+        if (initialReasoningText) {
           this.emit({
             type: "stream_event",
             event: {
               type: "content_block_start",
               index: 0,
-              content_block: { type: "thinking", thinking: r.summary || r.content || "" },
+              content_block: { type: "thinking", thinking: initialReasoningText },
             },
             parent_tool_use_id: null,
           });
@@ -2044,10 +2063,9 @@ export class CodexAdapter {
 
       case "reasoning": {
         const r = item as CodexReasoningItem;
+        const accumulatedText = this.reasoningTextByItemId.get(item.id);
         const thinkingText = (
-          this.reasoningTextByItemId.get(item.id)
-          || r.summary
-          || r.content
+          (accumulatedText ? accumulatedText : (normalizeReasoningText(r.summary) || normalizeReasoningText(r.content)))
           || ""
         ).trim();
 


### PR DESCRIPTION
## Summary
- Normalize Codex reasoning payloads before string operations in `web/server/codex-adapter.ts`.
- Handle `reasoning.summary` and `reasoning.content` when they arrive as arrays or objects, not just strings.
- Add a regression test covering empty array payloads in `web/server/codex-adapter.test.ts`.

## Why
- Recent Codex sessions can emit `item.started`/`item.completed` reasoning events with non-string `summary`/`content` (for example empty arrays).
- The previous implementation passed these values directly to `.trim()`, causing a crash during UI session startup.
- This change makes the adapter defensive and preserves existing behavior for string payloads.

## Testing
- Added regression test: `ignores non-string reasoning payloads (arrays) without crashing`.
- Other tests were not run in this environment.

## Review provenance
- Implemented by AI agent.
- Human review: not yet completed.
