### PR TITLE
fix(ws): reconnect current session after visibility restore

### DIFF
--- a/web/src/ws-visibility.test.ts
+++ b/web/src/ws-visibility.test.ts
@@ -18,13 +18,21 @@ const mockWsClose = vi.fn();
 let wsInstances: Array<{ onopen?: (() => void) | null; onclose?: (() => void) | null; onerror?: (() => void) | null; onmessage?: ((e: any) => void) | null }> = [];
 
 class MockWebSocket {
+  static OPEN = 1;
+  static CLOSED = 3;
+  static CONNECTING = 0;
+  static CLOSING = 2;
+  OPEN = 1;
+  CLOSED = 3;
+  CONNECTING = 0;
+  CLOSING = 2;
   send = mockWsSend;
   close = mockWsClose;
   onopen: (() => void) | null = null;
   onclose: (() => void) | null = null;
   onerror: (() => void) | null = null;
   onmessage: ((e: any) => void) | null = null;
-  readyState = 1;
+  readyState = MockWebSocket.OPEN;
   constructor() {
     wsInstances.push(this);
   }
@@ -170,5 +178,30 @@ describe("RC9: visibility-aware reconnection", () => {
     for (const fn of visibilityListeners) fn();
 
     expect(wsInstances).toHaveLength(1); // no reconnect
+  });
+
+  it("visibilitychange → visible reconnects current session even if sdkSessions is stale", async () => {
+    const { useStore } = await import("./store.js");
+
+    // Simulate stale sdkSessions list that doesn't include the current session.
+    useStore.setState({
+      currentSessionId: "test-1",
+      sdkSessions: [],
+    });
+
+    connectSession("test-1");
+    expect(wsInstances).toHaveLength(1);
+
+    // Hidden + close: no reconnect while hidden
+    Object.defineProperty(document, "hidden", { value: true, configurable: true });
+    for (const fn of visibilityListeners) fn();
+    wsInstances[0].onclose?.();
+    vi.advanceTimersByTime(5_000);
+    expect(wsInstances).toHaveLength(1);
+
+    // Visible: should reconnect from currentSessionId fallback.
+    Object.defineProperty(document, "hidden", { value: false, configurable: true });
+    for (const fn of visibilityListeners) fn();
+    expect(wsInstances).toHaveLength(2);
   });
 });

--- a/web/src/ws.test.ts
+++ b/web/src/ws.test.ts
@@ -116,6 +116,17 @@ describe("connectSession", () => {
     expect(lastWs).toBe(first);
   });
 
+  it("replaces a stale closed socket for the same session", () => {
+    wsModule.connectSession("s1");
+    const first = lastWs;
+    first.readyState = MockWebSocket.CLOSED;
+
+    wsModule.connectSession("s1");
+
+    expect(lastWs).not.toBe(first);
+    expect(first.close).toHaveBeenCalled();
+  });
+
   it("sends session_subscribe with last_seq on open", () => {
     localStorage.setItem("companion:last-seq:s1", "12");
     wsModule.connectSession("s1");

--- a/web/src/ws.ts
+++ b/web/src/ws.ts
@@ -13,6 +13,29 @@ const streamingDraftMessageIdBySession = new Map<string, string>();
 /** Track processed tool_use IDs to prevent duplicate task creation */
 const processedToolUseIds = new Map<string, Set<string>>();
 
+function isSocketUsable(ws: WebSocket | undefined): boolean {
+  return !!ws && (ws.readyState === WebSocket.OPEN || ws.readyState === WebSocket.CONNECTING);
+}
+
+function shouldReconnectSession(sessionId: string): boolean {
+  const store = useStore.getState();
+  const sdkSession = store.sdkSessions.find((s) => s.sessionId === sessionId);
+  if (sdkSession) return !sdkSession.archived;
+  // Fallback for freshly-created sessions that may not be in sdkSessions yet.
+  return store.currentSessionId === sessionId || store.sessions.has(sessionId);
+}
+
+function getReconnectCandidates(): string[] {
+  const store = useStore.getState();
+  const ids = new Set<string>();
+  for (const s of store.sdkSessions) {
+    if (!s.archived) ids.add(s.sessionId);
+  }
+  if (store.currentSessionId) ids.add(store.currentSessionId);
+  for (const id of store.sessions.keys()) ids.add(id);
+  return Array.from(ids);
+}
+
 // ── Page visibility handling ─────────────────────────────────────────────────
 // Mobile browsers (Android Chrome, iOS Safari) aggressively kill WebSocket
 // connections when the page is backgrounded. Without this handler, the frontend
@@ -34,11 +57,16 @@ if (typeof document !== "undefined") {
       }
     } else {
       pageHidden = false;
-      // Page is visible again — reconnect all active sessions
-      const store = useStore.getState();
-      for (const s of store.sdkSessions) {
-        if (!s.archived && !sockets.has(s.sessionId)) {
-          connectSession(s.sessionId);
+      // Page is visible again — reconnect all known active sessions.
+      for (const sessionId of getReconnectCandidates()) {
+        if (!shouldReconnectSession(sessionId)) continue;
+        const ws = sockets.get(sessionId);
+        if (!isSocketUsable(ws)) {
+          if (ws) {
+            try { ws.close(); } catch {}
+            sockets.delete(sessionId);
+          }
+          connectSession(sessionId);
         }
       }
     }
@@ -964,7 +992,12 @@ function handleParsedMessage(
 }
 
 export function connectSession(sessionId: string) {
-  if (sockets.has(sessionId)) return;
+  const existing = sockets.get(sessionId);
+  if (isSocketUsable(existing)) return;
+  if (existing) {
+    try { existing.close(); } catch {}
+    sockets.delete(sessionId);
+  }
 
   const store = useStore.getState();
   store.setConnectionStatus(sessionId, "connecting");
@@ -1008,12 +1041,7 @@ function scheduleReconnect(sessionId: string) {
     reconnectTimers.delete(sessionId);
     // Re-check visibility — page may have been hidden during the delay
     if (pageHidden) return;
-    const store = useStore.getState();
-    // Reconnect any active (non-archived) session
-    const sdkSession = store.sdkSessions.find((s) => s.sessionId === sessionId);
-    if (sdkSession && !sdkSession.archived) {
-      connectSession(sessionId);
-    }
+    if (shouldReconnectSession(sessionId)) connectSession(sessionId);
   }, WS_RECONNECT_DELAY_MS);
   reconnectTimers.set(sessionId, timer);
 }


### PR DESCRIPTION
## Summary
- fix WebSocket reconnection on tab visibility restore so active/current sessions reconnect even when `sdkSessions` is stale
- replace stale closed socket entries before reconnecting to avoid blocked reconnect attempts
- add regression tests for visibility restore and stale closed-socket replacement

## Why
- users could see "disconnected" after returning to the tab even though the backend session was still active

## Testing
- cd web && bun run test -- ws-visibility.test.ts ws.test.ts
- cd web && bun run typecheck

## Review provenance
- Implemented by AI agent
- Human review: no
