### PR TITLE
feat(dashboard): Linear-grade fleet UI with agent detail drawer

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -1,0 +1,125 @@
+# DESIGN.md — Companion Fleet Dashboard
+
+Register: **product**. This is an operator tool, not marketing. The bar is earned familiarity (Linear, Stripe, Raycast). The interface disappears into the task: glance at fleet health, spot a DOWN agent, click in for detail. Calm and precise. No marketing hero, no decoration.
+
+Scene that forces the theme: an operator glancing at fleet health from a laptop at night, over a private Tailscale network, wanting to spot a DOWN agent at a glance. Dark, Linear-grade. Color strategy: **Restrained** (tinted neutrals + one indigo accent + the semantic status set).
+
+## Color tokens (OKLCH)
+
+Every neutral is tinted toward the accent hue (277), chroma ~0.005–0.01. Never `#000` or `#fff`.
+
+```css
+:root {
+  /* Layered cool near-black surfaces, separated by 1px hairlines */
+  --surface-canvas:   oklch(0.17 0.008 277);  /* page background        */
+  --surface-raised:   oklch(0.21 0.009 277);  /* panels, top bar, drawer */
+  --surface-hover:    oklch(0.25 0.010 277);  /* row hover               */
+  --border-hairline:  oklch(0.30 0.010 277);  /* 1px separators          */
+
+  /* Text */
+  --text-primary: oklch(0.95 0.006 277);  /* agent names, headings      */
+  --text-dim:     oklch(0.74 0.008 277);  /* secondary values, labels   */
+  --text-faint:   oklch(0.56 0.008 277);  /* meta, timestamps, captions */
+
+  /* Single accent — indigo/violet (~#5e6ad2). Selection, focus, primary action ONLY */
+  --accent:          oklch(0.62 0.19 277);
+  --accent-hover:    oklch(0.67 0.19 277);
+  --accent-ring:     oklch(0.62 0.19 277 / 0.55);  /* focus ring          */
+  --accent-selected: oklch(0.62 0.19 277 / 0.14);  /* selected row tint    */
+
+  /* Status — calm, slightly desaturated. ALWAYS paired with a text label. Static. */
+  --status-ok:      oklch(0.72 0.13 152);  /* green  — healthy   */
+  --status-degraded:oklch(0.78 0.13 85);   /* amber  — degraded  */
+  --status-down:    oklch(0.64 0.16 25);   /* red    — down      */
+  --status-unknown: oklch(0.60 0.008 277); /* grey   — unknown   */
+
+  --scrim: oklch(0.12 0.008 277 / 0.55);   /* drawer backdrop, no blur   */
+}
+```
+
+Accent is never decorative: it appears only on the focus ring, the selected row, and the primary link/action. Status colors never carry meaning alone, the text label always rides with the dot.
+
+## Typography
+
+No web fonts, no Google Fonts. Must work offline on a tailnet. System stacks only.
+
+```css
+--font-ui:   -apple-system, BlinkMacSystemFont, "Segoe UI", Inter, system-ui, sans-serif;
+--font-mono: ui-monospace, "SF Mono", Menlo, monospace;  /* URLs, ids, codes, states */
+```
+
+Fixed rem scale, ratio ~1.2. Hierarchy comes from weight + size contrast, not color.
+
+| Token        | Size      | Use                                  |
+|--------------|-----------|--------------------------------------|
+| `--text-xs`  | 0.75rem   | meta, timestamps, badge text         |
+| `--text-sm`  | 0.875rem  | row secondary values, drawer labels  |
+| `--text-base`| 1rem      | agent name, drawer values, body      |
+| `--text-md`  | 1.2rem    | drawer header, section titles        |
+| `--text-lg`  | 1.44rem   | wordmark (kept small)                |
+
+Weights: `400` body/dim, `500` agent names and labels, `600` wordmark and drawer header. Line length capped 65–75ch in any prose (errors).
+
+## Spacing rhythm
+
+4px base. Vary padding for rhythm, dense rows breathe less than the drawer.
+
+```css
+--space-1: 4px;  --space-2: 8px;  --space-3: 12px;
+--space-4: 16px; --space-5: 24px; --space-6: 32px;
+```
+
+Top bar: `--space-2` vertical, `--space-4` horizontal. Agent row: `--space-3` vertical, `--space-4` horizontal. Drawer body: `--space-5`.
+
+## Border radius
+
+```css
+--radius-sm: 4px;   /* badges, pills, status dot container */
+--radius-md: 6px;   /* rows, buttons, error block          */
+--radius-lg: 10px;  /* drawer panel corners (left side)    */
+```
+
+## Component vocabulary
+
+**Top bar** — compact, single line, `--surface-raised`, hairline bottom border. Left: wordmark `Companion` (600), then `·` separators in `--text-faint` to workspace name. Right: connection pill (live / stale), `updated HH:MM:SS` in mono `--text-faint`, auto-refresh note in `--text-xs`. No hero title, no tagline.
+
+**Summary counts** — slim inline row, not stat cards. `Total 12 · Healthy 9 · Degraded 2 · Down 1`. Numbers in `--text-primary` 500, labels in `--text-dim`. Each count label carries its status dot. No gradient cards, no hero-metric template.
+
+**Agent row** — the core. Each row is a `<button>` (full width, `text-align:left`), dense, keyboard-navigable. Visible contents in order: status dot + LABEL, agent name (`--text-base` 500), URL (mono, truncated with ellipsis, copy affordance), tailnet online, machine state, HTTP code, model. States:
+- default: `--surface-canvas`, hairline bottom divider.
+- hover: `--surface-hover`, copy affordance reveals.
+- focus-visible: 2px `--accent-ring` inset ring, no layout shift.
+- selected (drawer open from it): `--accent-selected` background, 2px `--accent` left inset via box-shadow (not a border-left side-stripe).
+- active: `--surface-hover`, no transform.
+
+**Status dot + label** — 8px static circle in the status color, paired with its text label (`ok` / `degraded` / `down` / `unknown`). No pulse, no glow, no animation ever.
+
+**Kind badge** — small mono uppercase chip, `--surface-hover` background, `--text-dim`, `--radius-sm`. Identifies agent kind. No icon-card grid.
+
+**Pills** — connection pill: `live` uses `--status-ok` dot + `--text-dim` label on `--surface-hover`; `stale` uses `--status-degraded`. Status pill (drawer header) mirrors the row dot+label in the matching status color at low tint.
+
+**Copy affordance** — ghost icon button beside any mono URL/id. default `--text-faint`, hover `--text-dim`, focus accent ring, active confirms with a brief `Copied` swap (text only, no motion of layout).
+
+**Slide-over drawer** — right panel ~420px (`100%` on narrow screens), `--surface-raised`, `--radius-lg` on left corners, hairline left border. Built 100% client-side from the clicked service object, no extra fetch. Backdrop `--scrim`, no blur.
+- Header: agent name (600) + status pill + `×` close button.
+- Body: definition list of ALL fields — URL as a real clickable `<a>` (accent link) + copy button, host, fly_app, machine_state, tailnet online, model, vault, http_status, health. `error`, when present, renders in a prominent tinted block (`--status-down` at low tint, full border, mono, `--radius-md`). Labels `--text-dim` `--text-sm`, values `--text-primary`, technical values in mono.
+- Footer: primary `Open service` link (accent) to the url.
+- A11y: `role="dialog" aria-modal="true"`. Move focus into the drawer on open, trap focus, close on Esc and on scrim click, RETURN focus to the originating row on close.
+
+**Drift block** — kept, lower in the page, collapsible (`<details>`). Calm and monospace: hairline-bordered region on `--surface-raised`, mono `--text-dim` content, `--radius-md`. Not alarmist.
+
+**Empty state** — `No services in this fleet yet.` centered, `--text-dim`, no illustration.
+
+**Loading state** — skeleton rows (hairline-bordered, `--surface-raised` shimmer-free placeholders) under the caption `Waiting for first poll…`. Not a spinner.
+
+## Motion
+
+- Durations 150–250ms. Ease-out only, exponential. No bounce, no elastic.
+- `--ease-out-quint: cubic-bezier(0.22, 1, 0.36, 1);`
+- Drawer in/out: `transform: translateX()` over ~200ms `--ease-out-quint`, scrim opacity fades alongside.
+- Allowed only to convey state: drawer in/out, row hover, selection, copy confirm. Never animate layout properties (width, height, top, margin).
+- `prefers-reduced-motion`: drawer appears with no slide, scrim with no fade. All hover transitions drop to instant.
+
+## Absolute bans honored
+
+No side-stripe colored borders (selection uses inset box-shadow, not `border-left`). No gradient text (`background-clip:text`). No decorative glassmorphism (scrim is a flat tint, no blur). No hero-metric template. No identical icon+heading+text card grid. No modal as first thought (detail uses the slide-over drawer). No em dashes in UI copy. No pulsing/glowing status dots. No web fonts. Every word of copy earns its place.

--- a/PRODUCT.md
+++ b/PRODUCT.md
@@ -1,0 +1,31 @@
+---
+register: product
+---
+
+# PRODUCT.md
+
+## Product Purpose
+
+Companion is a Go control plane CLI for managing fleets of persistent "Hermes" AI agents and the tooling around them: agents deployed on Fly.io, durable "Granite" memory vaults shared between them, isolated runtimes, and access gated through a Tailscale VPN. The dashboard is the operator's fleet status surface. It is served locally during work and deployable as a tiny, stateless, Tailscale-only Fly app. Its single job is to make the live state of a fleet legible at a glance: which agents are up, which vaults they hold, what the planner intends, and what just changed. It is not a browser UI for Claude Code or Codex, and not a place to author or run prompts.
+
+## Users
+
+Fleet operators and developers running their own agent fleets. They are technical: they read TOML, run `plan`/`apply`, and live in a terminal. They reach the dashboard over Tailscale, often on a second monitor, glancing rather than studying. They want to confirm health and topology in seconds, then return to their work. The same surface serves a personal fleet, a client deployment, or a workspace someone else runs.
+
+## Brand & Tone
+
+Calm, precise, trustworthy, engineering-grade, understated. The reference points are Linear, Stripe, and Raycast: confident restraint, real data shown plainly, nothing shouting for attention. State the truth of the fleet without dressing it up. When something is healthy, it should feel quiet. When something is wrong, it should be unmistakable without alarm theater.
+
+## Anti-references
+
+- No marketing-hero dashboards: no big-number vanity metrics, no "welcome back" splash.
+- No flashy gradients, film-grain, or decorative glass.
+- No neon-on-black crypto/"command center" aesthetic.
+- No generic AI-SaaS template: rounded purple cards, sparkle icons, gradient CTAs.
+
+## Strategic principles
+
+- **Clarity over decoration.** Every pixel reports state. If it isn't telling the operator something true, it doesn't ship.
+- **Density when useful.** A fleet has many agents, vaults, and links. Show them compactly; don't pad one fact across a whole card.
+- **Status legible at a glance.** Health, drift, and topology readable in under two seconds from across a room.
+- **Familiarity is a feature.** Operators already know these patterns from their tools. Borrow the conventions; don't reinvent the table.

--- a/internal/web/assets/dashboard.css
+++ b/internal/web/assets/dashboard.css
@@ -851,20 +851,23 @@ body.legacy th {
   font-size: var(--t-xs);
 }
 
