### PR TITLE
feat(security): add security headers and rate limiting middleware

### DIFF
--- a/web/server/index.ts
+++ b/web/server/index.ts
@@ -12,6 +12,8 @@ import { Hono } from "hono";
 import { cors } from "hono/cors";
 import { serveStatic } from "hono/bun";
 import { cacheControlMiddleware } from "./cache-headers.js";
+import { securityHeaders } from "./middleware/security-headers.js";
+import { rateLimit } from "./middleware/rate-limit.js";
 import { createRoutes } from "./routes.js";
 import { CliLauncher } from "./cli-launcher.js";
 import { WsBridge } from "./ws-bridge.js";
@@ -130,7 +132,15 @@ if (managedAuthEnabled) {
   console.log("[server] Managed auth disabled");
 }
 
+// Security headers on all responses
+app.use("/*", securityHeaders());
+
+// CORS for API routes
 app.use("/api/*", cors());
+
+// Rate limiting: 100 req/min for API, prevents abuse
+app.use("/api/*", rateLimit({ max: 100, windowMs: 60_000 }));
+
 app.route("/api", createRoutes(orchestrator, launcher, wsBridge, terminalManager, prPoller, recorder, cronScheduler, agentExecutor, linearAgentBridge, port));
 
 // Dynamic manifest — embeds auth token in start_url so PWA auto-authenticates

--- a/web/server/middleware/rate-limit.test.ts
+++ b/web/server/middleware/rate-limit.test.ts
@@ -1,0 +1,68 @@
+import { describe, it, expect } from "vitest";
+import { Hono } from "hono";
+import { rateLimit } from "./rate-limit.js";
+
+function createApp(max: number, windowMs: number) {
+  const app = new Hono();
+  app.use("/*", rateLimit({ max, windowMs }));
+  app.get("/test", (c) => c.text("ok"));
+  return app;
+}
+
+describe("rateLimit middleware", () => {
+  it("should_allow_requests_under_limit", async () => {
+    const app = createApp(5, 60_000);
+    const res = await app.request("/test");
+    expect(res.status).toBe(200);
+    expect(res.headers.get("X-RateLimit-Limit")).toBe("5");
+    expect(res.headers.get("X-RateLimit-Remaining")).toBe("4");
+  });
+
+  it("should_return_429_when_limit_exceeded", async () => {
+    const app = createApp(3, 60_000);
+
+    // Exhaust the limit
+    for (let i = 0; i < 3; i++) {
+      const res = await app.request("/test");
+      expect(res.status).toBe(200);
+    }
+
+    // Next request should be blocked
+    const res = await app.request("/test");
+    expect(res.status).toBe(429);
+    const body = await res.json();
+    expect(body.error).toBe("Too many requests");
+    expect(res.headers.get("Retry-After")).toBeTruthy();
+  });
+
+  it("should_set_rate_limit_headers_on_every_response", async () => {
+    const app = createApp(10, 60_000);
+    const res = await app.request("/test");
+    expect(res.headers.get("X-RateLimit-Limit")).toBe("10");
+    expect(res.headers.get("X-RateLimit-Remaining")).toBe("9");
+    expect(res.headers.get("X-RateLimit-Reset")).toBeTruthy();
+  });
+
+  it("should_decrement_remaining_count_with_each_request", async () => {
+    const app = createApp(5, 60_000);
+
+    const res1 = await app.request("/test");
+    expect(res1.headers.get("X-RateLimit-Remaining")).toBe("4");
+
+    const res2 = await app.request("/test");
+    expect(res2.headers.get("X-RateLimit-Remaining")).toBe("3");
+
+    const res3 = await app.request("/test");
+    expect(res3.headers.get("X-RateLimit-Remaining")).toBe("2");
+  });
+
+  it("should_show_zero_remaining_when_at_limit", async () => {
+    const app = createApp(2, 60_000);
+    await app.request("/test");
+    await app.request("/test");
+    // At limit but not over — next response from the 429 handler
+    const res = await app.request("/test");
+    expect(res.status).toBe(429);
+    expect(res.headers.get("X-RateLimit-Remaining")).toBe("0");
+  });
+});

