### PR TITLE
feat(web): add Claude Opus 4.7 to model list

### DIFF
--- a/web/src/utils/backends.ts
+++ b/web/src/utils/backends.ts
@@ -40,6 +40,7 @@ export function toModelOptions(models: BackendModelInfo[]): ModelOption[] {
 // ─── Static fallbacks ────────────────────────────────────────────────────────
 
 export const CLAUDE_MODELS: ModelOption[] = [
+  { value: "claude-opus-4-7", label: "Opus 4.7", icon: "" },
   { value: "claude-opus-4-6", label: "Opus 4.6", icon: "" },
   { value: "claude-sonnet-4-6", label: "Sonnet 4.6", icon: "" },
   { value: "claude-haiku-4-5-20251001", label: "Haiku 4.5", icon: "" },


### PR DESCRIPTION
## Summary

Anthropic released **Claude Opus 4.7** (`claude-opus-4-7`) on 2026-04-16, but the static `CLAUDE_MODELS` fallback in `web/src/utils/backends.ts` still tops out at Opus 4.6. This PR adds the new model as the first entry so it becomes the default selection for Claude backends when the dynamic model list is unavailable.

## Changes

- `web/src/utils/backends.ts` — prepend `{ value: "claude-opus-4-7", label: "Opus 4.7", icon: "" }` to `CLAUDE_MODELS`.

```diff
 export const CLAUDE_MODELS: ModelOption[] = [
+  { value: "claude-opus-4-7", label: "Opus 4.7", icon: "" },
   { value: "claude-opus-4-6", label: "Opus 4.6", icon: "" },
   { value: "claude-sonnet-4-6", label: "Sonnet 4.6", icon: "" },
   { value: "claude-haiku-4-5-20251001", label: "Haiku 4.5", icon: "" },
 ];
```

## Notes

- The label follows the existing convention used for Opus/Sonnet 4.6 (no dated suffix); only Haiku keeps the dated alias because that's how the published model ID is spelled.
- This only touches the static fallback. `toModelOptions()` + dynamic `BackendModelInfo` fetching paths are untouched, so any backend that already reports 4.7 will continue to override the fallback as before.
- `getDefaultModel()` transparently picks up the new entry because it returns `CLAUDE_MODELS[0].value`.
- Test fixtures referencing older Opus IDs were intentionally left alone to avoid unrelated churn.

## Test plan

- [ ] `bun test` (Claude backend tests) still passes with the new entry
- [ ] Frontend `ModelSwitcher` renders "Opus 4.7" as the top option for the Claude backend
- [ ] New Claude sessions default to `claude-opus-4-7` when no dynamic list is available