### PR TITLE
fix(composer): ignore keyboard events during IME composition

### DIFF
--- a/web/src/components/Composer.test.tsx
+++ b/web/src/components/Composer.test.tsx
@@ -189,6 +189,24 @@ describe("Composer sending messages", () => {
     }));
   });
 
+  it("pressing Enter during IME composition does NOT send the message", () => {
+    // When using CJK input methods (Chinese/Japanese/Korean), pressing Enter
+    // confirms the raw input instead of sending. The keydown event fires with
+    // isComposing=true in this case and should be ignored.
+    const { container } = render(<Composer sessionId="s1" />);
+    const textarea = container.querySelector("textarea")!;
+
+    fireEvent.change(textarea, { target: { value: "abc" } });
+    fireEvent.keyDown(textarea, {
+      key: "Enter",
+      shiftKey: false,
+      nativeEvent: { isComposing: true },
+      isComposing: true,
+    });
+
+    expect(mockSendToSession).not.toHaveBeenCalled();
+  });
+
   it("pressing Shift+Enter does NOT send the message", () => {
     const { container } = render(<Composer sessionId="s1" />);
     const textarea = container.querySelector("textarea")!;

--- a/web/src/components/Composer.tsx
+++ b/web/src/components/Composer.tsx
@@ -165,6 +165,9 @@ export function Composer({ sessionId }: { sessionId: string }) {
   }
 
   function handleKeyDown(e: React.KeyboardEvent) {
+    // Ignore key events during IME composition (e.g. Chinese/Japanese/Korean input)
+    if (e.nativeEvent.isComposing) return;
+
     // Slash menu navigation
     if (slashMenuOpen && filteredCommands.length > 0) {
       if (e.key === "ArrowDown") {


### PR DESCRIPTION
## Summary
- When using CJK input methods (Chinese/Japanese/Korean), pressing Enter to confirm raw alphabetic input was incorrectly triggering the message send action
- Added an `isComposing` guard at the top of `handleKeyDown` in `Composer.tsx` so all keyboard events during IME composition are properly ignored

## Why
- CJK users frequently press Enter to commit raw English letters from the IME candidate window. Without the composing check, this Enter keystroke was intercepted as "send message", making it impossible to type English text while an IME is active.

## Testing
- Added a test case verifying that Enter during IME composition does not send the message
- All 4940 existing tests pass, typecheck clean

## Review provenance
- Implemented by AI agent
- Human review: no
