### PR TITLE
feat(composer): add configurable send message keyboard shortcut

### DIFF
--- a/web/src/components/Composer.test.tsx
+++ b/web/src/components/Composer.test.tsx
@@ -115,6 +115,7 @@ function setupMockStore(overrides: {
     setSdkSessions: vi.fn(),
     promptSuggestions: new Map<string, string[]>(),
     clearPromptSuggestions: mockClearPromptSuggestions,
+    sendKey: "Enter",
   };
 }
 
@@ -220,6 +221,34 @@ describe("Composer sending messages", () => {
     fireEvent.keyDown(textarea, { key: "Enter", shiftKey: false });
 
     expect(textarea.value).toBe("");
+  });
+
+  it("respects sendKey=Ctrl+Enter — plain Enter does not send", () => {
+    // When sendKey is Ctrl+Enter, plain Enter should not send the message.
+    mockStoreState.sendKey = "Ctrl+Enter";
+    const { container } = render(<Composer sessionId="s1" />);
+    const textarea = container.querySelector("textarea")!;
+
+    fireEvent.change(textarea, { target: { value: "test message" } });
+    fireEvent.keyDown(textarea, { key: "Enter", shiftKey: false, ctrlKey: false });
+
+    expect(mockSendToSession).not.toHaveBeenCalled();
+    mockStoreState.sendKey = "Enter";
+  });
+
+  it("respects sendKey=Ctrl+Enter — Ctrl+Enter sends the message", () => {
+    mockStoreState.sendKey = "Ctrl+Enter";
+    const { container } = render(<Composer sessionId="s1" />);
+    const textarea = container.querySelector("textarea")!;
+
+    fireEvent.change(textarea, { target: { value: "test message" } });
+    fireEvent.keyDown(textarea, { key: "Enter", shiftKey: false, ctrlKey: true });
+
+    expect(mockSendToSession).toHaveBeenCalledWith("s1", expect.objectContaining({
+      type: "user_message",
+      content: "test message",
+    }));
+    mockStoreState.sendKey = "Enter";
   });
 });
 

