### PR TITLE
fix(topbar): prevent Session tab from being clipped on Android

### DIFF
--- a/web/src/components/TopBar.tsx
+++ b/web/src/components/TopBar.tsx
@@ -151,7 +151,7 @@ export function TopBar() {
         </button>
 
         {showWorkspaceControls && (
-          <div className="flex-1 flex items-center justify-center gap-0.5 min-w-0 overflow-x-auto [scrollbar-width:none] [&::-webkit-scrollbar]:hidden">
+          <div className="flex-1 flex items-center justify-start md:justify-center gap-0.5 min-w-0 overflow-x-auto [scrollbar-width:none] [&::-webkit-scrollbar]:hidden">
               <button
                 onClick={() => activateWorkspaceTab("chat")}
                 className={`h-full px-3 text-[12px] font-medium transition-colors cursor-pointer flex items-center gap-1.5 border-b-[1.5px] shrink-0 ${


### PR DESCRIPTION
## Summary
- On Android, the Session tab was unreachable because `justify-center` on the scrollable tab container pushed it into negative scroll territory
- Changed to `justify-start md:justify-center` so mobile starts scroll at Session tab while desktop keeps centered layout

## Root Cause
`justify-center` + `overflow-x-auto` with hidden scrollbar: when flex children overflow a centered container, overflow is symmetric but scroll origin starts at 0. Left-side overflow is unreachable. On narrow Android viewports, all 6 tabs exceed container width, clipping the first tab (Session).

## Testing
- All 15 TopBar tests pass including accessibility
- Desktop layout unchanged (tabs centered at md+ breakpoints)

## Review provenance
- Investigated and implemented by AI agent (Claude)
- Human review: no

🤖 Generated with [Claude Code](https://claude.com/claude-code)