-.grid {
+/* Scoped to body.legacy: the dashboard has its own .muted, drift <pre>, and
+   never uses .grid/.card/<code>. Leaving these global let the legacy typography
+   and <pre>/<code> chrome bleed into the dashboard. */
+body.legacy .grid {
   display: grid;
   grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
   gap: 0.75rem;
 }
-.card {
+body.legacy .card {
   background: var(--panel-2);
   border: 1px solid var(--line);
   border-radius: var(--r);
   padding: 0.875rem;
 }
-.muted { color: var(--text-faint); font-size: var(--t-sm); }
+body.legacy .muted { color: var(--text-faint); font-size: var(--t-sm); }
 
-pre {
+body.legacy pre {
   background: var(--panel-2);
   border: 1px solid var(--line);
   border-radius: var(--r);
@@ -875,7 +878,7 @@ pre {
   font-size: var(--t-xs);
   line-height: 1.6;
 }
-code {
+body.legacy code {
   background: var(--panel-2);
   border-radius: 4px;
   padding: 0.125rem 0.3rem;

--- a/internal/web/assets/dashboard.css
+++ b/internal/web/assets/dashboard.css
@@ -1,356 +1,885 @@
+/* Companion fleet dashboard — Variant A "Pure list + drawer".
+   Dark, Linear-grade. OKLCH everywhere; neutrals tinted toward the indigo
+   accent hue (277). No web fonts: system UI + mono stacks only. */
+
 :root {
-  --bg: #0d0b0a;
-  --bg-raise: #161311;
-  --bg-card: #1a1614;
-  --line: rgba(231, 221, 209, 0.10);
-  --line-strong: rgba(231, 221, 209, 0.18);
-  --fg: #f4ede3;
-  --fg-dim: #b8ab9c;
-  --fg-faint: #94887b;
-  --coral: #d97757;
-  --coral-soft: rgba(217, 119, 87, 0.14);
-  --ok: #5fb878;
-  --warn: #e3a857;
-  --down: #e0654f;
-  --unknown: #7c7167;
-  --mono: "JetBrains Mono", ui-monospace, "SFMono-Regular", Menlo, monospace;
-  --sans: "Inter", ui-sans-serif, system-ui, -apple-system, "Segoe UI", sans-serif;
-  --radius: 14px;
-  color-scheme: dark;
+  /* One root hue drives every neutral + accent tint. The brief's rule —
+     "tint every neutral toward the accent hue" — is self-documenting here:
+     change --hue and the whole surface set retunes together. */
+  --hue:           277;
+
+  /* Accent (the single indigo). Used only for selection/focus/primary action. */
+  --accent:        oklch(0.62 0.19 var(--hue));
+  --accent-hover:  oklch(0.67 0.19 var(--hue));
+  --accent-quiet:  oklch(0.62 0.19 var(--hue) / 0.16);
+  --accent-ring:   oklch(0.70 0.17 var(--hue) / 0.55);
+  /* Filled-button surface: darker than --accent so white text clears WCAG AA
+     (4.5:1). The button darkens on hover, which keeps contrast climbing rather
+     than dropping the way a lighter --accent-hover would. */
+  --accent-strong:       oklch(0.555 0.19 var(--hue)); /* white text 4.9:1 */
+  --accent-strong-hover: oklch(0.515 0.19 var(--hue)); /* white text 5.8:1 */
+
+  /* Layered cool near-black surfaces, tinted toward --hue. */
+  --canvas:        oklch(0.18 0.008 var(--hue));
+  --panel:         oklch(0.205 0.009 var(--hue));
+  --panel-2:       oklch(0.225 0.010 var(--hue));
+  --row-hover:     oklch(0.245 0.011 var(--hue));
+  --row-active:    oklch(0.27 0.013 var(--hue));
+
+  /* Hairlines. */
+  --line:          oklch(0.30 0.010 var(--hue));
+  --line-strong:   oklch(0.36 0.012 var(--hue));
+
+  /* Text. */
+  --text:          oklch(0.95 0.006 var(--hue));
+  --text-2:        oklch(0.80 0.008 var(--hue));
+  --text-3:        oklch(0.66 0.009 var(--hue));
+  /* 0.60, not lower: column headers, dl keys, and muted placeholders use this
+     at ~11px, so it must clear WCAG AA (4.5:1) on --panel and --canvas. */
+  --text-faint:    oklch(0.60 0.009 var(--hue));
+
+  /* Semantic status (calm, slightly desaturated). Dot + always a label.
+     Status hues are fixed semantic anchors, not derived from --hue. */
+  --ok:            oklch(0.74 0.13 150);
+  --ok-bg:         oklch(0.74 0.13 150 / 0.12);
+  --degraded:      oklch(0.80 0.13 80);
+  --degraded-bg:   oklch(0.80 0.13 80 / 0.13);
+  --down:          oklch(0.66 0.17 25);
+  --down-bg:       oklch(0.66 0.17 25 / 0.13);
+  --unknown:       oklch(0.62 0.010 var(--hue));
+  --unknown-bg:    oklch(0.62 0.010 var(--hue) / 0.12);
+
+  --r:             8px;
+  --r-sm:          6px;
+
+  --ui: -apple-system, BlinkMacSystemFont, "Segoe UI", Inter, system-ui, sans-serif;
+  --mono: ui-monospace, "SF Mono", Menlo, monospace;
+
+  /* Type scale, ratio ~1.2. */
+  --t-xs:  0.6875rem;
+  --t-sm:  0.8125rem;
+  --t-md:  0.875rem;
+  --t-lg:  1.0rem;
+  --t-xl:  1.1875rem;
+
+  --ease: cubic-bezier(0.22, 1, 0.36, 1); /* ease-out-quint-ish */
 }
 
 * { box-sizing: border-box; }
 
-html, body { margin: 0; }
+html, body { height: 100%; }
+
+body {
+  margin: 0;
+  background: var(--canvas);
+  color: var(--text);
+  font-family: var(--ui);
+  font-size: var(--t-md);
+  line-height: 1.45;
+  -webkit-font-smoothing: antialiased;
+  text-rendering: optimizeLegibility;
+}
+
+::selection { background: var(--accent-quiet); }
+
+/* ---------- Top bar ---------- */
+
+.topbar {
+  position: sticky;
+  top: 0;
+  z-index: 10;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+  height: 48px;
+  padding: 0 1.25rem;
+  /* Flat opaque tinted surface — no glassmorphism. Only a 1px hairline. */
+  background: var(--panel);
+  border-bottom: 1px solid var(--line);
+}
+
+.topbar__left, .topbar__right {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  min-width: 0;
+}
+
+.wordmark {
+  font-size: var(--t-md);
+  font-weight: 650;
+  letter-spacing: -0.01em;
+  color: var(--text);
+}
+
+.topbar__sep {
+  width: 1px;
+  height: 16px;
+  background: var(--line-strong);
+}
+
+.topbar__ws {
+  font-family: var(--mono);
+  font-size: var(--t-sm);
+  color: var(--text-2);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.topbar__updated {
+  font-size: var(--t-sm);
+  font-variant-numeric: tabular-nums;
+  color: var(--text-3);
+}
+
+.topbar__refresh {
+  font-size: var(--t-xs);
+  color: var(--text-faint);
+}
+
+.conn {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.4rem;
+  padding: 0.15rem 0.55rem;
+  border: 1px solid var(--line);
+  border-radius: 999px;
+  font-size: var(--t-xs);
+  font-weight: 550;
+  color: var(--text-2);
+  white-space: nowrap;
+}
+.conn__dot {
+  width: 6px; height: 6px;
+  border-radius: 50%;
+  background: var(--unknown);
+}
+.conn.is-live { color: var(--text-2); border-color: var(--line-strong); }
+.conn.is-live .conn__dot { background: var(--ok); }
+.conn.is-stale {
+  color: var(--degraded);
+  border-color: oklch(0.80 0.13 80 / 0.4);
+  background: var(--degraded-bg);
+}
+.conn.is-stale .conn__dot { background: var(--degraded); }
+
+/* ---------- Layout ---------- */
+
+.wrap {
+  max-width: 1120px;
+  margin: 0 auto;
+  padding: 1.25rem 1.25rem 4rem;
+}
+
+/* ---------- Filters / segmented control ---------- */
+
+.filters {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.375rem;
+  margin: 0.25rem 0 1rem;
+}
+
+.seg {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.45rem;
+  padding: 0.3rem 0.65rem;
+  background: var(--panel);
+  border: 1px solid var(--line);
+  border-radius: var(--r-sm);
+  color: var(--text-3);
+  font-family: var(--ui);
+  font-size: var(--t-sm);
+  font-weight: 500;
+  cursor: pointer;
+  transition: background 140ms var(--ease), border-color 140ms var(--ease), color 140ms var(--ease);
+}
+.seg:hover { background: var(--panel-2); color: var(--text-2); }
+.seg:focus-visible {
+  outline: 2px solid var(--accent-ring);
+  outline-offset: 2px;
+}
+.seg.is-active {
+  background: var(--accent-quiet);
+  border-color: oklch(0.62 0.19 var(--hue) / 0.5);
+  color: var(--text);
+}
+.seg__count {
+  font-variant-numeric: tabular-nums;
+  font-size: var(--t-xs);
+  color: var(--text-faint);
+  background: oklch(0.30 0.010 var(--hue) / 0.6);
+  border-radius: 999px;
+  padding: 0.05rem 0.4rem;
+  min-width: 1.2rem;
+  text-align: center;
+}
+.seg.is-active .seg__count { color: var(--text-2); }
+.seg__swatch {
+  width: 7px; height: 7px;
+  border-radius: 50%;
+}
+.seg__swatch--ok { background: var(--ok); }
+.seg__swatch--degraded { background: var(--degraded); }
+.seg__swatch--down { background: var(--down); }
+
+/* ---------- List ---------- */
+
+.list {
+  background: var(--panel);
+  border: 1px solid var(--line);
+  border-radius: var(--r);
+  overflow: hidden;
+}
+
+.list__head {
+  display: grid;
+  grid-template-columns: 116px minmax(140px, 1.4fr) minmax(180px, 2fr) 92px 96px 64px minmax(120px, 1.2fr);
+  align-items: center;
+  gap: 0.75rem;
+  padding: 0.5rem 1rem;
+  /* The .list panel has overflow:hidden, so it is this header's sticky
+     containing block. top:0 pins the header flush at the list's top edge;
+     a non-zero offset would push it down over the first row and hide it. */
+  position: sticky;
+  top: 0;
+  z-index: 5;
+  background: var(--panel-2);
+  border-bottom: 1px solid var(--line);
+}
+.col {
+  font-size: var(--t-xs);
+  font-weight: 600;
+  letter-spacing: 0.03em;
+  text-transform: uppercase;
+  color: var(--text-faint);
+}
+.col-http { text-align: center; }
+
+/* Rows */
+.row {
+  display: grid;
+  grid-template-columns: 116px minmax(140px, 1.4fr) minmax(180px, 2fr) 92px 96px 64px minmax(120px, 1.2fr);
+  align-items: center;
+  gap: 0.75rem;
+  width: 100%;
+  padding: 0.6rem 1rem;
+  background: transparent;
+  border: 0;
+  border-top: 1px solid var(--line);
+  font-family: var(--ui);
+  font-size: var(--t-sm);
+  color: var(--text-2);
+  text-align: left;
+  cursor: pointer;
+  transition: background 120ms var(--ease);
+}
+.row:first-child { border-top: 0; }
+.row:hover { background: var(--row-hover); }
+.row:active { background: var(--row-active); }
+/* Inset box-shadow ring instead of outline: the .list has overflow:hidden,
+   which clips an outline-offset:-2px ring on the first/last rows. An inset
+   shadow always renders fully inside the row. */
+.row:focus-visible {
+  outline: none;
+  box-shadow: inset 0 0 0 2px var(--accent-ring);
+}
+.row.is-selected {
+  background: var(--accent-quiet);
+  box-shadow: inset 2px 0 0 var(--accent);
+}
+/* Focused selected row keeps both the left stripe and the ring. */
+.row.is-selected:focus-visible {
+  box-shadow: inset 2px 0 0 var(--accent), inset 0 0 0 2px var(--accent-ring);
+}
+
+/* Status cell: dot + label */
+.cell-status {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.45rem;
+  min-width: 0;
+}
+.dot {
+  width: 8px; height: 8px;
+  border-radius: 50%;
+  flex: none;
+  background: var(--unknown);
+}
+.dot--ok { background: var(--ok); }
+.dot--degraded { background: var(--degraded); }
+.dot--down { background: var(--down); }
+.dot--unknown { background: var(--unknown); }
+.status-label {
+  font-size: var(--t-sm);
+  font-weight: 550;
+  color: var(--text);
+  text-transform: capitalize;
+}
+
+.cell-name { min-width: 0; }
+.svc-id {
+  font-weight: 550;
+  color: var(--text);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  display: block;
+}
+.svc-kind {
+  font-size: var(--t-xs);
+  color: var(--text-faint);
+  font-family: var(--mono);
+}
+
+/* URL cell */
+.cell-url {
+  display: flex;
+  align-items: center;
+  gap: 0.4rem;
+  min-width: 0;
+}
+.svc-url {
+  font-family: var(--mono);
+  font-size: var(--t-xs);
+  color: var(--text-3);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  min-width: 0;
+}
+.svc-url--none { color: var(--text-faint); font-family: var(--ui); }
+
+.copy {
+  flex: none;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 22px; height: 22px;
+  border: 1px solid transparent;
+  border-radius: var(--r-sm);
+  background: transparent;
+  color: var(--text-faint);
+  cursor: pointer;
+  opacity: 0;
+  transition: opacity 120ms var(--ease), background 120ms var(--ease), color 120ms var(--ease);
+}
+.row:hover .copy, .copy:focus-visible { opacity: 1; }
+.copy:hover { background: var(--panel-2); color: var(--text-2); }
+.copy:focus-visible {
+  outline: 2px solid var(--accent-ring);
+  outline-offset: 1px;
+  opacity: 1;
+}
+/* Copied confirmation swaps the clipboard glyph for a checkmark, so success
+   is conveyed by icon shape, not color alone. */
+.copy.is-copied { color: var(--ok); opacity: 1; }
+.copy svg { width: 13px; height: 13px; display: block; }
+.copy svg.check { display: none; }
+.copy.is-copied svg.clip { display: none; }
+.copy.is-copied svg.check { display: block; }
+
+/* Tailnet / machine / http / model cells */
+.tag {
+  display: inline-flex;
+  align-items: center;
+  font-size: var(--t-xs);
+  font-weight: 550;
+  padding: 0.1rem 0.45rem;
+  border-radius: var(--r-sm);
+  border: 1px solid var(--line);
+}
+.tag--online { color: var(--text-2); }
+.tag--offline { color: var(--text-faint); }
+
+.state-text {
+  font-size: var(--t-xs);
+  color: var(--text-3);
+}
+.state-text--started { color: var(--text-2); }
+.state-text--stopped { color: var(--degraded); }
+.muted { color: var(--text-faint); }
+
+.http {
+  display: inline-block;
+  text-align: center;
+  font-family: var(--mono);
+  font-size: var(--t-xs);
+  font-weight: 600;
+  font-variant-numeric: tabular-nums;
+  width: 100%;
+}
+.http--ok { color: var(--ok); }
+.http--bad { color: var(--down); }
+.http--none { color: var(--text-faint); }
+
+.svc-model {
+  font-family: var(--mono);
+  font-size: var(--t-xs);
+  color: var(--text-3);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  display: block;
+}
+
+/* ---------- States (empty / loading) ---------- */
+
+.state {
+  padding: 2.5rem 1rem;
+  text-align: center;
+}
+.state__text {
+  margin: 0;
+  color: var(--text-faint);
+  font-size: var(--t-sm);
+}
+.state--empty .state__text { color: var(--text-3); }
+
+.skel-rows {
+  display: flex;
+  flex-direction: column;
+  gap: 0.6rem;
+  max-width: 640px;
+  margin: 0 auto 1.25rem;
+}
+.skel-row {
+  height: 14px;
+  border-radius: 4px;
+  background: linear-gradient(90deg,
+    oklch(0.245 0.010 var(--hue)) 0%,
+    oklch(0.285 0.012 var(--hue)) 50%,
+    oklch(0.245 0.010 var(--hue)) 100%);
+  background-size: 200% 100%;
+  animation: skel 1.4s var(--ease) infinite;
+}
+.skel-row:nth-child(2) { width: 82%; }
+.skel-row:nth-child(3) { width: 64%; }
+@keyframes skel {
+  0% { background-position: 200% 0; }
+  100% { background-position: -200% 0; }
+}
+
+/* ---------- Drift ---------- */
+
+.drift {
+  margin-top: 1rem;
+  border: 1px solid var(--line);
+  border-radius: var(--r);
+  background: var(--panel);
+  overflow: hidden;
+}
+.drift__toggle {
+  display: flex;
+  align-items: center;
+  gap: 0.6rem;
+  width: 100%;
+  padding: 0.6rem 1rem;
+  background: transparent;
+  border: 0;
+  color: var(--text-2);
+  font-family: var(--ui);
+  font-size: var(--t-sm);
+  cursor: pointer;
+  transition: background 120ms var(--ease);
+}
+.drift__toggle:hover { background: var(--row-hover); }
+.drift__toggle:focus-visible {
+  outline: 2px solid var(--accent-ring);
+  outline-offset: -2px;
+}
+.drift__chev {
+  width: 0; height: 0;
+  border-left: 5px solid var(--text-faint);
+  border-top: 4px solid transparent;
+  border-bottom: 4px solid transparent;
+  transition: transform 150ms var(--ease);
+}
+.drift__toggle[aria-expanded="true"] .drift__chev { transform: rotate(90deg); }
+.drift__title { font-weight: 550; color: var(--text); }
+.drift__badge {
+  margin-left: auto;
+  font-size: var(--t-xs);
+  font-weight: 550;
+  padding: 0.1rem 0.5rem;
+  border-radius: 999px;
+  border: 1px solid var(--line);
+  color: var(--text-3);
+}
+.drift__badge.is-drift {
+  color: var(--degraded);
+  border-color: oklch(0.80 0.13 80 / 0.4);
+  background: var(--degraded-bg);
+}
+.drift__panel {
+  margin: 0;
+  padding: 0.75rem 1rem 1rem;
+  border-top: 1px solid var(--line);
+  font-family: var(--mono);
+  font-size: var(--t-xs);
+  line-height: 1.6;
+  color: var(--text-3);
+  white-space: pre-wrap;
+  word-break: break-word;
+}
+
+/* ---------- Scrim + Drawer ---------- */
+
+.scrim {
+  position: fixed;
+  inset: 0;
+  z-index: 40;
+  background: oklch(0.12 0.008 var(--hue) / 0.55);
+  opacity: 0;
+  transition: opacity 200ms var(--ease);
+}
+.scrim.is-open { opacity: 1; }
+
+.drawer {
+  position: fixed;
+  top: 0;
+  right: 0;
+  z-index: 50;
+  width: 420px;
+  max-width: 100vw;
+  height: 100%;
+  display: flex;
+  flex-direction: column;
+  background: var(--panel);
+  border-left: 1px solid var(--line-strong);
+  box-shadow: -16px 0 40px oklch(0.10 0.008 var(--hue) / 0.45);
+  transform: translateX(100%);
+  transition: transform 200ms var(--ease);
+}
+.drawer.is-open { transform: translateX(0); }
+
+.drawer__head {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 0.75rem;
+  padding: 1rem 1.1rem;
+  border-bottom: 1px solid var(--line);
+}
+.drawer__heading {
+  display: flex;
+  align-items: center;
+  gap: 0.6rem;
+  flex-wrap: wrap;
+  min-width: 0;
+}
+.drawer__title {
+  margin: 0;
+  font-size: var(--t-xl);
+  font-weight: 650;
+  letter-spacing: -0.01em;
+  color: var(--text);
+  word-break: break-word;
+}
+.status-pill {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.4rem;
+  padding: 0.15rem 0.55rem;
+  border-radius: 999px;
+  border: 1px solid var(--line);
+  font-size: var(--t-xs);
+  font-weight: 600;
+  text-transform: capitalize;
+  color: var(--text-2);
+}
+.status-pill__dot { width: 7px; height: 7px; border-radius: 50%; background: var(--unknown); }
+.status-pill--ok { color: var(--ok); border-color: oklch(0.74 0.13 150 / 0.4); background: var(--ok-bg); }
+.status-pill--ok .status-pill__dot { background: var(--ok); }
+.status-pill--degraded { color: var(--degraded); border-color: oklch(0.80 0.13 80 / 0.4); background: var(--degraded-bg); }
+.status-pill--degraded .status-pill__dot { background: var(--degraded); }
+.status-pill--down { color: var(--down); border-color: oklch(0.66 0.17 25 / 0.4); background: var(--down-bg); }
+.status-pill--down .status-pill__dot { background: var(--down); }
+.status-pill--unknown .status-pill__dot { background: var(--unknown); }
+
+.drawer__close {
+  flex: none;
+  width: 30px; height: 30px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  border: 1px solid transparent;
+  border-radius: var(--r-sm);
+  background: transparent;
+  color: var(--text-3);
+  line-height: 1;
+  cursor: pointer;
+  transition: background 120ms var(--ease), color 120ms var(--ease);
+}
+.drawer__close:hover { background: var(--panel-2); color: var(--text); }
+.drawer__close:focus-visible { outline: 2px solid var(--accent-ring); outline-offset: 1px; }
+.drawer__close svg { width: 16px; height: 16px; display: block; }
+
+.drawer__body {
+  flex: 1;
+  overflow-y: auto;
+  padding: 0.5rem 1.1rem 1.25rem;
+}
+
+.dl { margin: 0; }
+.dl__row {
+  display: grid;
+  grid-template-columns: 104px 1fr;
+  gap: 0.75rem;
+  padding: 0.55rem 0;
+  border-bottom: 1px solid var(--line);
+  align-items: start;
+}
+.dl__row:last-child { border-bottom: 0; }
+.dl__key {
+  font-size: var(--t-xs);
+  font-weight: 600;
+  letter-spacing: 0.02em;
+  text-transform: uppercase;
+  color: var(--text-faint);
+  padding-top: 0.1rem;
+}
+.dl__val {
+  font-size: var(--t-sm);
+  color: var(--text);
+  min-width: 0;
+  word-break: break-word;
+}
+.dl__val--mono { font-family: var(--mono); font-size: var(--t-xs); color: var(--text-2); }
+.dl__val .muted { color: var(--text-faint); }
+
+.dl__url {
+  display: flex;
+  align-items: center;
+  gap: 0.4rem;
+  min-width: 0;
+}
+.dl__link {
+  font-family: var(--mono);
+  font-size: var(--t-xs);
+  color: var(--accent);
+  text-decoration: none;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  min-width: 0;
+}
+.dl__link:hover { color: var(--accent-hover); text-decoration: underline; }
+.dl__link:focus-visible { outline: 2px solid var(--accent-ring); outline-offset: 2px; border-radius: 2px; }
+.dl__url .copy { opacity: 1; }
+
+.error-block {
+  margin-top: 0.5rem;
+  padding: 0.7rem 0.8rem;
+  border: 1px solid oklch(0.66 0.17 25 / 0.4);
+  border-radius: var(--r-sm);
+  background: var(--down-bg);
+}
+.error-block__label {
+  font-size: var(--t-xs);
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.03em;
+  color: var(--down);
+  margin-bottom: 0.3rem;
+}
+.error-block__text {
+  font-family: var(--mono);
+  font-size: var(--t-xs);
+  line-height: 1.5;
+  color: var(--text);
+  word-break: break-word;
+}
+
+.drawer__foot {
+  flex: none;
+  padding: 0.85rem 1.1rem;
+  border-top: 1px solid var(--line);
+}
+.btn-primary {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.4rem;
+  width: 100%;
+  padding: 0.55rem 1rem;
+  background: var(--accent-strong);
+  border: 1px solid var(--accent-strong);
+  border-radius: var(--r-sm);
+  color: oklch(0.99 0.005 var(--hue));
+  font-family: var(--ui);
+  font-size: var(--t-sm);
+  font-weight: 600;
+  text-decoration: none;
+  cursor: pointer;
+  transition: background 120ms var(--ease), border-color 120ms var(--ease);
+}
+.btn-primary:hover { background: var(--accent-strong-hover); border-color: var(--accent-strong-hover); }
+.btn-primary:active { background: var(--accent-strong); }
+.btn-primary:focus-visible { outline: 2px solid var(--accent-ring); outline-offset: 2px; }
+.btn-primary svg { width: 13px; height: 13px; display: block; }
+.btn-primary[aria-disabled="true"] {
+  background: var(--panel-2);
+  border-color: var(--line);
+  color: var(--text-faint);
+  cursor: default;
+  pointer-events: none;
+}
 
 .sr-only {
   position: absolute;
-  width: 1px;
-  height: 1px;
-  padding: 0;
-  margin: -1px;
+  width: 1px; height: 1px;
+  padding: 0; margin: -1px;
   overflow: hidden;
-  clip: rect(0, 0, 0, 0);
+  clip: rect(0 0 0 0);
   white-space: nowrap;
   border: 0;
 }
 
-body {
-  background:
-    radial-gradient(900px 500px at 85% -10%, rgba(217, 119, 87, 0.12), transparent 60%),
-    radial-gradient(700px 600px at -5% 0%, rgba(126, 183, 162, 0.06), transparent 55%),
-    var(--bg);
-  color: var(--fg);
-  font-family: var(--sans);
-  font-size: 14px;
-  line-height: 1.5;
-  min-height: 100vh;
-  -webkit-font-smoothing: antialiased;
+/* ---------- Responsive ---------- */
+
+@media (max-width: 860px) {
+  .list__head { display: none; }
+  .row {
+    grid-template-columns: 1fr auto;
+    grid-template-areas:
+      "status http"
+      "name   model"
+      "url    url"
+      "net    machine";
+    row-gap: 0.4rem;
+  }
+  .cell-status { grid-area: status; }
+  .cell-name { grid-area: name; }
+  .cell-url { grid-area: url; }
+  .cell-net { grid-area: net; }
+  .cell-machine { grid-area: machine; justify-self: end; }
+  .cell-http { grid-area: http; justify-self: end; }
+  .cell-model { grid-area: model; justify-self: end; min-width: 0; }
+  .http { width: auto; }
+  .copy { opacity: 1; }
 }
 
-/* film grain overlay */
-.grain {
-  position: fixed;
-  inset: 0;
-  pointer-events: none;
-  z-index: 100;
-  opacity: 0.035;
-  background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='120' height='120'%3E%3Cfilter id='n'%3E%3CfeTurbulence type='fractalNoise' baseFrequency='0.85' numOctaves='3'/%3E%3C/filter%3E%3Crect width='100%25' height='100%25' filter='url(%23n)'/%3E%3C/svg%3E");
+@media (max-width: 520px) {
+  .drawer { width: 100vw; border-left: 0; }
+  .topbar__updated, .topbar__refresh { display: none; }
 }
 
-/* ---------- hero ---------- */
-.hero {
-  max-width: 1180px;
-  margin: 0 auto;
-  padding: 30px 28px 18px;
-}
-.hero__bar {
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  gap: 16px;
-}
-.wordmark {
-  display: inline-flex;
-  align-items: center;
-  gap: 10px;
-  font-weight: 700;
-  font-size: 17px;
-  letter-spacing: -0.01em;
-}
-.wordmark__dot {
-  width: 11px; height: 11px;
-  border-radius: 50%;
-  background: var(--coral);
-  box-shadow: 0 0 0 4px var(--coral-soft);
-}
-.hero__meta { display: flex; align-items: center; gap: 14px; }
-.hero__ws {
-  font-family: var(--mono);
-  font-size: 12px;
-  color: var(--fg-dim);
-  padding: 4px 9px;
-  border: 1px solid var(--line);
-  border-radius: 8px;
-}
-.pill {
-  display: inline-flex;
-  align-items: center;
-  gap: 7px;
-  font-family: var(--mono);
-  font-size: 11px;
-  text-transform: uppercase;
-  letter-spacing: 0.06em;
-  color: var(--fg-dim);
-  padding: 4px 10px;
-  border: 1px solid var(--line);
-  border-radius: 999px;
-}
-.pill__dot { width: 7px; height: 7px; border-radius: 50%; background: var(--unknown); }
-.pill.live .pill__dot { background: var(--ok); animation: blip 2s ease-in-out infinite; }
-.pill.stale .pill__dot { background: var(--down); }
-@keyframes blip { 0%,100% { opacity: 1; } 50% { opacity: 0.35; } }
-
-.hero__title {
-  margin: 26px 0 6px;
-  font-size: clamp(34px, 6vw, 56px);
-  font-weight: 700;
-  letter-spacing: -0.03em;
-  line-height: 1;
-}
-.hero__tagline {
-  margin: 0;
-  max-width: 56ch;
-  color: var(--fg-dim);
-  font-size: 15px;
-}
-
-/* ---------- layout ---------- */
-.wrap {
-  max-width: 1180px;
-  margin: 0 auto;
-  padding: 14px 28px 60px;
-  display: flex;
-  flex-direction: column;
-  gap: 22px;
-}
-
-/* ---------- stats ---------- */
-.stats {
-  display: grid;
-  grid-template-columns: repeat(4, 1fr);
-  gap: 14px;
-}
-.stat {
-  position: relative;
-  background: linear-gradient(180deg, var(--bg-card), var(--bg-raise));
-  border: 1px solid var(--line);
-  border-radius: var(--radius);
-  padding: 18px 20px;
-  overflow: hidden;
-}
-.stat::before {
-  content: "";
-  position: absolute;
-  left: 0; top: 0; bottom: 0;
-  width: 3px;
-  background: var(--unknown);
-}
-.stat--total::before { background: var(--coral); }
-.stat--ok::before { background: var(--ok); }
-.stat--warn::before { background: var(--warn); }
-.stat--down::before { background: var(--down); }
-.stat__num {
-  font-family: var(--mono);
-  font-size: 38px;
-  font-weight: 700;
-  line-height: 1;
-  letter-spacing: -0.02em;
-}
-.stat__label {
-  margin-top: 8px;
-  font-size: 12px;
-  text-transform: uppercase;
-  letter-spacing: 0.08em;
-  color: var(--fg-faint);
-}
-
-/* ---------- panels ---------- */
-.panel {
-  background: var(--bg-raise);
-  border: 1px solid var(--line);
-  border-radius: var(--radius);
-  overflow: hidden;
-}
-.panel__head {
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  padding: 16px 20px;
-  border-bottom: 1px solid var(--line);
-}
-.panel__head h2 {
-  margin: 0;
-  font-size: 14px;
-  font-weight: 600;
-  letter-spacing: 0.01em;
-}
-.panel__hint {
-  font-family: var(--mono);
-  font-size: 11px;
-  color: var(--fg-faint);
-}
-
-/* ---------- table ---------- */
-.table-wrap { overflow-x: auto; }
-.services {
-  width: 100%;
-  border-collapse: collapse;
-  font-size: 13px;
-}
-.services th {
-  text-align: left;
-  padding: 11px 16px;
-  font-size: 11px;
-  font-weight: 600;
-  text-transform: uppercase;
-  letter-spacing: 0.07em;
-  color: var(--fg-faint);
-  background: rgba(0,0,0,0.18);
-  white-space: nowrap;
-}
-.services td {
-  padding: 13px 16px;
-  border-top: 1px solid var(--line);
-  vertical-align: middle;
-  white-space: nowrap;
-}
-.services tbody tr { transition: background 120ms ease; }
-.services tbody tr:hover { background: rgba(217, 119, 87, 0.05); }
-.col-status { width: 34px; }
-.col-center { text-align: center; }
-td.col-center { text-align: center; }
-.empty td { color: var(--fg-faint); text-align: center; padding: 28px; }
-
-.mono { font-family: var(--mono); }
-.svc-id { font-family: var(--mono); font-weight: 600; color: var(--fg); }
-.svc-host { font-family: var(--mono); color: var(--fg-dim); font-size: 12px; }
-.svc-model { color: var(--fg-dim); }
-.kind {
-  font-family: var(--mono);
-  font-size: 11px;
-  color: var(--fg-dim);
-  border: 1px solid var(--line);
-  border-radius: 6px;
-  padding: 2px 7px;
-}
-
-.dot {
-  display: inline-block;
-  width: 10px; height: 10px;
-  border-radius: 50%;
-  background: var(--unknown);
-  box-shadow: 0 0 0 0 currentColor;
-}
-.dot--ok { background: var(--ok); color: var(--ok); animation: pulse 2.6s infinite; }
-.dot--degraded { background: var(--warn); color: var(--warn); }
-.dot--down { background: var(--down); color: var(--down); }
-.dot--unknown { background: var(--unknown); }
-@keyframes pulse {
-  0% { box-shadow: 0 0 0 0 rgba(95,184,120,0.5); }
-  70% { box-shadow: 0 0 0 6px rgba(95,184,120,0); }
-  100% { box-shadow: 0 0 0 0 rgba(95,184,120,0); }
-}
-
-.state {
-  font-family: var(--mono);
-  font-size: 11px;
-  padding: 2px 8px;
-  border-radius: 6px;
-  border: 1px solid var(--line);
-  color: var(--fg-dim);
-}
-.state--started { color: var(--ok); border-color: rgba(95,184,120,0.4); }
-.state--stopped { color: var(--down); border-color: rgba(224,101,79,0.4); }
-
-.tag {
-  font-family: var(--mono);
-  font-size: 11px;
-  font-weight: 500;
-}
-.tag--up { color: var(--ok); }
-.tag--off { color: var(--fg-faint); }
-.http { font-family: var(--mono); font-size: 12px; }
-.http--ok { color: var(--ok); }
-.http--bad { color: var(--down); }
-.http--none { color: var(--fg-faint); }
-
-/* ---------- drift ---------- */
-.badge {
-  font-family: var(--mono);
-  font-size: 11px;
-  padding: 3px 9px;
-  border-radius: 999px;
-  border: 1px solid var(--line);
-  color: var(--fg-dim);
-}
-.badge--clean { color: var(--ok); border-color: rgba(95,184,120,0.4); }
-.badge--drift { color: var(--warn); border-color: rgba(227,168,87,0.45); }
-.drift {
-  margin: 0;
-  padding: 18px 20px;
-  font-family: var(--mono);
-  font-size: 12.5px;
-  line-height: 1.65;
-  color: var(--fg-dim);
-  white-space: pre-wrap;
-  overflow-x: auto;
-}
-
-/* ---------- footer ---------- */
-.foot {
-  max-width: 1180px;
-  margin: 0 auto;
-  padding: 0 28px 40px;
-  display: flex;
-  align-items: center;
-  gap: 10px;
-  color: var(--fg-faint);
-  font-family: var(--mono);
-  font-size: 11px;
-}
-.foot a { color: var(--fg-dim); text-decoration: none; }
-.foot a:hover { color: var(--coral); }
-.foot__sep { opacity: 0.5; }
-
-.flash { animation: flash 0.6s ease; }
-@keyframes flash { from { background: var(--coral-soft); } to { background: transparent; } }
-
-/* ---------- legacy server-rendered pages ---------- */
-body.legacy { padding: 0; }
-.topbar {
-  display: flex; align-items: center; justify-content: space-between;
-  padding: 16px 28px; border-bottom: 1px solid var(--line);
-  max-width: 1180px; margin: 0 auto;
-}
-.topbar .brand { font-weight: 700; color: var(--fg); text-decoration: none; }
-.topbar nav a { color: var(--fg-dim); margin-left: 18px; text-decoration: none; font-size: 13px; }
-.topbar nav a:hover { color: var(--coral); }
-body.legacy main { max-width: 1180px; margin: 0 auto; padding: 24px 28px; }
-body.legacy h1 { font-size: 24px; }
-body.legacy table { width: 100%; border-collapse: collapse; }
-body.legacy th, body.legacy td { padding: 10px 12px; border-bottom: 1px solid var(--line); text-align: left; font-size: 13px; }
-body.legacy .grid { display: grid; grid-template-columns: repeat(auto-fit, minmax(220px,1fr)); gap: 12px; }
-body.legacy .card { background: var(--bg-card); border: 1px solid var(--line); border-radius: 10px; padding: 14px; }
-body.legacy .muted { color: var(--fg-faint); font-size: 12px; }
-body.legacy pre { background: var(--bg-card); border: 1px solid var(--line); border-radius: 10px; padding: 16px; white-space: pre-wrap; color: var(--fg-dim); }
-body.legacy code { background: var(--bg-card); border-radius: 4px; padding: 2px 5px; font-family: var(--mono); }
-
-@media (max-width: 720px) {
-  .stats { grid-template-columns: repeat(2, 1fr); }
-  .hero__tagline { font-size: 14px; }
-}
+/* ---------- Reduced motion ---------- */
 
 @media (prefers-reduced-motion: reduce) {
-  .dot--ok, .pill.live .pill__dot, .flash { animation: none; }
+  * { transition-duration: 0.01ms !important; animation-duration: 0.01ms !important; animation-iteration-count: 1 !important; }
+  .drawer { transition: none; }
+  .skel-row { animation: none; background: oklch(0.265 0.011 var(--hue)); }
+}
+
+/* ---------- Legacy server-rendered pages ----------
+   These classes are emitted by internal/web/web.go for the simple
+   server-rendered pages (body.legacy). They share this stylesheet, so map
+   them onto the new dark Linear-grade tokens to stay coherent. The dashboard
+   .topbar above is a flex status bar; legacy pages scope their own layout
+   under body.legacy so the two never collide. */
+
+body.legacy {
+  margin: 0;
+  padding: 0;
+  background: var(--canvas);
+  color: var(--text);
+  font-family: var(--ui);
+}
+
+body.legacy .topbar {
+  position: static;
+  height: auto;
+  max-width: 1120px;
+  margin: 0 auto;
+  padding: 0.875rem 1.5rem;
+  background: var(--panel);
+  border-bottom: 1px solid var(--line);
+}
+.topbar .brand {
+  font-weight: 650;
+  letter-spacing: -0.01em;
+  color: var(--text);
+  text-decoration: none;
+}
+.topbar nav a {
+  margin-left: 1.125rem;
+  color: var(--text-3);
+  text-decoration: none;
+  font-size: var(--t-sm);
+}
+.topbar nav a:hover { color: var(--accent); }
+
+body.legacy main {
+  max-width: 1120px;
+  margin: 0 auto;
+  padding: 1.5rem 1.5rem 4rem;
+}
+body.legacy h1 {
+  font-size: var(--t-xl);
+  font-weight: 650;
+  letter-spacing: -0.01em;
+  color: var(--text);
+}
+body.legacy h2 {
+  font-size: var(--t-lg);
+  font-weight: 650;
+  letter-spacing: -0.01em;
+  color: var(--text);
+  margin: 1.5rem 0 0.5rem;
+}
+body.legacy table {
+  width: 100%;
+  border-collapse: collapse;
+}
+body.legacy th,
+body.legacy td {
+  padding: 0.625rem 0.75rem;
+  border-bottom: 1px solid var(--line);
+  text-align: left;
+  font-size: var(--t-sm);
+}
+body.legacy th {
+  color: var(--text-faint);
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.03em;
+  font-size: var(--t-xs);
+}
+
+.grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: 0.75rem;
+}
+.card {
+  background: var(--panel-2);
+  border: 1px solid var(--line);
+  border-radius: var(--r);
+  padding: 0.875rem;
+}
+.muted { color: var(--text-faint); font-size: var(--t-sm); }
+
+pre {
+  background: var(--panel-2);
+  border: 1px solid var(--line);
+  border-radius: var(--r);
+  padding: 1rem;
+  white-space: pre-wrap;
+  color: var(--text-2);
+  font-family: var(--mono);
+  font-size: var(--t-xs);
+  line-height: 1.6;
+}
+code {
+  background: var(--panel-2);
+  border-radius: 4px;
+  padding: 0.125rem 0.3rem;
+  font-family: var(--mono);
+  font-size: var(--t-xs);
+  color: var(--text-2);
 }

--- a/internal/web/assets/dashboard.js
+++ b/internal/web/assets/dashboard.js
@@ -204,6 +204,9 @@
 
     btn.addEventListener("click", function () { openDrawer(svc, btn); });
     btn.addEventListener("keydown", function (ev) {
+      // Only act on keys aimed at the row itself. Enter/Space on the nested
+      // copy button must copy, not also open the drawer via this bubbled event.
+      if (ev.target !== btn) return;
       if (ev.key === "Enter" || ev.key === " " || ev.key === "Spacebar") {
         ev.preventDefault();
         openDrawer(svc, btn);

--- a/internal/web/assets/dashboard.js
+++ b/internal/web/assets/dashboard.js
@@ -347,11 +347,16 @@
 
   // Mark the pill stale once the freshest payload we hold ages past
   // staleAfterMs, even if the control plane stays reachable (frozen state).
+  // The delay is measured from the payload's age, not from now: a poll that
+  // keeps returning the same frozen generated_at must not keep re-arming a
+  // full-length timer (every poll < staleAfterMs) and so never fire.
   function scheduleStaleCheck() {
     if (staleTimer) clearTimeout(staleTimer);
+    var ageMs = Date.now() - state.lastGeneratedAt;
+    var delayMs = Math.max(0, staleAfterMs - ageMs) + 250;
     staleTimer = setTimeout(function () {
       if (Date.now() - state.lastGeneratedAt >= staleAfterMs) setConn(false);
-    }, staleAfterMs + 250);
+    }, delayMs);
   }
 
   // ---- drawer ------------------------------------------------------------

--- a/internal/web/assets/dashboard.js
+++ b/internal/web/assets/dashboard.js
@@ -1,120 +1,593 @@
+/* Companion fleet dashboard — Variant A.
+   Vanilla JS. Polls /api/status, renders a dense agent list, opens a
+   client-side slide-over drawer per row. XSS-safe: every value reaches the
+   DOM via textContent or is escaped; no innerHTML interpolation of data. */
 (function () {
   "use strict";
 
   var body = document.body;
   var serverInterval = parseInt(body.getAttribute("data-interval"), 10) || 30;
-  // Poll the API a touch faster than the server's own refresh, but never
-  // hammer it: clamp between 5s and the server interval.
+  // Poll a little ahead of the server refresh, but clamp 5..15s.
   var pollMs = Math.max(5, Math.min(serverInterval, 15)) * 1000;
+  var workspaceAttr = body.getAttribute("data-workspace") || "";
 
   var els = {
     workspace: document.getElementById("workspace-name"),
     connPill: document.getElementById("conn-pill"),
     connText: document.getElementById("conn-text"),
-    total: document.getElementById("stat-total"),
-    healthy: document.getElementById("stat-healthy"),
-    degraded: document.getElementById("stat-degraded"),
-    down: document.getElementById("stat-down"),
-    body: document.getElementById("services-body"),
     updated: document.getElementById("updated"),
-    driftBadge: document.getElementById("drift-badge"),
-    driftText: document.getElementById("drift-text"),
     refreshNote: document.getElementById("refresh-note"),
+    listBody: document.getElementById("services-body"),
+    countAll: document.getElementById("count-all"),
+    countHealthy: document.getElementById("count-healthy"),
+    countDegraded: document.getElementById("count-degraded"),
+    countDown: document.getElementById("count-down"),
+    filterStatus: document.getElementById("filter-status"),
+    driftToggle: document.getElementById("drift-toggle"),
+    driftPanel: document.getElementById("drift-panel"),
+    driftBadge: document.getElementById("drift-badge"),
+    scrim: document.getElementById("scrim"),
+    drawer: document.getElementById("drawer"),
+    drawerTitle: document.getElementById("drawer-title"),
+    drawerPill: document.getElementById("drawer-pill"),
+    drawerPillText: document.getElementById("drawer-pill-text"),
+    drawerBody: document.getElementById("drawer-body"),
+    drawerFoot: document.getElementById("drawer-foot"),
+    drawerClose: document.getElementById("drawer-close"),
   };
 
+  els.workspace.textContent = workspaceAttr;
   els.refreshNote.textContent = "auto-refresh " + Math.round(pollMs / 1000) + "s";
 
-  function esc(value) {
-    var div = document.createElement("div");
-    div.textContent = value == null ? "" : String(value);
-    return div.innerHTML;
+  var state = {
+    services: [],
+    filter: "all",
+    selectedId: null,
+    lastFocused: null,
+    open: false,
+    hadFirstPoll: false,   // true once any poll has succeeded
+    lastGeneratedAt: 0,    // epoch ms of the latest payload's generated_at
+  };
+
+  // A successful-but-old payload is still stale: if the newest data we hold is
+  // older than ~2x the poll interval, the control plane is reachable but
+  // frozen. Floor at 30s so a slow tailnet does not flap the pill.
+  var staleAfterMs = Math.max(pollMs * 2, 30000);
+  var staleTimer = null;
+
+  var reduceMotion = window.matchMedia("(prefers-reduced-motion: reduce)").matches;
+
+  // ---- helpers ----------------------------------------------------------
+
+  function el(tag, cls, text) {
+    var n = document.createElement(tag);
+    if (cls) n.className = cls;
+    if (text != null) n.textContent = text;
+    return n;
   }
 
-  function healthClass(health) {
-    switch (health) {
-      case "ok": return "dot--ok";
-      case "degraded": return "dot--degraded";
-      case "down": return "dot--down";
-      default: return "dot--unknown";
-    }
+  function healthOf(svc) {
+    var h = svc && svc.health;
+    return h === "ok" || h === "degraded" || h === "down" ? h : "unknown";
   }
 
-  function machineCell(state) {
-    if (!state) return '<span class="state">—</span>';
-    var cls = state === "started" ? "state--started" : state === "stopped" ? "state--stopped" : "";
-    return '<span class="state ' + cls + '">' + esc(state) + "</span>";
+  var STATUS_LABEL = { ok: "Healthy", degraded: "Degraded", down: "Down", unknown: "Unknown" };
+
+  // Only http(s) URLs are safe to turn into a clickable href. A topology with a
+  // "javascript:" or "data:" url would otherwise become a script-executing
+  // link. Returns the trimmed url when it is openable, else "".
+  function httpUrl(value) {
+    if (typeof value !== "string") return "";
+    var v = value.trim();
+    return /^https?:\/\//i.test(v) ? v : "";
   }
 
-  function httpCell(svc) {
-    if (!svc.http_status) {
-      return '<span class="http http--none">—</span>';
-    }
-    var ok = svc.http_status >= 200 && svc.http_status < 300;
-    return '<span class="http ' + (ok ? "http--ok" : "http--bad") + '">' + esc(svc.http_status) + "</span>";
-  }
-
-  function row(svc) {
-    var online = svc.online
-      ? '<span class="tag tag--up">online</span>'
-      : '<span class="tag tag--off">—</span>';
-    var host = svc.host ? '<span class="svc-host">' + esc(svc.host) + "</span>" : '<span class="svc-host">—</span>';
-    var model = svc.model ? '<span class="svc-model">' + esc(svc.model) + "</span>" : '<span class="svc-model">—</span>';
-    var title = svc.error ? ' title="' + esc(svc.error) + '"' : "";
-    var health = svc.health || "unknown";
+  // Two stacked SVGs — clipboard (default) + checkmark (copied). The success
+  // state swaps the glyph via .is-copied, so confirmation is not color-only.
+  function copyIcons() {
+    // Static markup only; no value interpolation, so innerHTML is XSS-safe.
     return (
-      "<tr" + title + ">" +
-      '<td><span class="dot ' + healthClass(svc.health) + '" role="img" aria-label="' + esc(health) + '"></span></td>' +
-      '<td><span class="svc-id">' + esc(svc.id) + "</span></td>" +
-      '<td><span class="kind">' + esc(svc.kind) + "</span></td>" +
-      "<td>" + host + "</td>" +
-      "<td>" + machineCell(svc.machine_state) + "</td>" +
-      '<td class="col-center">' + online + "</td>" +
-      "<td>" + model + "</td>" +
-      '<td class="col-center">' + httpCell(svc) + "</td>" +
-      "</tr>"
+      '<svg class="clip" viewBox="0 0 16 16" fill="none" aria-hidden="true" focusable="false">' +
+      '<rect x="5.5" y="5.5" width="7.5" height="7.5" rx="1.5" stroke="currentColor" stroke-width="1.3"/>' +
+      '<path d="M3 10.5V4A1.5 1.5 0 0 1 4.5 2.5H10" stroke="currentColor" stroke-width="1.3"/>' +
+      "</svg>" +
+      '<svg class="check" viewBox="0 0 16 16" fill="none" aria-hidden="true" focusable="false">' +
+      '<path d="M3.5 8.5l3 3 6-6.5" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>' +
+      "</svg>"
     );
   }
 
-  function render(data) {
-    var ws = data.workspace || body.getAttribute("data-workspace") || "";
-    els.workspace.textContent = ws ? ws : "";
+  function makeCopyButton(value, label) {
+    var btn = el("button", "copy");
+    btn.type = "button";
+    btn.setAttribute("aria-label", label || "Copy URL");
+    btn.innerHTML = copyIcons();
+    btn.addEventListener("click", function (ev) {
+      ev.stopPropagation();
+      doCopy(value, btn);
+    });
+    return btn;
+  }
 
-    var s = data.summary || {};
-    els.total.textContent = s.total != null ? s.total : 0;
-    els.healthy.textContent = s.healthy != null ? s.healthy : 0;
-    els.degraded.textContent = s.degraded != null ? s.degraded : 0;
-    els.down.textContent = s.down != null ? s.down : 0;
-
-    var services = data.services || [];
-    if (services.length === 0) {
-      els.body.innerHTML = '<tr class="empty"><td colspan="8">No services in this fleet yet.</td></tr>';
+  function doCopy(value, btn) {
+    var prevLabel = btn.getAttribute("aria-label") || "Copy URL";
+    var done = function () {
+      btn.classList.add("is-copied");
+      btn.setAttribute("aria-label", "Copied");
+      setTimeout(function () {
+        btn.classList.remove("is-copied");
+        btn.setAttribute("aria-label", prevLabel);
+      }, 1200);
+    };
+    if (navigator.clipboard && navigator.clipboard.writeText) {
+      navigator.clipboard.writeText(value).then(done, function () { fallbackCopy(value, done); });
     } else {
-      els.body.innerHTML = services.map(row).join("");
+      fallbackCopy(value, done);
+    }
+  }
+
+  function fallbackCopy(value, done) {
+    var ta = document.createElement("textarea");
+    ta.value = value;
+    ta.setAttribute("readonly", "");
+    ta.style.position = "fixed";
+    ta.style.opacity = "0";
+    document.body.appendChild(ta);
+    ta.select();
+    try { document.execCommand("copy"); done(); } catch (e) { /* ignore */ }
+    document.body.removeChild(ta);
+  }
+
+  // ---- row construction --------------------------------------------------
+
+  function buildRow(svc) {
+    var health = healthOf(svc);
+    // The row is a div with role="button", not a <button> element: it contains
+    // the copy <button>, and a button cannot legally nest another button.
+    // tabindex + a keydown handler keep it keyboard-operable.
+    var btn = el("div", "row");
+    btn.setAttribute("role", "button");
+    btn.tabIndex = 0;
+    btn.dataset.id = svc.id || "";
+    btn.dataset.health = health;
+    if (svc.id === state.selectedId) btn.classList.add("is-selected");
+    // Accessible name carries id, health, and tailnet presence ("online"/
+    // "offline") so screen-reader users hear reachability without the dot.
+    btn.setAttribute(
+      "aria-label",
+      (svc.id || "service") + ", " + STATUS_LABEL[health] + ", " + (svc.online ? "online" : "offline")
+    );
+
+    // status
+    var status = el("span", "cell-status");
+    status.appendChild(el("span", "dot dot--" + health));
+    status.appendChild(el("span", "status-label", STATUS_LABEL[health]));
+    btn.appendChild(status);
+
+    // name + kind
+    var name = el("span", "cell-name");
+    name.appendChild(el("span", "svc-id", svc.id || "—"));
+    name.appendChild(el("span", "svc-kind", svc.kind || ""));
+    btn.appendChild(name);
+
+    // url + copy
+    var urlCell = el("span", "cell-url");
+    if (svc.url) {
+      urlCell.appendChild(el("span", "svc-url", svc.url));
+      urlCell.appendChild(makeCopyButton(svc.url, "Copy URL for " + (svc.id || "service")));
+    } else {
+      urlCell.appendChild(el("span", "svc-url svc-url--none", "—"));
+    }
+    btn.appendChild(urlCell);
+
+    // tailnet
+    var net = el("span", "cell-net");
+    if (svc.online) net.appendChild(el("span", "tag tag--online", "online"));
+    else net.appendChild(el("span", "tag tag--offline", "offline"));
+    btn.appendChild(net);
+
+    // machine
+    var machine = el("span", "cell-machine");
+    machine.appendChild(machineNode(svc.machine_state));
+    btn.appendChild(machine);
+
+    // http
+    var http = el("span", "cell-http");
+    http.appendChild(httpNode(svc.http_status));
+    btn.appendChild(http);
+
+    // model
+    var model = el("span", "cell-model");
+    if (svc.model) model.appendChild(el("span", "svc-model", svc.model));
+    else model.appendChild(el("span", "svc-model muted", "—"));
+    btn.appendChild(model);
+
+    btn.addEventListener("click", function () { openDrawer(svc, btn); });
+    btn.addEventListener("keydown", function (ev) {
+      if (ev.key === "Enter" || ev.key === " " || ev.key === "Spacebar") {
+        ev.preventDefault();
+        openDrawer(svc, btn);
+      }
+    });
+    return btn;
+  }
+
+  function machineNode(stateVal) {
+    if (!stateVal) return el("span", "state-text muted", "—");
+    var cls = stateVal === "started" ? "state-text--started" : stateVal === "stopped" ? "state-text--stopped" : "";
+    return el("span", "state-text " + cls, stateVal);
+  }
+
+  function httpNode(code) {
+    if (!code) return el("span", "http http--none", "—");
+    var ok = code >= 200 && code < 300;
+    return el("span", "http " + (ok ? "http--ok" : "http--bad"), String(code));
+  }
+
+  // ---- render ------------------------------------------------------------
+
+  function applyFilter(svc) {
+    if (state.filter === "all") return true;
+    return healthOf(svc) === state.filter;
+  }
+
+  // Problems-first ordering: a DOWN agent surfaces at the top of the single
+  // flat list at a glance (the brief's core scene). Secondary sort is a
+  // stable pass on the incoming order so equal-health rows keep their order.
+  var HEALTH_RANK = { down: 0, degraded: 1, unknown: 2, ok: 3 };
+
+  function sortProblemsFirst(list) {
+    return list
+      .map(function (svc, i) { return { svc: svc, i: i }; })
+      .sort(function (a, b) {
+        var ra = HEALTH_RANK[healthOf(a.svc)];
+        var rb = HEALTH_RANK[healthOf(b.svc)];
+        if (ra !== rb) return ra - rb;
+        return a.i - b.i; // stable secondary sort
+      })
+      .map(function (w) { return w.svc; });
+  }
+
+  function renderList() {
+    var bodyEl = els.listBody;
+    bodyEl.textContent = "";
+
+    // Empty state — distinct from the loading skeleton. Only reached once a
+    // poll has succeeded with zero services (the skeleton is replaced here,
+    // never stacked, because textContent above clears the node first).
+    if (!state.services.length) {
+      var empty = el("div", "state state--empty");
+      empty.appendChild(el("p", "state__text", "No services in this fleet yet."));
+      bodyEl.appendChild(empty);
+      return;
     }
 
-    if (data.generated_at) {
-      var when = new Date(data.generated_at);
-      els.updated.textContent = "updated " + when.toLocaleTimeString();
+    var shown = sortProblemsFirst(state.services.filter(applyFilter));
+    if (!shown.length) {
+      var none = el("div", "state state--empty");
+      none.appendChild(el("p", "state__text", "No " + (STATUS_LABEL[state.filter] || "matching").toLowerCase() + " services."));
+      bodyEl.appendChild(none);
+      return;
     }
 
+    var frag = document.createDocumentFragment();
+    shown.forEach(function (svc) { frag.appendChild(buildRow(svc)); });
+    bodyEl.appendChild(frag);
+  }
+
+  function renderCounts() {
+    // Count by exact health so each chip equals the rows its filter shows. The
+    // server summary folds "unknown" into "degraded", which would make the
+    // Degraded chip disagree with the Degraded filter (and skew "All" never).
+    els.countAll.textContent = state.services.length;
+    els.countHealthy.textContent = countBy("ok");
+    els.countDegraded.textContent = countBy("degraded");
+    els.countDown.textContent = countBy("down");
+  }
+
+  function countBy(h) {
+    return state.services.reduce(function (n, svc) { return n + (healthOf(svc) === h ? 1 : 0); }, 0);
+  }
+
+  function renderDrift(data) {
     var count = data.drift_count || 0;
     if (count > 0) {
       els.driftBadge.textContent = count + (count === 1 ? " issue" : " issues");
-      els.driftBadge.className = "badge badge--drift";
+      els.driftBadge.className = "drift__badge is-drift";
     } else {
       els.driftBadge.textContent = "clean";
-      els.driftBadge.className = "badge badge--clean";
+      els.driftBadge.className = "drift__badge";
     }
-    els.driftText.textContent = data.drift_text && data.drift_text.trim() ? data.drift_text : "= no-op";
-
-    els.connPill.className = "pill live";
-    els.connText.textContent = "live";
+    var text = data.drift_text && data.drift_text.trim() ? data.drift_text : "No drift. Fleet matches plan.";
+    els.driftPanel.textContent = text;
   }
 
-  function markStale() {
-    els.connPill.className = "pill stale";
-    els.connText.textContent = "stale";
+  function render(data) {
+    state.hadFirstPoll = true;
+    state.services = Array.isArray(data.services) ? data.services : [];
+    var ws = data.workspace || workspaceAttr;
+    if (ws) els.workspace.textContent = ws;
+
+    renderCounts();
+    renderList();
+    announceFilter();
+    renderDrift(data);
+
+    var genMs = 0;
+    if (data.generated_at) {
+      var when = new Date(data.generated_at);
+      if (!isNaN(when.getTime())) {
+        genMs = when.getTime();
+        els.updated.textContent = "updated " + when.toLocaleTimeString();
+      }
+    }
+    // Fall back to receipt time if the payload carries no usable timestamp,
+    // so the staleness clock still advances.
+    state.lastGeneratedAt = genMs || Date.now();
+
+    // If a drawer is open, refresh its contents from the latest data.
+    if (state.open && state.selectedId) {
+      var fresh = state.services.filter(function (s) { return s.id === state.selectedId; })[0];
+      if (fresh) fillDrawer(fresh);
+    }
+
+    setConn(true);
+    scheduleStaleCheck();
   }
+
+  function setConn(live) {
+    if (live) {
+      els.connPill.className = "conn is-live";
+      els.connText.textContent = "live";
+    } else {
+      els.connPill.className = "conn is-stale";
+      els.connText.textContent = "stale";
+    }
+  }
+
+  // Mark the pill stale once the freshest payload we hold ages past
+  // staleAfterMs, even if the control plane stays reachable (frozen state).
+  function scheduleStaleCheck() {
+    if (staleTimer) clearTimeout(staleTimer);
+    staleTimer = setTimeout(function () {
+      if (Date.now() - state.lastGeneratedAt >= staleAfterMs) setConn(false);
+    }, staleAfterMs + 250);
+  }
+
+  // ---- drawer ------------------------------------------------------------
+
+  function dlRow(key, valNode) {
+    var row = el("div", "dl__row");
+    row.appendChild(el("dt", "dl__key", key));
+    var dd = el("dd", "dl__val");
+    if (typeof valNode === "string" || valNode == null) {
+      dd.textContent = valNode == null || valNode === "" ? "—" : valNode;
+      if (valNode == null || valNode === "") dd.classList.add("muted");
+    } else {
+      dd.appendChild(valNode);
+    }
+    row.appendChild(dd);
+    return row;
+  }
+
+  function monoVal(value) {
+    if (!value) { var m = el("span", "muted", "—"); return m; }
+    return el("span", "dl__val--mono", value);
+  }
+
+  function fillDrawer(svc) {
+    var health = healthOf(svc);
+    els.drawerTitle.textContent = svc.id || "Service";
+    els.drawerPill.className = "status-pill status-pill--" + health;
+    els.drawerPillText.textContent = STATUS_LABEL[health];
+
+    // body
+    els.drawerBody.textContent = "";
+    var dl = el("dl", "dl");
+
+    // URL row: link + copy. Only http(s) urls become a clickable link; a
+    // non-openable url is shown as plain text (still copyable). No url => muted.
+    var urlNode;
+    var safeUrl = httpUrl(svc.url);
+    if (safeUrl) {
+      urlNode = el("span", "dl__url");
+      var link = el("a", "dl__link", safeUrl);
+      link.href = safeUrl;
+      link.target = "_blank";
+      link.rel = "noopener noreferrer";
+      urlNode.appendChild(link);
+      urlNode.appendChild(makeCopyButton(safeUrl, "Copy URL"));
+    } else if (svc.url) {
+      urlNode = el("span", "dl__url");
+      urlNode.appendChild(el("span", "dl__val--mono", svc.url));
+      urlNode.appendChild(makeCopyButton(svc.url, "Copy URL"));
+    } else {
+      urlNode = el("span", "muted", "—");
+    }
+    // Field order matches the brief exactly: URL, host, fly_app,
+    // machine_state, tailnet, model, vault, http_status, health. Kind is not
+    // in the brief's list, so it trails after Health rather than sitting
+    // second. Missing values render an em-dash, never "undefined".
+    dl.appendChild(dlRow("URL", urlNode));
+    dl.appendChild(dlRow("Host", monoVal(svc.host)));
+    dl.appendChild(dlRow("Fly app", monoVal(svc.fly_app)));
+    dl.appendChild(dlRow("Machine", machineNode(svc.machine_state)));
+    dl.appendChild(dlRow("Tailnet", svc.online ? "online" : "offline"));
+    dl.appendChild(dlRow("Model", monoVal(svc.model)));
+    dl.appendChild(dlRow("Vault", monoVal(svc.vault)));
+    dl.appendChild(dlRow("HTTP", httpNode(svc.http_status)));
+    dl.appendChild(dlRow("Health", STATUS_LABEL[health]));
+    dl.appendChild(dlRow("Kind", svc.kind || "—"));
+    els.drawerBody.appendChild(dl);
+
+    if (svc.error) {
+      var block = el("div", "error-block");
+      block.appendChild(el("div", "error-block__label", "Probe error"));
+      block.appendChild(el("div", "error-block__text", svc.error));
+      els.drawerBody.appendChild(block);
+    }
+
+    // footer: only offer "Open" for an http(s) url.
+    els.drawerFoot.textContent = "";
+    if (safeUrl) {
+      var open = el("a", "btn-primary");
+      // Inline external-link glyph (arrow out of box) reads as "open in new
+      // tab". Static markup only — the label is appended via textContent.
+      open.innerHTML =
+        '<svg viewBox="0 0 16 16" fill="none" aria-hidden="true" focusable="false">' +
+        '<path d="M6 3.5h6.5V10" stroke="currentColor" stroke-width="1.3" stroke-linecap="round" stroke-linejoin="round"/>' +
+        '<path d="M12 4 4 12" stroke="currentColor" stroke-width="1.3" stroke-linecap="round"/>' +
+        "</svg>";
+      open.appendChild(document.createTextNode("Open service"));
+      open.href = safeUrl;
+      open.target = "_blank";
+      open.rel = "noopener noreferrer";
+      els.drawerFoot.appendChild(open);
+    } else {
+      var disabled = el("span", "btn-primary", "No URL to open");
+      disabled.setAttribute("aria-disabled", "true");
+      els.drawerFoot.appendChild(disabled);
+    }
+  }
+
+  function focusable() {
+    return Array.prototype.slice.call(
+      els.drawer.querySelectorAll('a[href], button:not([disabled]), [tabindex]:not([tabindex="-1"])')
+    ).filter(function (n) { return n.offsetParent !== null || n === document.activeElement; });
+  }
+
+  function openDrawer(svc, originRow) {
+    state.selectedId = svc.id;
+    state.lastFocused = originRow || document.activeElement;
+    state.open = true;
+
+    // selection highlight
+    var rows = els.listBody.querySelectorAll(".row");
+    Array.prototype.forEach.call(rows, function (r) {
+      r.classList.toggle("is-selected", r.dataset.id === svc.id);
+    });
+
+    fillDrawer(svc);
+
+    els.scrim.hidden = false;
+    els.drawer.hidden = false;
+    // force reflow so the transform transition runs
+    void els.drawer.offsetWidth;
+    els.scrim.classList.add("is-open");
+    els.drawer.classList.add("is-open");
+    document.body.style.overflow = "hidden";
+
+    var target = els.drawerClose;
+    if (reduceMotion) {
+      target.focus();
+    } else {
+      setTimeout(function () { target.focus(); }, 60);
+    }
+  }
+
+  function closeDrawer() {
+    if (!state.open) return;
+    state.open = false;
+    els.scrim.classList.remove("is-open");
+    els.drawer.classList.remove("is-open");
+    document.body.style.overflow = "";
+
+    var finish = function () {
+      els.drawer.hidden = true;
+      els.scrim.hidden = true;
+    };
+    if (reduceMotion) finish();
+    else setTimeout(finish, 200);
+
+    var rows = els.listBody.querySelectorAll(".row.is-selected");
+    Array.prototype.forEach.call(rows, function (r) { r.classList.remove("is-selected"); });
+
+    // Return focus to the originating row. A poll may have rebuilt the list
+    // while the drawer was open, so the original node can be detached; fall
+    // back to the row with the same id, then to the list itself.
+    var prev = state.lastFocused;
+    var prevId = state.selectedId;
+    state.selectedId = null;
+    state.lastFocused = null;
+    if (prev && document.contains(prev) && typeof prev.focus === "function") {
+      prev.focus();
+    } else if (prevId) {
+      var rebuilt = els.listBody.querySelector('.row[data-id="' + (window.CSS && CSS.escape ? CSS.escape(prevId) : prevId) + '"]');
+      if (rebuilt) rebuilt.focus();
+    }
+  }
+
+  function onKeydown(ev) {
+    if (!state.open) return;
+    if (ev.key === "Escape") { ev.preventDefault(); closeDrawer(); return; }
+    if (ev.key === "Tab") {
+      var items = focusable();
+      if (!items.length) { ev.preventDefault(); return; }
+      var first = items[0], last = items[items.length - 1];
+      if (ev.shiftKey && document.activeElement === first) { ev.preventDefault(); last.focus(); }
+      else if (!ev.shiftKey && document.activeElement === last) { ev.preventDefault(); first.focus(); }
+      else if (!els.drawer.contains(document.activeElement)) { ev.preventDefault(); first.focus(); }
+    }
+  }
+
+  els.drawerClose.addEventListener("click", closeDrawer);
+  els.scrim.addEventListener("click", closeDrawer);
+  document.addEventListener("keydown", onKeydown);
+
+  // ---- filters -----------------------------------------------------------
+
+  // These four filters are mutually exclusive, so they are a single-select
+  // radiogroup (role=radio + aria-checked), not four ambiguous toggles. The
+  // active filter and its result count are also announced via a live region.
+  function announceFilter() {
+    if (!els.filterStatus) return;
+    var shown = state.services.filter(applyFilter).length;
+    var label = STATUS_LABEL[state.filter];
+    var name = state.filter === "all" ? "all" : (label ? label.toLowerCase() : state.filter);
+    els.filterStatus.textContent =
+      "Showing " + shown + " " + name + (shown === 1 ? " service" : " services");
+  }
+
+  var segs = Array.prototype.slice.call(document.querySelectorAll(".seg"));
+
+  // Select a filter and update the radiogroup state. Roving tabindex: only the
+  // checked radio is in the tab order (tabindex 0); the rest are -1 and reached
+  // with arrow keys, per the WAI-ARIA radiogroup pattern.
+  function selectFilter(seg, focusIt) {
+    state.filter = seg.dataset.filter || "all";
+    segs.forEach(function (s) {
+      var active = s === seg;
+      s.classList.toggle("is-active", active);
+      s.setAttribute("aria-checked", active ? "true" : "false");
+      s.tabIndex = active ? 0 : -1;
+    });
+    if (focusIt) seg.focus();
+    renderList();
+    announceFilter();
+  }
+
+  segs.forEach(function (seg, i) {
+    seg.tabIndex = seg.classList.contains("is-active") ? 0 : -1;
+    seg.addEventListener("click", function () { selectFilter(seg, false); });
+    seg.addEventListener("keydown", function (ev) {
+      var next = null;
+      if (ev.key === "ArrowRight" || ev.key === "ArrowDown") next = segs[(i + 1) % segs.length];
+      else if (ev.key === "ArrowLeft" || ev.key === "ArrowUp") next = segs[(i - 1 + segs.length) % segs.length];
+      else if (ev.key === "Home") next = segs[0];
+      else if (ev.key === "End") next = segs[segs.length - 1];
+      if (next) { ev.preventDefault(); selectFilter(next, true); }
+    });
+  });
+
+  // ---- drift toggle ------------------------------------------------------
+
+  els.driftToggle.addEventListener("click", function () {
+    var expanded = els.driftToggle.getAttribute("aria-expanded") === "true";
+    els.driftToggle.setAttribute("aria-expanded", expanded ? "false" : "true");
+    els.driftPanel.hidden = expanded;
+  });
+
+  // ---- polling -----------------------------------------------------------
 
   function poll() {
     fetch("/api/status", { headers: { Accept: "application/json" }, cache: "no-store" })
@@ -123,7 +596,12 @@
         return r.json();
       })
       .then(render)
-      .catch(markStale);
+      .catch(function () {
+        // Reachability failed: mark stale. On a failed FIRST poll we leave the
+        // loading skeleton ("Waiting for first poll") in place — it is never
+        // replaced by the empty state until a poll has actually succeeded.
+        setConn(false);
+      });
   }
 
   poll();

--- a/internal/web/assets/index.html
+++ b/internal/web/assets/index.html
@@ -3,80 +3,96 @@
 <head>
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
-  <title>Companion · Fleet Status</title>
-  <link rel="preconnect" href="https://fonts.googleapis.com">
-  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500;700&display=swap" rel="stylesheet">
+  <title>Companion · Fleet</title>
   <link rel="stylesheet" href="/assets/dashboard.css">
 </head>
 <body data-interval="{{.IntervalSec}}" data-workspace="{{.Workspace}}">
-  <div class="grain" aria-hidden="true"></div>
 
-  <header class="hero">
-    <div class="hero__bar">
-      <div class="wordmark">
-        <span class="wordmark__dot"></span>
-        Companion
-      </div>
-      <div class="hero__meta">
-        <span class="pill" id="conn-pill" role="status"><span class="pill__dot"></span><span id="conn-text">connecting…</span></span>
-        <span class="hero__ws" id="workspace-name"></span>
-      </div>
+  <header class="topbar">
+    <div class="topbar__left">
+      <span class="wordmark">Companion</span>
+      <span class="topbar__sep" aria-hidden="true"></span>
+      <span class="topbar__ws" id="workspace-name"></span>
     </div>
-    <h1 class="hero__title">Fleet status</h1>
-    <p class="hero__tagline">Secure fleets of task-optimized AI agents — tools, memory, and private access. Live over Tailscale.</p>
+    <div class="topbar__right">
+      <span class="conn" id="conn-pill" role="status" aria-live="polite">
+        <span class="conn__dot" aria-hidden="true"></span>
+        <span id="conn-text">connecting</span>
+      </span>
+      <span class="topbar__updated" id="updated">updated --:--:--</span>
+      <span class="topbar__refresh" id="refresh-note"></span>
+    </div>
   </header>
 
   <main class="wrap">
-    <section class="stats" id="stats" aria-live="polite" aria-label="Fleet health summary">
-      <article class="stat stat--total"><div class="stat__num" id="stat-total">—</div><div class="stat__label">Services</div></article>
-      <article class="stat stat--ok"><div class="stat__num" id="stat-healthy">—</div><div class="stat__label">Healthy</div></article>
-      <article class="stat stat--warn"><div class="stat__num" id="stat-degraded">—</div><div class="stat__label">Degraded</div></article>
-      <article class="stat stat--down"><div class="stat__num" id="stat-down">—</div><div class="stat__label">Down</div></article>
+
+    <div class="filters" role="radiogroup" aria-label="Filter services by health">
+      <button class="seg is-active" type="button" data-filter="all" role="radio" aria-checked="true">
+        <span class="seg__label">All</span><span class="seg__count" id="count-all">0</span>
+      </button>
+      <button class="seg" type="button" data-filter="ok" role="radio" aria-checked="false">
+        <span class="seg__swatch seg__swatch--ok" aria-hidden="true"></span>
+        <span class="seg__label">Healthy</span><span class="seg__count" id="count-healthy">0</span>
+      </button>
+      <button class="seg" type="button" data-filter="degraded" role="radio" aria-checked="false">
+        <span class="seg__swatch seg__swatch--degraded" aria-hidden="true"></span>
+        <span class="seg__label">Degraded</span><span class="seg__count" id="count-degraded">0</span>
+      </button>
+      <button class="seg" type="button" data-filter="down" role="radio" aria-checked="false">
+        <span class="seg__swatch seg__swatch--down" aria-hidden="true"></span>
+        <span class="seg__label">Down</span><span class="seg__count" id="count-down">0</span>
+      </button>
+      <span class="sr-only" id="filter-status" role="status" aria-live="polite"></span>
+    </div>
+
+    <section class="list" aria-label="Fleet agents">
+      <div class="list__head" role="row">
+        <span class="col col-status" role="columnheader">Status</span>
+        <span class="col col-name" role="columnheader">Service</span>
+        <span class="col col-url" role="columnheader">URL</span>
+        <span class="col col-net" role="columnheader">Tailnet</span>
+        <span class="col col-machine" role="columnheader">Machine</span>
+        <span class="col col-http" role="columnheader">HTTP</span>
+        <span class="col col-model" role="columnheader">Model</span>
+      </div>
+      <div class="list__body" id="services-body">
+        <div class="state state--loading" id="state-loading">
+          <div class="skel-rows" aria-hidden="true">
+            <span class="skel-row"></span><span class="skel-row"></span><span class="skel-row"></span>
+          </div>
+          <p class="state__text">Waiting for first poll</p>
+        </div>
+      </div>
     </section>
 
-    <section class="panel">
-      <div class="panel__head">
-        <h2>Services</h2>
-        <span class="panel__hint" id="updated">—</span>
-      </div>
-      <div class="table-wrap">
-        <table class="services">
-          <thead>
-            <tr>
-              <th class="col-status" scope="col"><span class="sr-only">Health</span></th>
-              <th scope="col">Service</th>
-              <th scope="col">Kind</th>
-              <th scope="col">Host</th>
-              <th scope="col">Machine</th>
-              <th class="col-center" scope="col">Tailnet</th>
-              <th scope="col">Model</th>
-              <th class="col-center" scope="col">HTTP</th>
-            </tr>
-          </thead>
-          <tbody id="services-body">
-            <tr class="empty"><td colspan="8">Waiting for first poll…</td></tr>
-          </tbody>
-        </table>
-      </div>
+    <section class="drift" id="drift" aria-label="Configuration drift">
+      <button class="drift__toggle" type="button" id="drift-toggle" aria-expanded="false" aria-controls="drift-panel">
+        <span class="drift__chev" aria-hidden="true"></span>
+        <span class="drift__title">Drift</span>
+        <span class="drift__badge" id="drift-badge">clean</span>
+      </button>
+      <pre class="drift__panel" id="drift-panel" hidden>No drift report.</pre>
     </section>
 
-    <section class="panel panel--drift">
-      <div class="panel__head">
-        <h2>Drift</h2>
-        <span class="badge" id="drift-badge">—</span>
-      </div>
-      <pre class="drift" id="drift-text">No drift report.</pre>
-    </section>
   </main>
 
-  <footer class="foot">
-    <span>Companion control plane</span>
-    <span class="foot__sep">·</span>
-    <a href="/api/status">/api/status</a>
-    <span class="foot__sep">·</span>
-    <span id="refresh-note"></span>
-  </footer>
+  <div class="scrim" id="scrim" hidden></div>
+
+  <aside class="drawer" id="drawer" role="dialog" aria-modal="true" aria-labelledby="drawer-title" hidden tabindex="-1">
+    <header class="drawer__head">
+      <div class="drawer__heading">
+        <h2 class="drawer__title" id="drawer-title">Service</h2>
+        <span class="status-pill" id="drawer-pill"><span class="status-pill__dot"></span><span id="drawer-pill-text">unknown</span></span>
+      </div>
+      <button class="drawer__close" type="button" id="drawer-close" aria-label="Close detail">
+        <svg viewBox="0 0 16 16" fill="none" aria-hidden="true" focusable="false">
+          <path d="M3.5 3.5l9 9M12.5 3.5l-9 9" stroke="currentColor" stroke-width="1.4" stroke-linecap="round"/>
+        </svg>
+      </button>
+    </header>
+    <div class="drawer__body" id="drawer-body"></div>
+    <footer class="drawer__foot" id="drawer-foot"></footer>
+  </aside>
 
   <script src="/assets/dashboard.js"></script>
 </body>

--- a/internal/web/web_test.go
+++ b/internal/web/web_test.go
@@ -1,0 +1,60 @@
+package web
+
+import (
+	"html/template"
+	"io/fs"
+	"strings"
+	"testing"
+)
+
+// TestIndexTemplateRenders guards the contract between the Go handler and the
+// embedded index.html: it must stay a parseable template that injects the
+// workspace name and refresh interval, and must keep referencing the served
+// asset paths. A stray "{{" in the markup or a renamed placeholder would break
+// the dashboard at runtime; this keeps it failing in CI instead.
+func TestIndexTemplateRenders(t *testing.T) {
+	tpl, err := template.ParseFS(assets, "assets/index.html")
+	if err != nil {
+		t.Fatalf("parse index.html template: %v", err)
+	}
+
+	var sb strings.Builder
+	if err := tpl.Execute(&sb, map[string]any{
+		"Workspace":   "test-workspace",
+		"IntervalSec": 30,
+	}); err != nil {
+		t.Fatalf("execute index.html template: %v", err)
+	}
+	out := sb.String()
+
+	for _, want := range []string{
+		`data-interval="30"`,
+		`data-workspace="test-workspace"`,
+		`/assets/dashboard.css`,
+		`/assets/dashboard.js`,
+	} {
+		if !strings.Contains(out, want) {
+			t.Errorf("rendered index.html missing %q", want)
+		}
+	}
+}
+
+// TestEmbeddedAssetsPresent ensures the three frontend files the dashboard
+// serves are actually embedded and non-empty, so go:embed cannot silently ship
+// a stylesheet-less or script-less build.
+func TestEmbeddedAssetsPresent(t *testing.T) {
+	for _, name := range []string{
+		"assets/index.html",
+		"assets/dashboard.css",
+		"assets/dashboard.js",
+	} {
+		data, err := fs.ReadFile(assets, name)
+		if err != nil {
+			t.Errorf("embedded asset %s: %v", name, err)
+			continue
+		}
+		if len(data) == 0 {
+			t.Errorf("embedded asset %s is empty", name)
+		}
+	}
+}


### PR DESCRIPTION
## Summary

Redesigns the local Companion dashboard (`go run ./cmd/companion dashboard`) from the warm, marketing-style surface into a calm, dense operator tool in the Linear register. Layered OKLCH near-black surfaces tinted toward a single indigo accent, system fonts (no web-font dependency), and static (non-pulsing) status. Each agent row surfaces its **status** and **URL**, sorted problems-first so a down agent is at the top; clicking a row opens a client-side **slide-over detail drawer** (URL copy + open, probe-error block, focus trap, Esc/scrim close, focus return). Adds a health filter radiogroup (roving tabindex + arrow keys) and a collapsible drift panel. This is frontend only: `/api/status` already exposes every field, so there are no Go/API logic changes. Adds `PRODUCT.md` + `DESIGN.md` (product register + design system) and a Go test guarding the index template/embedded assets; legacy server-rendered pages are remapped onto the new tokens.

![list view](https://vanish.sh/f/RTU4hOutTbIq.png)
![detail drawer](https://vanish.sh/f/54_Wm3EMWaNj.png)

## Test plan

- `go test ./...`, `go vet ./...` pass; `gofmt -l` clean; new `internal/web/web_test.go` covers template render + embedded assets.
- Shell `-n` checks and `validate --workspace examples/{minimal,webui}` pass (matches CI).
- Browser-verified against a mocked fleet: problems-first sort, filter counts match the filtered rows, row click + Enter/Space open the drawer, Esc closes and returns focus to the (rebuilt) row, arrow-key filter navigation, and `javascript:`/`data:` URLs render inert (no clickable href).

## Review notes (already addressed)

- `/impeccable audit`: fixed two WCAG AA contrast misses (muted label text 3.5→4.5:1; primary button 3.7→4.9:1).
- Review board + `cubic` review: scheme-allowlisted URLs (no `javascript:` href), focus-return fallback after a poll rebuilds the list, valid HTML (row is `div[role=button]`, no nested `<button>`), and chip counts computed by exact health so they match the filters.

## Non-blocking known issues

- The inline copy button is a 22px target (below the 44px touch guideline). Acceptable for this desktop/second-monitor operator tool: the whole row is the primary target and copy is duplicated in the drawer.

Generated by an AI agent (Claude Code); validated locally as above. Not yet human-reviewed.