### PR TITLE
feat(docker): add standalone docker-compose CLI to default image

### DIFF
--- a/web/docker/Dockerfile.the-companion
+++ b/web/docker/Dockerfile.the-companion
@@ -64,6 +64,14 @@ ENV PATH="/root/.cargo/bin:$PATH"
 # get.docker.com installs dockerd, docker CLI, containerd, and docker-compose-plugin
 RUN curl -fsSL https://get.docker.com | sh
 
+# ── Layer 7b: Docker Compose standalone CLI ──────────────────────────────────
+# The plugin (docker compose) is already installed above; this adds the
+# standalone `docker-compose` binary so both invocation styles work.
+RUN COMPOSE_VERSION=$(curl -fsSL https://api.github.com/repos/docker/compose/releases/latest | jq -r .tag_name) \
+    && curl -fsSL "https://github.com/docker/compose/releases/download/${COMPOSE_VERSION}/docker-compose-linux-$(uname -m)" \
+       -o /usr/local/bin/docker-compose \
+    && chmod +x /usr/local/bin/docker-compose
+
 # ── Layer 8: GitHub CLI ──────────────────────────────────────────────────────
 RUN curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg \
     | dd of=/usr/share/keyrings/githubcli-archive-keyring.gpg \


### PR DESCRIPTION
## Summary
- Add standalone `docker-compose` CLI binary to the default Docker image
- The Docker Compose plugin (`docker compose` subcommand) was already installed via `get.docker.com`, but this adds the standalone `docker-compose` binary so both invocation styles work out of the box

## Why
- Many existing projects and scripts reference `docker-compose` (standalone) rather than `docker compose` (plugin)
- Having both available ensures maximum compatibility for any project cloned into the container

## Testing
- Verified Dockerfile syntax and layer ordering
- The standalone binary is downloaded from the official Docker Compose GitHub releases

## Review provenance
- Implemented by AI agent
- Human review: no
