### PR TITLE
feat(identity): add companion soul defaults

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -81,6 +81,7 @@ The CI gates are `go test ./...`, `go test -race ./...`, shell syntax checks, in
 
 - Companion workspaces are folders containing `companion.toml`, `providers.toml`, `defaults.toml`, optional `webui.toml`, `agents/*.toml`, `vaults/*.toml`, and identities.
 - The repository root is not a live Companion workspace. Use `examples/minimal` and `examples/webui` for public examples, and `.local/` or an external path for real fleets.
+- Use `[defaults.companion_soul]` for fleet-wide Hermes identity additions that must be appended to every rendered `SOUL.md`, such as Granite memory discipline. Keep agent-specific `SOUL.md` files focused on the agent identity; do not duplicate the global block into every file. Agents can opt out with `[companion_soul] enabled = false`.
 
 Use `lifecycle = "absent"` for desired deletion. Persistent data requires explicit destroy flags and backup intent.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -52,6 +52,7 @@ Expected CI gates are `go test ./...`, `go test -race ./...`, shell syntax check
 - Do not run live provider mutations unless the user explicitly asks for them.
 - Keep secrets private: print names only, never values.
 - Keep real workspace config private under `.local/` or outside the repo.
+- Use `[defaults.companion_soul]` for fleet-wide Hermes `SOUL.md` additions such as Granite memory rules; it is appended after each agent identity and can be disabled per agent with `[companion_soul] enabled = false`.
 - Preserve idempotency and explicit destroy semantics.
 - Run `gofmt` on touched Go files and add focused Go tests for behavior changes.
 - Use commitzen for commits and PR titles, for example `fix(state): preserve imported resource attrs`.

--- a/README.md
+++ b/README.md
@@ -303,6 +303,20 @@ companion identity init example-agent --name "Example Agent" --workspace .
 companion identity render example-agent --workspace .
 ```
 
+Use `companion_soul` for fleet-wide identity rules that must be appended to every agent `SOUL.md`, for example a shared Granite memory policy:
+
+```toml
+[defaults.companion_soul]
+path = "identities/companion-soul.md"
+```
+
+Agents can opt out without changing their own identity file:
+
+```toml
+[companion_soul]
+enabled = false
+```
+
 Every agent can have a default Granite vault:
 
 ```toml

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -366,11 +366,20 @@ func (a *app) validateCommand() *cobra.Command {
 					if agent.Identity.Path != "" {
 						identity = agent.Identity.Path
 					}
+				}
+				companionSoul := "disabled"
+				if agent.CompanionSoul.Enabled {
+					companionSoul = "inline"
+					if agent.CompanionSoul.Path != "" {
+						companionSoul = agent.CompanionSoul.Path
+					}
+				}
+				if agent.Identity.Enabled || agent.CompanionSoul.Enabled {
 					if _, err := a.hydrateAgentIdentity(agent); err != nil {
 						return err
 					}
 				}