--- a/web/src/components/Composer.tsx
+++ b/web/src/components/Composer.tsx
@@ -42,6 +42,7 @@ export function Composer({ sessionId }: { sessionId: string }) {
   const isCodex = sessionData?.backend_type === "codex";
   const modes: ModeOption[] = isCodex ? CODEX_MODES : CLAUDE_MODES;
   const modeLabel = modes.find((m) => m.value === currentMode)?.label?.toLowerCase() || currentMode;
+  const sendKey = useStore((s) => s.sendKey);
 
   const mention = useMentionMenu({
     text,
@@ -234,9 +235,21 @@ export function Composer({ sessionId }: { sessionId: string }) {
       toggleMode();
       return;
     }
-    if (e.key === "Enter" && !e.shiftKey) {
-      e.preventDefault();
-      handleSend();
+    if (e.key === "Enter") {
+      const modifier = e.metaKey || e.ctrlKey ? "Cmd" : e.shiftKey ? "Shift" : null;
+      if (sendKey === "Enter" && !modifier) {
+        e.preventDefault();
+        handleSend();
+      } else if (sendKey === "Cmd+Enter" && (e.metaKey || e.ctrlKey)) {
+        e.preventDefault();
+        handleSend();
+      } else if (sendKey === "Ctrl+Enter" && e.ctrlKey) {
+        e.preventDefault();
+        handleSend();
+      } else if (sendKey === "Shift+Enter" && e.shiftKey) {
+        e.preventDefault();
+        handleSend();
+      }
     }
   }
 
@@ -622,7 +635,7 @@ export function Composer({ sessionId }: { sessionId: string }) {
               onPaste={handlePaste}
               aria-label="Message input"
               placeholder={isConnected
-                ? "Type a message... (/ + @)"
+                ? `Type a message... (${sendKey === "Enter" ? "Enter" : sendKey} to send)`
                 : "Waiting for CLI connection..."}
               disabled={!isConnected}
               rows={1}

--- a/web/src/components/Composer.tsx
+++ b/web/src/components/Composer.tsx
@@ -240,7 +240,7 @@ export function Composer({ sessionId }: { sessionId: string }) {
       if (sendKey === "Enter" && !modifier) {
         e.preventDefault();
         handleSend();
-      } else if (sendKey === "Cmd+Enter" && (e.metaKey || e.ctrlKey)) {
+      } else if (sendKey === "Cmd+Enter" && e.metaKey) {
         e.preventDefault();
         handleSend();
       } else if (sendKey === "Ctrl+Enter" && e.ctrlKey) {

--- a/web/src/components/SettingsPage.test.tsx
+++ b/web/src/components/SettingsPage.test.tsx
@@ -34,6 +34,8 @@ interface MockStoreState {
   setUpdateInfo: ReturnType<typeof vi.fn>;
   setUpdateOverlayActive: ReturnType<typeof vi.fn>;
   setEditorTabEnabled: ReturnType<typeof vi.fn>;
+  sendKey: string;
+  setSendKey: ReturnType<typeof vi.fn>;
 }
 
 let mockState: MockStoreState;
@@ -54,6 +56,8 @@ function createMockState(overrides: Partial<MockStoreState> = {}): MockStoreStat
     setUpdateInfo: vi.fn(),
     setUpdateOverlayActive: vi.fn(),
     setEditorTabEnabled: vi.fn(),
+    sendKey: "Enter",
+    setSendKey: vi.fn(),
     ...overrides,
   };
 }
@@ -1037,6 +1041,46 @@ describe("SettingsPage", () => {
 
     const toggle = screen.getByRole("switch", { name: "" });
     expect(toggle).toHaveAttribute("aria-checked", "true");
+  });
+
+  // ─── Send key toggle tests ──────────────────────────────────
+
+  // The "Send message" toggle button in the General section cycles through
+  // the send key options when clicked and calls setSendKey with the next value.
+  it("cycles send key option when Send message button is clicked", async () => {
+    render(<SettingsPage />);
+    await screen.findByText("Anthropic key configured");
+
+    // Default is "Enter", clicking should cycle to "Cmd+Enter"
+    fireEvent.click(screen.getByRole("button", { name: /Send message/i }));
+    expect(mockState.setSendKey).toHaveBeenCalledWith("Cmd+Enter");
+  });
+
+  // When sendKey is "Shift+Enter" (last option), clicking wraps back to "Enter".
+  it("wraps send key back to Enter after Shift+Enter", async () => {
+    mockState = createMockState({ sendKey: "Shift+Enter" });
+    render(<SettingsPage />);
+    await screen.findByText("Anthropic key configured");
+
+    fireEvent.click(screen.getByRole("button", { name: /Send message/i }));
+    expect(mockState.setSendKey).toHaveBeenCalledWith("Enter");
+  });
+
+  // The description text changes based on the current send key setting.
+  it("shows Enter-specific description when sendKey is Enter", async () => {
+    render(<SettingsPage />);
+    await screen.findByText("Anthropic key configured");
+
+    expect(screen.getByText("Press Enter to send. Shift+Enter for new line.")).toBeInTheDocument();
+  });
+
+  // When sendKey is not "Enter", the description shows the modifier key.
+  it("shows modifier description when sendKey is Ctrl+Enter", async () => {
+    mockState = createMockState({ sendKey: "Ctrl+Enter" });
+    render(<SettingsPage />);
+    await screen.findByText("Anthropic key configured");
+
+    expect(screen.getByText("Press Ctrl+Enter to send. Enter for new line.")).toBeInTheDocument();
   });
 
   // ─── Webhooks section tests ──────────────────────────────────

--- a/web/src/components/SettingsPage.tsx
+++ b/web/src/components/SettingsPage.tsx
@@ -35,6 +35,8 @@ export function SettingsPage({ embedded = false }: SettingsPageProps) {
   const toggleDarkMode = useStore((s) => s.toggleDarkMode);
   const diffBase = useStore((s) => s.diffBase);
   const setDiffBase = useStore((s) => s.setDiffBase);
+  const sendKey = useStore((s) => s.sendKey);
+  const setSendKey = useStore((s) => s.setSendKey);
   const notificationSound = useStore((s) => s.notificationSound);
   const toggleNotificationSound = useStore((s) => s.toggleNotificationSound);
   const notificationDesktop = useStore((s) => s.notificationDesktop);
@@ -339,6 +341,24 @@ export function SettingsPage({ embedded = false }: SettingsPageProps) {
                 </button>
                 <p className="text-xs text-cc-muted px-1">
                   Last commit shows only uncommitted changes. Default branch shows all changes since diverging from main.
+                </p>
+
+                <button
+                  type="button"
+                  onClick={() => {
+                    const options: string[] = ["Enter", "Cmd+Enter", "Ctrl+Enter", "Shift+Enter"];
+                    const next = options[(options.indexOf(sendKey) + 1) % options.length];
+                    setSendKey(next as typeof sendKey);
+                  }}
+                  className="w-full flex items-center justify-between px-3 py-3 min-h-[44px] rounded-lg text-sm bg-cc-hover text-cc-fg hover:bg-cc-active transition-colors cursor-pointer"
+                >
+                  <span>Send message</span>
+                  <span className="text-xs text-cc-muted font-mono-code">{sendKey}</span>
+                </button>
+                <p className="text-xs text-cc-muted px-1">
+                  {sendKey === "Enter"
+                    ? "Press Enter to send. Shift+Enter for new line."
+                    : `Press ${sendKey} to send. Enter for new line.`}
                 </p>
               </div>
             </section>

--- a/web/src/store/ui-slice.ts
+++ b/web/src/store/ui-slice.ts
@@ -2,6 +2,7 @@ import type { StateCreator } from "zustand";
 import type { AppState } from "./index.js";
 
 export type DiffBase = "last-commit" | "default-branch";
+export type SendKey = "Enter" | "Ctrl+Enter" | "Shift+Enter" | "Cmd+Enter";
 import { type TaskPanelConfig, getInitialTaskPanelConfig, getDefaultConfig, persistTaskPanelConfig } from "../components/task-panel-sections.js";
 
 function getInitialDarkMode(): boolean {
@@ -25,6 +26,15 @@ function getInitialNotificationDesktop(): boolean {
   return false;
 }
 
+const VALID_SEND_KEYS = new Set<string>(["Enter", "Ctrl+Enter", "Shift+Enter", "Cmd+Enter"]);
+
+function getInitialSendKey(): SendKey {
+  if (typeof window === "undefined") return "Enter";
+  const stored = localStorage.getItem("cc-send-key");
+  if (stored && VALID_SEND_KEYS.has(stored)) return stored as SendKey;
+  return "Enter";
+}
+
 export function getInitialDiffBase(): DiffBase {
   if (typeof window === "undefined") return "last-commit";
   const stored = window.localStorage.getItem("cc-diff-base");
@@ -46,6 +56,7 @@ export interface UiSlice {
   chatTabReentryTickBySession: Map<string, number>;
   diffPanelSelectedFile: Map<string, string>;
   diffBase: DiffBase;
+  sendKey: SendKey;
 
   setDarkMode: (v: boolean) => void;
   toggleDarkMode: () => void;
@@ -66,6 +77,7 @@ export interface UiSlice {
   markChatTabReentry: (sessionId: string) => void;
   setDiffPanelSelectedFile: (sessionId: string, filePath: string | null) => void;
   setDiffBase: (base: DiffBase) => void;
+  setSendKey: (key: SendKey) => void;
 }
 
 export const createUiSlice: StateCreator<AppState, [], [], UiSlice> = (set) => ({
@@ -82,6 +94,7 @@ export const createUiSlice: StateCreator<AppState, [], [], UiSlice> = (set) => (
   chatTabReentryTickBySession: new Map(),
   diffPanelSelectedFile: new Map(),
   diffBase: getInitialDiffBase(),
+  sendKey: getInitialSendKey(),
 
   setDarkMode: (v) => {
     localStorage.setItem("cc-dark-mode", String(v));
@@ -182,5 +195,11 @@ export const createUiSlice: StateCreator<AppState, [], [], UiSlice> = (set) => (
       localStorage.setItem("cc-diff-base", base);
     }
     set({ diffBase: base });
+  },
+  setSendKey: (key) => {
+    if (typeof window !== "undefined") {
+      localStorage.setItem("cc-send-key", key);
+    }
+    set({ sendKey: key });
   },
 });


### PR DESCRIPTION
## Summary
- Add configurable "Send message" keyboard shortcut in Settings > General
- Options: Enter (default), Cmd+Enter, Ctrl+Enter, Shift+Enter
- Persisted to localStorage, Composer placeholder shows active shortcut
- Added tests for the send key toggle button in SettingsPage

## Why
Some users prefer Ctrl+Enter to send (freeing Enter for newlines), a common pattern in Slack, Discord, and other chat apps.

## Testing
- `cd web && bun run typecheck` — pass
- `cd web && bun run test` — 4945/4945 pass
- Added 6 new tests: 2 for Composer Ctrl+Enter mode, 4 for SettingsPage send key toggle

## Review provenance
- Implemented by AI agent
- Human review: no
