### PR TITLE
fix(claude-adapter): re-apply user echo drop fix reverted by #589

### DIFF
--- a/web/server/claude-adapter.test.ts
+++ b/web/server/claude-adapter.test.ts
@@ -342,9 +342,10 @@ describe("Known non-standard CLI message types", () => {
     spy.mockRestore();
   });
 
-  it("user echo with non-string content serializes to JSON", () => {
-    // When the user echo content is an array (e.g. tool_result blocks),
-    // it should be JSON-stringified before sending to the browser.
+  it("user echo with non-string content is silently dropped", () => {
+    // User echo messages with tool_result arrays are redundant — the tool
+    // results are already present in the subsequent assistant message content
+    // blocks. Forwarding them caused raw JSON text bubbles in the chat UI.
     const ws = createMockSocket("sess-1");
     adapter.attachWebSocket(ws);
 
@@ -360,11 +361,9 @@ describe("Known non-standard CLI message types", () => {
       }) + "\n",
     );
 
-    expect(browserMessageCb).toHaveBeenCalledWith(
-      expect.objectContaining({
-        type: "user_message",
-        content: JSON.stringify(complexContent),
-      }),
+    // Should NOT emit a user_message to the browser
+    expect(browserMessageCb).not.toHaveBeenCalledWith(
+      expect.objectContaining({ type: "user_message" }),
     );
   });
 });

--- a/web/server/claude-adapter.ts
+++ b/web/server/claude-adapter.ts
@@ -26,7 +26,6 @@ import type {
   CLIControlRequestMessage,
   CLIControlResponseMessage,
   CLIAuthStatusMessage,
-  CLIUserEchoMessage,
   CLICompactBoundaryMessage,
   CLITaskNotificationMessage,
   CLIFilesPersistedMessage,
@@ -450,10 +449,9 @@ export class ClaudeAdapter implements IBackendAdapter {
 
       case "user":
         // CLI echoes back user messages (including tool_result blocks from
-        // subagents). These are informational — the bridge already persists
-        // user messages from the browser side, so we emit them for history
-        // completeness but don't need special handling.
-        this.handleUserEcho(msg as CLIUserEchoMessage);
+        // subagents). These are purely informational — the bridge already
+        // persists user messages from the browser side. Silently drop them
+        // to avoid rendering raw tool_result JSON in the chat UI.
         break;
 
       case "rate_limit_event":
@@ -714,23 +712,6 @@ export class ClaudeAdapter implements IBackendAdapter {
       type: "tool_use_summary",
       summary: msg.summary,
       tool_use_ids: msg.preceding_tool_use_ids,
-    });
-  }
-
-  // -- User echo --------------------------------------------------------------
-
-  private handleUserEcho(msg: CLIUserEchoMessage): void {
-    // The CLI echoes user messages back (including subagent tool_result blocks).
-    // Only emit for non-string content (e.g. tool_result arrays from subagents)
-    // that didn't originate from the browser composer. Plain string echoes are
-    // duplicates of messages the browser already has, so silently drop them.
-    if (typeof msg.message.content === "string") return;
-
-    const content = JSON.stringify(msg.message.content);
-    this.browserMessageCb?.({
-      type: "user_message",
-      content,
-      timestamp: Date.now(),
     });
   }
 


### PR DESCRIPTION
## Summary
- Re-apply the user echo drop fix from #592 that was inadvertently reverted by #589's merge resolution
- Silently drop all CLI `user` echo messages (both string and tool_result arrays) — they're redundant since tool results already arrive in assistant message content blocks

## Why
PR #592 fixed raw JSON `tool_result` bubbles appearing in the chat UI. PR #589 (orchestrator/PID recycling fix) touched `claude-adapter.ts` and its merge re-introduced the old `handleUserEcho()` method, reverting the fix.

## Testing
- Updated test to verify all user echoes are silently dropped
- 61/61 adapter tests pass
- Typecheck clean

## Review provenance
- Investigated & implemented by AI agent
- Human review: no
