### PR TITLE
fix(ws-bridge): broadcast permissionMode changes from CLI to browsers

### DIFF
--- a/web/server/ws-bridge.test.ts
+++ b/web/server/ws-bridge.test.ts
@@ -786,6 +786,37 @@ describe("CLI handlers", () => {
     expect(permUpdates).toHaveLength(0);
   });
 
+  it("handleCLIMessage: system.status broadcasts session_update on plan→default (ExitPlanMode scenario)", async () => {
+    // Regression test for the exact bug: after ExitPlanMode approval, the CLI
+    // sends system.status with permissionMode:"default" but the browser was
+    // never notified, leaving the plan toggle stuck.
+    const cli = makeCliSocket("s1");
+    const browser = makeBrowserSocket("s1");
+    bridge.handleCLIOpen(cli, "s1");
+    bridge.handleBrowserOpen(browser, "s1");
+
+    // First put the session into plan mode
+    await bridge.handleCLIMessage(cli, JSON.stringify({
+      type: "system", subtype: "status", status: "idle",
+      permissionMode: "plan", uuid: "uuid-plan", session_id: "s1",
+    }));
+    expect(bridge.getSession("s1")!.state.permissionMode).toBe("plan");
+    browser.send.mockClear();
+
+    // CLI exits plan mode (ExitPlanMode scenario)
+    await bridge.handleCLIMessage(cli, JSON.stringify({
+      type: "system", subtype: "status", status: "idle",
+      permissionMode: "default", uuid: "uuid-exit-plan", session_id: "s1",
+    }));
+
+    const calls = browser.send.mock.calls.map(([arg]: [string]) => JSON.parse(arg));
+    expect(calls).toContainEqual(expect.objectContaining({
+      type: "session_update",
+      session: expect.objectContaining({ permissionMode: "default" }),
+    }));
+    expect(bridge.getSession("s1")!.state.permissionMode).toBe("default");
+  });
+
   it("handleCLIMessage: forwards compact_boundary as system_event and persists it", async () => {
     const cli = makeCliSocket("s1");
     const browser = makeBrowserSocket("s1");

--- a/web/server/ws-bridge.test.ts
+++ b/web/server/ws-bridge.test.ts
@@ -751,6 +751,39 @@ describe("CLI handlers", () => {
 
     const calls = browser.send.mock.calls.map(([arg]: [string]) => JSON.parse(arg));
     expect(calls).toContainEqual(expect.objectContaining({ type: "status_change", status: "compacting" }));
+    // When the CLI changes permissionMode via system.status, the server should
+    // broadcast a session_update so browsers sync their UI (e.g. plan toggle).
+    expect(calls).toContainEqual(expect.objectContaining({
+      type: "session_update",
+      session: expect.objectContaining({ permissionMode: "plan" }),
+    }));
+  });
+
+  it("handleCLIMessage: system.status does NOT broadcast session_update when permissionMode unchanged", async () => {
+    // Pre-set the session to "default" mode, then send a status with the same mode.
+    const cli = makeCliSocket("s1");
+    const browser = makeBrowserSocket("s1");
+    bridge.handleCLIOpen(cli, "s1");
+    bridge.handleBrowserOpen(browser, "s1");
+    browser.send.mockClear();
+
+    const statusMsg = JSON.stringify({
+      type: "system",
+      subtype: "status",
+      status: "idle",
+      permissionMode: "default",
+      uuid: "uuid-3",
+      session_id: "s1",
+    });
+
+    await bridge.handleCLIMessage(cli, statusMsg);
+
+    const calls = browser.send.mock.calls.map(([arg]: [string]) => JSON.parse(arg));
+    // Should NOT have a session_update for permissionMode since it didn't change.
+    const permUpdates = calls.filter(
+      (c: Record<string, unknown>) => c.type === "session_update" && (c.session as Record<string, unknown>)?.permissionMode,
+    );
+    expect(permUpdates).toHaveLength(0);
   });
 
   it("handleCLIMessage: forwards compact_boundary as system_event and persists it", async () => {

--- a/web/server/ws-bridge.ts
+++ b/web/server/ws-bridge.ts
@@ -466,10 +466,16 @@ export class WsBridge {
         } else {
           session.stateMachine.transition("ready", "compaction_ended");
         }
-        // Claude status messages may include permissionMode (not in the typed interface)
+        // Claude status messages may include permissionMode (not in the typed interface).
+        // When the CLI changes mode autonomously (e.g. after ExitPlanMode approval),
+        // we must broadcast the update so browsers sync their UI (plan toggle, etc.).
         const permMode = (msg as unknown as { permissionMode?: string }).permissionMode;
-        if (permMode) {
+        if (permMode && permMode !== session.state.permissionMode) {
           session.state.permissionMode = permMode;
+          this.broadcastToBrowsers(session, {
+            type: "session_update",
+            session: { permissionMode: permMode },
+          });
         }
         this.persistSession(session);
       }


### PR DESCRIPTION
## Summary
- When the CLI exits plan mode autonomously (after ExitPlanMode tool approval), it reports the new `permissionMode` in its `system.status` message
- The server was updating internal state but **never broadcasting** a `session_update` to connected browsers
- This left the browser UI out of sync: the plan toggle stayed active, and a redundant `set_permission_mode` was sent ~97s later
- Now we broadcast `session_update` only when the CLI-reported mode actually differs from current session state

## Root cause analysis (session `a839816e`)
1. User approves ExitPlanMode → CLI auto-exits plan mode → sends `system.status` with `permissionMode: "default"`
2. Server updates `session.state.permissionMode` but doesn't tell the browser
3. Browser still thinks it's in plan mode → later sends redundant `set_permission_mode` to `"default"`
4. Meanwhile, user sends a message but the CLI takes ~3.6 min to respond (separate CLI-side issue)

## Testing
- Updated existing test to verify `session_update` is broadcast on mode change
- Added new test: no `session_update` when mode is unchanged (avoids unnecessary chatter)
- Typecheck passes (`tsc --noEmit`)

## Review provenance
- Implemented by AI agent
- Human review: no
