### PR TITLE
feat(home): pro ChatGPT/Cursor-style homepage redesign

### DIFF
--- a/web/src/components/HomePage.test.tsx
+++ b/web/src/components/HomePage.test.tsx
@@ -1525,5 +1525,19 @@ describe("HomePage", () => {
       expect(screen.queryByText(/sets where your code lives/)).not.toBeInTheDocument();
       expect(localStorage.getItem("cc-onboarding-dismissed")).toBe("true");
     });
+
+    it("does not mention Branch from session when backend is codex", async () => {
+      // The onboarding tip conditionally shows the "Branch from session"
+      // sentence only for Claude backend. Codex users should not see it
+      // since the branching feature is Claude-only.
+      localStorage.setItem("cc-backend", "codex");
+      render(<HomePage />);
+      await screen.findByPlaceholderText("Fix a bug, build a feature, refactor code...");
+
+      // The tip itself should still render (toolbar explanation)
+      expect(screen.getByText(/sets where your code lives/)).toBeInTheDocument();
+      // But the Claude-only sentence should be absent
+      expect(screen.queryByText(/branch from session/i)).not.toBeInTheDocument();
+    });
   });
 });

--- a/web/src/components/HomePage.tsx
+++ b/web/src/components/HomePage.tsx
@@ -1485,8 +1485,10 @@ export function HomePage() {
                   <path d="M8 1.5a6.5 6.5 0 100 13 6.5 6.5 0 000-13zM0 8a8 8 0 1116 0A8 8 0 010 8zm6.5-.25A.75.75 0 017.25 7h1a.75.75 0 01.75.75v2.75h.25a.75.75 0 010 1.5h-2a.75.75 0 010-1.5h.25v-2h-.25a.75.75 0 01-.75-.75zM8 6a1 1 0 110-2 1 1 0 010 2z" />
                 </svg>
                 <span className="flex-1">
-                  The toolbar sets where your code lives, which model to use, and how the session runs.{" "}
-                  <strong className="text-cc-fg">Branch from session</strong> below lets you fork or continue a previous Claude session.
+                  The toolbar sets where your code lives, which model to use, and how the session runs.
+                  {backend === "claude" && (
+                    <>{" "}<strong className="text-cc-fg">Branch from session</strong> below lets you fork or continue a previous Claude session.</>
+                  )}
                 </span>
                 <button
                   onClick={() => {


### PR DESCRIPTION
## Summary
- Vertically centered hero input with all controls (model, mode, folder, branch, env, sandbox) flattened into a single toolbar row inside the input card
- Removes separate bordered sections for Workspace/Runtime for a cleaner, more professional layout inspired by ChatGPT/Cursor
- Resume "Branch from session" as a subtle centered link below the card
- Backend toggle centered below the card
- Compact mobile layout with smaller logo, tighter spacing, and flow-wrapped controls
- Uses `my-auto` instead of `justify-center` on scroll container to prevent top content from becoming inaccessible when content grows tall

## Testing
- 56 HomePage tests pass
- TypeScript check passes
- Vercel preview deployed

## Review provenance
- Implemented by AI agent (Claude)
- Human review: pending
