### PR TITLE
fix(linear): log webhook acceptance and rejection

### DIFF
--- a/web/server/routes/linear-agent-routes.test.ts
+++ b/web/server/routes/linear-agent-routes.test.ts
@@ -215,6 +215,41 @@ describe("POST /linear/agent-webhook", () => {
       expect.stringContaining("No agent found for oauthClientId"),
     );
   });
+
+  it("sanitizes user-controlled fields before logging webhook diagnostics", async () => {
+    vi.mocked(agentStore.listAgents).mockReturnValue([]);
+
+    const maliciousPayload = {
+      ...validPayload,
+      action: "created\nforged",
+      oauthClientId: "evil\n[linear-agent-routes] Accepted AgentSessionEvent",
+      agentSession: {
+        ...validPayload.agentSession,
+        id: "session-123\tforged",
+      },
+    };
+
+    const res = await app.request("/linear/agent-webhook", {
+      method: "POST",
+      body: JSON.stringify(maliciousPayload),
+      headers: { "Content-Type": "application/json", "linear-signature": "valid-sig" },
+    });
+
+    expect(res.status).toBe(404);
+    expect(consoleErrorSpy).toHaveBeenCalledWith(
+      "[linear-agent-routes] No agent found for oauthClientId: evil_[linear-agent-routes] Accepted AgentSessionEvent action=created_forged sessionId=session-123_forged",
+    );
+  });
+});
+
+describe("console spy cleanup", () => {
+  it("restores console spies before later describe blocks run", () => {
+    // Regression test: webhook tests install console spies, but later describes
+    // should still see the original console implementations.
+    expect(vi.isMockFunction(console.log)).toBe(false);
+    expect(vi.isMockFunction(console.warn)).toBe(false);
+    expect(vi.isMockFunction(console.error)).toBe(false);
+  });
 });
 
 // ─── OAuth callback tests ───────────────────────────────────────────────────
@@ -225,14 +260,6 @@ describe("GET /linear/oauth/callback", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     ({ app } = createApp());
-  });
-
-  it("restores console spies before later describe blocks run", () => {
-    // Regression test: webhook tests install console spies, but later describes
-    // should still see the original console implementations.
-    expect(vi.isMockFunction(console.log)).toBe(false);
-    expect(vi.isMockFunction(console.warn)).toBe(false);
-    expect(vi.isMockFunction(console.error)).toBe(false);
   });
 
   it("redirects with error when error parameter is present", async () => {

--- a/web/server/routes/linear-agent-routes.ts
+++ b/web/server/routes/linear-agent-routes.ts
@@ -13,6 +13,10 @@ import * as staging from "../linear-staging.js";
 import { getSettings, updateSettings } from "../settings-manager.js";
 import { findOAuthConnectionByClientId } from "../linear-oauth-connections.js";
 
+function sanitizeLogField(value: string | undefined): string {
+  return (value || "unknown").replace(/[\r\n\t]/g, "_").slice(0, 128);
+}
+
 /**
  * Register the Linear Agent SDK pre-auth routes (before auth middleware).
  * Includes the webhook (HMAC-SHA256 verified) and the OAuth callback
@@ -40,9 +44,9 @@ export function registerLinearAgentWebhookRoute(
       return c.json({ ok: true, ignored: true });
     }
 
-    const action = payload.action || "unknown";
-    const oauthClientId = payload.oauthClientId || "unknown";
-    const linearSessionId = payload.agentSession?.id || "unknown";
+    const action = sanitizeLogField(payload.action);
+    const oauthClientId = sanitizeLogField(payload.oauthClientId);
+    const linearSessionId = sanitizeLogField(payload.agentSession?.id);
 
     // Look up credentials: first try OAuth connection (new model), then inline (legacy)
     const oauthConn = payload.oauthClientId ? findOAuthConnectionByClientId(payload.oauthClientId) : null;


### PR DESCRIPTION
## Summary
- add explicit webhook diagnostics for accepted, rejected-signature, and missing-agent Linear agent events
- cover the new logging behavior in webhook route tests

## Why
- the recent `did not respond` failures were silent from Companion's perspective when the webhook was rejected before dispatch
- this makes the next failure diagnosable from server logs

## Testing
- cd web && bun run typecheck
- cd web && bun run test

## Review provenance
- Implemented by AI agent
- Human review: no