--- a/web/server/middleware/rate-limit.test.ts
+++ b/web/server/middleware/rate-limit.test.ts
@@ -2,9 +2,9 @@ import { describe, it, expect } from "vitest";
 import { Hono } from "hono";
 import { rateLimit } from "./rate-limit.js";
 
-function createApp(max: number, windowMs: number) {
+function createApp(max: number, windowMs: number, trustProxy = false) {
   const app = new Hono();
-  app.use("/*", rateLimit({ max, windowMs }));
+  app.use("/*", rateLimit({ max, windowMs, trustProxy }));
   app.get("/test", (c) => c.text("ok"));
   return app;
 }
@@ -64,5 +64,54 @@ describe("rateLimit middleware", () => {
     const res = await app.request("/test");
     expect(res.status).toBe(429);
     expect(res.headers.get("X-RateLimit-Remaining")).toBe("0");
+  });
+
+  it("should_not_trust_x_forwarded_for_by_default", async () => {
+    const app = createApp(2, 60_000);
+
+    // Exhaust limit with 2 requests
+    await app.request("/test");
+    await app.request("/test");
+
+    // Spoofed X-Forwarded-For should NOT bypass rate limit when trustProxy is false
+    const res = await app.request("/test", {
+      headers: { "x-forwarded-for": "1.2.3.4" },
+    });
+    expect(res.status).toBe(429);
+  });
+
+  it("should_rate_limit_even_when_rotating_x_forwarded_for_values", async () => {
+    const app = createApp(2, 60_000);
+
+    // Each request uses a different spoofed X-Forwarded-For
+    await app.request("/test", {
+      headers: { "x-forwarded-for": "10.0.0.1" },
+    });
+    await app.request("/test", {
+      headers: { "x-forwarded-for": "10.0.0.2" },
+    });
+
+    // Should still be rate-limited because X-Forwarded-For is ignored
+    const res = await app.request("/test", {
+      headers: { "x-forwarded-for": "10.0.0.3" },
+    });
+    expect(res.status).toBe(429);
+  });
+
+  it("should_use_rightmost_ip_from_x_forwarded_for_when_trust_proxy_enabled", async () => {
+    const app = createApp(5, 60_000, true);
+
+    // X-Forwarded-For: <client>, <proxy1>, <proxy2>
+    // Rightmost (proxy2) should be used as the key
+    const res = await app.request("/test", {
+      headers: { "x-forwarded-for": "spoofed-client, 10.0.0.1, 192.168.1.1" },
+    });
+    expect(res.status).toBe(200);
+
+    // Same rightmost IP should decrement the same counter
+    const res2 = await app.request("/test", {
+      headers: { "x-forwarded-for": "different-client, 10.0.0.2, 192.168.1.1" },
+    });
+    expect(res2.headers.get("X-RateLimit-Remaining")).toBe("3");
   });
 });

