### PR TITLE
fix(claude-adapter): drop tool_result user echo messages rendered as raw JSON

### DIFF
--- a/web/server/claude-adapter.test.ts
+++ b/web/server/claude-adapter.test.ts
@@ -342,9 +342,10 @@ describe("Known non-standard CLI message types", () => {
     spy.mockRestore();
   });
 
-  it("user echo with non-string content serializes to JSON", () => {
-    // When the user echo content is an array (e.g. tool_result blocks),
-    // it should be JSON-stringified before sending to the browser.
+  it("user echo with non-string content is silently dropped", () => {
+    // User echo messages with tool_result arrays are redundant — the tool
+    // results are already present in the subsequent assistant message content
+    // blocks. Emitting them as user_message caused raw JSON text bubbles.
     const ws = createMockSocket("sess-1");
     adapter.attachWebSocket(ws);
 
@@ -360,10 +361,10 @@ describe("Known non-standard CLI message types", () => {
       }) + "\n",
     );
 
-    expect(browserMessageCb).toHaveBeenCalledWith(
+    // Should NOT emit a user_message to the browser
+    expect(browserMessageCb).not.toHaveBeenCalledWith(
       expect.objectContaining({
         type: "user_message",
-        content: JSON.stringify(complexContent),
       }),
     );
   });

--- a/web/server/claude-adapter.ts
+++ b/web/server/claude-adapter.ts
@@ -721,17 +721,12 @@ export class ClaudeAdapter implements IBackendAdapter {
 
   private handleUserEcho(msg: CLIUserEchoMessage): void {
     // The CLI echoes user messages back (including subagent tool_result blocks).
-    // Only emit for non-string content (e.g. tool_result arrays from subagents)
-    // that didn't originate from the browser composer. Plain string echoes are
-    // duplicates of messages the browser already has, so silently drop them.
-    if (typeof msg.message.content === "string") return;
-
-    const content = JSON.stringify(msg.message.content);
-    this.browserMessageCb?.({
-      type: "user_message",
-      content,
-      timestamp: Date.now(),
-    });
+    // These are redundant — tool results are already included in the subsequent
+    // assistant message content blocks. Emitting them as user_message causes the
+    // browser to render raw JSON text bubbles. Drop all echoes silently.
+    // Plain string echoes are duplicates of messages the browser already has,
+    // and array echoes (tool_result blocks) are duplicates of the assistant
+    // message that follows.
   }
 
   // -- Auth status ------------------------------------------------------------


### PR DESCRIPTION
## Summary
- Drop CLI user echo messages containing `tool_result` content blocks that were being rendered as raw JSON text bubbles in the browser UI
- These echoes are redundant — tool results are already included in the subsequent `assistant` message content blocks

## Why
When the CLI echoes back user messages with `tool_result` arrays (e.g. from subagent tool calls), `handleUserEcho()` was `JSON.stringify()`-ing the content and forwarding it as a `user_message`. The browser rendered these as plain text user bubbles showing raw JSON like `[{"tool_use_id":"toolu_01RAk...","type":"tool_result","content":"..."}]`.

## Testing
- Updated existing test to verify tool_result echoes are now silently dropped
- All 61 claude-adapter tests pass
- Typecheck clean

## Review provenance
- Root cause investigated and fix implemented by AI agent
- Human review: no
