### PR TITLE
test(companion): enforce global testing standard

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,6 +26,21 @@ jobs:
       - name: Run tests
         run: go test ./...
 
+      - name: Run race tests
+        run: go test -race ./...
+
+      - name: Check coverage floor
+        run: |
+          set -euo pipefail
+          go test -coverprofile=coverage.out ./...
+          go tool cover -func=coverage.out | awk '/^total:/ {
+            gsub("%", "", $3)
+            if (($3 + 0) < 55) {
+              printf("coverage %.1f%% is below required 55.0%%\n", $3)
+              exit 1
+            }
+          }'
+
       - name: Validate shell scripts
         run: |
           sh -n install.sh

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -49,6 +49,34 @@ Provider e2e tests should use local mocks through `mode = "api"` and `api_base_u
 - Run `gofmt` on touched Go files.
 - Add focused Go tests for changed planning, config, provider, state, render, CLI, or output behavior.
 
+## Testing Standard
+
+Tests in this repository must prove product behavior, not implementation trivia. A good test describes an observable Companion contract: TOML normalization, workspace loading, resource graph shape, idempotent plans, generated Fly TOML, provider API parsing, SQLite evidence, CLI output, dashboard JSON, or secret redaction.
+
+Weak tests are not acceptable. Do not add tests that only check `err == nil`, mirror the implementation, mock the unit under test, assert no meaningful behavior, or use snapshots/golden files without a real output contract.
+
+Use the established hermetic patterns:
+
+- Table-driven tests for config variants, provider responses, URL modes, lifecycle states, and error cases.
+- `t.TempDir()` for workspaces, generated files, and SQLite state.
+- `httptest` for external HTTP APIs.
+- `execx.FakeRunner` for Fly/Tailscale CLI behavior.
+- Local provider mocks for e2e-style apply/plan tests.
+- `t.Helper()` for fixture builders and assertion helpers.
+- Regression tests for fixed bugs, especially idempotency, deletion safety, URL computation, and secret redaction.
+- No live Fly, Tailscale, or OpenRouter calls unless the user explicitly requests live operations.
+
+Coverage expectations by area:
+
+- `internal/config`, `internal/workspace`, `internal/envfile`: defaults, validation failures, overrides, path safety, and public example workspaces.
+- `internal/resource`, `internal/plan`, `internal/state`: stable graphs, idempotence, drift, explicit deletion, protected resources, and SQLite writes/migrations.
+- `internal/render`, `internal/hermes`, `internal/outputs`, `internal/deps`: deterministic generated artifacts, redacted secrets, correct URLs/dependencies, and no invented runtime URLs.
+- `internal/fly`, `internal/tailscale`, `internal/openrouter`, `internal/tailscalectl`: API/CLI parsing, auth headers, provider errors, offline/duplicate states, and safe deletion targeting.
+- `internal/cli`: temporary-workspace command flows, useful errors, provider-mock apply/plan, and no secret values in stdout/stderr.
+- `internal/web`, `internal/status`: `/api/status` contract, health rollups, agent/support separation, embedded assets, and user links kept separate from health probes.
+
+The CI gates are `go test ./...`, `go test -race ./...`, shell syntax checks, installable CLI verification, public workspace validation, Docker builds, and a global coverage floor. Treat coverage as a regression guard, not a substitute for meaningful assertions.
+
 ## Workspace Semantics
 
 - Companion workspaces are folders containing `companion.toml`, `providers.toml`, `defaults.toml`, optional `webui.toml`, `agents/*.toml`, `vaults/*.toml`, and identities.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -34,6 +34,18 @@ go run ./cmd/companion dashboard --addr 127.0.0.1:8787 --workspace examples/mini
 
 The `dashboard` command (alias: `serve`) live-polls the fleet and serves a status UI embedded via `go:embed`. Enabling `[dashboard]` in a workspace deploys it as its own tiny, stateless Fly app behind Tailscale; `apply` keeps its `fleet.json` topology in sync via `dashboard_config.main`.
 
+## Testing Standard
+
+Follow `AGENTS.md` as the source of truth. Every change should add or update tests that prove Companion's observable behavior: config contracts, workspace loading, planning/idempotence, resource/state evidence, provider parsing, render output, CLI UX, dashboard API, and secret redaction.
+
+Do not add weak tests. Avoid tests that only check `err == nil`, duplicate implementation logic, mock the code being tested, or snapshot output that is not a real public/generated contract.
+
+Use hermetic patterns: table-driven cases, `t.TempDir()` for files and state, `httptest` for external HTTP, `execx.FakeRunner` for CLI integrations, local provider mocks for e2e flows, and `t.Helper()` for fixtures. Never call live Fly, Tailscale, or OpenRouter unless the user explicitly requested a live operation.
+
+When touching a subsystem, cover its product invariants: config defaults/validation, resource graph stability, explicit destroy semantics, protected resources, deterministic generated TOML/scripts, provider auth/error parsing, SQLite persistence/migration behavior, CLI output without secrets, and dashboard `/api/status` links/health/support grouping.
+
+Expected CI gates are `go test ./...`, `go test -race ./...`, shell syntax checks, installable CLI verification, public workspace validation, Docker builds, and a global coverage floor. Coverage is only a regression guard; meaningful assertions remain required.
+
 ## Claude-Specific Notes
 
 - Prefer the repository's Go/TOML patterns over the archived TypeScript web UI patterns.

--- a/internal/cli/cli_test.go
+++ b/internal/cli/cli_test.go
@@ -116,6 +116,44 @@ func TestAppEnvLoadsEnvFileAndShellOverrides(t *testing.T) {
 	}
 }
 
+func TestPlanCommandDoesNotPrintSecretValues(t *testing.T) {
+	root := t.TempDir()
+	writeTestWorkspace(t, root, map[string]string{
+		"sample": `
+[agent]
+id = "sample"
+fly_app = "example-companion-sample"
+tailscale_hostname = "sample"
+`,
+	})
+	writeTestFile(t, root, ".env", `
+TS_AUTHKEY = "tailscale-auth-secret"
+API_SERVER_KEY = "api-server-secret"
+FLY_API_TOKEN = "fly-token-secret"
+TAILSCALE_API_KEY = "tailscale-api-secret"
+`)
+	runner := &execx.FakeRunner{Responses: map[string]execx.Result{
+		"tailscale status --json": {Stdout: `{"Peer":{}}`},
+	}}
+	cmd := newRootCommand(runner)
+	var output bytes.Buffer
+	cmd.SetOut(&output)
+	cmd.SetArgs([]string{"--workspace", root, "--env-file", ".env", "plan"})
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("plan command: %v", err)
+	}
+	for _, secretValue := range []string{"tailscale-auth-secret", "api-server-secret", "fly-token-secret", "tailscale-api-secret"} {
+		if strings.Contains(output.String(), secretValue) {
+			t.Fatalf("plan output leaked secret value %q:\n%s", secretValue, output.String())
+		}
+	}
+	for _, secretName := range []string{"TS_AUTHKEY", "API_SERVER_KEY"} {
+		if !strings.Contains(output.String(), secretName) {
+			t.Fatalf("plan output should mention missing/reused secret name %q, got:\n%s", secretName, output.String())
+		}
+	}
+}
+
 func TestValidateProvidersRequiresCredentials(t *testing.T) {
 	root := t.TempDir()
 	writeTestWorkspace(t, root, map[string]string{

--- a/internal/deps/openwebui.go
+++ b/internal/deps/openwebui.go
@@ -58,6 +58,43 @@ func AgentAPIBaseURL(agent config.Agent, devices []tailscale.Device) string {
 	return fmt.Sprintf("http://%s:%d", host, api.Port)
 }
 
+func AgentDashboardURL(agent config.Agent, devices []tailscale.Device) string {
+	host := TailscaleDNSName(devices, agent.TailscaleHostname)
+	if host == "" {
+		return ""
+	}
+	switch agent.DashboardMode {
+	case "serve":
+		return "https://" + host + "/"
+	case "tailnet-port":
+		return fmt.Sprintf("http://%s:%d", host, agent.DashboardPort)
+	default:
+		return ""
+	}
+}
+
+func OpenWebUIURL(cfg config.OpenWebUI, devices []tailscale.Device) string {
+	host := TailscaleDNSName(devices, cfg.TailscaleHostname)
+	if host == "" {
+		return ""
+	}
+	if cfg.TailscaleServe {
+		return "https://" + host + "/"
+	}
+	return fmt.Sprintf("http://%s:%d", host, cfg.Port)
+}
+
+func OpenWebUIHealthURL(cfg config.OpenWebUI, devices []tailscale.Device) string {
+	host := TailscaleDNSName(devices, cfg.TailscaleHostname)
+	if host == "" {
+		return ""
+	}
+	if cfg.TailscaleServe {
+		return "https://" + host + "/health"
+	}
+	return fmt.Sprintf("http://%s:%d/health", host, cfg.Port)
+}
+
 func TailscaleDNSName(devices []tailscale.Device, hostname string) string {
 	matches := tailscale.FindByHostname(devices, hostname)
 	if len(matches) == 0 {

--- a/internal/deps/openwebui_test.go
+++ b/internal/deps/openwebui_test.go
@@ -53,3 +53,158 @@ func TestAgentAPIBaseURLKeepsExplicitHost(t *testing.T) {
 		t.Fatalf("unexpected base URL: %s", got)
 	}
 }
+
+func TestAgentDashboardURLUsesConfiguredHermesDashboardMode(t *testing.T) {
+	devices := []tailscale.Device{
+		{HostName: "agent", DNSName: "agent.tail.ts.net.", Online: false},
+		{HostName: "agent", DNSName: "agent-2.tail.ts.net.", Online: true},
+	}
+	tests := []struct {
+		name  string
+		agent config.Agent
+		want  string
+	}{
+		{
+			name: "tailscale serve uses https dashboard",
+			agent: config.Agent{
+				TailscaleHostname: "agent",
+				DashboardMode:     "serve",
+				DashboardPort:     9119,
+			},
+			want: "https://agent-2.tail.ts.net/",
+		},
+		{
+			name: "tailnet port keeps explicit dashboard port",
+			agent: config.Agent{
+				TailscaleHostname: "agent",
+				DashboardMode:     "tailnet-port",
+				DashboardPort:     9119,
+			},
+			want: "http://agent-2.tail.ts.net:9119",
+		},
+		{
+			name: "off mode exposes no user dashboard URL",
+			agent: config.Agent{
+				TailscaleHostname: "agent",
+				DashboardMode:     "off",
+				DashboardPort:     9119,
+			},
+			want: "",
+		},
+		{
+			name: "missing tailscale device exposes no invented URL",
+			agent: config.Agent{
+				TailscaleHostname: "missing",
+				DashboardMode:     "serve",
+				DashboardPort:     9119,
+			},
+			want: "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := AgentDashboardURL(tt.agent, devices); got != tt.want {
+				t.Fatalf("AgentDashboardURL() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestOpenWebUIURLUsesTailnetAccessMode(t *testing.T) {
+	devices := []tailscale.Device{{
+		HostName: "companion-webui",
+		DNSName:  "companion-webui.tail.ts.net.",
+		Online:   true,
+	}}
+	tests := []struct {
+		name string
+		cfg  config.OpenWebUI
+		want string
+	}{
+		{
+			name: "tailscale serve uses https support URL",
+			cfg: config.OpenWebUI{
+				TailscaleHostname: "companion-webui",
+				TailscaleServe:    true,
+				Port:              8080,
+			},
+			want: "https://companion-webui.tail.ts.net/",
+		},
+		{
+			name: "tailnet port uses configured webui port",
+			cfg: config.OpenWebUI{
+				TailscaleHostname: "companion-webui",
+				TailscaleServe:    false,
+				Port:              8080,
+			},
+			want: "http://companion-webui.tail.ts.net:8080",
+		},
+		{
+			name: "missing tailscale device exposes no invented URL",
+			cfg: config.OpenWebUI{
+				TailscaleHostname: "missing-webui",
+				TailscaleServe:    true,
+				Port:              8080,
+			},
+			want: "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := OpenWebUIURL(tt.cfg, devices); got != tt.want {
+				t.Fatalf("OpenWebUIURL() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestOpenWebUIHealthURLUsesSameTailnetAccessMode(t *testing.T) {
+	devices := []tailscale.Device{{
+		HostName: "companion-webui",
+		DNSName:  "companion-webui.tail.ts.net.",
+		Online:   true,
+	}}
+	tests := []struct {
+		name string
+		cfg  config.OpenWebUI
+		want string
+	}{
+		{
+			name: "tailscale serve probes webui health over https",
+			cfg: config.OpenWebUI{
+				TailscaleHostname: "companion-webui",
+				TailscaleServe:    true,
+				Port:              8080,
+			},
+			want: "https://companion-webui.tail.ts.net/health",
+		},
+		{
+			name: "tailnet port probes configured webui port",
+			cfg: config.OpenWebUI{
+				TailscaleHostname: "companion-webui",
+				TailscaleServe:    false,
+				Port:              8080,
+			},
+			want: "http://companion-webui.tail.ts.net:8080/health",
+		},
+		{
+			name: "missing tailscale device has no health probe",
+			cfg: config.OpenWebUI{
+				TailscaleHostname: "missing-webui",
+				TailscaleServe:    true,
+				Port:              8080,
+			},
+			want: "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := OpenWebUIHealthURL(tt.cfg, devices); got != tt.want {
+				t.Fatalf("OpenWebUIHealthURL() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}

--- a/internal/fly/fly_test.go
+++ b/internal/fly/fly_test.go
@@ -88,3 +88,13 @@ func TestListMachinesParsesFlyImageRefObject(t *testing.T) {
 		t.Fatalf("unexpected machines: %#v", machines)
 	}
 }
+
+func TestDeleteVolumeIgnoresAlreadyMissingRemoteVolume(t *testing.T) {
+	runner := &execx.FakeRunner{Responses: map[string]execx.Result{
+		"fly volumes destroy vol-missing -a app --yes": {ExitCode: 1, Stderr: "Error: no volume found"},
+	}}
+	provider := New(runner)
+	if err := provider.DeleteVolume(context.Background(), "app", "vol-missing"); err != nil {
+		t.Fatalf("delete missing volume should be idempotent: %v", err)
+	}
+}

--- a/internal/resource/resource_test.go
+++ b/internal/resource/resource_test.go
@@ -221,6 +221,47 @@ func TestDashboardTopologyHashGating(t *testing.T) {
 	}
 }
 
+func TestDashboardTopologyHashTracksResolvedUserURLs(t *testing.T) {
+	ws := dashboardWorkspace(t, "research")
+	ws.Config.OpenWebUI = config.OpenWebUI{
+		Enabled:           true,
+		ID:                "open-webui",
+		Runtime:           "fly.default",
+		Network:           "tailscale.default",
+		FlyApp:            "co-webui",
+		TailscaleHostname: "companion-webui",
+		Port:              8080,
+		TailscaleServe:    true,
+	}
+
+	missingHash, missingTopo, err := hashDashboardTopology(ws, nil)
+	if err != nil {
+		t.Fatalf("hash missing devices: %v", err)
+	}
+	resolvedHash, resolvedTopo, err := hashDashboardTopology(ws, []tailscale.Device{
+		{HostName: "research", DNSName: "research.tail.ts.net.", Online: true},
+		{HostName: "companion-webui", DNSName: "companion-webui.tail.ts.net.", Online: true},
+	})
+	if err != nil {
+		t.Fatalf("hash resolved devices: %v", err)
+	}
+	if missingHash == resolvedHash {
+		t.Fatalf("topology hash should change when user-facing dashboard URLs become resolvable")
+	}
+	if missingTopo.Services[0].URL != "" || missingTopo.Services[1].URL != "" {
+		t.Fatalf("missing devices should not invent display URLs: %#v", missingTopo.Services)
+	}
+	if resolvedTopo.Services[0].URL != "https://research.tail.ts.net/" {
+		t.Fatalf("agent URL should be in dashboard topology, got %#v", resolvedTopo.Services[0])
+	}
+	if resolvedTopo.Services[1].Kind != "openwebui" || resolvedTopo.Services[1].URL != "https://companion-webui.tail.ts.net/" {
+		t.Fatalf("support WebUI URL should be in dashboard topology, got %#v", resolvedTopo.Services[1])
+	}
+	if resolvedTopo.Services[1].HealthURL != "https://companion-webui.tail.ts.net/health" {
+		t.Fatalf("support WebUI health probe should be in dashboard topology, got %#v", resolvedTopo.Services[1])
+	}
+}
+
 func dashboardWorkspace(t *testing.T, agentIDs ...string) *workspace.Workspace {
 	t.Helper()
 	root := t.TempDir()

--- a/internal/state/state_test.go
+++ b/internal/state/state_test.go
@@ -2,6 +2,7 @@ package state
 
 import (
 	"context"
+	"database/sql"
 	"path/filepath"
 	"testing"
 )
@@ -34,5 +35,52 @@ func TestImportResourceIsIdempotentByDesiredAddress(t *testing.T) {
 	}
 	if resources[0].ObservedJSON != `{"region":"cdg"}` {
 		t.Fatalf("expected updated attrs, got %q", resources[0].ObservedJSON)
+	}
+}
+
+func TestOpenReplacesLegacyResourceSchema(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "state.sqlite")
+	db, err := sql.Open("sqlite", path)
+	if err != nil {
+		t.Fatalf("open raw sqlite: %v", err)
+	}
+	if _, err := db.Exec(`CREATE TABLE resources (id TEXT PRIMARY KEY, attrs_json TEXT NOT NULL)`); err != nil {
+		t.Fatalf("create legacy resources table: %v", err)
+	}
+	if _, err := db.Exec(`INSERT INTO resources(id, attrs_json) VALUES ('legacy', '{}')`); err != nil {
+		t.Fatalf("insert legacy resource: %v", err)
+	}
+	if err := db.Close(); err != nil {
+		t.Fatalf("close raw sqlite: %v", err)
+	}
+
+	store, err := Open(path)
+	if err != nil {
+		t.Fatalf("open migrated state: %v", err)
+	}
+	defer store.Close()
+
+	resources, err := store.ListResources(context.Background())
+	if err != nil {
+		t.Fatalf("list migrated resources: %v", err)
+	}
+	if len(resources) != 0 {
+		t.Fatalf("legacy resources should be dropped during schema replacement, got %#v", resources)
+	}
+	if err := store.UpsertResource(context.Background(), Resource{
+		Address:      "fly_app.agent.sample",
+		Class:        "managed",
+		ProviderRef:  "fly.default",
+		ExternalID:   "co-sample",
+		ObservedJSON: "{}",
+	}); err != nil {
+		t.Fatalf("upsert after migration: %v", err)
+	}
+	resource, ok, err := store.GetResource(context.Background(), "fly_app.agent.sample")
+	if err != nil {
+		t.Fatalf("get migrated resource: %v", err)
+	}
+	if !ok || resource.ExternalID != "co-sample" {
+		t.Fatalf("state schema did not accept new resource contract: ok=%v resource=%#v", ok, resource)
 	}
 }

--- a/internal/status/status.go
+++ b/internal/status/status.go
@@ -121,7 +121,7 @@ func collectTarget(ctx context.Context, client *http.Client, target Target, devi
 		Kind:   target.Kind,
 		FlyApp: target.FlyApp,
 		Host:   target.TailscaleHostname,
-		URL:    target.HealthURL,
+		URL:    target.URL,
 		Model:  target.Model,
 		Vault:  target.Vault,
 		Health: HealthUnknown,

--- a/internal/status/status_test.go
+++ b/internal/status/status_test.go
@@ -46,15 +46,21 @@ func TestBuildTopology(t *testing.T) {
 				Runtime:           "fly.default",
 				FlyApp:            "co-research",
 				TailscaleHostname: "research",
+				DashboardMode:     "serve",
+				DashboardPort:     9119,
 				Model:             config.Model{Default: "gpt"},
 				DefaultVault:      config.DefaultVault{Name: "Research"},
 				APIServer:         config.APIServer{Enabled: true, Port: 8642},
 			},
 			{ID: "gone", Lifecycle: "absent", FlyApp: "co-gone", TailscaleHostname: "gone"},
 		},
-		OpenWebUI: config.OpenWebUI{Enabled: true, ID: "open-webui", Runtime: "fly.default", FlyApp: "co-webui", TailscaleHostname: "companion-webui"},
+		OpenWebUI: config.OpenWebUI{Enabled: true, ID: "open-webui", Runtime: "fly.default", FlyApp: "co-webui", TailscaleHostname: "companion-webui", Port: 8080, TailscaleServe: true},
 	}
-	topo := BuildTopology("ws", cfg, nil, ProviderSummary{Tailnet: "example.ts.net"}, time.Time{})
+	devices := []tailscale.Device{
+		{HostName: "research", DNSName: "research.example.ts.net.", Online: true},
+		{HostName: "companion-webui", DNSName: "companion-webui.example.ts.net.", Online: true},
+	}
+	topo := BuildTopology("ws", cfg, devices, ProviderSummary{Tailnet: "example.ts.net"}, time.Time{})
 
 	if len(topo.Services) != 2 {
 		t.Fatalf("expected 2 services (absent agent skipped), got %d", len(topo.Services))
@@ -65,8 +71,17 @@ func TestBuildTopology(t *testing.T) {
 	if topo.Services[0].HealthURL == "" {
 		t.Fatalf("agent with api server should have a health URL")
 	}
+	if topo.Services[0].URL != "https://research.example.ts.net/" {
+		t.Fatalf("agent URL should point at Hermes dashboard, got %q", topo.Services[0].URL)
+	}
 	if topo.Services[1].Kind != "openwebui" {
 		t.Fatalf("expected open webui target, got %+v", topo.Services[1])
+	}
+	if topo.Services[1].URL != "https://companion-webui.example.ts.net/" {
+		t.Fatalf("open webui URL should be exposed, got %q", topo.Services[1].URL)
+	}
+	if topo.Services[1].HealthURL != "https://companion-webui.example.ts.net/health" {
+		t.Fatalf("open webui health URL should be exposed, got %q", topo.Services[1].HealthURL)
 	}
 
 	// JSON round-trip is stable and carries the provider summary.
@@ -83,6 +98,43 @@ func TestBuildTopology(t *testing.T) {
 	}
 }
 
+func TestBuildTopologyDoesNotInventDisplayURLsWithoutTailscaleDevices(t *testing.T) {
+	cfg := &config.Config{
+		Agents: []config.Agent{{
+			ID:                "research",
+			Runtime:           "fly.default",
+			FlyApp:            "co-research",
+			TailscaleHostname: "research",
+			DashboardMode:     "serve",
+			DashboardPort:     9119,
+			APIServer:         config.APIServer{Enabled: true, Port: 8642},
+		}},
+		OpenWebUI: config.OpenWebUI{
+			Enabled:           true,
+			ID:                "open-webui",
+			Runtime:           "fly.default",
+			FlyApp:            "co-webui",
+			TailscaleHostname: "companion-webui",
+			Port:              8080,
+			TailscaleServe:    true,
+		},
+	}
+
+	topo := BuildTopology("ws", cfg, nil, ProviderSummary{}, time.Time{})
+	if got := topo.Services[0].URL; got != "" {
+		t.Fatalf("agent display URL should stay empty without a resolved device, got %q", got)
+	}
+	if got := topo.Services[0].HealthURL; got != "http://research:8642/health" {
+		t.Fatalf("agent health probe should still use configured hostname fallback, got %q", got)
+	}
+	if got := topo.Services[1].URL; got != "" {
+		t.Fatalf("Open WebUI display URL should stay empty without a resolved device, got %q", got)
+	}
+	if got := topo.Services[1].HealthURL; got != "" {
+		t.Fatalf("Open WebUI health URL should stay empty without a resolved device, got %q", got)
+	}
+}
+
 func TestCollectHealthAndSummary(t *testing.T) {
 	ok := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusOK)
@@ -96,7 +148,7 @@ func TestCollectHealthAndSummary(t *testing.T) {
 	topo := FleetTopology{
 		Workspace: "ws",
 		Services: []Target{
-			{ID: "up", Kind: "agent", FlyApp: "co-up", TailscaleHostname: "up", HealthURL: ok.URL + "/health"},
+			{ID: "up", Kind: "agent", FlyApp: "co-up", TailscaleHostname: "up", URL: "https://up.example.ts.net/", HealthURL: ok.URL + "/health"},
 			{ID: "degraded", Kind: "agent", FlyApp: "co-deg", HealthURL: bad.URL + "/health"},
 			{ID: "down", Kind: "agent", FlyApp: "co-down", HealthURL: "http://127.0.0.1:0/health"},
 			{ID: "webui", Kind: "openwebui", FlyApp: "co-webui", TailscaleHostname: "companion-webui"},
@@ -123,6 +175,12 @@ func TestCollectHealthAndSummary(t *testing.T) {
 	if byID["up"].MachineState != "started" {
 		t.Fatalf("up machine state should be started, got %q", byID["up"].MachineState)
 	}
+	if byID["up"].URL != "https://up.example.ts.net/" {
+		t.Fatalf("up URL should expose dashboard URL, got %q", byID["up"].URL)
+	}
+	if byID["degraded"].URL != "" {
+		t.Fatalf("health URL should not leak into display URL, got %q", byID["degraded"].URL)
+	}
 	if byID["degraded"].Health != HealthDegrade {
 		t.Fatalf("degraded should be degraded, got %q", byID["degraded"].Health)
 	}
@@ -136,6 +194,40 @@ func TestCollectHealthAndSummary(t *testing.T) {
 
 	if snap.Summary.Total != 4 || snap.Summary.Healthy != 1 || snap.Summary.Down != 2 || snap.Summary.Degraded != 1 {
 		t.Fatalf("unexpected summary: %+v", snap.Summary)
+	}
+}
+
+func TestCollectUsesOpenWebUIHealthProbe(t *testing.T) {
+	webui := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/health" {
+			t.Fatalf("unexpected health probe path: %s", r.URL.Path)
+		}
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"status":true}`))
+	}))
+	defer webui.Close()
+
+	topo := FleetTopology{
+		Workspace: "ws",
+		Services: []Target{{
+			ID:                "open-webui",
+			Kind:              "openwebui",
+			FlyApp:            "co-webui",
+			TailscaleHostname: "companion-webui",
+			URL:               "https://companion-webui.example.ts.net/",
+			HealthURL:         webui.URL + "/health",
+		}},
+	}
+	snap := Collect(context.Background(), topo, nil, nil, nil)
+
+	if len(snap.Services) != 1 {
+		t.Fatalf("expected one service, got %#v", snap.Services)
+	}
+	if snap.Services[0].Health != HealthOK || snap.Services[0].HTTPStatus != http.StatusOK {
+		t.Fatalf("Open WebUI health probe should mark service ok, got %#v", snap.Services[0])
+	}
+	if snap.Services[0].URL != "https://companion-webui.example.ts.net/" {
+		t.Fatalf("Open WebUI display URL should remain separate from health URL, got %q", snap.Services[0].URL)
 	}
 }
 

--- a/internal/status/topology.go
+++ b/internal/status/topology.go
@@ -27,6 +27,7 @@ type Target struct {
 	FlyApp            string `json:"fly_app,omitempty"`
 	ProviderRef       string `json:"provider_ref,omitempty"`
 	TailscaleHostname string `json:"tailscale_hostname,omitempty"`
+	URL               string `json:"url,omitempty"`
 	HealthURL         string `json:"health_url,omitempty"`
 	Model             string `json:"model,omitempty"`
 	Vault             string `json:"vault,omitempty"`
@@ -74,6 +75,7 @@ func BuildTopology(workspaceName string, cfg *config.Config, devices []tailscale
 			FlyApp:            agent.FlyApp,
 			ProviderRef:       agent.Runtime,
 			TailscaleHostname: agent.TailscaleHostname,
+			URL:               deps.AgentDashboardURL(agent, devices),
 			Model:             agent.Model.Default,
 			Vault:             agent.DefaultVault.Name,
 		}
@@ -89,6 +91,8 @@ func BuildTopology(workspaceName string, cfg *config.Config, devices []tailscale
 			FlyApp:            cfg.OpenWebUI.FlyApp,
 			ProviderRef:       cfg.OpenWebUI.Runtime,
 			TailscaleHostname: cfg.OpenWebUI.TailscaleHostname,
+			URL:               deps.OpenWebUIURL(cfg.OpenWebUI, devices),
+			HealthURL:         deps.OpenWebUIHealthURL(cfg.OpenWebUI, devices),
 		})
 	}
 	return topo

--- a/internal/web/assets/dashboard.css
+++ b/internal/web/assets/dashboard.css
@@ -235,6 +235,39 @@ body {
   overflow: hidden;
 }
 
+.section-title {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  margin: 1rem 0 0.45rem;
+  font-size: var(--t-xs);
+  font-weight: 600;
+  letter-spacing: 0.03em;
+  text-transform: uppercase;
+  color: var(--text-faint);
+}
+
+.section-count {
+  min-width: 1.35rem;
+  height: 1.25rem;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0 0.4rem;
+  border: 1px solid var(--line);
+  border-radius: 999px;
+  color: var(--text-3);
+  background: var(--panel-2);
+}
+
+.support-section {
+  margin-top: 1rem;
+}
+
+.support-section[hidden] {
+  display: none;
+}
+
 .list__head {
   display: grid;
   grid-template-columns: 116px minmax(140px, 1.4fr) minmax(180px, 2fr) 92px 96px 64px minmax(120px, 1.2fr);

--- a/internal/web/assets/dashboard.js
+++ b/internal/web/assets/dashboard.js
@@ -18,6 +18,9 @@
     updated: document.getElementById("updated"),
     refreshNote: document.getElementById("refresh-note"),
     listBody: document.getElementById("services-body"),
+    supportSection: document.getElementById("support-section"),
+    supportBody: document.getElementById("support-body"),
+    supportCount: document.getElementById("support-count"),
     countAll: document.getElementById("count-all"),
     countHealthy: document.getElementById("count-healthy"),
     countDegraded: document.getElementById("count-degraded"),
@@ -234,6 +237,14 @@
     return healthOf(svc) === state.filter;
   }
 
+  function agentServices() {
+    return state.services.filter(function (svc) { return svc.kind === "agent"; });
+  }
+
+  function supportServices() {
+    return state.services.filter(function (svc) { return svc.kind !== "agent"; });
+  }
+
   // Problems-first ordering: a DOWN agent surfaces at the top of the single
   // flat list at a glance (the brief's core scene). Secondary sort is a
   // stable pass on the incoming order so equal-health rows keep their order.
@@ -254,18 +265,19 @@
   function renderList() {
     var bodyEl = els.listBody;
     bodyEl.textContent = "";
+    var agents = agentServices();
 
     // Empty state — distinct from the loading skeleton. Only reached once a
     // poll has succeeded with zero services (the skeleton is replaced here,
     // never stacked, because textContent above clears the node first).
-    if (!state.services.length) {
+    if (!agents.length) {
       var empty = el("div", "state state--empty");
-      empty.appendChild(el("p", "state__text", "No services in this fleet yet."));
+      empty.appendChild(el("p", "state__text", "No agents in this fleet yet."));
       bodyEl.appendChild(empty);
       return;
     }
 
-    var shown = sortProblemsFirst(state.services.filter(applyFilter));
+    var shown = sortProblemsFirst(agents.filter(applyFilter));
     if (!shown.length) {
       var none = el("div", "state state--empty");
       none.appendChild(el("p", "state__text", "No " + (STATUS_LABEL[state.filter] || "matching").toLowerCase() + " services."));
@@ -278,18 +290,32 @@
     bodyEl.appendChild(frag);
   }
 
+  function renderSupport() {
+    var support = supportServices();
+    if (!els.supportSection || !els.supportBody) return;
+    els.supportSection.hidden = support.length === 0;
+    els.supportBody.textContent = "";
+    if (els.supportCount) els.supportCount.textContent = support.length;
+    if (!support.length) return;
+
+    var frag = document.createDocumentFragment();
+    sortProblemsFirst(support).forEach(function (svc) { frag.appendChild(buildRow(svc)); });
+    els.supportBody.appendChild(frag);
+  }
+
   function renderCounts() {
     // Count by exact health so each chip equals the rows its filter shows. The
     // server summary folds "unknown" into "degraded", which would make the
     // Degraded chip disagree with the Degraded filter (and skew "All" never).
-    els.countAll.textContent = state.services.length;
+    var agents = agentServices();
+    els.countAll.textContent = agents.length;
     els.countHealthy.textContent = countBy("ok");
     els.countDegraded.textContent = countBy("degraded");
     els.countDown.textContent = countBy("down");
   }
 
   function countBy(h) {
-    return state.services.reduce(function (n, svc) { return n + (healthOf(svc) === h ? 1 : 0); }, 0);
+    return agentServices().reduce(function (n, svc) { return n + (healthOf(svc) === h ? 1 : 0); }, 0);
   }
 
   function renderDrift(data) {
@@ -313,6 +339,7 @@
 
     renderCounts();
     renderList();
+    renderSupport();
     announceFilter();
     renderDrift(data);
 
@@ -470,7 +497,7 @@
     state.open = true;
 
     // selection highlight
-    var rows = els.listBody.querySelectorAll(".row");
+    var rows = document.querySelectorAll(".list__body .row");
     Array.prototype.forEach.call(rows, function (r) {
       r.classList.toggle("is-selected", r.dataset.id === svc.id);
     });
@@ -507,7 +534,7 @@
     if (reduceMotion) finish();
     else setTimeout(finish, 200);
 
-    var rows = els.listBody.querySelectorAll(".row.is-selected");
+    var rows = document.querySelectorAll(".list__body .row.is-selected");
     Array.prototype.forEach.call(rows, function (r) { r.classList.remove("is-selected"); });
 
     // Return focus to the originating row. A poll may have rebuilt the list
@@ -520,7 +547,7 @@
     if (prev && document.contains(prev) && typeof prev.focus === "function") {
       prev.focus();
     } else if (prevId) {
-      var rebuilt = els.listBody.querySelector('.row[data-id="' + (window.CSS && CSS.escape ? CSS.escape(prevId) : prevId) + '"]');
+      var rebuilt = document.querySelector('.list__body .row[data-id="' + (window.CSS && CSS.escape ? CSS.escape(prevId) : prevId) + '"]');
       if (rebuilt) rebuilt.focus();
     }
   }
@@ -549,7 +576,7 @@
   // active filter and its result count are also announced via a live region.
   function announceFilter() {
     if (!els.filterStatus) return;
-    var shown = state.services.filter(applyFilter).length;
+    var shown = agentServices().filter(applyFilter).length;
     var label = STATUS_LABEL[state.filter];
     var name = state.filter === "all" ? "all" : (label ? label.toLowerCase() : state.filter);
     els.filterStatus.textContent =

--- a/internal/web/assets/index.html
+++ b/internal/web/assets/index.html
@@ -45,6 +45,10 @@
       <span class="sr-only" id="filter-status" role="status" aria-live="polite"></span>
     </div>
 
+    <div class="section-title">
+      <span>Agents</span>
+    </div>
+
     <section class="list" aria-label="Fleet agents">
       <div class="list__head" role="row">
         <span class="col col-status" role="columnheader">Status</span>
@@ -62,6 +66,25 @@
           </div>
           <p class="state__text">Waiting for first poll</p>
         </div>
+      </div>
+    </section>
+
+    <section class="support-section" id="support-section" aria-label="Support services" hidden>
+      <div class="section-title">
+        <span>Support</span>
+        <span class="section-count" id="support-count">0</span>
+      </div>
+      <div class="list list--support">
+        <div class="list__head" role="row">
+          <span class="col col-status" role="columnheader">Status</span>
+          <span class="col col-name" role="columnheader">Service</span>
+          <span class="col col-url" role="columnheader">URL</span>
+          <span class="col col-net" role="columnheader">Tailnet</span>
+          <span class="col col-machine" role="columnheader">Machine</span>
+          <span class="col col-http" role="columnheader">HTTP</span>
+          <span class="col col-model" role="columnheader">Model</span>
+        </div>
+        <div class="list__body" id="support-body"></div>
       </div>
     </section>
 

--- a/internal/web/web.go
+++ b/internal/web/web.go
@@ -38,17 +38,39 @@ func Serve(ctx context.Context, addr string, src status.Source, interval time.Du
 	poller := status.NewPoller(src, interval)
 	go poller.Run(ctx)
 
+	handler, err := newDashboardHandler(poller, interval, cfg, flyProvider, tsProvider)
+	if err != nil {
+		return err
+	}
+	server := &http.Server{Addr: addr, Handler: handler}
+
+	errCh := make(chan error, 1)
+	go func() {
+		errCh <- server.ListenAndServe()
+	}()
+	select {
+	case <-ctx.Done():
+		_ = server.Shutdown(context.Background())
+		return ctx.Err()
+	case err := <-errCh:
+		if err == http.ErrServerClosed {
+			return nil
+		}
+		return err
+	}
+}
+
+func newDashboardHandler(poller *status.Poller, interval time.Duration, cfg *config.Config, flyProvider provider.FlyRuntime, tsProvider provider.TailscaleNetwork) (http.Handler, error) {
 	mux := http.NewServeMux()
-	server := &http.Server{Addr: addr, Handler: mux}
 
 	staticFS, err := fs.Sub(assets, "assets")
 	if err != nil {
-		return err
+		return nil, err
 	}
 
 	indexTpl, err := template.ParseFS(assets, "assets/index.html")
 	if err != nil {
-		return err
+		return nil, err
 	}
 
 	mux.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
@@ -122,20 +144,7 @@ func Serve(ctx context.Context, addr string, src status.Source, interval time.Du
 		}
 	}
 
-	errCh := make(chan error, 1)
-	go func() {
-		errCh <- server.ListenAndServe()
-	}()
-	select {
-	case <-ctx.Done():
-		_ = server.Shutdown(context.Background())
-		return ctx.Err()
-	case err := <-errCh:
-		if err == http.ErrServerClosed {
-			return nil
-		}
-		return err
-	}
+	return mux, nil
 }
 
 func renderPage(w http.ResponseWriter, name string, data pageData) {

--- a/internal/web/web_test.go
+++ b/internal/web/web_test.go
@@ -1,10 +1,17 @@
 package web
 
 import (
+	"context"
+	"encoding/json"
 	"html/template"
 	"io/fs"
+	"net/http"
+	"net/http/httptest"
 	"strings"
 	"testing"
+	"time"
+
+	"github.com/The-Vibe-Company/companion/internal/status"
 )
 
 // TestIndexTemplateRenders guards the contract between the Go handler and the
@@ -57,4 +64,96 @@ func TestEmbeddedAssetsPresent(t *testing.T) {
 			t.Errorf("embedded asset %s is empty", name)
 		}
 	}
+}
+
+func TestStatusAPIExposesDashboardContract(t *testing.T) {
+	poller := status.NewPoller(staticSource{snapshot: status.Snapshot{
+		Workspace:   "test-workspace",
+		GeneratedAt: time.Unix(100, 0).UTC(),
+		Services: []status.ServiceStatus{
+			{ID: "research", Kind: "agent", URL: "https://research.tail.ts.net/", Health: status.HealthOK, Online: true},
+			{ID: "open-webui", Kind: "openwebui", URL: "https://companion-webui.tail.ts.net/", Health: status.HealthOK, Online: true},
+		},
+		Summary: status.Summary{Total: 2, Healthy: 2},
+	}}, time.Minute)
+	poller.Refresh(context.Background())
+
+	handler, err := newDashboardHandler(poller, time.Minute, nil, nil, nil)
+	if err != nil {
+		t.Fatalf("dashboard handler: %v", err)
+	}
+	recorder := httptest.NewRecorder()
+	handler.ServeHTTP(recorder, httptest.NewRequest(http.MethodGet, "/api/status", nil))
+
+	if recorder.Code != http.StatusOK {
+		t.Fatalf("GET /api/status status = %d, body=%s", recorder.Code, recorder.Body.String())
+	}
+	if got := recorder.Header().Get("Cache-Control"); got != "no-store" {
+		t.Fatalf("GET /api/status Cache-Control = %q, want no-store", got)
+	}
+	var got status.Snapshot
+	if err := json.NewDecoder(recorder.Body).Decode(&got); err != nil {
+		t.Fatalf("decode status JSON: %v", err)
+	}
+	if got.Workspace != "test-workspace" {
+		t.Fatalf("workspace = %q", got.Workspace)
+	}
+	if len(got.Services) != 2 {
+		t.Fatalf("expected two services, got %#v", got.Services)
+	}
+	if got.Services[0].Kind != "agent" || got.Services[0].URL != "https://research.tail.ts.net/" {
+		t.Fatalf("agent contract lost: %#v", got.Services[0])
+	}
+	if got.Services[1].Kind != "openwebui" || got.Services[1].URL != "https://companion-webui.tail.ts.net/" {
+		t.Fatalf("support service contract lost: %#v", got.Services[1])
+	}
+}
+
+func TestDashboardAssetsKeepAgentAndSupportContracts(t *testing.T) {
+	indexHTML := readAsset(t, "assets/index.html")
+	dashboardJS := readAsset(t, "assets/dashboard.js")
+	dashboardCSS := readAsset(t, "assets/dashboard.css")
+
+	for _, want := range []string{
+		`aria-label="Fleet agents"`,
+		`id="services-body"`,
+		`id="support-section"`,
+		`id="support-body"`,
+		`id="support-count"`,
+	} {
+		if !strings.Contains(indexHTML, want) {
+			t.Fatalf("dashboard index missing contract %q", want)
+		}
+	}
+	for _, want := range []string{
+		`function agentServices()`,
+		`function supportServices()`,
+		`renderSupport();`,
+		`svc.kind === "agent"`,
+		`svc.kind !== "agent"`,
+	} {
+		if !strings.Contains(dashboardJS, want) {
+			t.Fatalf("dashboard JS missing contract %q", want)
+		}
+	}
+	if !strings.Contains(dashboardCSS, ".support-section[hidden]") {
+		t.Fatalf("dashboard CSS must keep support section hide/show rule")
+	}
+}
+
+type staticSource struct {
+	snapshot status.Snapshot
+}
+
+func (s staticSource) Collect(context.Context) status.Snapshot {
+	return s.snapshot
+}
+
+func readAsset(t *testing.T, name string) string {
+	t.Helper()
+	data, err := fs.ReadFile(assets, name)
+	if err != nil {
+		t.Fatalf("read embedded asset %s: %v", name, err)
+	}
+	return string(data)
 }


### PR DESCRIPTION
## What changed

- Added a project-wide testing standard to `AGENTS.md` and `CLAUDE.md`, including weak-test anti-patterns, hermetic test patterns, and expectations by module.
- Strengthened CI with `go test -race ./...` and a 55% global coverage floor.
- Added behavioral tests across CLI, deps, Fly, resource, state, status, and web/dashboard contracts.
- Updated the dashboard topology/status contract so agent links point to Hermes dashboards and Open WebUI appears as a support service with both a user URL and a `/health` probe.

## Why

Companion is an infra/control-plane product, so tests need to prove user-visible and operator-visible contracts: deterministic config/resource behavior, idempotence, safe deletion, provider parsing, secret redaction, and dashboard status semantics. The Open WebUI dashboard status previously had no health probe, which could leave it as `unknown` even when the service was healthy.

## Screenshot

Anonymized dashboard fixture using the real embedded assets:

![Dashboard agents and support sections](https://vanish.sh/f/I8hxgW7UNJnv.png)

## Validation

- `go test ./...`
- `go test -race ./...`
- `go test -coverprofile=/tmp/companion.cover ./...` -> `56.1%`
- `sh -n install.sh`
- `bash -n install.sh bin/start-on-fly bin/run-hermes-process bin/start-open-webui-on-fly bin/start-dashboard-on-fly`
- `go install ./cmd/companion` and `companion version`
- `go run ./cmd/companion validate --workspace examples/minimal`
- `go run ./cmd/companion validate --workspace examples/webui`
- Live dashboard redeployed and verified: `victor` and `open-webui` both report `ok` with HTTP 200 on `https://companion-dashboard-1.tail5f910b.ts.net/api/status`.

## AI / review note

Generated by an AI agent. Human review is still required.