--- a/web/server/middleware/rate-limit.ts
+++ b/web/server/middleware/rate-limit.ts
@@ -1,0 +1,84 @@
+import type { MiddlewareHandler } from "hono";
+
+interface RateLimitOptions {
+  /** Maximum requests allowed in the window */
+  max: number;
+  /** Time window in milliseconds */
+  windowMs: number;
+}
+
+interface RateLimitEntry {
+  count: number;
+  resetAt: number;
+}
+
+/**
+ * Simple in-memory rate limiter middleware for Hono.
+ *
+ * Uses IP-based tracking with automatic cleanup of expired entries.
+ * Suitable for single-instance deployments (Takumi-T use case).
+ *
+ * Returns 429 Too Many Requests when limit is exceeded.
+ */
+export function rateLimit(options: RateLimitOptions): MiddlewareHandler {
+  const { max, windowMs } = options;
+  const store = new Map<string, RateLimitEntry>();
+
+  // Periodic cleanup every 60 seconds to prevent memory leak
+  const cleanupInterval = setInterval(() => {
+    const now = Date.now();
+    for (const [key, entry] of store) {
+      if (now >= entry.resetAt) store.delete(key);
+    }
+  }, 60_000);
+
+  // Allow cleanup timer to not prevent process exit
+  if (cleanupInterval.unref) cleanupInterval.unref();
+
+  return async (c, next) => {
+    const ip = getClientIp(c) ?? "unknown";
+    const now = Date.now();
+
+    let entry = store.get(ip);
+    if (!entry || now >= entry.resetAt) {
+      entry = { count: 0, resetAt: now + windowMs };
+      store.set(ip, entry);
+    }
+
+    entry.count++;
+
+    // Set rate limit headers (RFC 6585 / draft-ietf-httpapi-ratelimit-headers)
+    c.header("X-RateLimit-Limit", String(max));
+    c.header("X-RateLimit-Remaining", String(Math.max(0, max - entry.count)));
+    c.header("X-RateLimit-Reset", String(Math.ceil(entry.resetAt / 1000)));
+
+    if (entry.count > max) {
+      c.header("Retry-After", String(Math.ceil((entry.resetAt - now) / 1000)));
+      return c.json({ error: "Too many requests" }, 429);
+    }
+
+    await next();
+  };
+}
+
+/** Extract client IP from request, considering reverse proxy headers. */
+function getClientIp(c: { req: { header: (name: string) => string | undefined }; env?: unknown }): string | undefined {
+  // Trust X-Forwarded-For from nginx reverse proxy
+  const forwarded = c.req.header("x-forwarded-for");
+  if (forwarded) return forwarded.split(",")[0].trim();
+
+  const realIp = c.req.header("x-real-ip");
+  if (realIp) return realIp;
+
+  // Bun server requestIP
+  const bunServer = c.env as { requestIP?: (req: Request) => { address: string } | null };
+  if (bunServer?.requestIP) {
+    const raw = (c as any).req?.raw;
+    if (raw) {
+      const ip = bunServer.requestIP(raw);
+      if (ip) return ip.address;
+    }
+  }
+
+  return undefined;
+}

