### PR TITLE
fix(codex): handle unhandled Codex notification methods to prevent protocol drift warnings

### DIFF
--- a/web/server/codex-adapter.test.ts
+++ b/web/server/codex-adapter.test.ts
@@ -3802,6 +3802,7 @@ describe("CodexAdapter with ICodexTransport", () => {
     // log but NOT emit an error to the browser since Codex will retry.
     const { mock, messages } = await initAdapter();
     const warnSpy = vi.spyOn(log, "warn").mockImplementation(() => {});
+    const logSpy = vi.spyOn(console, "log").mockImplementation(() => {});
 
     mock.pushNotification("error", {
       error: {
@@ -3819,6 +3820,11 @@ describe("CodexAdapter with ICodexTransport", () => {
     const errors = messages.filter((m) => m.type === "error") as Array<{ message: string }>;
     expect(errors.length).toBe(0);
 
+    // Should log the transient error
+    expect(logSpy).toHaveBeenCalledWith(
+      expect.stringContaining("Codex transient error (will retry): Reconnecting... 2/5"),
+    );
+
     // Should NOT trigger protocol drift warning
     expect(warnSpy).not.toHaveBeenCalledWith(
       "protocol-monitor",
@@ -3826,6 +3832,7 @@ describe("CodexAdapter with ICodexTransport", () => {
       expect.objectContaining({ messageName: "error" }),
     );
     warnSpy.mockRestore();
+    logSpy.mockRestore();
   });
 
   it("handles bare 'error' notification with willRetry=false by emitting to browser", async () => {
@@ -3848,10 +3855,12 @@ describe("CodexAdapter with ICodexTransport", () => {
     expect(errors[0].message).toBe("Fatal stream error");
   });
 
-  it("accepts mcpServer/startupStatus/updated without protocol drift", async () => {
+  it("accepts mcpServer/startupStatus/updated without protocol drift and triggers MCP status refresh", async () => {
     // Codex v2 sends per-server MCP startup progress notifications.
-    const { mock } = await initAdapter();
+    // The handler should trigger a full MCP status refresh via handleOutgoingMcpGetStatus().
+    const { mock, adapter } = await initAdapter();
     const warnSpy = vi.spyOn(log, "warn").mockImplementation(() => {});
+    const mcpSpy = vi.spyOn(adapter as never as { handleOutgoingMcpGetStatus: () => Promise<void> }, "handleOutgoingMcpGetStatus").mockResolvedValue(undefined);
 
     mock.pushNotification("mcpServer/startupStatus/updated", {
       name: "linear",
@@ -3860,12 +3869,16 @@ describe("CodexAdapter with ICodexTransport", () => {
     });
     await new Promise((r) => setTimeout(r, 20));
 
+    // Should trigger MCP status refresh
+    expect(mcpSpy).toHaveBeenCalledTimes(1);
+
     expect(warnSpy).not.toHaveBeenCalledWith(
       "protocol-monitor",
       "Backend protocol drift detected",
       expect.objectContaining({ messageName: "mcpServer/startupStatus/updated" }),
     );
     warnSpy.mockRestore();
+    mcpSpy.mockRestore();
   });
 
   it("accepts informational notifications without protocol drift", async () => {

--- a/web/server/codex-adapter.test.ts
+++ b/web/server/codex-adapter.test.ts
@@ -3796,6 +3796,111 @@ describe("CodexAdapter with ICodexTransport", () => {
     expect(errors[0].message).toBe("something went wrong");
   });
 
+  it("handles bare 'error' notification with willRetry=true without emitting to browser", async () => {
+    // Codex sends bare "error" notifications for transient stream disconnections
+    // (e.g. "Reconnecting... 2/5"). When willRetry is true, the adapter should
+    // log but NOT emit an error to the browser since Codex will retry.
+    const { mock, messages } = await initAdapter();
+    const warnSpy = vi.spyOn(log, "warn").mockImplementation(() => {});
+
+    mock.pushNotification("error", {
+      error: {
+        message: "Reconnecting... 2/5",
+        codexErrorInfo: { responseStreamDisconnected: { httpStatusCode: null } },
+        additionalDetails: "stream disconnected before completion",
+      },
+      willRetry: true,
+      threadId: "thr_123",
+      turnId: "turn_456",
+    });
+    await new Promise((r) => setTimeout(r, 20));
+
+    // Should NOT emit error to browser
+    const errors = messages.filter((m) => m.type === "error") as Array<{ message: string }>;
+    expect(errors.length).toBe(0);
+
+    // Should NOT trigger protocol drift warning
+    expect(warnSpy).not.toHaveBeenCalledWith(
+      "protocol-monitor",
+      "Backend protocol drift detected",
+      expect.objectContaining({ messageName: "error" }),
+    );
+    warnSpy.mockRestore();
+  });
+
+  it("handles bare 'error' notification with willRetry=false by emitting to browser", async () => {
+    // When willRetry is false/absent, the error is final and should be shown.
+    const { mock, messages } = await initAdapter();
+
+    mock.pushNotification("error", {
+      error: {
+        message: "Fatal stream error",
+        additionalDetails: "connection terminated",
+      },
+      willRetry: false,
+      threadId: "thr_123",
+      turnId: "turn_456",
+    });
+    await new Promise((r) => setTimeout(r, 20));
+
+    const errors = messages.filter((m) => m.type === "error") as Array<{ message: string }>;
+    expect(errors.length).toBe(1);
+    expect(errors[0].message).toBe("Fatal stream error");
+  });
+
+  it("accepts mcpServer/startupStatus/updated without protocol drift", async () => {
+    // Codex v2 sends per-server MCP startup progress notifications.
+    const { mock } = await initAdapter();
+    const warnSpy = vi.spyOn(log, "warn").mockImplementation(() => {});
+
+    mock.pushNotification("mcpServer/startupStatus/updated", {
+      name: "linear",
+      status: "starting",
+      error: null,
+    });
+    await new Promise((r) => setTimeout(r, 20));
+
+    expect(warnSpy).not.toHaveBeenCalledWith(
+      "protocol-monitor",
+      "Backend protocol drift detected",
+      expect.objectContaining({ messageName: "mcpServer/startupStatus/updated" }),
+    );
+    warnSpy.mockRestore();
+  });
+
+  it("accepts informational notifications without protocol drift", async () => {
+    // configWarning, deprecationNotice, thread/compacted, and legacy event
+    // variants should be silently accepted without triggering drift warnings.
+    const { mock } = await initAdapter();
+    const warnSpy = vi.spyOn(log, "warn").mockImplementation(() => {});
+
+    const infoNotifications = [
+      { method: "configWarning", params: { summary: "Project config disabled" } },
+      { method: "deprecationNotice", params: { summary: "collab is deprecated" } },
+      { method: "codex/event/deprecation_notice", params: { msg: { type: "deprecation_notice" } } },
+      { method: "thread/compacted", params: { threadId: "thr_1", turnId: "turn_1" } },
+      { method: "codex/event/mcp_startup_update", params: { msg: { type: "mcp_startup_update" } } },
+      { method: "codex/event/turn_aborted", params: { msg: { type: "turn_aborted" } } },
+      { method: "codex/event/view_image_tool_call", params: { msg: { type: "view_image_tool_call" } } },
+      { method: "codex/event/web_search_begin", params: { msg: { type: "web_search_begin" } } },
+      { method: "codex/event/web_search_end", params: { msg: { type: "web_search_end" } } },
+    ];
+
+    for (const n of infoNotifications) {
+      mock.pushNotification(n.method, n.params);
+    }
+    await new Promise((r) => setTimeout(r, 20));
+
+    for (const n of infoNotifications) {
+      expect(warnSpy).not.toHaveBeenCalledWith(
+        "protocol-monitor",
+        "Backend protocol drift detected",
+        expect.objectContaining({ messageName: n.method }),
+      );
+    }
+    warnSpy.mockRestore();
+  });
+
   it("handles codex/event/token_count without protocol drift and updates token usage", async () => {
     const { mock, messages } = await initAdapter();
     const warnSpy = vi.spyOn(log, "warn").mockImplementation(() => {});

--- a/web/server/codex-adapter.ts
+++ b/web/server/codex-adapter.ts
@@ -1659,6 +1659,41 @@ export class CodexAdapter implements IBackendAdapter {
         }
         break;
       }
+      // Bare "error" notification — Codex sends this for transient stream
+      // disconnections and retries (e.g. "Reconnecting... 2/5").
+      case "error": {
+        const errObj = params.error as { message?: string; additionalDetails?: string } | undefined;
+        const willRetry = params.willRetry as boolean | undefined;
+        const message = errObj?.message || errObj?.additionalDetails || "Unknown Codex error";
+        if (willRetry) {
+          console.log(`[codex-adapter] Codex transient error (will retry): ${message}`);
+        } else {
+          console.error(`[codex-adapter] Codex error: ${message}`);
+          this.emit({ type: "error", message });
+        }
+        break;
+      }
+      // MCP server startup progress — Codex v2 reports per-server status as
+      // they initialise. Trigger a full mcp_get_status refresh so the browser
+      // sees up-to-date server states.
+      case "mcpServer/startupStatus/updated":
+        this.handleOutgoingMcpGetStatus();
+        break;
+      // Context compaction — similar to codex/event/context_compacted.
+      case "thread/compacted":
+        break;
+      // Informational: config or deprecation warnings from Codex runtime.
+      case "configWarning":
+      case "deprecationNotice":
+      case "codex/event/deprecation_notice":
+        break;
+      // Legacy event variants already covered by canonical item/* handlers.
+      case "codex/event/mcp_startup_update":
+      case "codex/event/turn_aborted":
+      case "codex/event/view_image_tool_call":
+      case "codex/event/web_search_begin":
+      case "codex/event/web_search_end":
+        break;
       case "companion/wsReconnected":
         this.handleWsReconnected();
         break;

--- a/web/server/codex-protocol-drift.test.ts
+++ b/web/server/codex-protocol-drift.test.ts
@@ -74,6 +74,22 @@ describe("Codex adapter method drift vs upstream protocol snapshot", () => {
       "codex/event/agent_reasoning",
       "codex/event/agent_reasoning_delta",
       "codex/event/agent_reasoning_section_break",
+      // Bare "error" notification for transient stream disconnections.
+      "error",
+      // Per-server MCP startup progress updates.
+      "mcpServer/startupStatus/updated",
+      // Context compaction event (v2 form of codex/event/context_compacted).
+      "thread/compacted",
+      // Informational warnings from Codex runtime.
+      "configWarning",
+      "deprecationNotice",
+      "codex/event/deprecation_notice",
+      // Legacy event variants for MCP startup, turn abort, image viewing, web search.
+      "codex/event/mcp_startup_update",
+      "codex/event/turn_aborted",
+      "codex/event/view_image_tool_call",
+      "codex/event/web_search_begin",
+      "codex/event/web_search_end",
       // Companion-internal notification emitted by codex-ws-proxy.cjs on
       // WebSocket reconnection — not part of the upstream Codex protocol.
       "companion/wsReconnected",


### PR DESCRIPTION
## Summary
- Handle 10 previously unhandled Codex JSON-RPC notification methods that were triggering false "protocol drift" warnings in the UI
- Bare `"error"` notifications (transient stream disconnections like "Reconnecting... 2/5") are now handled gracefully — logged silently when `willRetry` is true, emitted to browser when false
- `mcpServer/startupStatus/updated` triggers MCP status refresh so the browser sees live server states
- Informational notifications (`configWarning`, `deprecationNotice`, `thread/compacted`) and legacy event variants silently accepted

## Why
- Session 785f9d94 was showing "Codex protocol drift: unsupported incoming notification 'error'" because Codex sends bare `error` notifications for transient reconnections, which weren't handled in the adapter switch
- Multiple other notification methods observed in production logs were also unhandled

## Testing
- 4 new test cases: bare error with/without retry, mcpServer startup status, all informational notifications
- Updated protocol drift snapshot test allowlist
- All 4915 tests pass, typecheck clean

## Review provenance
- Investigated and implemented by AI agent (Claude Opus 4.6)
- Human review: no