-				fmt.Fprintf(cmd.OutOrStdout(), "%s: ok runtime=%s network=%s fly_app=%s tailscale=%s lifecycle=%s identity=%s\n", agent.ID, agent.Runtime, agent.Network, agent.FlyApp, agent.TailscaleHostname, agent.Lifecycle, identity)
+				fmt.Fprintf(cmd.OutOrStdout(), "%s: ok runtime=%s network=%s fly_app=%s tailscale=%s lifecycle=%s identity=%s companion_soul=%s\n", agent.ID, agent.Runtime, agent.Network, agent.FlyApp, agent.TailscaleHostname, agent.Lifecycle, identity, companionSoul)
 			}
 			if cfg.OpenWebUI.Enabled {
 				ids := []string{}
@@ -789,11 +798,12 @@ func (a *app) identityRenderCommand() *cobra.Command {
 			if err != nil {
 				return err
 			}
-			if !agent.Identity.Enabled {
-				return fmt.Errorf("agent %s identity is disabled", agent.ID)
+			identity, ok := render.EffectiveAgentIdentity(agent)
+			if !ok {
+				return fmt.Errorf("agent %s identity and companion_soul are disabled", agent.ID)
 			}
-			fmt.Fprint(cmd.OutOrStdout(), agent.Identity.Soul)
-			if !strings.HasSuffix(agent.Identity.Soul, "\n") {
+			fmt.Fprint(cmd.OutOrStdout(), identity.Soul)
+			if !strings.HasSuffix(identity.Soul, "\n") {
 				fmt.Fprintln(cmd.OutOrStdout())
 			}
 			return nil
@@ -1202,24 +1212,34 @@ func (a *app) stateRemoveCommand() *cobra.Command {
 }
 
 func (a *app) hydrateAgentIdentity(agent config.Agent) (config.Agent, error) {
-	if !agent.Identity.Enabled {
-		return agent, nil
+	if agent.Identity.Enabled && strings.TrimSpace(agent.Identity.Soul) == "" {
+		if agent.Identity.Path == "" {
+			return agent, fmt.Errorf("agent %s identity requires path or soul", agent.ID)
+		}
+		path := agent.Identity.Path
+		if !filepath.IsAbs(path) {
+			path = filepath.Join(a.rootDir, filepath.FromSlash(path))
+		}
+		data, err := os.ReadFile(path)
+		if err != nil {
+			return agent, fmt.Errorf("read identity for agent %s: %w", agent.ID, err)
+		}
+		agent.Identity.Soul = string(data)
 	}
-	if strings.TrimSpace(agent.Identity.Soul) != "" {
-		return agent, nil
+	if agent.CompanionSoul.Enabled && strings.TrimSpace(agent.CompanionSoul.Text) == "" {
+		if agent.CompanionSoul.Path == "" {
+			return agent, fmt.Errorf("agent %s companion_soul requires path or text", agent.ID)
+		}
+		path := agent.CompanionSoul.Path
+		if !filepath.IsAbs(path) {
+			path = filepath.Join(a.rootDir, filepath.FromSlash(path))
+		}
+		data, err := os.ReadFile(path)
+		if err != nil {
+			return agent, fmt.Errorf("read companion_soul for agent %s: %w", agent.ID, err)
+		}
+		agent.CompanionSoul.Text = string(data)
 	}
-	if agent.Identity.Path == "" {
-		return agent, fmt.Errorf("agent %s identity requires path or soul", agent.ID)
-	}
-	path := agent.Identity.Path
-	if !filepath.IsAbs(path) {
-		path = filepath.Join(a.rootDir, filepath.FromSlash(path))
-	}
-	data, err := os.ReadFile(path)
-	if err != nil {
-		return agent, fmt.Errorf("read identity for agent %s: %w", agent.ID, err)
-	}
-	agent.Identity.Soul = string(data)
 	return agent, nil
 }
 

--- a/internal/cli/cli_test.go
+++ b/internal/cli/cli_test.go
@@ -310,6 +310,13 @@ func TestHydrateAgentIdentityReadsRelativePath(t *testing.T) {
 	if err := os.WriteFile(path, []byte("# Sample Agent\n\nYou are Sample Agent.\n"), 0o644); err != nil {
 		t.Fatalf("write identity: %v", err)
 	}
+	companionSoulPath := filepath.Join(root, "identities", "companion-soul.md")
+	if err := os.MkdirAll(filepath.Dir(companionSoulPath), 0o755); err != nil {
+		t.Fatalf("mkdir companion soul dir: %v", err)
+	}
+	if err := os.WriteFile(companionSoulPath, []byte("## Companion Memory\n\nAlways capture durable knowledge in Granite.\n"), 0o644); err != nil {
+		t.Fatalf("write companion soul: %v", err)
+	}
 
 	agent, err := (&app{rootDir: root}).hydrateAgentIdentity(config.Agent{
 		ID: "sample",
@@ -318,12 +325,70 @@ func TestHydrateAgentIdentityReadsRelativePath(t *testing.T) {
 			Path:      "identities/sample/SOUL.md",
 			Overwrite: true,
 		},
+		CompanionSoul: config.CompanionSoul{
+			Enabled: true,
+			Path:    "identities/companion-soul.md",
+		},
 	})
 	if err != nil {
 		t.Fatalf("hydrate identity: %v", err)
 	}
 	if agent.Identity.Soul != "# Sample Agent\n\nYou are Sample Agent.\n" {
 		t.Fatalf("unexpected hydrated soul: %q", agent.Identity.Soul)
+	}
+	if agent.CompanionSoul.Text != "## Companion Memory\n\nAlways capture durable knowledge in Granite.\n" {
+		t.Fatalf("unexpected hydrated companion soul: %q", agent.CompanionSoul.Text)
+	}
+}
+
+func TestIdentityRenderIncludesInheritedCompanionSoul(t *testing.T) {
+	root := t.TempDir()
+	writeTestWorkspace(t, root, map[string]string{
+		"sample": `
+[agent]
+id = "sample"
+fly_app = "example-companion-sample"
+tailscale_hostname = "sample"
+`,
+	})
+	writeTestFile(t, root, "defaults.toml", `[defaults]
+region = "cdg"
+
+[defaults.model]
+enabled = false
+
+[defaults.api_server]
+enabled = true
+open_webui_enabled = true
+
+[defaults.companion_soul]
+path = "identities/companion-soul.md"
+`)
+	writeTestFile(t, root, "identities/companion-soul.md", `## Companion Memory
+
+Always capture durable knowledge in Granite.
+`)
+
+	cmd := NewRootCommand()
+	var output bytes.Buffer
+	cmd.SetOut(&output)
+	cmd.SetArgs([]string{"--workspace", root, "identity", "render", "sample"})
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("identity render: %v", err)
+	}
+	if output.String() != "## Companion Memory\n\nAlways capture durable knowledge in Granite.\n" {
+		t.Fatalf("unexpected render output: %q", output.String())
+	}
+
+	validateCmd := NewRootCommand()
+	output.Reset()
+	validateCmd.SetOut(&output)
+	validateCmd.SetArgs([]string{"--workspace", root, "validate"})
+	if err := validateCmd.Execute(); err != nil {
+		t.Fatalf("validate: %v", err)
+	}
+	if !strings.Contains(output.String(), "identity=disabled companion_soul=identities/companion-soul.md") {
+		t.Fatalf("validate output should expose inherited companion soul, got: %s", output.String())
 	}
 }
 

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -165,6 +165,63 @@ func TestIdentityEnabledRequiresPathOrSoul(t *testing.T) {
 	}
 }
 
+func TestCompanionSoulDefaultsOverridesAndDisable(t *testing.T) {
+	cfg, err := Normalize(RawConfig{
+		Defaults: RawDefaults{
+			CompanionSoul: RawCompanionSoul{Path: strPtr("identities/companion-soul.md")},
+		},
+		Agents: []RawAgent{
+			{ID: strPtr("agent-a"), FlyApp: strPtr("agent-a"), TailscaleHostname: strPtr("agent-a")},
+			{ID: strPtr("agent-b"), FlyApp: strPtr("agent-b"), TailscaleHostname: strPtr("agent-b"), CompanionSoul: RawCompanionSoul{
+				Text: strPtr("Use Granite for durable memory."),
+			}},
+			{ID: strPtr("agent-c"), FlyApp: strPtr("agent-c"), TailscaleHostname: strPtr("agent-c"), CompanionSoul: RawCompanionSoul{
+				Enabled: boolPtr(false),
+			}},
+		},
+	})
+	if err != nil {
+		t.Fatalf("normalize: %v", err)
+	}
+	if !cfg.Agents[0].CompanionSoul.Enabled || cfg.Agents[0].CompanionSoul.Path != "identities/companion-soul.md" {
+		t.Fatalf("expected inherited companion soul path, got %#v", cfg.Agents[0].CompanionSoul)
+	}
+	if !cfg.Agents[1].CompanionSoul.Enabled || cfg.Agents[1].CompanionSoul.Path != "identities/companion-soul.md" || cfg.Agents[1].CompanionSoul.Text != "Use Granite for durable memory." {
+		t.Fatalf("expected companion soul text override to keep inherited path, got %#v", cfg.Agents[1].CompanionSoul)
+	}
+	if cfg.Agents[2].CompanionSoul.Enabled {
+		t.Fatalf("expected agent companion soul to be disabled, got %#v", cfg.Agents[2].CompanionSoul)
+	}
+}
+
+func TestCompanionSoulRejectsAbsolutePath(t *testing.T) {
+	_, err := Normalize(RawConfig{
+		Agents: []RawAgent{{
+			ID:                strPtr("agent-a"),
+			FlyApp:            strPtr("agent-a"),
+			TailscaleHostname: strPtr("agent-a"),
+			CompanionSoul:     RawCompanionSoul{Path: strPtr("/tmp/companion-soul.md")},
+		}},
+	})
+	if err == nil {
+		t.Fatalf("expected absolute companion_soul path to be rejected")
+	}
+}
+
+func TestCompanionSoulEnabledRequiresPathOrText(t *testing.T) {
+	_, err := Normalize(RawConfig{
+		Agents: []RawAgent{{
+			ID:                strPtr("agent-a"),
+			FlyApp:            strPtr("agent-a"),
+			TailscaleHostname: strPtr("agent-a"),
+			CompanionSoul:     RawCompanionSoul{Enabled: boolPtr(true)},
+		}},
+	})
+	if err == nil {
+		t.Fatalf("expected enabled companion_soul without path or text to be rejected")
+	}
+}
+
 func TestDashboardDisabledWhenUnset(t *testing.T) {
 	cfg, err := Normalize(RawConfig{
 		Agents: []RawAgent{{ID: strPtr("sample"), FlyApp: strPtr("example-companion-sample"), TailscaleHostname: strPtr("sample")}},

--- a/internal/config/types.go
+++ b/internal/config/types.go
@@ -23,25 +23,26 @@ type RawConfig struct {
 }
 
 type RawDefaults struct {
-	Region                     *string         `toml:"region"`
-	VolumeName                 *string         `toml:"volume_name"`
-	VolumeSizeGB               *int            `toml:"volume_size_gb"`
-	Memory                     *string         `toml:"memory"`
-	CPUs                       *int            `toml:"cpus"`
-	DashboardMode              *string         `toml:"dashboard_mode"`
-	DashboardHost              *string         `toml:"dashboard_host"`
-	DashboardInsecure          *bool           `toml:"dashboard_insecure"`
-	DashboardPort              *int            `toml:"dashboard_port"`
-	GraniteEnabled             *bool           `toml:"granite_enabled"`
-	TailscaleAuthKeySecretName *string         `toml:"tailscale_authkey_secret_name"`
-	TailscaleAcceptDNS         *bool           `toml:"tailscale_accept_dns"`
-	TSExtraArgs                *string         `toml:"ts_extra_args"`
-	TailscaledExtraArgs        *string         `toml:"tailscaled_extra_args"`
-	GraniteTemplate            *string         `toml:"granite_template"`
-	Identity                   RawIdentity     `toml:"identity"`
-	Model                      RawModel        `toml:"model"`
-	APIServer                  RawAPIServer    `toml:"api_server"`
-	DefaultVault               RawDefaultVault `toml:"default_vault"`
+	Region                     *string          `toml:"region"`
+	VolumeName                 *string          `toml:"volume_name"`
+	VolumeSizeGB               *int             `toml:"volume_size_gb"`
+	Memory                     *string          `toml:"memory"`
+	CPUs                       *int             `toml:"cpus"`
+	DashboardMode              *string          `toml:"dashboard_mode"`
+	DashboardHost              *string          `toml:"dashboard_host"`
+	DashboardInsecure          *bool            `toml:"dashboard_insecure"`
+	DashboardPort              *int             `toml:"dashboard_port"`
+	GraniteEnabled             *bool            `toml:"granite_enabled"`
+	TailscaleAuthKeySecretName *string          `toml:"tailscale_authkey_secret_name"`
+	TailscaleAcceptDNS         *bool            `toml:"tailscale_accept_dns"`
+	TSExtraArgs                *string          `toml:"ts_extra_args"`
+	TailscaledExtraArgs        *string          `toml:"tailscaled_extra_args"`
+	GraniteTemplate            *string          `toml:"granite_template"`
+	Identity                   RawIdentity      `toml:"identity"`
+	CompanionSoul              RawCompanionSoul `toml:"companion_soul"`
+	Model                      RawModel         `toml:"model"`
+	APIServer                  RawAPIServer     `toml:"api_server"`
+	DefaultVault               RawDefaultVault  `toml:"default_vault"`
 }
 
 type RawAgent struct {
@@ -69,6 +70,7 @@ type RawAgent struct {
 	TailscaledExtraArgs        *string              `toml:"tailscaled_extra_args"`
 	GraniteTemplate            *string              `toml:"granite_template"`
 	Identity                   RawIdentity          `toml:"identity"`
+	CompanionSoul              RawCompanionSoul     `toml:"companion_soul"`
 	Model                      RawModel             `toml:"model"`
 	APIServer                  RawAPIServer         `toml:"api_server"`
 	DefaultVault               RawDefaultVault      `toml:"default_vault"`
@@ -80,6 +82,12 @@ type RawIdentity struct {
 	Path      *string `toml:"path"`
 	Soul      *string `toml:"soul"`
 	Overwrite *bool   `toml:"overwrite"`
+}
+
+type RawCompanionSoul struct {
+	Enabled *bool   `toml:"enabled"`
+	Path    *string `toml:"path"`
+	Text    *string `toml:"text"`
 }
 
 type RawModel struct {
@@ -194,25 +202,26 @@ type Config struct {
 }
 
 type Defaults struct {
-	Region                     string       `json:"region"`
-	VolumeName                 string       `json:"volume_name"`
-	VolumeSizeGB               int          `json:"volume_size_gb"`
-	Memory                     string       `json:"memory"`
-	CPUs                       int          `json:"cpus"`
-	DashboardMode              string       `json:"dashboard_mode"`
-	DashboardHost              string       `json:"dashboard_host"`
-	DashboardInsecure          bool         `json:"dashboard_insecure"`
-	DashboardPort              int          `json:"dashboard_port"`
-	GraniteEnabled             bool         `json:"granite_enabled"`
-	TailscaleAuthKeySecretName string       `json:"tailscale_authkey_secret_name"`
-	TailscaleAcceptDNS         bool         `json:"tailscale_accept_dns"`
-	TSExtraArgs                string       `json:"ts_extra_args,omitempty"`
-	TailscaledExtraArgs        string       `json:"tailscaled_extra_args,omitempty"`
-	GraniteTemplate            string       `json:"granite_template,omitempty"`
-	Identity                   Identity     `json:"identity"`
-	Model                      Model        `json:"model"`
-	APIServer                  APIServer    `json:"api_server"`
-	DefaultVault               DefaultVault `json:"default_vault"`
+	Region                     string        `json:"region"`
+	VolumeName                 string        `json:"volume_name"`
+	VolumeSizeGB               int           `json:"volume_size_gb"`
+	Memory                     string        `json:"memory"`
+	CPUs                       int           `json:"cpus"`
+	DashboardMode              string        `json:"dashboard_mode"`
+	DashboardHost              string        `json:"dashboard_host"`
+	DashboardInsecure          bool          `json:"dashboard_insecure"`
+	DashboardPort              int           `json:"dashboard_port"`
+	GraniteEnabled             bool          `json:"granite_enabled"`
+	TailscaleAuthKeySecretName string        `json:"tailscale_authkey_secret_name"`
+	TailscaleAcceptDNS         bool          `json:"tailscale_accept_dns"`
+	TSExtraArgs                string        `json:"ts_extra_args,omitempty"`
+	TailscaledExtraArgs        string        `json:"tailscaled_extra_args,omitempty"`
+	GraniteTemplate            string        `json:"granite_template,omitempty"`
+	Identity                   Identity      `json:"identity"`
+	CompanionSoul              CompanionSoul `json:"companion_soul"`
+	Model                      Model         `json:"model"`
+	APIServer                  APIServer     `json:"api_server"`
+	DefaultVault               DefaultVault  `json:"default_vault"`
 }
 
 type Agent struct {
@@ -240,6 +249,7 @@ type Agent struct {
 	TailscaledExtraArgs        string            `json:"tailscaled_extra_args,omitempty"`
 	GraniteTemplate            string            `json:"granite_template,omitempty"`
 	Identity                   Identity          `json:"identity"`
+	CompanionSoul              CompanionSoul     `json:"companion_soul"`
 	Model                      Model             `json:"model"`
 	APIServer                  APIServer         `json:"api_server"`
 	DefaultVault               DefaultVault      `json:"default_vault"`
@@ -251,6 +261,12 @@ type Identity struct {
 	Path      string `json:"path,omitempty"`
 	Soul      string `json:"soul,omitempty"`
 	Overwrite bool   `json:"overwrite"`
+}
+
+type CompanionSoul struct {
+	Enabled bool   `json:"enabled"`
+	Path    string `json:"path,omitempty"`
+	Text    string `json:"text,omitempty"`
 }
 
 type Model struct {
@@ -472,6 +488,14 @@ func (c *Config) Validate() error {
 				return fmt.Errorf("agent %s identity.path must be relative to the Companion root", agent.ID)
 			}
 		}
+		if agent.CompanionSoul.Enabled {
+			if strings.TrimSpace(agent.CompanionSoul.Path) == "" && strings.TrimSpace(agent.CompanionSoul.Text) == "" {
+				return fmt.Errorf("agent %s companion_soul requires path or text when enabled", agent.ID)
+			}
+			if filepath.IsAbs(agent.CompanionSoul.Path) {
+				return fmt.Errorf("agent %s companion_soul.path must be relative to the Companion root", agent.ID)
+			}
+		}
 		for _, conn := range agent.VaultConnections {
 			if err := validateConnection(agent.ID, conn); err != nil {
 				return err
@@ -614,6 +638,7 @@ func normalizeDefaults(raw RawDefaults) Defaults {
 	defaults.APIServer = normalizeAPIServer(nil, raw.APIServer, "")
 	defaults.DefaultVault = normalizeDefaultVault(nil, raw.DefaultVault, "")
 	defaults.Identity = normalizeIdentity(nil, raw.Identity)
+	defaults.CompanionSoul = normalizeCompanionSoul(nil, raw.CompanionSoul)
 	return defaults
 }
 
@@ -657,6 +682,7 @@ func normalizeAgent(defaults Defaults, raw RawAgent) (Agent, error) {
 	agent.APIServer = normalizeAPIServer(&defaults.APIServer, raw.APIServer, id)
 	agent.DefaultVault = normalizeDefaultVault(&defaults.DefaultVault, raw.DefaultVault, id)
 	agent.Identity = normalizeIdentity(&defaults.Identity, raw.Identity)
+	agent.CompanionSoul = normalizeCompanionSoul(&defaults.CompanionSoul, raw.CompanionSoul)
 	agent.VaultConnections = normalizeVaultConnections(raw.VaultConnections)
 	return agent, nil
 }
@@ -678,6 +704,24 @@ func normalizeIdentity(base *Identity, raw RawIdentity) Identity {
 	identity.Soul = stringValue(raw.Soul, identity.Soul)
 	identity.Overwrite = boolValue(raw.Overwrite, identity.Overwrite)
 	return identity
+}
+
+func normalizeCompanionSoul(base *CompanionSoul, raw RawCompanionSoul) CompanionSoul {
+	soul := CompanionSoul{Enabled: false}
+	if base != nil {
+		soul = *base
+	}
+	if base == nil && !rawCompanionSoulSet(raw) {
+		return soul
+	}
+	enabledFallback := soul.Enabled
+	if rawCompanionSoulSet(raw) && raw.Enabled == nil {
+		enabledFallback = true
+	}
+	soul.Enabled = boolValue(raw.Enabled, enabledFallback)
+	soul.Path = stringValue(raw.Path, soul.Path)
+	soul.Text = stringValue(raw.Text, soul.Text)
+	return soul
 }
 
 func normalizeModel(base *Model, raw RawModel, _ string) Model {
@@ -971,6 +1015,10 @@ func rawAPIServerSet(raw RawAPIServer) bool {
 
 func rawIdentitySet(raw RawIdentity) bool {
 	return raw.Enabled != nil || raw.Path != nil || raw.Soul != nil || raw.Overwrite != nil
+}
+
+func rawCompanionSoulSet(raw RawCompanionSoul) bool {
+	return raw.Enabled != nil || raw.Path != nil || raw.Text != nil
 }
 
 func rawDashboardSet(raw RawDashboard) bool {

--- a/internal/render/render.go
+++ b/internal/render/render.go
@@ -27,12 +27,8 @@ func AgentFlyTOML(agent config.Agent) (string, error) {
 		return "", err
 	}
 	identityJSON := ""
-	if agent.Identity.Enabled {
-		identityJSON, err = compactJSON(config.Identity{
-			Enabled:   agent.Identity.Enabled,
-			Soul:      agent.Identity.Soul,
-			Overwrite: agent.Identity.Overwrite,
-		})
+	if identity, ok := EffectiveAgentIdentity(agent); ok {
+		identityJSON, err = compactJSON(identity)
 		if err != nil {
 			return "", err
 		}
@@ -101,6 +97,34 @@ func AgentFlyTOML(agent config.Agent) (string, error) {
 		"",
 	)
 	return strings.Join(lines, "\n"), nil
+}
+
+func EffectiveAgentIdentity(agent config.Agent) (config.Identity, bool) {
+	soul := ""
+	if agent.Identity.Enabled {
+		soul = strings.TrimRight(agent.Identity.Soul, "\n")
+	}
+	if agent.CompanionSoul.Enabled {
+		companionSoul := strings.TrimRight(agent.CompanionSoul.Text, "\n")
+		if strings.TrimSpace(companionSoul) != "" {
+			if strings.TrimSpace(soul) != "" {
+				soul += "\n\n"
+			}
+			soul += companionSoul
+		}
+	}
+	if strings.TrimSpace(soul) == "" {
+		return config.Identity{}, false
+	}
+	overwrite := agent.Identity.Overwrite
+	if !agent.Identity.Enabled && agent.Identity.Path == "" && agent.Identity.Soul == "" {
+		overwrite = true
+	}
+	return config.Identity{
+		Enabled:   true,
+		Soul:      soul,
+		Overwrite: overwrite,
+	}, true
 }
 
 func OpenWebUIFlyTOML(cfg config.OpenWebUI, connections []config.OpenWebUIConnection) (string, error) {

--- a/internal/render/render_test.go
+++ b/internal/render/render_test.go
@@ -204,6 +204,70 @@ func TestAgentRenderIncludesIdentityJSON(t *testing.T) {
 	}
 }
 
+func TestAgentRenderAppendsCompanionSoulToIdentityJSON(t *testing.T) {
+	toml, err := AgentFlyTOML(config.Agent{
+		ID:                         "sample",
+		FlyApp:                     "sample",
+		Region:                     "cdg",
+		VolumeName:                 "data",
+		Memory:                     "1gb",
+		CPUs:                       1,
+		TailscaleHostname:          "sample",
+		TailscaleAuthKeySecretName: "TS_AUTHKEY",
+		DashboardHost:              "0.0.0.0",
+		DashboardMode:              "serve",
+		DashboardPort:              9119,
+		Identity: config.Identity{
+			Enabled:   true,
+			Soul:      "# Sample Agent\n\nYou are direct.\n",
+			Overwrite: true,
+		},
+		CompanionSoul: config.CompanionSoul{
+			Enabled: true,
+			Text:    "## Companion Memory\n\nAlways capture durable knowledge in Granite.\n",
+		},
+	})
+	if err != nil {
+		t.Fatalf("render: %v", err)
+	}
+	want := `\"soul\":\"# Sample Agent\\n\\nYou are direct.\\n\\n## Companion Memory\\n\\nAlways capture durable knowledge in Granite.\"`
+	if !strings.Contains(toml, want) {
+		t.Fatalf("companion soul was not appended after identity, missing %q in\n%s", want, toml)
+	}
+}
+
+func TestAgentRenderCreatesIdentityFromCompanionSoul(t *testing.T) {
+	toml, err := AgentFlyTOML(config.Agent{
+		ID:                         "sample",
+		FlyApp:                     "sample",
+		Region:                     "cdg",
+		VolumeName:                 "data",
+		Memory:                     "1gb",
+		CPUs:                       1,
+		TailscaleHostname:          "sample",
+		TailscaleAuthKeySecretName: "TS_AUTHKEY",
+		DashboardHost:              "0.0.0.0",
+		DashboardMode:              "serve",
+		DashboardPort:              9119,
+		CompanionSoul: config.CompanionSoul{
+			Enabled: true,
+			Text:    "## Companion Memory\n\nAlways capture durable knowledge in Granite.",
+		},
+	})
+	if err != nil {
+		t.Fatalf("render: %v", err)
+	}
+	for _, want := range []string{
+		`HERMES_IDENTITY_JSON = "{\"enabled\":true`,
+		`\"soul\":\"## Companion Memory\\n\\nAlways capture durable knowledge in Granite.\"`,
+		`\"overwrite\":true}`,
+	} {
+		if !strings.Contains(toml, want) {
+			t.Fatalf("missing %q in\n%s", want, toml)
+		}
+	}
+}
+
 func TestAgentRenderOmitsDisabledIdentity(t *testing.T) {
 	toml, err := AgentFlyTOML(config.Agent{
 		ID:                         "sample",
@@ -220,6 +284,10 @@ func TestAgentRenderOmitsDisabledIdentity(t *testing.T) {
 		Identity: config.Identity{
 			Enabled: false,
 			Soul:    "# Should not be rendered",
+		},
+		CompanionSoul: config.CompanionSoul{
+			Enabled: false,
+			Text:    "# Should not be rendered either",
 		},
 	})
 	if err != nil {

--- a/internal/resource/resource.go
+++ b/internal/resource/resource.go
@@ -865,21 +865,34 @@ func desiredSizeGB(resource Resource) int {
 }
 
 func hydrateAgentIdentity(root string, agent config.Agent) (config.Agent, error) {
-	if !agent.Identity.Enabled || agent.Identity.Soul != "" {
-		return agent, nil
+	if agent.Identity.Enabled && strings.TrimSpace(agent.Identity.Soul) == "" {
+		path := agent.Identity.Path
+		if path == "" {
+			return agent, fmt.Errorf("agent %s identity requires path or soul", agent.ID)
+		}
+		if !filepath.IsAbs(path) {
+			path = filepath.Join(root, filepath.FromSlash(path))
+		}
+		data, err := os.ReadFile(path)
+		if err != nil {
+			return agent, fmt.Errorf("read identity for agent %s: %w", agent.ID, err)
+		}
+		agent.Identity.Soul = string(data)
 	}
-	path := agent.Identity.Path
-	if path == "" {
-		return agent, nil
+	if agent.CompanionSoul.Enabled && strings.TrimSpace(agent.CompanionSoul.Text) == "" {
+		path := agent.CompanionSoul.Path
+		if path == "" {
+			return agent, fmt.Errorf("agent %s companion_soul requires path or text", agent.ID)
+		}
+		if !filepath.IsAbs(path) {
+			path = filepath.Join(root, filepath.FromSlash(path))
+		}
+		data, err := os.ReadFile(path)
+		if err != nil {
+			return agent, fmt.Errorf("read companion_soul for agent %s: %w", agent.ID, err)
+		}
+		agent.CompanionSoul.Text = string(data)
 	}
-	if !filepath.IsAbs(path) {
-		path = filepath.Join(root, filepath.FromSlash(path))
-	}
-	data, err := os.ReadFile(path)
-	if err != nil {
-		return agent, fmt.Errorf("read identity for agent %s: %w", agent.ID, err)
-	}
-	agent.Identity.Soul = string(data)
 	return agent, nil
 }
 

--- a/internal/resource/resource_test.go
+++ b/internal/resource/resource_test.go
@@ -71,6 +71,38 @@ func TestTargetedSelectIncludesDependenciesInStableOrder(t *testing.T) {
 	}
 }
 
+func TestAgentConfigHashIncludesCompanionSoul(t *testing.T) {
+	agent := config.Agent{
+		ID:                         "sample",
+		FlyApp:                     "sample",
+		Region:                     "cdg",
+		VolumeName:                 "data",
+		Memory:                     "1gb",
+		CPUs:                       1,
+		TailscaleHostname:          "sample",
+		TailscaleAuthKeySecretName: "TS_AUTHKEY",
+		DashboardHost:              "0.0.0.0",
+		DashboardMode:              "serve",
+		DashboardPort:              9119,
+		CompanionSoul: config.CompanionSoul{
+			Enabled: true,
+			Text:    "Always capture durable knowledge in Granite.",
+		},
+	}
+	before, err := hashAgentConfig(agent)
+	if err != nil {
+		t.Fatalf("hash before: %v", err)
+	}
+	agent.CompanionSoul.Text = "Always capture decisions and durable knowledge in Granite."
+	after, err := hashAgentConfig(agent)
+	if err != nil {
+		t.Fatalf("hash after: %v", err)
+	}
+	if before == after {
+		t.Fatalf("expected companion soul text to affect agent config hash")
+	}
+}
+
 func TestBuildPlanBlocksProtectedVolumeDestroy(t *testing.T) {
 	ws := testWorkspace(t)
 	store := openTestState(t)

--- a/internal/workspace/workspace.go
+++ b/internal/workspace/workspace.go
@@ -100,6 +100,7 @@ type agentFile struct {
 	APIServer        config.RawAPIServer         `toml:"api_server"`
 	DefaultVault     config.RawDefaultVault      `toml:"default_vault"`
 	Identity         config.RawIdentity          `toml:"identity"`
+	CompanionSoul    config.RawCompanionSoul     `toml:"companion_soul"`
 	VaultConnection  []config.RawVaultConnection `toml:"vault_connections"`
 	VaultConnections []config.RawVaultConnection `toml:"vault_connection"`
 }
@@ -284,6 +285,9 @@ func (w *Workspace) Validate() error {
 		}
 		if agent.Identity.Enabled && filepath.IsAbs(agent.Identity.Path) {
 			return fmt.Errorf("agent %s identity path must be relative to the workspace", agent.ID)
+		}
+		if agent.CompanionSoul.Enabled && filepath.IsAbs(agent.CompanionSoul.Path) {
+			return fmt.Errorf("agent %s companion_soul path must be relative to the workspace", agent.ID)
 		}
 	}
 	if w.Config.OpenWebUI.Enabled {
@@ -546,6 +550,7 @@ func (f agentFile) toRawAgent() config.RawAgent {
 		TailscaledExtraArgs:        f.Agent.TailscaledExtraArgs,
 		GraniteTemplate:            f.Agent.GraniteTemplate,
 		Identity:                   identity,
+		CompanionSoul:              f.CompanionSoul,
 		Model:                      f.Model,
 		APIServer:                  f.APIServer,
 		DefaultVault:               f.DefaultVault,

--- a/internal/workspace/workspace_test.go
+++ b/internal/workspace/workspace_test.go
@@ -178,6 +178,53 @@ identity = "/tmp/SOUL.md"
 	}
 }
 
+func TestLoadCompanionSoulDefaultsAndAgentDisable(t *testing.T) {
+	root := t.TempDir()
+	writeMinimalWorkspace(t, root)
+	writeWorkspaceFile(t, root, "defaults.toml", `[defaults]
+region = "cdg"
+
+[defaults.model]
+enabled = false
+
+[defaults.companion_soul]
+path = "identities/companion-soul.md"
+`)
+	writeWorkspaceFile(t, root, "agents/enabled.toml", `[agent]
+id = "enabled"
+fly_app = "example-companion-enabled"
+tailscale_hostname = "enabled"
+`)
+	writeWorkspaceFile(t, root, "agents/disabled.toml", `[agent]
+id = "disabled"
+fly_app = "example-companion-disabled"
+tailscale_hostname = "disabled"
+
+[companion_soul]
+enabled = false
+`)
+	ws, err := Load(root)
+	if err != nil {
+		t.Fatalf("load workspace: %v", err)
+	}
+	byID := map[string]struct {
+		enabled bool
+		path    string
+	}{}
+	for _, agent := range ws.Config.Agents {
+		byID[agent.ID] = struct {
+			enabled bool
+			path    string
+		}{enabled: agent.CompanionSoul.Enabled, path: agent.CompanionSoul.Path}
+	}
+	if !byID["enabled"].enabled || byID["enabled"].path != "identities/companion-soul.md" {
+		t.Fatalf("expected enabled agent to inherit companion soul, got %#v", ws.Config.Agents)
+	}
+	if byID["disabled"].enabled {
+		t.Fatalf("expected disabled agent to opt out, got %#v", ws.Config.Agents)
+	}
+}
+
 func TestLoadFailsOnDuplicateVaultIDs(t *testing.T) {
 	root := t.TempDir()
 	writeMinimalWorkspace(t, root)


### PR DESCRIPTION
## What changed
- Added `[defaults.companion_soul]` and per-agent `[companion_soul]` config to append fleet-wide SOUL.md guidance after agent identities.
- Hydrated companion soul files from workspace paths and used the effective identity in render/apply and `identity render`.
- Documented the setting in AGENTS.md, CLAUDE.md, and README.md.
- Added behavior tests for config inheritance/disable, workspace loading, render output, CLI output, and rollout hash changes.

## Why
Hermes agents need a default, centrally managed identity appendix for durable Granite memory rules without duplicating that text in every agent-specific SOUL.md. Agents can opt out explicitly with `[companion_soul] enabled = false`.

## Validation
- `go test ./...`
- `go test -race ./...`
- `go run ./cmd/companion validate --workspace examples/minimal`
- `go run ./cmd/companion validate --workspace examples/webui`

## Review
Generated by an AI coding agent. Human reviewed: not yet.