### PR TITLE
fix(dashboard): keep Fly dashboard tailnet-only

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,6 +1,8 @@
 fly.*.toml
 bin/__pycache__/
-.companion/
+.companion/*
+!.companion/generated/
+!.companion/generated/fleet.json
 archived/
 .env
 /companion

--- a/README.md
+++ b/README.md
@@ -359,7 +359,7 @@ cpus = 1
 tailscale_serve = true
 ```
 
-`companion apply` then deploys the dashboard as a tiny, stateless Fly app (smallest machine, no volume, scales to zero when idle) that holds read-only Fly/Tailscale tokens as Fly secrets and polls the fleet on a timer. The set of services and URLs it polls is a non-secret topology manifest (`.companion/generated/fleet.json`) that apply keeps in sync: `dashboard_config.main` carries the topology fingerprint, so adding or changing an agent and re-applying redeploys the dashboard with the refreshed targets — no manual rebuild. This mirrors how `openwebui_config.main` keeps Open WebUI's backend URLs current.
+`companion apply` then deploys the dashboard as a tiny, stateless Fly app (smallest machine, no volume, no public Fly HTTP service) that holds read-only Fly/Tailscale tokens as Fly secrets and polls the fleet on a timer. The set of services and URLs it polls is a non-secret topology manifest (`.companion/generated/fleet.json`) that apply keeps in sync: `dashboard_config.main` carries the topology fingerprint, so adding or changing an agent and re-applying redeploys the dashboard with the refreshed targets — no manual rebuild. This mirrors how `openwebui_config.main` keeps Open WebUI's backend URLs current.
 
 The deployed image is built from `Dockerfile.dashboard` (the `companion` binary + Tailscale + `fleet.json`). To run it on your own server instead, `git clone` the repo and `go build ./cmd/companion`, then run `companion dashboard --manifest <fleet.json>` with `FLY_API_TOKEN`/`TAILSCALE_API_KEY` in the environment.
 

--- a/examples/minimal/dashboard.toml
+++ b/examples/minimal/dashboard.toml
@@ -1,7 +1,7 @@
 # Optional dedicated status dashboard.
 #
 # When enabled, `companion apply` deploys a tiny, stateless Fly app (smallest
-# machine, no volume, scales to zero) reachable only over Tailscale. It polls
+# machine, no volume, no public Fly HTTP service) reachable only over Tailscale. It polls
 # every service in the fleet and serves a live status page. apply keeps its
 # topology (the services + URLs to poll) in sync with this workspace, so adding
 # an agent and re-applying updates the dashboard automatically.

--- a/examples/webui/dashboard.toml
+++ b/examples/webui/dashboard.toml
@@ -7,7 +7,7 @@ fly_app = "example-companion-dashboard"
 tailscale_hostname = "companion-dashboard"
 port = 9300
 refresh_interval = 30
-# Smallest Fly machine on purpose: stateless, no volume, scales to zero.
+# Smallest Fly machine on purpose: stateless, no volume, tailnet-only.
 memory = "256mb"
 cpus = 1
 tailscale_serve = true

--- a/internal/render/render.go
+++ b/internal/render/render.go
@@ -173,7 +173,8 @@ func OpenWebUIFlyTOML(cfg config.OpenWebUI, connections []config.OpenWebUIConnec
 
 // DashboardFlyTOML renders the Fly config for the dedicated status dashboard.
 // The dashboard is stateless: no [[mounts]] block, and the smallest possible
-// machine. It scales to zero when idle and is reached only over Tailscale.
+// machine. It declares no Fly HTTP service, so it is reached only over
+// Tailscale Serve.
 func DashboardFlyTOML(cfg config.Dashboard) (string, error) {
 	if !cfg.Enabled {
 		return "", fmt.Errorf("dashboard is disabled in the workspace")
@@ -211,13 +212,6 @@ func DashboardFlyTOML(cfg config.Dashboard) (string, error) {
 		"",
 		"[processes]",
 		fmt.Sprintf("  app = %s", quote(process)),
-		"",
-		// Scale to zero when idle; the dashboard is on-demand and cheap to wake.
-		"[http_service]",
-		fmt.Sprintf("  internal_port = %d", cfg.Port),
-		`  auto_stop_machines = "stop"`,
-		"  auto_start_machines = true",
-		"  min_machines_running = 0",
 		"",
 		"[[vm]]",
 		`  cpu_kind = "shared"`,

--- a/internal/render/render_test.go
+++ b/internal/render/render_test.go
@@ -72,8 +72,6 @@ func TestDashboardRenderSmallestStatelessMachine(t *testing.T) {
 		`memory = "256mb"`,
 		"cpus = 1",
 		`cpu_kind = "shared"`,
-		`auto_stop_machines = "stop"`,
-		"min_machines_running = 0",
 		`COMPANION_FLEET_MANIFEST = "/workspace/fleet.json"`,
 		"companion dashboard --manifest /workspace/fleet.json --interval 30s",
 	} {
@@ -83,6 +81,9 @@ func TestDashboardRenderSmallestStatelessMachine(t *testing.T) {
 	}
 	if strings.Contains(toml, "[[mounts]]") {
 		t.Fatalf("dashboard must be stateless (no [[mounts]]):\n%s", toml)
+	}
+	if strings.Contains(toml, "[http_service]") {
+		t.Fatalf("dashboard must be tailnet-only (no Fly http_service):\n%s", toml)
 	}
 	if !strings.Contains(toml, "[[vm]]") {
 		t.Fatalf("dashboard must declare a [[vm]] sizing block:\n%s", toml)

--- a/internal/resource/resource.go
+++ b/internal/resource/resource.go
@@ -388,7 +388,7 @@ func planResource(ctx context.Context, ws *workspace.Workspace, store *state.Sto
 			resource.DesiredHash = hash
 		}
 		if resource.Dashboard != nil {
-			hash, _, err := hashDashboardTopology(ws, devices)
+			hash, err := hashDashboardConfig(ws, devices)
 			if err != nil {
 				return Change{}, err
 			}
@@ -402,7 +402,7 @@ func planResource(ctx context.Context, ws *workspace.Workspace, store *state.Sto
 	case "openwebui_config":
 		return planOpenWebUIConfig(ctx, ws, store, devices, resource)
 	case "dashboard_config":
-		hash, _, err := hashDashboardTopology(ws, devices)
+		hash, err := hashDashboardConfig(ws, devices)
 		if err != nil {
 			return Change{}, err
 		}
@@ -486,7 +486,7 @@ func applyResource(ctx context.Context, ws *workspace.Workspace, store *state.St
 			if err != nil {
 				return err
 			}
-			hash, _, err := hashDashboardTopology(ws, devices)
+			hash, err := hashDashboardConfig(ws, devices)
 			if err != nil {
 				return err
 			}
@@ -531,7 +531,7 @@ func applyResource(ctx context.Context, ws *workspace.Workspace, store *state.St
 		if err != nil {
 			return err
 		}
-		hash, _, err := hashDashboardTopology(ws, devices)
+		hash, err := hashDashboardConfig(ws, devices)
 		if err != nil {
 			return err
 		}
@@ -709,6 +709,21 @@ func hashDashboardTopology(ws *workspace.Workspace, devices []tailscale.Device) 
 		return "", status.FleetTopology{}, err
 	}
 	return hashValue(string(data)), topo, nil
+}
+
+func hashDashboardConfig(ws *workspace.Workspace, devices []tailscale.Device) (string, error) {
+	topologyHash, _, err := hashDashboardTopology(ws, devices)
+	if err != nil {
+		return "", err
+	}
+	toml, err := render.DashboardFlyTOML(ws.Config.Dashboard)
+	if err != nil {
+		return "", err
+	}
+	return hashMap(map[string]any{
+		"fly_toml": toml,
+		"topology": topologyHash,
+	}), nil
 }
 
 func dashboardProviderSummary(ws *workspace.Workspace) status.ProviderSummary {


### PR DESCRIPTION
## Summary
- keep the dedicated dashboard Fly config tailnet-only by removing the public Fly HTTP service
- include the generated fleet manifest in the Docker build context while keeping the rest of .companion ignored
- make dashboard config drift include both the rendered Fly TOML and the fleet topology

## Validation
- go test ./...
- go run ./cmd/companion validate --providers --workspace /Users/stan/Vibe/infra/companion --env-file /Users/stan/Vibe/infra/companion/.env
- go run ./cmd/companion plan dashboard --workspace /Users/stan/Vibe/infra/companion --env-file /Users/stan/Vibe/infra/companion/.env
- deployed tvc-companion-dashboard and verified it has no Fly public IPs
- verified dashboard health over Tailscale: https://companion-dashboard.tail5f910b.ts.net/healthz

## Review
Generated by an AI agent. Human review pending.