--- a/web/server/middleware/rate-limit.ts
+++ b/web/server/middleware/rate-limit.ts
@@ -5,6 +5,12 @@ interface RateLimitOptions {
   max: number;
   /** Time window in milliseconds */
   windowMs: number;
+  /**
+   * Whether to trust proxy headers (X-Forwarded-For).
+   * Only enable this when running behind a trusted reverse proxy.
+   * Default: false
+   */
+  trustProxy?: boolean;
 }
 
 interface RateLimitEntry {
@@ -21,7 +27,7 @@ interface RateLimitEntry {
  * Returns 429 Too Many Requests when limit is exceeded.
  */
 export function rateLimit(options: RateLimitOptions): MiddlewareHandler {
-  const { max, windowMs } = options;
+  const { max, windowMs, trustProxy = false } = options;
   const store = new Map<string, RateLimitEntry>();
 
   // Periodic cleanup every 60 seconds to prevent memory leak
@@ -36,7 +42,7 @@ export function rateLimit(options: RateLimitOptions): MiddlewareHandler {
   if (cleanupInterval.unref) cleanupInterval.unref();
 
   return async (c, next) => {
-    const ip = getClientIp(c) ?? "unknown";
+    const ip = getClientIp(c, trustProxy) ?? "unknown";
     const now = Date.now();
 
     let entry = store.get(ip);
@@ -61,11 +67,26 @@ export function rateLimit(options: RateLimitOptions): MiddlewareHandler {
   };
 }
 
-/** Extract client IP from request, considering reverse proxy headers. */
-function getClientIp(c: { req: { header: (name: string) => string | undefined }; env?: unknown }): string | undefined {
-  // Trust X-Forwarded-For from nginx reverse proxy
-  const forwarded = c.req.header("x-forwarded-for");
-  if (forwarded) return forwarded.split(",")[0].trim();
+/**
+ * Extract client IP from request.
+ *
+ * When trustProxy is false (default), X-Forwarded-For is ignored to prevent
+ * IP spoofing. Only x-real-ip (typically set by a trusted reverse proxy at
+ * the network level) or the connection remote address are used.
+ *
+ * When trustProxy is true, the RIGHTMOST IP in X-Forwarded-For is used
+ * because it is the one appended by the closest trusted proxy, whereas the
+ * leftmost value is client-controlled and trivially spoofable.
+ */
+function getClientIp(c: { req: { header: (name: string) => string | undefined }; env?: unknown }, trustProxy: boolean): string | undefined {
+  if (trustProxy) {
+    const forwarded = c.req.header("x-forwarded-for");
+    if (forwarded) {
+      const parts = forwarded.split(",").map((s) => s.trim()).filter(Boolean);
+      // Rightmost IP is appended by the closest trusted proxy
+      return parts[parts.length - 1];
+    }
+  }
 
   const realIp = c.req.header("x-real-ip");
   if (realIp) return realIp;

--- a/web/server/middleware/security-headers.test.ts
+++ b/web/server/middleware/security-headers.test.ts
@@ -1,0 +1,64 @@
+import { describe, it, expect } from "vitest";
+import { Hono } from "hono";
+import { securityHeaders } from "./security-headers.js";
+
+function createApp() {
+  const app = new Hono();
+  app.use("/*", securityHeaders());
+  app.get("/test", (c) => c.text("ok"));
+  return app;
+}
+
+describe("securityHeaders middleware", () => {
+  it("should_set_x_content_type_options_when_responding", async () => {
+    const app = createApp();
+    const res = await app.request("/test");
+    expect(res.headers.get("X-Content-Type-Options")).toBe("nosniff");
+  });
+
+  it("should_set_x_frame_options_deny_when_responding", async () => {
+    const app = createApp();
+    const res = await app.request("/test");
+    expect(res.headers.get("X-Frame-Options")).toBe("DENY");
+  });
+
+  it("should_set_referrer_policy_when_responding", async () => {
+    const app = createApp();
+    const res = await app.request("/test");
+    expect(res.headers.get("Referrer-Policy")).toBe(
+      "strict-origin-when-cross-origin",
+    );
+  });
+
+  it("should_set_permissions_policy_when_responding", async () => {
+    const app = createApp();
+    const res = await app.request("/test");
+    expect(res.headers.get("Permissions-Policy")).toBe(
+      "camera=(), microphone=(), geolocation=(), payment=()",
+    );
+  });
+
+  it("should_set_csp_with_self_and_websocket_when_responding", async () => {
+    const app = createApp();
+    const res = await app.request("/test");
+    const csp = res.headers.get("Content-Security-Policy");
+    expect(csp).toContain("default-src 'self'");
+    expect(csp).toContain("connect-src 'self' ws: wss: blob:");
+    expect(csp).toContain("frame-ancestors 'none'");
+  });
+
+  it("should_set_hsts_when_request_is_https", async () => {
+    const app = createApp();
+    const res = await app.request("/test", {
+      headers: { "X-Forwarded-Proto": "https" },
+    });
+    const hsts = res.headers.get("Strict-Transport-Security");
+    expect(hsts).toBe("max-age=63072000; includeSubDomains; preload");
+  });
+
+  it("should_not_set_hsts_when_request_is_http", async () => {
+    const app = createApp();
+    const res = await app.request("http://localhost/test");
+    expect(res.headers.get("Strict-Transport-Security")).toBeNull();
+  });
+});

--- a/web/server/middleware/security-headers.ts
+++ b/web/server/middleware/security-headers.ts
@@ -1,0 +1,56 @@
+import type { MiddlewareHandler } from "hono";
+
+/**
+ * Hono middleware that sets security response headers on all responses.
+ *
+ * Headers follow OWASP recommendations and Shinkofa security standards.
+ * CSP uses a permissive policy suitable for a SPA with inline styles
+ * (Tailwind) and WebSocket connections. Tighten as needed.
+ */
+export function securityHeaders(): MiddlewareHandler {
+  return async (c, next) => {
+    await next();
+
+    // Prevent MIME-type sniffing
+    c.header("X-Content-Type-Options", "nosniff");
+
+    // Prevent clickjacking — DENY unless iframe embedding is needed
+    c.header("X-Frame-Options", "DENY");
+
+    // Control referrer information sent with requests
+    c.header("Referrer-Policy", "strict-origin-when-cross-origin");
+
+    // HSTS — enforce HTTPS for 2 years, include subdomains
+    // Only set when served over HTTPS (detected via X-Forwarded-Proto or direct TLS)
+    const proto = c.req.header("x-forwarded-proto") ?? "";
+    if (proto === "https" || c.req.url.startsWith("https://")) {
+      c.header(
+        "Strict-Transport-Security",
+        "max-age=63072000; includeSubDomains; preload",
+      );
+    }
+
+    // Restrict browser features the app doesn't need
+    c.header(
+      "Permissions-Policy",
+      "camera=(), microphone=(), geolocation=(), payment=()",
+    );
+
+    // Content-Security-Policy — permissive enough for SPA + WebSocket + inline styles
+    // 'unsafe-inline' for styles is required by Tailwind's runtime injection
+    // connect-src allows ws:/wss: for WebSocket and blob: for recordings
+    const csp = [
+      "default-src 'self'",
+      "script-src 'self'",
+      "style-src 'self' 'unsafe-inline'",
+      "img-src 'self' data: blob:",
+      "font-src 'self'",
+      "connect-src 'self' ws: wss: blob:",
+      "worker-src 'self' blob:",
+      "frame-ancestors 'none'",
+      "base-uri 'self'",
+      "form-action 'self'",
+    ].join("; ");
+    c.header("Content-Security-Policy", csp);
+  };
+}

--- a/web/server/middleware/security-headers.ts
+++ b/web/server/middleware/security-headers.ts
@@ -50,6 +50,7 @@ export function securityHeaders(): MiddlewareHandler {
       "frame-ancestors 'none'",
       "base-uri 'self'",
       "form-action 'self'",
+      "object-src 'none'",
     ].join("; ");
     c.header("Content-Security-Policy", csp);
   };


### PR DESCRIPTION
## Summary
The Companion currently serves no security headers on HTTP responses. This PR adds two Hono middlewares:

### Security headers (all responses)
| Header | Value |
|--------|-------|
| X-Content-Type-Options | `nosniff` |
| X-Frame-Options | `DENY` |
| Referrer-Policy | `strict-origin-when-cross-origin` |
| Permissions-Policy | `camera=(), microphone=(), geolocation=(), payment=()` |
| Content-Security-Policy | `default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; connect-src 'self' ws: wss: blob:; frame-ancestors 'none'` |
| Strict-Transport-Security | `max-age=63072000; includeSubDomains; preload` (HTTPS only) |

CSP allows `'unsafe-inline'` for styles (required by Tailwind) and `ws:/wss:` for WebSocket connections.

### Rate limiting (API routes)
- 100 requests/minute per IP (configurable)
- Standard `X-RateLimit-*` headers on every response
- `429 Too Many Requests` with `Retry-After` when exceeded
- In-memory store with periodic cleanup (suitable for single-instance deployment)

### Files added
- `web/server/middleware/security-headers.ts` + test (7 tests)
- `web/server/middleware/rate-limit.ts` + test (5 tests)
- `web/server/index.ts` — middleware registration (3 lines)

## Test plan
- [x] 12 new tests pass (7 security headers, 5 rate limiting)
- [x] Full test suite (205 files) still passes
- [x] TypeScript typecheck passes with 0 errors
- [x] Verified CSP does not break the SPA frontend (WebSocket, inline styles, blob URLs all allowed)

## Development methodology
This contribution was developed using MNK-GoRin, a structured AI-assisted
development methodology by [The Ermite](https://theermite.com). Each change
went through: audit → plan validation → test-driven generation → human review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)