### PR TITLE
feat(console): Companion Web Console v1

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,7 +44,7 @@ jobs:
       - name: Validate shell scripts
         run: |
           sh -n install.sh
-          bash -n install.sh bin/start-on-fly bin/run-hermes-process bin/start-open-webui-on-fly bin/start-dashboard-on-fly
+          bash -n install.sh bin/start-on-fly bin/run-hermes-process bin/start-open-webui-on-fly bin/start-dashboard-on-fly bin/build-console-ui
 
       - name: Verify installable CLI package
         run: |
@@ -63,6 +63,29 @@ jobs:
 
       - name: Build Open WebUI Docker image
         run: docker build -f Dockerfile.open-webui .
+
+  web:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "22"
+          cache: npm
+          cache-dependency-path: web/package-lock.json
+
+      - name: Install console UI dependencies
+        run: npm --prefix web ci
+
+      - name: Typecheck console UI
+        run: npm --prefix web run typecheck
+
+      - name: Build console UI
+        run: npm --prefix web run build
+
+      - name: Test console UI
+        run: npm --prefix web run test
 
   build:
     runs-on: ubuntu-latest

--- a/bin/build-console-ui
+++ b/bin/build-console-ui
@@ -1,0 +1,76 @@
+#!/usr/bin/env bash
+# build-console-ui builds the Companion Console SPA (web/) and copies the
+# emitted bundle into internal/console/assets/ so it is embedded by the Go
+# console via //go:embed.
+#
+# The embed contract (see internal/console/console.go) is:
+#   - fs.ReadFile(assets, "assets/index.html")  -> internal/console/assets/index.html
+#   - fs.Sub(assets, "assets") served at /assets -> internal/console/assets/assets/*
+# Vite emits exactly this shape under web/dist (index.html + assets/<hashed>.js,.css),
+# so the bundle is mirrored verbatim. The built index.html keeps the
+# %%CONSOLE_TOKEN%% / %%CONSOLE_WORKSPACE%% sentinels the Go server injects at
+# serve time.
+#
+# A plain `go build ./...` (e.g. in CI) embeds whatever is committed at
+# internal/console/assets/index.html. This script is the production step that
+# replaces that placeholder with the real SPA; it is intentionally NOT run by a
+# bare `go build`, so CI stays green on the committed placeholder.
+set -Eeuo pipefail
+
+log() {
+    printf '[build-console-ui] %s\n' "$*"
+}
+
+die() {
+    log "error: $*"
+    exit 1
+}
+
+# Resolve the repository root from this script's location so the build works
+# from any working directory without relying on `cd` at the call site.
+script_dir="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" >/dev/null 2>&1 && pwd -P)"
+repo_root="$(cd -- "${script_dir}/.." >/dev/null 2>&1 && pwd -P)"
+
+web_dir="${repo_root}/web"
+dist_dir="${web_dir}/dist"
+assets_dir="${repo_root}/internal/console/assets"
+
+command -v npm >/dev/null 2>&1 || die "npm is required but was not found on PATH"
+[ -f "${web_dir}/package.json" ] || die "missing ${web_dir}/package.json (run from a checkout with the console UI)"
+
+# Ensure dependencies are present. CI installs them separately, but a local
+# invocation of this script should self-heal a missing node_modules.
+if [ ! -d "${web_dir}/node_modules" ]; then
+    if [ -f "${web_dir}/package-lock.json" ]; then
+        log "installing web dependencies (npm ci)"
+        npm --prefix "${web_dir}" ci
+    else
+        log "installing web dependencies (npm install)"
+        npm --prefix "${web_dir}" install
+    fi
+fi
+
+log "building console UI (npm --prefix web run build)"
+npm --prefix "${web_dir}" run build
+
+[ -f "${dist_dir}/index.html" ] || die "vite build did not emit ${dist_dir}/index.html"
+[ -d "${dist_dir}/assets" ] || die "vite build did not emit ${dist_dir}/assets"
+
+# Copy into the embed dir only after a successful build so a failed build never
+# leaves the embedded UI half-written. Clear prior build output first so stale
+# hashed bundles do not accumulate inside the embed, then mirror web/dist.
+log "syncing build into ${assets_dir}"
+mkdir -p "${assets_dir}/assets"
+rm -rf "${assets_dir}/assets"
+cp -R "${dist_dir}/assets" "${assets_dir}/assets"
+cp "${dist_dir}/index.html" "${assets_dir}/index.html"
+
+# Guard the embed contract: the copied index.html must reference the hashed
+# bundle (i.e. be the real SPA, not the placeholder) and must keep the token
+# sentinel the Go server injects at serve time.
+grep -Eq '/assets/.*\.(js|css)' "${assets_dir}/index.html" \
+    || die "embedded index.html does not reference a hashed asset bundle"
+grep -q '%%CONSOLE_TOKEN%%' "${assets_dir}/index.html" \
+    || die "embedded index.html is missing the %%CONSOLE_TOKEN%% sentinel"
+
+log "done: console UI embedded at ${assets_dir}"

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -12,6 +12,7 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/The-Vibe-Company/companion/internal/config"
+	"github.com/The-Vibe-Company/companion/internal/console"
 	"github.com/The-Vibe-Company/companion/internal/deps"
 	"github.com/The-Vibe-Company/companion/internal/envfile"
 	"github.com/The-Vibe-Company/companion/internal/execx"
@@ -69,6 +70,7 @@ func newRootCommand(runner execx.Runner) *cobra.Command {
 	cmd.AddCommand(a.tailscaleCommand())
 	cmd.AddCommand(a.vaultCommand())
 	cmd.AddCommand(a.dashboardCommand())
+	cmd.AddCommand(a.consoleCommand())
 	cmd.AddCommand(a.versionCommand())
 	return cmd
 }
@@ -840,6 +842,43 @@ func (a *app) dashboardCommand() *cobra.Command {
 // dashboardAddr lets the deployed container bind to Fly's injected PORT without
 // templating the value into the generated config.
 func dashboardAddr(addr string) string {
+	if port := os.Getenv("PORT"); port != "" {
+		return "0.0.0.0:" + port
+	}
+	return addr
+}
+
+func (a *app) consoleCommand() *cobra.Command {
+	var addr string
+	var devUI string
+	cmd := &cobra.Command{
+		Use:   "console",
+		Short: "Serve the Companion console (local fleet admin UI + API)",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			env, err := a.env()
+			if err != nil {
+				return err
+			}
+			addr = consoleAddr(addr)
+			opts := console.Options{
+				WorkspaceDir: a.rootDir,
+				EnvFile:      a.envFile,
+				Env:          env,
+				Runner:       a.runnerWithEnv(env),
+				DevUI:        devUI,
+			}
+			fmt.Fprintf(cmd.OutOrStdout(), "serving Companion console at http://%s\n", addr)
+			return console.Serve(cmd.Context(), addr, opts)
+		},
+	}
+	cmd.Flags().StringVar(&addr, "addr", "127.0.0.1:8788", "listen address (PORT env wins when set)")
+	cmd.Flags().StringVar(&devUI, "dev-ui", "", "reverse-proxy the UI to this dev origin (e.g. http://127.0.0.1:5173)")
+	return cmd
+}
+
+// consoleAddr mirrors dashboardAddr so a deployed console binds to Fly's
+// injected PORT, while keeping the console's own local default port.
+func consoleAddr(addr string) string {
 	if port := os.Getenv("PORT"); port != "" {
 		return "0.0.0.0:" + port
 	}

--- a/internal/console/.gitignore
+++ b/internal/console/.gitignore
@@ -1,0 +1,4 @@
+# Built SPA bundles synced in by bin/build-console-ui for production images.
+# The committed assets/index.html placeholder is what a bare `go build` embeds;
+# the real hashed JS/CSS are generated artifacts and must not be committed.
+/assets/assets/

--- a/internal/console/api.go
+++ b/internal/console/api.go
@@ -269,6 +269,14 @@ func (s *Server) handleDeleteAgent(w http.ResponseWriter, r *http.Request) {
 // against current state and providers, cache the plan hash, and return
 // PlanResponse. The cached hash is what a subsequent apply must echo back.
 func (s *Server) handlePlan(w http.ResponseWriter, r *http.Request) {
+	// Optional body carries the destroy confirmations; an absent body plans safely
+	// (protected destructions are reported as blocked rather than performed).
+	var req PlanRequest
+	if err := decodeJSONOptional(r, &req); err != nil {
+		writeJSONError(w, http.StatusBadRequest, "invalid request body: "+err.Error())
+		return
+	}
+
 	ws, err := s.loadWorkspace()
 	if err != nil {
 		writeJSONError(w, http.StatusBadRequest, err.Error())
@@ -292,7 +300,7 @@ func (s *Server) handlePlan(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	plan, err := resource.BuildPlan(r.Context(), ws, store, providers, s.planOptions(ws, env))
+	plan, err := resource.BuildPlan(r.Context(), ws, store, providers, s.planOptions(ws, env, req.AllowProtectedDestroy, req.DestroyData))
 	if err != nil {
 		writeJSONError(w, http.StatusBadGateway, err.Error())
 		return
@@ -304,12 +312,15 @@ func (s *Server) handlePlan(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	hash := hashBytes(planJSON)
-	s.setPlanHash(hash)
+	s.setPlan(hash, req.AllowProtectedDestroy, req.DestroyData)
 
+	protectedConfirm, destroyData := planDestroyFlags(plan.Changes)
 	writeJSON(w, http.StatusOK, PlanResponse{
-		Hash:    hash,
-		Text:    plan.String(),
-		Changes: planChanges(plan.Changes),
+		Hash:                     hash,
+		Text:                     plan.String(),
+		Changes:                  planChanges(plan.Changes),
+		RequiresProtectedConfirm: protectedConfirm,
+		RequiresDestroyData:      destroyData,
 	})
 }
 
@@ -323,7 +334,7 @@ func (s *Server) handleApply(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	latest := s.planHash()
+	latest, allowProtectedDestroy, destroyData := s.currentPlan()
 	if latest == "" {
 		writeJSONError(w, http.StatusConflict, "no current plan: run plan before apply")
 		return
@@ -333,7 +344,7 @@ func (s *Server) handleApply(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	id, ok := s.runner.Start(s.applyRun())
+	id, ok := s.runner.Start(s.applyRun(allowProtectedDestroy, destroyData))
 	if !ok {
 		writeJSONError(w, http.StatusConflict, "an apply is already in progress")
 		return
@@ -342,9 +353,10 @@ func (s *Server) handleApply(w http.ResponseWriter, r *http.Request) {
 }
 
 // applyRun returns the function the OperationRunner executes for an apply. It
-// reloads the workspace, state, and providers fresh, runs resource.Apply, and
-// reports the addresses that actually mutated plus the canonical plan JSON.
-func (s *Server) applyRun() func(ctx context.Context) (changed []string, planJSON []byte, err error) {
+// reloads the workspace, state, and providers fresh, runs resource.Apply with the
+// destroy confirmations the cached plan was computed under, and reports the
+// addresses that actually mutated plus the canonical plan JSON.
+func (s *Server) applyRun(allowProtectedDestroy, destroyData bool) func(ctx context.Context) (changed []string, planJSON []byte, err error) {
 	return func(ctx context.Context) ([]string, []byte, error) {
 		ws, err := s.loadWorkspace()
 		if err != nil {
@@ -365,7 +377,7 @@ func (s *Server) applyRun() func(ctx context.Context) (changed []string, planJSO
 			return nil, nil, err
 		}
 
-		plan, err := resource.Apply(ctx, ws, store, providers, s.planOptions(ws, env))
+		plan, err := resource.Apply(ctx, ws, store, providers, s.planOptions(ws, env, allowProtectedDestroy, destroyData))
 		planJSON, jerr := plan.JSON()
 		if jerr != nil && err == nil {
 			err = jerr
@@ -446,13 +458,44 @@ func (s *Server) handleAgentLogs(w http.ResponseWriter, r *http.Request) {
 // --- shared helpers -------------------------------------------------------
 
 // planOptions builds the resource Options used for both plan and apply so the
-// two stay consistent (same generated dir and env).
-func (s *Server) planOptions(ws *workspace.Workspace, env map[string]string) resource.Options {
-	return resource.Options{
-		Root:         ws.Root,
-		GeneratedDir: filepath.Join(ws.Root, ".companion", "generated"),
-		Env:          env,
+// two stay consistent (same generated dir, env, and destroy confirmations). The
+// destroy flags default to false: a plain plan/apply reports protected
+// destructions as blocked rather than performing them.
+func (s *Server) planOptions(ws *workspace.Workspace, env map[string]string, allowProtectedDestroy, destroyData bool) resource.Options {
+	opts := resource.Options{
+		Root:                  ws.Root,
+		GeneratedDir:          filepath.Join(ws.Root, ".companion", "generated"),
+		Env:                   env,
+		AllowProtectedDestroy: allowProtectedDestroy,
 	}
+	if destroyData {
+		// The engine refuses to destroy a persistent-data resource (a Fly volume)
+		// unless DestroyData AND BackupFirst are both set; pair them so the console
+		// always takes a backup before removing data.
+		opts.DestroyData = true
+		opts.BackupFirst = true
+	}
+	return opts
+}
+
+// planDestroyFlags inspects a computed plan and reports whether it needs the
+// operator's destroy confirmations: protectedConfirm when a protected resource is
+// being destroyed or is blocked pending confirmation, and destroyData when a Fly
+// volume is being destroyed (which additionally needs the data acknowledgement).
+func planDestroyFlags(changes []resource.Change) (protectedConfirm, destroyData bool) {
+	for _, c := range changes {
+		// "!" = blocked, "-" = delete. Both indicate a destruction intent.
+		if c.Kind != "!" && c.Kind != "-" {
+			continue
+		}
+		if c.Protected {
+			protectedConfirm = true
+		}
+		if strings.HasPrefix(c.Address, "fly_volume.") {
+			destroyData = true
+		}
+	}
+	return protectedConfirm, destroyData
 }
 
 // reloadValidated re-loads the workspace from disk. workspace.Load already runs
@@ -711,18 +754,23 @@ func hashBytes(b []byte) string {
 	return hex.EncodeToString(sum[:])
 }
 
-// setPlanHash records the latest computed plan hash under the server mutex.
-func (s *Server) setPlanHash(hash string) {
+// setPlan records the latest computed plan hash and the destroy confirmations it
+// was computed with, under the server mutex. Apply replays these exact options so
+// the operator can only apply the plan they actually reviewed.
+func (s *Server) setPlan(hash string, allowProtectedDestroy, destroyData bool) {
 	s.mu.Lock()
 	s.latestPlanHash = hash
+	s.latestAllowProtectedDestroy = allowProtectedDestroy
+	s.latestDestroyData = destroyData
 	s.mu.Unlock()
 }
 
-// planHash returns the most recently computed plan hash under the server mutex.
-func (s *Server) planHash() string {
+// currentPlan returns the most recently computed plan hash and its destroy
+// confirmations under the server mutex.
+func (s *Server) currentPlan() (hash string, allowProtectedDestroy, destroyData bool) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
-	return s.latestPlanHash
+	return s.latestPlanHash, s.latestAllowProtectedDestroy, s.latestDestroyData
 }
 
 // rfc3339 is the timestamp layout used for operation times in API responses.

--- a/internal/console/api.go
+++ b/internal/console/api.go
@@ -1,0 +1,684 @@
+package console
+
+import (
+	"context"
+	"crypto/sha256"
+	"database/sql"
+	"encoding/hex"
+	"net/http"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/The-Vibe-Company/companion/internal/config"
+	"github.com/The-Vibe-Company/companion/internal/provider"
+	"github.com/The-Vibe-Company/companion/internal/resource"
+	"github.com/The-Vibe-Company/companion/internal/state"
+	"github.com/The-Vibe-Company/companion/internal/status"
+	"github.com/The-Vibe-Company/companion/internal/workspace"
+)
+
+// soulPreviewLen bounds the soul preview returned in AgentDetail so the API
+// never dumps a full identity (which may carry sensitive operating context).
+const soulPreviewLen = 280
+
+// handleWorkspace -> GET /api/console/workspace : WorkspaceInfo with provider
+// credentials redacted to name + presence only.
+func (s *Server) handleWorkspace(w http.ResponseWriter, r *http.Request) {
+	ws, err := s.loadWorkspace()
+	if err != nil {
+		writeJSONError(w, http.StatusBadRequest, err.Error())
+		return
+	}
+	env, err := s.env()
+	if err != nil {
+		writeJSONError(w, http.StatusBadRequest, err.Error())
+		return
+	}
+
+	creds := provider.New(ws, env).RequiredCredentials()
+	providers := make([]ProviderCred, 0, len(creds))
+	for _, c := range creds {
+		// Names + presence only: a value never leaves the process.
+		providers = append(providers, ProviderCred{Name: c.Name, Present: c.Present})
+	}
+
+	writeJSON(w, http.StatusOK, WorkspaceInfo{
+		Name:       ws.Name,
+		Root:       ws.Root,
+		AgentCount: len(ws.Config.Agents),
+		Providers:  providers,
+	})
+}
+
+// handleListAgents -> GET /api/console/agents : []AgentSummary, built from config
+// (no live network) and enriched from the latest status snapshot when available.
+func (s *Server) handleListAgents(w http.ResponseWriter, r *http.Request) {
+	ws, err := s.loadWorkspace()
+	if err != nil {
+		writeJSONError(w, http.StatusBadRequest, err.Error())
+		return
+	}
+	byID := s.snapshotByID()
+	summaries := make([]AgentSummary, 0, len(ws.Config.Agents))
+	for _, agent := range ws.Config.Agents {
+		summaries = append(summaries, s.agentSummary(agent, byID))
+	}
+	writeJSON(w, http.StatusOK, summaries)
+}
+
+// handleGetAgent -> GET /api/console/agents/{id} : AgentDetail (404 if unknown).
+func (s *Server) handleGetAgent(w http.ResponseWriter, r *http.Request) {
+	ws, err := s.loadWorkspace()
+	if err != nil {
+		writeJSONError(w, http.StatusBadRequest, err.Error())
+		return
+	}
+	agent, ok := findAgent(ws.Config, r.PathValue("id"))
+	if !ok {
+		writeJSONError(w, http.StatusNotFound, "agent not found")
+		return
+	}
+	writeJSON(w, http.StatusOK, s.agentDetail(agent, s.snapshotByID()))
+}
+
+// handleCreateAgent -> POST /api/console/agents : write agents/<id>.toml, reload
+// + validate, and return 201 + AgentDetail. On validation failure the freshly
+// created file is removed (rollback) and 400 is returned.
+func (s *Server) handleCreateAgent(w http.ResponseWriter, r *http.Request) {
+	var in AgentInput
+	if err := decodeJSON(r, &in); err != nil {
+		writeJSONError(w, http.StatusBadRequest, "invalid request body: "+err.Error())
+		return
+	}
+
+	id := strings.TrimSpace(in.ID)
+	// Best-effort duplicate check: when the workspace already loads, reject a
+	// colliding id. A workspace that does not yet load (e.g. it has no agents,
+	// which Companion's "at least one agent" rule rejects) is allowed here so the
+	// FIRST agent can be created; the post-write reload then validates it.
+	if ws, err := s.loadWorkspace(); err == nil {
+		if _, exists := findAgent(ws.Config, id); exists {
+			writeJSONError(w, http.StatusConflict, "agent already exists: "+id)
+			return
+		}
+	}
+
+	file, err := s.writer.BuildAgentFile(in)
+	if err != nil {
+		writeJSONError(w, http.StatusBadRequest, err.Error())
+		return
+	}
+	// Write the optional SOUL.md first (so identity resolves on reload), then the
+	// agent TOML. Both are fresh creates here, so rollback is a file removal.
+	if strings.TrimSpace(in.Soul) != "" {
+		if _, err := s.writer.WriteSoul(id, in.Soul); err != nil {
+			writeJSONError(w, http.StatusInternalServerError, err.Error())
+			return
+		}
+	}
+	if _, err := s.writer.WriteAgent(id, file); err != nil {
+		writeJSONError(w, http.StatusInternalServerError, err.Error())
+		return
+	}
+
+	reloaded, err := s.reloadValidated()
+	if err != nil {
+		// Roll back the create: remove the just-written agent file so the broken
+		// edit never persists in the workspace.
+		_ = s.writer.RemoveAgent(id)
+		writeJSONError(w, http.StatusBadRequest, "workspace validation failed: "+err.Error())
+		return
+	}
+
+	agent, ok := findAgent(reloaded.Config, id)
+	if !ok {
+		writeJSONError(w, http.StatusInternalServerError, "agent missing after create")
+		return
+	}
+	writeJSON(w, http.StatusCreated, s.agentDetail(agent, s.snapshotByID()))
+}
+
+// handleUpdateAgent -> PUT /api/console/agents/{id} : overwrite agents/<id>.toml
+// (with a backup), reload + validate, and return 200 + AgentDetail. On
+// validation failure the prior file is restored from the backup.
+func (s *Server) handleUpdateAgent(w http.ResponseWriter, r *http.Request) {
+	id := r.PathValue("id")
+
+	var in AgentInput
+	if err := decodeJSON(r, &in); err != nil {
+		writeJSONError(w, http.StatusBadRequest, "invalid request body: "+err.Error())
+		return
+	}
+	// The path id is authoritative; ignore any divergent body id.
+	in.ID = id
+
+	ws, err := s.loadWorkspace()
+	if err != nil {
+		writeJSONError(w, http.StatusBadRequest, err.Error())
+		return
+	}
+	if _, exists := findAgent(ws.Config, id); !exists {
+		writeJSONError(w, http.StatusNotFound, "agent not found")
+		return
+	}
+
+	file, err := s.writer.BuildAgentFile(in)
+	if err != nil {
+		writeJSONError(w, http.StatusBadRequest, err.Error())
+		return
+	}
+
+	var soulBackup string
+	if strings.TrimSpace(in.Soul) != "" {
+		soulBackup, err = s.writer.WriteSoul(id, in.Soul)
+		if err != nil {
+			writeJSONError(w, http.StatusInternalServerError, err.Error())
+			return
+		}
+	}
+	agentBackup, err := s.writer.WriteAgent(id, file)
+	if err != nil {
+		s.rollback(soulBackup)
+		writeJSONError(w, http.StatusInternalServerError, err.Error())
+		return
+	}
+
+	reloaded, err := s.reloadValidated()
+	if err != nil {
+		// Restore both files from their backups so a rejected edit leaves the
+		// workspace exactly as it was.
+		s.rollback(agentBackup)
+		s.rollback(soulBackup)
+		writeJSONError(w, http.StatusBadRequest, "workspace validation failed: "+err.Error())
+		return
+	}
+
+	agent, ok := findAgent(reloaded.Config, id)
+	if !ok {
+		writeJSONError(w, http.StatusInternalServerError, "agent missing after update")
+		return
+	}
+	writeJSON(w, http.StatusOK, s.agentDetail(agent, s.snapshotByID()))
+}
+
+// handleDeleteAgent -> DELETE /api/console/agents/{id} : set lifecycle="absent"
+// in the TOML (the file is kept so plan renders an explicit destroy) and return
+// 200 + AgentDetail.
+func (s *Server) handleDeleteAgent(w http.ResponseWriter, r *http.Request) {
+	id := r.PathValue("id")
+
+	ws, err := s.loadWorkspace()
+	if err != nil {
+		writeJSONError(w, http.StatusBadRequest, err.Error())
+		return
+	}
+	if _, exists := findAgent(ws.Config, id); !exists {
+		writeJSONError(w, http.StatusNotFound, "agent not found")
+		return
+	}
+
+	backup, err := s.writer.SetLifecycleAbsent(id)
+	if err != nil {
+		writeJSONError(w, http.StatusInternalServerError, err.Error())
+		return
+	}
+
+	reloaded, err := s.reloadValidated()
+	if err != nil {
+		s.rollback(backup)
+		writeJSONError(w, http.StatusBadRequest, "workspace validation failed: "+err.Error())
+		return
+	}
+
+	agent, ok := findAgent(reloaded.Config, id)
+	if !ok {
+		writeJSONError(w, http.StatusInternalServerError, "agent missing after delete")
+		return
+	}
+	writeJSON(w, http.StatusOK, s.agentDetail(agent, s.snapshotByID()))
+}
+
+// handlePlan -> POST /api/console/plan : reload the workspace, build the plan
+// against current state and providers, cache the plan hash, and return
+// PlanResponse. The cached hash is what a subsequent apply must echo back.
+func (s *Server) handlePlan(w http.ResponseWriter, r *http.Request) {
+	ws, err := s.loadWorkspace()
+	if err != nil {
+		writeJSONError(w, http.StatusBadRequest, err.Error())
+		return
+	}
+	env, err := s.env()
+	if err != nil {
+		writeJSONError(w, http.StatusBadRequest, err.Error())
+		return
+	}
+	store, err := s.openStore(ws)
+	if err != nil {
+		writeJSONError(w, http.StatusInternalServerError, err.Error())
+		return
+	}
+	defer store.Close()
+
+	providers, err := provider.NewSet(ws, env, s.cmdRunner())
+	if err != nil {
+		writeJSONError(w, http.StatusInternalServerError, err.Error())
+		return
+	}
+
+	plan, err := resource.BuildPlan(r.Context(), ws, store, providers, s.planOptions(ws, env))
+	if err != nil {
+		writeJSONError(w, http.StatusBadGateway, err.Error())
+		return
+	}
+
+	planJSON, err := plan.JSON()
+	if err != nil {
+		writeJSONError(w, http.StatusInternalServerError, err.Error())
+		return
+	}
+	hash := hashBytes(planJSON)
+	s.setPlanHash(hash)
+
+	writeJSON(w, http.StatusOK, PlanResponse{
+		Hash:    hash,
+		Text:    plan.String(),
+		Changes: planChanges(plan.Changes),
+	})
+}
+
+// handleApply -> POST /api/console/apply : require the supplied hash to match the
+// most recent plan hash (else 409 stale), then start a single async apply (409
+// when one is already active) and return 202 + ApplyResponse.
+func (s *Server) handleApply(w http.ResponseWriter, r *http.Request) {
+	var req ApplyRequest
+	if err := decodeJSON(r, &req); err != nil {
+		writeJSONError(w, http.StatusBadRequest, "invalid request body: "+err.Error())
+		return
+	}
+
+	latest := s.planHash()
+	if latest == "" {
+		writeJSONError(w, http.StatusConflict, "no current plan: run plan before apply")
+		return
+	}
+	if strings.TrimSpace(req.Hash) != latest {
+		writeJSONError(w, http.StatusConflict, "stale plan: re-run plan and apply the current hash")
+		return
+	}
+
+	id, ok := s.runner.Start(s.applyRun())
+	if !ok {
+		writeJSONError(w, http.StatusConflict, "an apply is already in progress")
+		return
+	}
+	writeJSON(w, http.StatusAccepted, ApplyResponse{OperationID: id})
+}
+
+// applyRun returns the function the OperationRunner executes for an apply. It
+// reloads the workspace, state, and providers fresh, runs resource.Apply, and
+// reports the addresses that actually mutated plus the canonical plan JSON.
+func (s *Server) applyRun() func(ctx context.Context) (changed []string, planJSON []byte, err error) {
+	return func(ctx context.Context) ([]string, []byte, error) {
+		ws, err := s.loadWorkspace()
+		if err != nil {
+			return nil, nil, err
+		}
+		env, err := s.env()
+		if err != nil {
+			return nil, nil, err
+		}
+		store, err := s.openStore(ws)
+		if err != nil {
+			return nil, nil, err
+		}
+		defer store.Close()
+
+		providers, err := provider.NewSet(ws, env, s.cmdRunner())
+		if err != nil {
+			return nil, nil, err
+		}
+
+		plan, err := resource.Apply(ctx, ws, store, providers, s.planOptions(ws, env))
+		planJSON, jerr := plan.JSON()
+		if jerr != nil && err == nil {
+			err = jerr
+		}
+		return mutatedAddresses(plan.Changes), planJSON, err
+	}
+}
+
+// handleGetOperation -> GET /api/console/operations/{id} : OperationStatus (404
+// if the id is unknown).
+func (s *Server) handleGetOperation(w http.ResponseWriter, r *http.Request) {
+	op, ok := s.runner.Get(r.PathValue("id"))
+	if !ok {
+		writeJSONError(w, http.StatusNotFound, "operation not found")
+		return
+	}
+	writeJSON(w, http.StatusOK, operationStatus(op))
+}
+
+// handleListApplies -> GET /api/console/applies : []ApplyHistoryEntry, newest
+// first, read from the workspace state applies table.
+func (s *Server) handleListApplies(w http.ResponseWriter, r *http.Request) {
+	ws, err := s.loadWorkspace()
+	if err != nil {
+		writeJSONError(w, http.StatusBadRequest, err.Error())
+		return
+	}
+	store, err := s.openStore(ws)
+	if err != nil {
+		writeJSONError(w, http.StatusInternalServerError, err.Error())
+		return
+	}
+	defer store.Close()
+
+	entries, err := NewHistory(store).List(r.Context(), 50)
+	if err != nil {
+		writeJSONError(w, http.StatusInternalServerError, err.Error())
+		return
+	}
+	writeJSON(w, http.StatusOK, entries)
+}
+
+// handleAgentLogs -> GET /api/console/agents/{id}/logs : recent offline state
+// events for the agent (subject = id). Live Fly/agent task logs are a later
+// Hermes feature; no live provider call is made here.
+func (s *Server) handleAgentLogs(w http.ResponseWriter, r *http.Request) {
+	id := r.PathValue("id")
+
+	ws, err := s.loadWorkspace()
+	if err != nil {
+		writeJSONError(w, http.StatusBadRequest, err.Error())
+		return
+	}
+	if _, exists := findAgent(ws.Config, id); !exists {
+		writeJSONError(w, http.StatusNotFound, "agent not found")
+		return
+	}
+	store, err := s.openStore(ws)
+	if err != nil {
+		writeJSONError(w, http.StatusInternalServerError, err.Error())
+		return
+	}
+	defer store.Close()
+
+	lines, err := recentAgentEvents(r.Context(), store, id, 100)
+	if err != nil {
+		writeJSONError(w, http.StatusInternalServerError, err.Error())
+		return
+	}
+	writeJSON(w, http.StatusOK, LogsResponse{
+		AgentID: id,
+		Lines:   lines,
+		Source:  "state-events",
+		Note:    "Live Fly/agent task logs are a later Hermes feature.",
+	})
+}
+
+// --- shared helpers -------------------------------------------------------
+
+// planOptions builds the resource Options used for both plan and apply so the
+// two stay consistent (same generated dir and env).
+func (s *Server) planOptions(ws *workspace.Workspace, env map[string]string) resource.Options {
+	return resource.Options{
+		Root:         ws.Root,
+		GeneratedDir: filepath.Join(ws.Root, ".companion", "generated"),
+		Env:          env,
+	}
+}
+
+// reloadValidated re-loads the workspace from disk. workspace.Load already runs
+// Validate, so a successful reload proves the just-written files form a valid
+// workspace; a non-nil error is the signal to roll back.
+func (s *Server) reloadValidated() (*workspace.Workspace, error) {
+	return s.loadWorkspace()
+}
+
+// rollback restores files from a backup dir, best effort. A blank dir (a fresh
+// create with no prior file) is a no-op.
+func (s *Server) rollback(backupDir string) {
+	if backupDir == "" {
+		return
+	}
+	_ = s.writer.Restore(backupDir)
+}
+
+// snapshotByID indexes the latest status snapshot services by id for agent
+// enrichment. It returns nil when no poller/snapshot is available, in which case
+// summaries carry only config-derived fields.
+func (s *Server) snapshotByID() map[string]status.ServiceStatus {
+	if s.poller == nil {
+		return nil
+	}
+	snapshot := s.poller.Snapshot()
+	if len(snapshot.Services) == 0 {
+		return nil
+	}
+	byID := make(map[string]status.ServiceStatus, len(snapshot.Services))
+	for _, svc := range snapshot.Services {
+		byID[svc.ID] = svc
+	}
+	return byID
+}
+
+// agentSummary builds the list-row view for an agent, enriched from the snapshot
+// service of the same id when present.
+func (s *Server) agentSummary(agent config.Agent, byID map[string]status.ServiceStatus) AgentSummary {
+	summary := AgentSummary{
+		ID:                agent.ID,
+		Model:             agent.Model.Default,
+		FlyApp:            agent.FlyApp,
+		TailscaleHostname: agent.TailscaleHostname,
+		Vault:             agent.DefaultVault.Name,
+		Lifecycle:         agent.Lifecycle,
+	}
+	if svc, ok := byID[agent.ID]; ok {
+		summary.Health = svc.Health
+		summary.FlyState = svc.MachineState
+		summary.URL = svc.URL
+	}
+	return summary
+}
+
+// agentDetail builds the full single-agent view. The soul preview is a short,
+// redacted prefix of the effective identity, never the full text.
+func (s *Server) agentDetail(agent config.Agent, byID map[string]status.ServiceStatus) AgentDetail {
+	vaultConnections := make([]string, 0, len(agent.VaultConnections))
+	for _, vc := range agent.VaultConnections {
+		vaultConnections = append(vaultConnections, vc.Name)
+	}
+	return AgentDetail{
+		AgentSummary:         s.agentSummary(agent, byID),
+		Region:               agent.Region,
+		Memory:               agent.Memory,
+		CPUs:                 agent.CPUs,
+		Runtime:              agent.Runtime,
+		Network:              agent.Network,
+		ModelProvider:        agent.ModelProvider,
+		SoulPreview:          s.soulPreview(agent),
+		CompanionSoulEnabled: agent.CompanionSoul.Enabled,
+		VaultConnections:     vaultConnections,
+	}
+}
+
+// soulPreview returns a short, single-line prefix of the agent's effective
+// identity for display. It reads the SOUL.md from disk when the identity is
+// file-backed, then truncates; it never returns the full soul.
+func (s *Server) soulPreview(agent config.Agent) string {
+	if !agent.Identity.Enabled {
+		return ""
+	}
+	soul := agent.Identity.Soul
+	if strings.TrimSpace(soul) == "" && agent.Identity.Path != "" {
+		path := agent.Identity.Path
+		if !filepath.IsAbs(path) {
+			path = filepath.Join(s.opts.WorkspaceDir, filepath.FromSlash(path))
+		}
+		if data, err := os.ReadFile(path); err == nil {
+			soul = string(data)
+		}
+	}
+	return truncatePreview(soul, soulPreviewLen)
+}
+
+// findAgent returns the config agent with the given id.
+func findAgent(cfg *config.Config, id string) (config.Agent, bool) {
+	id = strings.TrimSpace(id)
+	for _, agent := range cfg.Agents {
+		if agent.ID == id {
+			return agent, true
+		}
+	}
+	return config.Agent{}, false
+}
+
+// planChanges maps engine changes to the redacted PlanChange DTO.
+func planChanges(changes []resource.Change) []PlanChange {
+	out := make([]PlanChange, 0, len(changes))
+	for _, c := range changes {
+		out = append(out, PlanChange{
+			Kind:      c.Kind,
+			Action:    c.Action,
+			Address:   c.Address,
+			Message:   c.Message,
+			Protected: c.Protected,
+		})
+	}
+	return out
+}
+
+// mutatedAddresses returns the addresses of changes that actually mutate the
+// fleet (create/update/delete), excluding no-ops and informational rows. This is
+// what the operation reports as changed_resources.
+func mutatedAddresses(changes []resource.Change) []string {
+	out := []string{}
+	for _, c := range changes {
+		switch c.Kind {
+		case "+", "~", "-":
+			out = append(out, c.Address)
+		}
+	}
+	return out
+}
+
+// operationStatus maps the in-memory Operation to its JSON status DTO. Times are
+// rendered as RFC3339 strings (empty when zero).
+func operationStatus(op Operation) OperationStatus {
+	changed := op.Changed
+	if changed == nil {
+		changed = []string{}
+	}
+	st := OperationStatus{
+		ID:               op.ID,
+		State:            op.State,
+		ChangedResources: changed,
+		Error:            op.Error,
+	}
+	if !op.StartedAt.IsZero() {
+		st.StartedAt = op.StartedAt.UTC().Format(rfc3339)
+	}
+	if !op.FinishedAt.IsZero() {
+		st.FinishedAt = op.FinishedAt.UTC().Format(rfc3339)
+	}
+	return st
+}
+
+// recentAgentEvents reads up to limit recent state events whose subject matches
+// the agent id, newest first, and formats each as a single log line. A missing
+// events table yields an empty slice rather than an error.
+func recentAgentEvents(ctx context.Context, store *state.Store, id string, limit int) ([]string, error) {
+	lines := []string{}
+	if store == nil || store.DB == nil {
+		return lines, nil
+	}
+	if limit <= 0 {
+		limit = 100
+	}
+	rows, err := store.DB.QueryContext(
+		ctx,
+		`SELECT timestamp, command, level, message
+		 FROM events
+		 WHERE subject = ?
+		 ORDER BY id DESC
+		 LIMIT ?`,
+		id, limit,
+	)
+	if err != nil {
+		if isMissingTable(err) {
+			return lines, nil
+		}
+		return nil, err
+	}
+	defer rows.Close()
+
+	for rows.Next() {
+		var ts, command, level, message sql.NullString
+		if err := rows.Scan(&ts, &command, &level, &message); err != nil {
+			return nil, err
+		}
+		lines = append(lines, formatEventLine(ts.String, command.String, level.String, message.String))
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return lines, nil
+}
+
+// formatEventLine renders one state event as a compact, human-readable log line.
+func formatEventLine(ts, command, level, message string) string {
+	parts := make([]string, 0, 4)
+	if ts != "" {
+		parts = append(parts, ts)
+	}
+	if level != "" {
+		parts = append(parts, strings.ToUpper(level))
+	}
+	if command != "" {
+		parts = append(parts, command)
+	}
+	if message != "" {
+		parts = append(parts, message)
+	}
+	return strings.Join(parts, " ")
+}
+
+// truncatePreview returns a single-line prefix of s of at most n runes, with an
+// ellipsis when truncated. Newlines are collapsed to spaces so previews stay
+// one line.
+func truncatePreview(s string, n int) string {
+	s = strings.TrimSpace(strings.ReplaceAll(strings.ReplaceAll(s, "\r\n", " "), "\n", " "))
+	if s == "" {
+		return ""
+	}
+	runes := []rune(s)
+	if len(runes) <= n {
+		return s
+	}
+	return strings.TrimSpace(string(runes[:n])) + "…"
+}
+
+// hashBytes returns the sha256 hex digest of b. It is the plan-hash function
+// shared by plan (which caches it) and apply (which must echo it).
+func hashBytes(b []byte) string {
+	sum := sha256.Sum256(b)
+	return hex.EncodeToString(sum[:])
+}
+
+// setPlanHash records the latest computed plan hash under the server mutex.
+func (s *Server) setPlanHash(hash string) {
+	s.mu.Lock()
+	s.latestPlanHash = hash
+	s.mu.Unlock()
+}
+
+// planHash returns the most recently computed plan hash under the server mutex.
+func (s *Server) planHash() string {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.latestPlanHash
+}
+
+// rfc3339 is the timestamp layout used for operation times in API responses.
+const rfc3339 = "2006-01-02T15:04:05Z07:00"

--- a/internal/console/api.go
+++ b/internal/console/api.go
@@ -5,6 +5,7 @@ import (
 	"crypto/sha256"
 	"database/sql"
 	"encoding/hex"
+	"log"
 	"net/http"
 	"os"
 	"path/filepath"
@@ -93,6 +94,12 @@ func (s *Server) handleCreateAgent(w http.ResponseWriter, r *http.Request) {
 	}
 
 	id := strings.TrimSpace(in.ID)
+
+	// Serialize workspace mutations so two concurrent edits cannot interleave
+	// their read-modify-write-validate-rollback sequences.
+	s.writeMu.Lock()
+	defer s.writeMu.Unlock()
+
 	// Best-effort duplicate check: when the workspace already loads, reject a
 	// colliding id. A workspace that does not yet load (e.g. it has no agents,
 	// which Companion's "at least one agent" rule rejects) is allowed here so the
@@ -110,23 +117,31 @@ func (s *Server) handleCreateAgent(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	// Write the optional SOUL.md first (so identity resolves on reload), then the
-	// agent TOML. Both are fresh creates here, so rollback is a file removal.
+	// agent TOML. Track the soul so a failed create rolls it back too.
+	soulWritten := false
+	var soulBackup string
 	if strings.TrimSpace(in.Soul) != "" {
-		if _, err := s.writer.WriteSoul(id, in.Soul); err != nil {
+		soulBackup, err = s.writer.WriteSoul(id, in.Soul)
+		if err != nil {
 			writeJSONError(w, http.StatusInternalServerError, err.Error())
 			return
 		}
+		soulWritten = true
 	}
 	if _, err := s.writer.WriteAgent(id, file); err != nil {
+		s.rollbackSoul(id, soulBackup, soulWritten)
 		writeJSONError(w, http.StatusInternalServerError, err.Error())
 		return
 	}
 
 	reloaded, err := s.reloadValidated()
 	if err != nil {
-		// Roll back the create: remove the just-written agent file so the broken
-		// edit never persists in the workspace.
-		_ = s.writer.RemoveAgent(id)
+		// Roll back the create: remove the just-written agent file AND the soul so
+		// no half-written edit (and no orphan SOUL.md) persists in the workspace.
+		if rerr := s.writer.RemoveAgent(id); rerr != nil {
+			log.Printf("console: create rollback (remove agent %s) failed: %v", id, rerr)
+		}
+		s.rollbackSoul(id, soulBackup, soulWritten)
 		writeJSONError(w, http.StatusBadRequest, "workspace validation failed: "+err.Error())
 		return
 	}
@@ -153,6 +168,9 @@ func (s *Server) handleUpdateAgent(w http.ResponseWriter, r *http.Request) {
 	// The path id is authoritative; ignore any divergent body id.
 	in.ID = id
 
+	s.writeMu.Lock()
+	defer s.writeMu.Unlock()
+
 	ws, err := s.loadWorkspace()
 	if err != nil {
 		writeJSONError(w, http.StatusBadRequest, err.Error())
@@ -163,12 +181,16 @@ func (s *Server) handleUpdateAgent(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	file, err := s.writer.BuildAgentFile(in)
+	// Merge the form fields onto the EXISTING file so keys the console form does
+	// not model (volume sizing, dashboard/granite settings, [api_server],
+	// [[vault_connections]]) survive the update instead of being dropped.
+	file, err := s.writer.MergeAgentFile(id, in)
 	if err != nil {
 		writeJSONError(w, http.StatusBadRequest, err.Error())
 		return
 	}
 
+	soulWritten := false
 	var soulBackup string
 	if strings.TrimSpace(in.Soul) != "" {
 		soulBackup, err = s.writer.WriteSoul(id, in.Soul)
@@ -176,20 +198,21 @@ func (s *Server) handleUpdateAgent(w http.ResponseWriter, r *http.Request) {
 			writeJSONError(w, http.StatusInternalServerError, err.Error())
 			return
 		}
+		soulWritten = true
 	}
 	agentBackup, err := s.writer.WriteAgent(id, file)
 	if err != nil {
-		s.rollback(soulBackup)
+		s.rollbackSoul(id, soulBackup, soulWritten)
 		writeJSONError(w, http.StatusInternalServerError, err.Error())
 		return
 	}
 
 	reloaded, err := s.reloadValidated()
 	if err != nil {
-		// Restore both files from their backups so a rejected edit leaves the
-		// workspace exactly as it was.
+		// Restore the prior agent file and undo the soul write so a rejected edit
+		// leaves the workspace exactly as it was.
 		s.rollback(agentBackup)
-		s.rollback(soulBackup)
+		s.rollbackSoul(id, soulBackup, soulWritten)
 		writeJSONError(w, http.StatusBadRequest, "workspace validation failed: "+err.Error())
 		return
 	}
@@ -207,6 +230,9 @@ func (s *Server) handleUpdateAgent(w http.ResponseWriter, r *http.Request) {
 // 200 + AgentDetail.
 func (s *Server) handleDeleteAgent(w http.ResponseWriter, r *http.Request) {
 	id := r.PathValue("id")
+
+	s.writeMu.Lock()
+	defer s.writeMu.Unlock()
 
 	ws, err := s.loadWorkspace()
 	if err != nil {
@@ -436,13 +462,32 @@ func (s *Server) reloadValidated() (*workspace.Workspace, error) {
 	return s.loadWorkspace()
 }
 
-// rollback restores files from a backup dir, best effort. A blank dir (a fresh
-// create with no prior file) is a no-op.
+// rollback restores files from a backup dir. A blank dir (a fresh create with no
+// prior file) is a no-op. A restore failure is logged, not surfaced, since the
+// caller is already returning the triggering error.
 func (s *Server) rollback(backupDir string) {
 	if backupDir == "" {
 		return
 	}
-	_ = s.writer.Restore(backupDir)
+	if err := s.writer.Restore(backupDir); err != nil {
+		log.Printf("console: rollback (restore %s) failed: %v", backupDir, err)
+	}
+}
+
+// rollbackSoul undoes a SOUL.md write: it restores the prior file from its backup
+// when one existed, otherwise removes a freshly created soul (and its now-empty
+// identity directory). Failures are logged, not surfaced.
+func (s *Server) rollbackSoul(id, backupDir string, written bool) {
+	switch {
+	case backupDir != "":
+		if err := s.writer.Restore(backupDir); err != nil {
+			log.Printf("console: soul rollback (restore) failed for %s: %v", id, err)
+		}
+	case written:
+		if err := s.writer.RemoveSoul(id); err != nil {
+			log.Printf("console: soul rollback (remove) failed for %s: %v", id, err)
+		}
+	}
 }
 
 // snapshotByID indexes the latest status snapshot services by id for agent

--- a/internal/console/api_test.go
+++ b/internal/console/api_test.go
@@ -669,3 +669,62 @@ func TestCreateAgentRollbackRemovesOrphanSoul(t *testing.T) {
 		t.Fatalf("rolled-back create left an orphan SOUL.md (stat err = %v)", err)
 	}
 }
+
+func hasBlockedChange(changes []PlanChange) bool {
+	for _, c := range changes {
+		if c.Kind == "!" {
+			return true
+		}
+	}
+	return false
+}
+
+// TestPlanBlocksProtectedDestroyUntilConfirmed verifies the destroy-confirmation
+// flow: marking a protected agent absent makes a plain plan report its managed
+// resources as blocked (requiring explicit confirmation), and re-planning with
+// the destroy confirmations turns those blocks into real deletes.
+func TestPlanBlocksProtectedDestroyUntilConfirmed(t *testing.T) {
+	root := seededWorkspace(t)
+	srv := newTestServer(t, root, &execx.FakeRunner{})
+
+	// Mark the protected agent absent so its managed resources are slated for
+	// destruction.
+	del := do(t, srv, http.MethodDelete, "/api/console/agents/example-agent", nil, srv.Token())
+	if del.Code != http.StatusOK {
+		t.Fatalf("delete (mark absent) = %d: %s", del.Code, del.Body.String())
+	}
+
+	// A plain plan reports the protected destroys as blocked and asks for explicit
+	// confirmation; it must not silently destroy anything.
+	rec := do(t, srv, http.MethodPost, "/api/console/plan", PlanRequest{}, srv.Token())
+	if rec.Code != http.StatusOK {
+		t.Fatalf("plan = %d: %s", rec.Code, rec.Body.String())
+	}
+	var p PlanResponse
+	decode(t, rec, &p)
+	if !p.RequiresProtectedConfirm {
+		t.Fatalf("plan should require protected confirmation; changes=%+v", p.Changes)
+	}
+	if !hasBlockedChange(p.Changes) {
+		t.Fatalf("plan should contain a blocked (!) change before confirmation:\n%s", p.Text)
+	}
+	if !p.RequiresDestroyData {
+		t.Fatalf("plan destroying a fly_volume should require the persistent-data confirmation")
+	}
+
+	// Confirming unblocks the destroy: re-plan with both confirmations and the
+	// blocked items become real deletes, with a distinct hash.
+	rec2 := do(t, srv, http.MethodPost, "/api/console/plan",
+		PlanRequest{AllowProtectedDestroy: true, DestroyData: true}, srv.Token())
+	if rec2.Code != http.StatusOK {
+		t.Fatalf("confirmed plan = %d: %s", rec2.Code, rec2.Body.String())
+	}
+	var p2 PlanResponse
+	decode(t, rec2, &p2)
+	if hasBlockedChange(p2.Changes) {
+		t.Fatalf("confirmed plan must not contain blocked changes:\n%s", p2.Text)
+	}
+	if p2.Hash == p.Hash {
+		t.Fatalf("confirmed plan hash should differ from the blocked plan hash")
+	}
+}

--- a/internal/console/api_test.go
+++ b/internal/console/api_test.go
@@ -1,0 +1,642 @@
+package console
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/The-Vibe-Company/companion/internal/execx"
+	"github.com/The-Vibe-Company/companion/internal/state"
+	"github.com/The-Vibe-Company/companion/internal/workspace"
+)
+
+// Sentinel secret VALUES injected into the test env. The console must surface
+// credential NAMES and presence only; these literal values must never appear in
+// any API response body. Asserting their absence is the redaction contract.
+const (
+	secretOpenRouterValue = "sk-or-REDACT-ME-0123456789"
+	secretTSAuthKeyValue  = "tskey-auth-REDACT-ME-abcdef"
+	secretAPIServerValue  = "apisrv-REDACT-ME-zzz"
+)
+
+// testEnv is the explicit, hermetic environment injected into every console
+// Server under test. It carries the secret values whose NAMES (and only names)
+// the redacted API may expose, plus the secrets a full apply needs to render.
+func testEnv() map[string]string {
+	return map[string]string{
+		"OPENROUTER_API_KEY": secretOpenRouterValue,
+		"TS_AUTHKEY":         secretTSAuthKeyValue,
+		"API_SERVER_KEY":     secretAPIServerValue,
+	}
+}
+
+// seededAgentTOML mirrors examples/minimal/agents/example-agent.toml so the
+// seeded workspace loads + validates with a real agent present.
+const seededAgentTOML = `[agent]
+id = "example-agent"
+runtime = "fly.default"
+network = "tailscale.default"
+model_provider = "openrouter.default"
+lifecycle = "present"
+protect = true
+fly_app = "example-companion-agent"
+tailscale_hostname = "example-agent"
+
+[default_vault]
+enabled = true
+name = "Example Agent"
+mcp_role = "write"
+`
+
+// seededWorkspace builds a complete temp workspace (via the shared
+// newTestWorkspace helper) and writes one valid agent into it, so list/detail/
+// plan/apply have something real to operate on. It returns the workspace root.
+func seededWorkspace(t *testing.T) string {
+	t.Helper()
+	root := newTestWorkspace(t)
+	writeWS(t, root, "agents/example-agent.toml", seededAgentTOML)
+	// Sanity: the seeded workspace must load+validate before any test uses it.
+	if _, err := workspace.Load(root); err != nil {
+		t.Fatalf("seeded workspace does not load: %v", err)
+	}
+	return root
+}
+
+// newTestServer builds a console Server rooted at the given workspace with an
+// injected env, FakeRunner, and the deterministic test clock. The FakeRunner
+// answers `tailscale status --json` with an empty object so device enumeration
+// (used by plan/apply) parses without a live tailnet; all other commands return
+// ExitCode 0 with empty output, which the Fly CLI provider treats as success.
+func newTestServer(t *testing.T, root string, runner execx.Runner) *Server {
+	t.Helper()
+	if runner == nil {
+		runner = &execx.FakeRunner{Responses: map[string]execx.Result{
+			"tailscale status --json": {Stdout: `{}`},
+		}}
+	}
+	srv, err := NewServer(Options{
+		WorkspaceDir: root,
+		Env:          testEnv(),
+		Runner:       runner,
+		Clock:        fixedClock(testStamp),
+	})
+	if err != nil {
+		t.Fatalf("NewServer: %v", err)
+	}
+	return srv
+}
+
+// do issues a request against the server handler and returns the recorder. When
+// token is non-empty it is sent as the X-Console-Token header.
+func do(t *testing.T, srv *Server, method, target string, body any, token string) *httptest.ResponseRecorder {
+	t.Helper()
+	var reader *bytes.Reader
+	if body != nil {
+		raw, err := json.Marshal(body)
+		if err != nil {
+			t.Fatalf("marshal request body: %v", err)
+		}
+		reader = bytes.NewReader(raw)
+	} else {
+		reader = bytes.NewReader(nil)
+	}
+	req := httptest.NewRequest(method, target, reader)
+	if token != "" {
+		req.Header.Set("X-Console-Token", token)
+	}
+	rec := httptest.NewRecorder()
+	srv.Handler().ServeHTTP(rec, req)
+	return rec
+}
+
+// decode unmarshals a recorder body into v, failing the test on error.
+func decode(t *testing.T, rec *httptest.ResponseRecorder, v any) {
+	t.Helper()
+	if err := json.Unmarshal(rec.Body.Bytes(), v); err != nil {
+		t.Fatalf("decode response (%s): %v", rec.Body.String(), err)
+	}
+}
+
+// assertNoSecretValues fails if any injected secret VALUE leaked into the body.
+func assertNoSecretValues(t *testing.T, body string) {
+	t.Helper()
+	for _, secret := range []string{secretOpenRouterValue, secretTSAuthKeyValue, secretAPIServerValue} {
+		if strings.Contains(body, secret) {
+			t.Fatalf("response body leaked a secret value %q:\n%s", secret, body)
+		}
+	}
+}
+
+func TestWorkspaceEndpointRedactsProviders(t *testing.T) {
+	srv := newTestServer(t, seededWorkspace(t), nil)
+
+	rec := do(t, srv, http.MethodGet, "/api/console/workspace", nil, "")
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, body=%s", rec.Code, rec.Body.String())
+	}
+
+	// The whole point: names + presence only, never a value.
+	assertNoSecretValues(t, rec.Body.String())
+
+	var info WorkspaceInfo
+	decode(t, rec, &info)
+	if info.AgentCount != 1 {
+		t.Fatalf("agent_count = %d, want 1", info.AgentCount)
+	}
+	if len(info.Providers) == 0 {
+		t.Fatalf("expected redacted provider credentials, got none")
+	}
+	// The default workspace uses cli-mode providers, which surface the Tailscale
+	// auth key secret and the OpenRouter api key env as required credential names.
+	byName := map[string]bool{}
+	for _, p := range info.Providers {
+		byName[p.Name] = p.Present
+	}
+	for _, want := range []string{"OPENROUTER_API_KEY", "TS_AUTHKEY"} {
+		present, ok := byName[want]
+		if !ok {
+			t.Fatalf("missing redacted credential %q in %#v", want, info.Providers)
+		}
+		if !present {
+			t.Fatalf("credential %q present = false, want true (value injected via env)", want)
+		}
+	}
+}
+
+func TestListAgentsWithoutNetwork(t *testing.T) {
+	// A FakeRunner with no responses at all proves listing never touches the
+	// network: it must build purely from config.
+	srv := newTestServer(t, seededWorkspace(t), &execx.FakeRunner{})
+
+	rec := do(t, srv, http.MethodGet, "/api/console/agents", nil, "")
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, body=%s", rec.Code, rec.Body.String())
+	}
+	assertNoSecretValues(t, rec.Body.String())
+
+	var agents []AgentSummary
+	decode(t, rec, &agents)
+	if len(agents) != 1 {
+		t.Fatalf("agent count = %d, want 1: %#v", len(agents), agents)
+	}
+	got := agents[0]
+	if got.ID != "example-agent" {
+		t.Errorf("id = %q, want example-agent", got.ID)
+	}
+	if got.FlyApp != "example-companion-agent" {
+		t.Errorf("fly_app = %q, want example-companion-agent", got.FlyApp)
+	}
+	if got.Lifecycle != "present" {
+		t.Errorf("lifecycle = %q, want present", got.Lifecycle)
+	}
+	// No poller is attached in these tests, so live-only fields stay zero.
+	if got.Health != "" || got.FlyState != "" {
+		t.Errorf("expected zero live fields without a poller, got health=%q fly_state=%q", got.Health, got.FlyState)
+	}
+}
+
+func TestGetAgentDetail(t *testing.T) {
+	srv := newTestServer(t, seededWorkspace(t), &execx.FakeRunner{})
+
+	rec := do(t, srv, http.MethodGet, "/api/console/agents/example-agent", nil, "")
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, body=%s", rec.Code, rec.Body.String())
+	}
+	var detail AgentDetail
+	decode(t, rec, &detail)
+	if detail.ID != "example-agent" {
+		t.Errorf("id = %q, want example-agent", detail.ID)
+	}
+	if detail.Runtime != "fly.default" || detail.Network != "tailscale.default" {
+		t.Errorf("runtime/network = %q/%q, want fly.default/tailscale.default", detail.Runtime, detail.Network)
+	}
+	if detail.Vault != "Example Agent" {
+		t.Errorf("vault = %q, want Example Agent", detail.Vault)
+	}
+
+	// Unknown id is a 404.
+	miss := do(t, srv, http.MethodGet, "/api/console/agents/nope", nil, "")
+	if miss.Code != http.StatusNotFound {
+		t.Fatalf("GET unknown agent status = %d, want 404", miss.Code)
+	}
+}
+
+func TestCreateAgentWritesFileAndValidates(t *testing.T) {
+	root := seededWorkspace(t)
+	srv := newTestServer(t, root, &execx.FakeRunner{})
+
+	in := AgentInput{
+		ID:                "alpha-agent",
+		Model:             "anthropic/claude-3.7-sonnet",
+		FlyApp:            "alpha-companion-agent",
+		TailscaleHostname: "alpha-agent",
+		VaultName:         "Alpha Vault",
+	}
+	rec := do(t, srv, http.MethodPost, "/api/console/agents", in, srv.Token())
+	if rec.Code != http.StatusCreated {
+		t.Fatalf("status = %d, want 201, body=%s", rec.Code, rec.Body.String())
+	}
+	assertNoSecretValues(t, rec.Body.String())
+
+	var detail AgentDetail
+	decode(t, rec, &detail)
+	if detail.ID != "alpha-agent" {
+		t.Errorf("created id = %q, want alpha-agent", detail.ID)
+	}
+
+	// The agent file exists on disk and the workspace still loads + validates.
+	agentPath := filepath.Join(root, "agents", "alpha-agent.toml")
+	if _, err := os.Stat(agentPath); err != nil {
+		t.Fatalf("expected agents/alpha-agent.toml to exist: %v", err)
+	}
+	ws, err := workspace.Load(root)
+	if err != nil {
+		t.Fatalf("workspace.Load after create: %v", err)
+	}
+	if _, ok := findAgent(ws.Config, "alpha-agent"); !ok {
+		t.Fatalf("created agent missing from reloaded workspace")
+	}
+
+	// A fresh create must NOT require (or produce) a backup directory: there was
+	// no prior file to back up.
+	backups := filepath.Join(root, ".companion", "backups")
+	if entries, err := os.ReadDir(backups); err == nil && len(entries) != 0 {
+		t.Fatalf("fresh create should not write a backup, found %d entries under %s", len(entries), backups)
+	}
+}
+
+func TestCreateAgentRequiresSessionToken(t *testing.T) {
+	root := seededWorkspace(t)
+	srv := newTestServer(t, root, &execx.FakeRunner{})
+
+	in := AgentInput{ID: "beta-agent"}
+
+	// No token -> 403, and nothing is written.
+	rec := do(t, srv, http.MethodPost, "/api/console/agents", in, "")
+	if rec.Code != http.StatusForbidden {
+		t.Fatalf("missing-token status = %d, want 403, body=%s", rec.Code, rec.Body.String())
+	}
+	if _, err := os.Stat(filepath.Join(root, "agents", "beta-agent.toml")); !os.IsNotExist(err) {
+		t.Fatalf("forbidden create must not write a file (stat err=%v)", err)
+	}
+
+	// Wrong token -> 403.
+	bad := do(t, srv, http.MethodPost, "/api/console/agents", in, "not-the-token")
+	if bad.Code != http.StatusForbidden {
+		t.Fatalf("wrong-token status = %d, want 403", bad.Code)
+	}
+
+	// Correct token -> 201.
+	ok := do(t, srv, http.MethodPost, "/api/console/agents", in, srv.Token())
+	if ok.Code != http.StatusCreated {
+		t.Fatalf("valid-token status = %d, want 201, body=%s", ok.Code, ok.Body.String())
+	}
+	if _, err := os.Stat(filepath.Join(root, "agents", "beta-agent.toml")); err != nil {
+		t.Fatalf("valid create did not write file: %v", err)
+	}
+}
+
+func TestUpdateAgentBacksUpOldContents(t *testing.T) {
+	root := seededWorkspace(t)
+	srv := newTestServer(t, root, &execx.FakeRunner{})
+
+	agentPath := filepath.Join(root, "agents", "example-agent.toml")
+	original, err := os.ReadFile(agentPath)
+	if err != nil {
+		t.Fatalf("read seeded agent: %v", err)
+	}
+
+	in := AgentInput{
+		ID:                "example-agent",
+		FlyApp:            "example-companion-agent",
+		TailscaleHostname: "example-agent",
+		Memory:            "8gb",
+		VaultName:         "Example Agent",
+	}
+	rec := do(t, srv, http.MethodPut, "/api/console/agents/example-agent", in, srv.Token())
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200, body=%s", rec.Code, rec.Body.String())
+	}
+
+	var detail AgentDetail
+	decode(t, rec, &detail)
+	if detail.Memory != "8gb" {
+		t.Errorf("memory = %q, want 8gb", detail.Memory)
+	}
+
+	// The PUT must have produced a timestamped backup (fixed clock) holding the
+	// OLD contents, so a bad edit can be rolled back.
+	backupFile := filepath.Join(root, ".companion", "backups", backupStamp(testStamp), "agents", "example-agent.toml")
+	saved, err := os.ReadFile(backupFile)
+	if err != nil {
+		t.Fatalf("expected backup at %s: %v", backupFile, err)
+	}
+	if !bytes.Equal(saved, original) {
+		t.Fatalf("backup content mismatch:\n got %q\nwant %q", saved, original)
+	}
+
+	// The live workspace reflects the update.
+	ws, err := workspace.Load(root)
+	if err != nil {
+		t.Fatalf("workspace.Load after update: %v", err)
+	}
+	agent, _ := findAgent(ws.Config, "example-agent")
+	if agent.Memory != "8gb" {
+		t.Errorf("reloaded memory = %q, want 8gb", agent.Memory)
+	}
+}
+
+func TestDeleteAgentSetsLifecycleAbsentKeepsFile(t *testing.T) {
+	root := seededWorkspace(t)
+	srv := newTestServer(t, root, &execx.FakeRunner{})
+
+	rec := do(t, srv, http.MethodDelete, "/api/console/agents/example-agent", nil, srv.Token())
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200, body=%s", rec.Code, rec.Body.String())
+	}
+	var detail AgentDetail
+	decode(t, rec, &detail)
+	if detail.Lifecycle != "absent" {
+		t.Errorf("lifecycle = %q, want absent", detail.Lifecycle)
+	}
+
+	// DELETE is soft: the file must still exist.
+	agentPath := filepath.Join(root, "agents", "example-agent.toml")
+	if _, err := os.Stat(agentPath); err != nil {
+		t.Fatalf("agent file must remain after delete: %v", err)
+	}
+	ws, err := workspace.Load(root)
+	if err != nil {
+		t.Fatalf("workspace.Load after delete: %v", err)
+	}
+	agent, _ := findAgent(ws.Config, "example-agent")
+	if agent.Lifecycle != "absent" {
+		t.Errorf("reloaded lifecycle = %q, want absent", agent.Lifecycle)
+	}
+}
+
+func TestCreateAgentRejectsInvalidID(t *testing.T) {
+	root := seededWorkspace(t)
+	srv := newTestServer(t, root, &execx.FakeRunner{})
+
+	cases := []struct {
+		name string
+		id   string
+	}{
+		{"traversal", "../evil"},
+		{"underscore", "Bad_ID"},
+		{"uppercase", "BadID"},
+		{"slash", "team/agent"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			rec := do(t, srv, http.MethodPost, "/api/console/agents", AgentInput{ID: tc.id}, srv.Token())
+			if rec.Code != http.StatusBadRequest {
+				t.Fatalf("status = %d, want 400, body=%s", rec.Code, rec.Body.String())
+			}
+		})
+	}
+
+	// Nothing should have been written beyond the single seeded agent.
+	entries, err := os.ReadDir(filepath.Join(root, "agents"))
+	if err != nil {
+		t.Fatalf("read agents dir: %v", err)
+	}
+	if len(entries) != 1 {
+		t.Fatalf("invalid ids must not write files, found %d agent files: %v", len(entries), entries)
+	}
+	// And the traversal target must not have escaped the workspace.
+	if _, err := os.Stat(filepath.Join(filepath.Dir(root), "evil.toml")); err == nil {
+		t.Fatalf("path traversal escaped the workspace")
+	}
+}
+
+func TestPlanReturnsHashAndApplyGuardsStaleHash(t *testing.T) {
+	root := seededWorkspace(t)
+	srv := newTestServer(t, root, nil)
+
+	// POST /plan computes and caches a hash.
+	planRec := do(t, srv, http.MethodPost, "/api/console/plan", nil, srv.Token())
+	if planRec.Code != http.StatusOK {
+		t.Fatalf("plan status = %d, want 200, body=%s", planRec.Code, planRec.Body.String())
+	}
+	assertNoSecretValues(t, planRec.Body.String())
+
+	var plan PlanResponse
+	decode(t, planRec, &plan)
+	if plan.Hash == "" {
+		t.Fatalf("plan returned empty hash")
+	}
+	// A brand-new fleet must show creates.
+	if len(plan.Changes) == 0 {
+		t.Fatalf("expected plan changes for an unrealized fleet, got none: %s", plan.Text)
+	}
+
+	// Apply with a WRONG hash is rejected as stale (409) and starts nothing.
+	stale := do(t, srv, http.MethodPost, "/api/console/apply", ApplyRequest{Hash: "deadbeef"}, srv.Token())
+	if stale.Code != http.StatusConflict {
+		t.Fatalf("stale apply status = %d, want 409, body=%s", stale.Code, stale.Body.String())
+	}
+
+	// Apply with the correct hash is accepted (202) and yields a pollable op.
+	ok := do(t, srv, http.MethodPost, "/api/console/apply", ApplyRequest{Hash: plan.Hash}, srv.Token())
+	if ok.Code != http.StatusAccepted {
+		t.Fatalf("apply status = %d, want 202, body=%s", ok.Code, ok.Body.String())
+	}
+	var applied ApplyResponse
+	decode(t, ok, &applied)
+	if applied.OperationID == "" {
+		t.Fatalf("apply returned empty operation_id")
+	}
+
+	// The operation must converge to a terminal state and be retrievable. The
+	// FakeRunner drives every Fly command to success, so it should succeed.
+	op := waitForOperation(t, srv, applied.OperationID, OpSucceeded)
+	if op.State != OpSucceeded {
+		t.Fatalf("operation state = %q, want succeeded (error=%q)", op.State, op.Error)
+	}
+	if len(op.ChangedResources) == 0 {
+		t.Fatalf("expected changed resources after apply, got none")
+	}
+}
+
+func TestApplyRejectsBeforeAnyPlan(t *testing.T) {
+	srv := newTestServer(t, seededWorkspace(t), nil)
+
+	rec := do(t, srv, http.MethodPost, "/api/console/apply", ApplyRequest{Hash: "anything"}, srv.Token())
+	if rec.Code != http.StatusConflict {
+		t.Fatalf("apply-before-plan status = %d, want 409, body=%s", rec.Code, rec.Body.String())
+	}
+}
+
+func TestConcurrentApplyReturns409(t *testing.T) {
+	root := seededWorkspace(t)
+	srv := newTestServer(t, root, nil)
+
+	// Occupy the single apply slot with a long-running operation we control, so
+	// the conflict window is deterministic (no timing reliance).
+	release := make(chan struct{})
+	started := make(chan struct{})
+	id, ok := srv.runner.Start(func(ctx context.Context) ([]string, []byte, error) {
+		close(started)
+		<-release
+		return nil, []byte(`{"changes":[]}`), nil
+	})
+	if !ok {
+		t.Fatalf("failed to occupy the apply slot")
+	}
+	<-started
+	defer func() {
+		close(release)
+		waitForOperation(t, srv, id, OpSucceeded)
+	}()
+
+	// Compute a valid plan hash so the apply passes the stale-hash gate and is
+	// rejected specifically by the single-active-apply lock (409 conflict).
+	planRec := do(t, srv, http.MethodPost, "/api/console/plan", nil, srv.Token())
+	if planRec.Code != http.StatusOK {
+		t.Fatalf("plan status = %d, body=%s", planRec.Code, planRec.Body.String())
+	}
+	var plan PlanResponse
+	decode(t, planRec, &plan)
+
+	rec := do(t, srv, http.MethodPost, "/api/console/apply", ApplyRequest{Hash: plan.Hash}, srv.Token())
+	if rec.Code != http.StatusConflict {
+		t.Fatalf("second concurrent apply status = %d, want 409, body=%s", rec.Code, rec.Body.String())
+	}
+}
+
+func TestAppliesHistoryNewestFirst(t *testing.T) {
+	root := seededWorkspace(t)
+
+	// Seed apply history directly into the workspace state before serving.
+	ws, err := workspace.Load(root)
+	if err != nil {
+		t.Fatalf("load workspace: %v", err)
+	}
+	store, err := state.Open(ws.StatePath)
+	if err != nil {
+		t.Fatalf("open state: %v", err)
+	}
+	ctx := context.Background()
+	firstID, err := store.StartApply(ctx, map[string]any{"changes": 1})
+	if err != nil {
+		t.Fatalf("start first apply: %v", err)
+	}
+	if err := store.FinishApply(ctx, firstID, "succeeded"); err != nil {
+		t.Fatalf("finish first apply: %v", err)
+	}
+	secondID, err := store.StartApply(ctx, map[string]any{"changes": 2})
+	if err != nil {
+		t.Fatalf("start second apply: %v", err)
+	}
+	if err := store.FinishApply(ctx, secondID, "failed"); err != nil {
+		t.Fatalf("finish second apply: %v", err)
+	}
+	if err := store.Close(); err != nil {
+		t.Fatalf("close state: %v", err)
+	}
+
+	srv := newTestServer(t, root, &execx.FakeRunner{})
+	rec := do(t, srv, http.MethodGet, "/api/console/applies", nil, "")
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200, body=%s", rec.Code, rec.Body.String())
+	}
+
+	var entries []ApplyHistoryEntry
+	decode(t, rec, &entries)
+	if len(entries) != 2 {
+		t.Fatalf("expected two history entries, got %d: %#v", len(entries), entries)
+	}
+	// Newest first.
+	if entries[0].ID != secondID || entries[1].ID != firstID {
+		t.Fatalf("history order wrong: got ids %d,%d want %d,%d", entries[0].ID, entries[1].ID, secondID, firstID)
+	}
+	if entries[0].Status != "failed" || entries[1].Status != "succeeded" {
+		t.Fatalf("history statuses wrong: %#v", entries)
+	}
+}
+
+func TestAgentLogsOfflineNote(t *testing.T) {
+	srv := newTestServer(t, seededWorkspace(t), &execx.FakeRunner{})
+
+	rec := do(t, srv, http.MethodGet, "/api/console/agents/example-agent/logs", nil, "")
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200, body=%s", rec.Code, rec.Body.String())
+	}
+	assertNoSecretValues(t, rec.Body.String())
+
+	var logs LogsResponse
+	decode(t, rec, &logs)
+	if logs.AgentID != "example-agent" {
+		t.Errorf("agent_id = %q, want example-agent", logs.AgentID)
+	}
+	if logs.Source != "state-events" {
+		t.Errorf("source = %q, want state-events", logs.Source)
+	}
+	if !strings.Contains(logs.Note, "later Hermes feature") {
+		t.Errorf("note = %q, want the offline note mentioning the later Hermes feature", logs.Note)
+	}
+	if logs.Lines == nil {
+		t.Errorf("lines must be a non-nil (possibly empty) slice")
+	}
+
+	// Unknown agent logs -> 404.
+	miss := do(t, srv, http.MethodGet, "/api/console/agents/ghost/logs", nil, "")
+	if miss.Code != http.StatusNotFound {
+		t.Fatalf("logs for unknown agent status = %d, want 404", miss.Code)
+	}
+}
+
+func TestHealthzAndIndexInjectToken(t *testing.T) {
+	srv := newTestServer(t, seededWorkspace(t), &execx.FakeRunner{})
+
+	health := do(t, srv, http.MethodGet, "/healthz", nil, "")
+	if health.Code != http.StatusOK || strings.TrimSpace(health.Body.String()) != "ok" {
+		t.Fatalf("healthz = (%d, %q), want (200, ok)", health.Code, health.Body.String())
+	}
+
+	index := do(t, srv, http.MethodGet, "/", nil, "")
+	if index.Code != http.StatusOK {
+		t.Fatalf("index status = %d, want 200", index.Code)
+	}
+	body := index.Body.String()
+	// The served UI must carry the real session token so the SPA can send it on
+	// mutating calls...
+	if !strings.Contains(body, srv.Token()) {
+		t.Fatalf("served index did not inject the session token")
+	}
+	// ...and the raw sentinel must be fully replaced, never shipped to the page.
+	if strings.Contains(body, "%%CONSOLE_TOKEN%%") {
+		t.Fatalf("served index still contains the raw token sentinel:\n%s", body)
+	}
+	if strings.Contains(body, "%%CONSOLE_WORKSPACE%%") {
+		t.Fatalf("served index still contains the raw workspace sentinel:\n%s", body)
+	}
+}
+
+// waitForOperation polls the API operation endpoint until the operation reaches
+// the wanted terminal state or the bounded retry budget is exhausted. The runner
+// goroutine drives convergence; the loop is only a failure guard.
+func waitForOperation(t *testing.T, srv *Server, id, want string) OperationStatus {
+	t.Helper()
+	for i := 0; i < 2000; i++ {
+		rec := do(t, srv, http.MethodGet, "/api/console/operations/"+id, nil, "")
+		if rec.Code != http.StatusOK {
+			t.Fatalf("GET operation %s status = %d, body=%s", id, rec.Code, rec.Body.String())
+		}
+		var op OperationStatus
+		decode(t, rec, &op)
+		if op.State == want || op.State == OpSucceeded || op.State == OpFailed {
+			return op
+		}
+	}
+	t.Fatalf("operation %s did not reach %q in time", id, want)
+	return OperationStatus{}
+}

--- a/internal/console/api_test.go
+++ b/internal/console/api_test.go
@@ -640,3 +640,32 @@ func waitForOperation(t *testing.T, srv *Server, id, want string) OperationStatu
 	t.Fatalf("operation %s did not reach %q in time", id, want)
 	return OperationStatus{}
 }
+
+// TestCreateAgentRollbackRemovesOrphanSoul verifies that when a create writes a
+// SOUL.md but the resulting workspace fails to validate, BOTH the agent file and
+// the orphan SOUL.md are rolled back. The agent passes the writer's build-time
+// name checks but references an undefined fly provider, which only the post-write
+// workspace reload rejects — exercising the soul-rollback path.
+func TestCreateAgentRollbackRemovesOrphanSoul(t *testing.T) {
+	root := seededWorkspace(t)
+	srv := newTestServer(t, root, &execx.FakeRunner{})
+
+	in := AgentInput{
+		ID:                "broken",
+		FlyApp:            "broken-app",
+		TailscaleHostname: "broken",
+		Runtime:           "fly.doesnotexist", // valid shape; undefined provider -> reload fails
+		Soul:              "You are broken.",
+	}
+	rec := do(t, srv, http.MethodPost, "/api/console/agents", in, srv.Token())
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("create with undefined provider = %d, want 400: %s", rec.Code, rec.Body.String())
+	}
+
+	if _, err := os.Stat(filepath.Join(root, "agents", "broken.toml")); !os.IsNotExist(err) {
+		t.Fatalf("rolled-back create left an agent file (stat err = %v)", err)
+	}
+	if _, err := os.Stat(filepath.Join(root, "identities", "broken", "SOUL.md")); !os.IsNotExist(err) {
+		t.Fatalf("rolled-back create left an orphan SOUL.md (stat err = %v)", err)
+	}
+}

--- a/internal/console/assets/index.html
+++ b/internal/console/assets/index.html
@@ -1,0 +1,39 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Companion Console</title>
+    <!--
+      Committed placeholder. A bare `go build ./...` embeds THIS file via
+      //go:embed, so CI and `go install` stay green without a Node toolchain.
+      `bin/build-console-ui` overwrites it (and internal/console/assets/assets/)
+      with the real Vite-built SPA for production images; those built bundles
+      are gitignored. For local UI development run the Vite dev server and start
+      the console with `--dev-ui http://127.0.0.1:5173`.
+
+      The Go console replaces the token sentinels below at serve time with the
+      per-process session token and workspace name (see handleIndex in
+      console.go). The SPA reads window.__CONSOLE_TOKEN__ to authorize mutating
+      requests; in dev it falls back to GET /api/console/session.
+    -->
+    <meta name="console-token" content="%%CONSOLE_TOKEN%%" />
+    <script>
+      window.__CONSOLE_TOKEN__ = "%%CONSOLE_TOKEN%%";
+    </script>
+  </head>
+  <body data-workspace="%%CONSOLE_WORKSPACE%%">
+    <main style="font-family: system-ui, sans-serif; max-width: 42rem; margin: 4rem auto; padding: 0 1.5rem; line-height: 1.6;">
+      <h1>Companion Console</h1>
+      <p>
+        The console API is running. This is the placeholder shell — the built
+        single-page UI ships in production images and is produced locally by
+        <code>bin/build-console-ui</code>.
+      </p>
+      <p>
+        Mutating calls under <code>/api/console/</code> require the
+        <code>X-Console-Token</code> header to match the injected session token.
+      </p>
+    </main>
+  </body>
+</html>

--- a/internal/console/console.go
+++ b/internal/console/console.go
@@ -87,6 +87,11 @@ type Server struct {
 
 	mu             sync.Mutex
 	latestPlanHash string
+	// latestAllowProtectedDestroy / latestDestroyData capture the destroy
+	// confirmations the cached plan was computed with, so apply replays exactly
+	// the plan the operator reviewed rather than trusting flags re-sent at apply.
+	latestAllowProtectedDestroy bool
+	latestDestroyData           bool
 
 	// writeMu serializes workspace-mutating handlers (create/update/delete) so
 	// their read-modify-write-validate-rollback sequences cannot interleave.
@@ -426,4 +431,17 @@ func decodeJSON(r *http.Request, v any) error {
 	dec := json.NewDecoder(io.LimitReader(r.Body, 1<<20))
 	dec.DisallowUnknownFields()
 	return dec.Decode(v)
+}
+
+// decodeJSONOptional behaves like decodeJSON but treats an empty request body as
+// "no fields set", leaving v at its zero value. Used for endpoints whose body is
+// optional, such as plan, whose destroy confirmations default to false.
+func decodeJSONOptional(r *http.Request, v any) error {
+	if err := decodeJSON(r, v); err != nil {
+		if err == io.EOF {
+			return nil
+		}
+		return err
+	}
+	return nil
 }

--- a/internal/console/console.go
+++ b/internal/console/console.go
@@ -1,0 +1,411 @@
+// Package console implements the Companion "console" backend: an HTTP server
+// that lets an operator inspect and edit the local workspace (agents, plan,
+// apply, history) over a small JSON API plus an embedded UI. It is a
+// local-admin tool guarded by a per-process session token, not a multi-user
+// auth surface. All provider interaction is redacted to credential names and
+// never performs live mutations except through the existing resource apply
+// engine the CLI already uses.
+package console
+
+import (
+	"context"
+	"crypto/rand"
+	"embed"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"io"
+	"io/fs"
+	"net/http"
+	"net/http/httputil"
+	"net/url"
+	"path/filepath"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/The-Vibe-Company/companion/internal/envfile"
+	"github.com/The-Vibe-Company/companion/internal/execx"
+	"github.com/The-Vibe-Company/companion/internal/provider"
+	"github.com/The-Vibe-Company/companion/internal/state"
+	"github.com/The-Vibe-Company/companion/internal/status"
+	"github.com/The-Vibe-Company/companion/internal/workspace"
+)
+
+//go:embed assets
+var assets embed.FS
+
+// Sentinel markers the Vite-built (and placeholder) index.html carries verbatim.
+// handleIndex replaces them with the live session token and workspace name at
+// serve time. They are plain string replacements rather than Go template actions
+// because the production index.html is emitted by Vite, not text/template.
+const (
+	tokenSentinel     = "%%CONSOLE_TOKEN%%"
+	workspaceSentinel = "%%CONSOLE_WORKSPACE%%"
+)
+
+// Options configures a console Server.
+type Options struct {
+	// WorkspaceDir is the workspace root the console reads and edits.
+	WorkspaceDir string
+	// EnvFile is an optional path to a .env file. When relative it is resolved
+	// against WorkspaceDir.
+	EnvFile string
+	// Env optionally supplies explicit environment values (tests inject these);
+	// when set it overrides EnvFile loading.
+	Env map[string]string
+	// Runner is the command runner used for provider interactions. Tests inject
+	// an execx.FakeRunner; a nil runner falls back to a real shell runner.
+	Runner execx.Runner
+	// Interval is the status poll interval. Zero defaults to 30s.
+	Interval time.Duration
+	// Clock supplies the current time for deterministic backups; nil uses
+	// time.Now.
+	Clock func() time.Time
+	// DevUI optionally points at a dev-mode UI origin (e.g. a Vite server) to
+	// reverse-proxy the root and asset routes to during development.
+	DevUI string
+}
+
+// Server serves the console API and UI. It owns the session token, the apply
+// operation runner, the safe TOML writer, and a cache of the most recent plan
+// hash. Apply history is read per request from a store opened against the
+// workspace state path.
+type Server struct {
+	opts  Options
+	token string
+
+	runner *OperationRunner
+	writer *TomlWriter
+
+	assets    fs.FS
+	indexHTML []byte
+	poller    *status.Poller
+
+	devProxy *httputil.ReverseProxy
+
+	mu             sync.Mutex
+	latestPlanHash string
+}
+
+// NewServer builds a console Server: it generates the session token, applies
+// defaults, prepares the embedded assets and index HTML, and constructs the
+// operation runner, writer, and (best-effort) history. It performs no network
+// I/O.
+func NewServer(opts Options) (*Server, error) {
+	if opts.Interval <= 0 {
+		opts.Interval = 30 * time.Second
+	}
+	if opts.Clock == nil {
+		opts.Clock = time.Now
+	}
+
+	token, err := randomToken()
+	if err != nil {
+		return nil, err
+	}
+
+	staticFS, err := fs.Sub(assets, "assets")
+	if err != nil {
+		return nil, err
+	}
+	indexHTML, err := fs.ReadFile(assets, "assets/index.html")
+	if err != nil {
+		return nil, err
+	}
+
+	s := &Server{
+		opts:      opts,
+		token:     token,
+		runner:    NewOperationRunner(opts.Clock),
+		writer:    NewTomlWriter(opts.WorkspaceDir, opts.Clock),
+		assets:    staticFS,
+		indexHTML: indexHTML,
+	}
+
+	if strings.TrimSpace(opts.DevUI) != "" {
+		target, err := url.Parse(opts.DevUI)
+		if err != nil {
+			return nil, fmt.Errorf("parse dev-ui origin: %w", err)
+		}
+		s.devProxy = httputil.NewSingleHostReverseProxy(target)
+	}
+
+	return s, nil
+}
+
+// Token returns the per-process session token injected into the served UI.
+// Tests read it to send the X-Console-Token header on mutating requests.
+func (s *Server) Token() string {
+	return s.token
+}
+
+// Handler builds the console mux. It is pure: no goroutines, no network. The
+// status poller is attached separately by Serve.
+func (s *Server) Handler() http.Handler {
+	mux := http.NewServeMux()
+
+	// Read-only console API.
+	mux.HandleFunc("GET /api/console/session", s.handleSession)
+	mux.HandleFunc("GET /api/console/workspace", s.handleWorkspace)
+	mux.HandleFunc("GET /api/console/agents", s.handleListAgents)
+	mux.HandleFunc("GET /api/console/agents/{id}", s.handleGetAgent)
+	mux.HandleFunc("GET /api/console/agents/{id}/logs", s.handleAgentLogs)
+	mux.HandleFunc("GET /api/console/applies", s.handleListApplies)
+	mux.HandleFunc("GET /api/console/operations/{id}", s.handleGetOperation)
+
+	// Mutating console API (guarded by the session-token middleware).
+	mux.HandleFunc("POST /api/console/agents", s.handleCreateAgent)
+	mux.HandleFunc("PUT /api/console/agents/{id}", s.handleUpdateAgent)
+	mux.HandleFunc("DELETE /api/console/agents/{id}", s.handleDeleteAgent)
+	mux.HandleFunc("POST /api/console/plan", s.handlePlan)
+	mux.HandleFunc("POST /api/console/apply", s.handleApply)
+
+	// Status + health (reuse the existing snapshot contract).
+	mux.HandleFunc("GET /api/status", s.handleStatus)
+	mux.HandleFunc("GET /healthz", s.handleHealthz)
+
+	// Static UI: dev-proxy when configured, otherwise embedded assets.
+	mux.HandleFunc("GET /", s.handleIndex)
+	mux.Handle("GET /assets/", s.assetHandler())
+
+	return s.withSessionToken(mux)
+}
+
+// assetHandler serves embedded static assets, or proxies to the dev UI when
+// configured.
+func (s *Server) assetHandler() http.Handler {
+	if s.devProxy != nil {
+		return s.devProxy
+	}
+	return http.StripPrefix("/assets/", http.FileServer(http.FS(s.assets)))
+}
+
+// withSessionToken enforces the per-process session token on every mutating
+// request (POST/PUT/DELETE) under /api/console/. Read-only GETs are exempt so
+// the UI can load without a preflight.
+func (s *Server) withSessionToken(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if isMutating(r.Method) && strings.HasPrefix(r.URL.Path, "/api/console/") {
+			if r.Header.Get("X-Console-Token") != s.token {
+				writeJSONError(w, http.StatusForbidden, "invalid or missing console session token")
+				return
+			}
+		}
+		next.ServeHTTP(w, r)
+	})
+}
+
+func isMutating(method string) bool {
+	switch method {
+	case http.MethodPost, http.MethodPut, http.MethodDelete, http.MethodPatch:
+		return true
+	default:
+		return false
+	}
+}
+
+// handleIndex serves the embedded console UI with the session token injected,
+// or reverse-proxies to the dev UI origin when configured.
+func (s *Server) handleIndex(w http.ResponseWriter, r *http.Request) {
+	if r.URL.Path != "/" {
+		http.NotFound(w, r)
+		return
+	}
+	if s.devProxy != nil {
+		s.devProxy.ServeHTTP(w, r)
+		return
+	}
+	// Inject the live values into the embedded HTML by replacing the build-time
+	// sentinels. The Vite-built index.html is not a Go template, so a literal
+	// string replacement (not text/template) is what keeps both the placeholder
+	// and the real built asset working.
+	html := strings.ReplaceAll(string(s.indexHTML), tokenSentinel, s.token)
+	html = strings.ReplaceAll(html, workspaceSentinel, filepath.Base(s.opts.WorkspaceDir))
+	w.Header().Set("Content-Type", "text/html; charset=utf-8")
+	_, _ = io.WriteString(w, html)
+}
+
+// handleSession -> GET /api/console/session : returns the per-process session
+// token, but ONLY in dev mode (Options.DevUI set). In dev the UI is served by
+// Vite through the reverse proxy, so the token sentinels are never replaced and
+// the SPA cannot read the token from the page; this endpoint is its fallback. In
+// production the token is injected into the served HTML and this route 404s so
+// the token is never exposed through an unauthenticated GET. It is a GET, so the
+// mutating-token middleware already exempts it.
+func (s *Server) handleSession(w http.ResponseWriter, r *http.Request) {
+	if strings.TrimSpace(s.opts.DevUI) == "" {
+		http.NotFound(w, r)
+		return
+	}
+	w.Header().Set("Cache-Control", "no-store")
+	writeJSON(w, http.StatusOK, map[string]string{"token": s.token})
+}
+
+// handleHealthz is a trivial liveness endpoint.
+func (s *Server) handleHealthz(w http.ResponseWriter, r *http.Request) {
+	w.Header().Set("Content-Type", "text/plain")
+	_, _ = w.Write([]byte("ok"))
+}
+
+// handleStatus serves the most recent fleet status snapshot. When no poller is
+// attached it returns an empty snapshot so the endpoint stays available.
+func (s *Server) handleStatus(w http.ResponseWriter, r *http.Request) {
+	var snapshot status.Snapshot
+	if s.poller != nil {
+		snapshot = s.poller.Snapshot()
+	}
+	w.Header().Set("Content-Type", "application/json")
+	w.Header().Set("Cache-Control", "no-store")
+	_ = json.NewEncoder(w).Encode(snapshot)
+}
+
+// Serve runs the console HTTP server with graceful shutdown, mirroring
+// web.Serve. It starts a best-effort status poller goroutine: provider wiring
+// errors are tolerated so the API and UI keep serving even when the fleet
+// cannot be polled.
+func Serve(ctx context.Context, addr string, opts Options) error {
+	server, err := NewServer(opts)
+	if err != nil {
+		return err
+	}
+
+	if poller := server.buildPoller(opts); poller != nil {
+		server.poller = poller
+		go poller.Run(ctx)
+	}
+
+	httpServer := &http.Server{Addr: addr, Handler: server.Handler()}
+	errCh := make(chan error, 1)
+	go func() {
+		errCh <- httpServer.ListenAndServe()
+	}()
+	select {
+	case <-ctx.Done():
+		_ = httpServer.Shutdown(context.Background())
+		return ctx.Err()
+	case err := <-errCh:
+		if err == http.ErrServerClosed {
+			return nil
+		}
+		return err
+	}
+}
+
+// buildPoller best-effort constructs a workspace-backed status poller. Returning
+// nil (on any provider/workspace error) is acceptable: the server still serves
+// the API and UI, and /api/status returns an empty snapshot. The poller derives
+// the topology live from the workspace each tick, so newly created agents show
+// up without a restart.
+func (s *Server) buildPoller(opts Options) *status.Poller {
+	ws, err := s.loadWorkspace()
+	if err != nil {
+		return nil
+	}
+	env, err := s.env()
+	if err != nil {
+		return nil
+	}
+	providers, err := provider.NewSet(ws, env, s.cmdRunner())
+	if err != nil {
+		return nil
+	}
+	flyProvider := firstFly(providers)
+	tsProvider := firstTailscale(providers)
+	src := status.WorkspaceSource{
+		Workspace: ws.Name,
+		Config:    ws.Config,
+		Fly:       flyProvider,
+		Tailscale: tsProvider,
+	}
+	return status.NewPoller(src, opts.Interval)
+}
+
+// firstFly returns a Fly provider from the set (the sole one when there is just
+// one), or nil. The status poller tolerates a nil provider by skipping Fly
+// machine-state enrichment.
+func firstFly(set provider.Set) provider.FlyRuntime {
+	for _, p := range set.Fly {
+		return p
+	}
+	return nil
+}
+
+// firstTailscale returns a Tailscale provider from the set, or nil. A nil
+// provider makes the poller skip Tailscale presence enrichment.
+func firstTailscale(set provider.Set) provider.TailscaleNetwork {
+	for _, p := range set.Tailscale {
+		return p
+	}
+	return nil
+}
+
+// loadWorkspace loads the workspace fresh from disk. Every handler that needs
+// current config calls this so edits made through the console are reflected
+// immediately, and a reload after a write doubles as validation.
+func (s *Server) loadWorkspace() (*workspace.Workspace, error) {
+	return workspace.Load(s.opts.WorkspaceDir)
+}
+
+// env resolves the environment used for provider credential presence and apply.
+// An explicit opts.Env wins (tests inject it for hermetic, deterministic runs);
+// otherwise the optional EnvFile is loaded (resolved against WorkspaceDir). The
+// console never overlays the host shell environment, keeping behavior
+// reproducible; the CLI overlays shell env before constructing opts.Env.
+func (s *Server) env() (map[string]string, error) {
+	if s.opts.Env != nil {
+		return s.opts.Env, nil
+	}
+	path := s.opts.EnvFile
+	if path != "" && !filepath.IsAbs(path) {
+		path = filepath.Join(s.opts.WorkspaceDir, path)
+	}
+	if path == "" {
+		return map[string]string{}, nil
+	}
+	return envfile.LoadOptional(path)
+}
+
+// cmdRunner returns the command runner for provider interactions: the injected
+// runner (an execx.FakeRunner in tests) or a real shell runner rooted at the
+// workspace. It is distinct from the apply OperationRunner held in the runner
+// field.
+func (s *Server) cmdRunner() execx.Runner {
+	if s.opts.Runner != nil {
+		return s.opts.Runner
+	}
+	return execx.ShellRunner{Dir: s.opts.WorkspaceDir}
+}
+
+// openStore opens the workspace SQLite state store. Callers must Close it.
+func (s *Server) openStore(ws *workspace.Workspace) (*state.Store, error) {
+	return state.Open(ws.StatePath)
+}
+
+func randomToken() (string, error) {
+	buf := make([]byte, 32)
+	if _, err := rand.Read(buf); err != nil {
+		return "", err
+	}
+	return hex.EncodeToString(buf), nil
+}
+
+// writeJSON encodes v as a JSON response with the given status code.
+func writeJSON(w http.ResponseWriter, code int, v any) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(code)
+	_ = json.NewEncoder(w).Encode(v)
+}
+
+// writeJSONError writes a {"error": msg} JSON body with the given status code.
+func writeJSONError(w http.ResponseWriter, code int, msg string) {
+	writeJSON(w, code, map[string]string{"error": msg})
+}
+
+// decodeJSON reads and decodes a JSON request body into v, rejecting unknown
+// fields and oversized payloads.
+func decodeJSON(r *http.Request, v any) error {
+	dec := json.NewDecoder(io.LimitReader(r.Body, 1<<20))
+	dec.DisallowUnknownFields()
+	return dec.Decode(v)
+}

--- a/internal/console/console.go
+++ b/internal/console/console.go
@@ -178,7 +178,18 @@ func (s *Server) assetHandler() http.Handler {
 	if s.devProxy != nil {
 		return s.devProxy
 	}
-	return http.StripPrefix("/assets/", http.FileServer(http.FS(s.assets)))
+	return staticAssetHandler(s.assets)
+}
+
+// staticAssetHandler serves the embedded SPA bundle. The embedded FS mirrors the
+// Vite dist that bin/build-console-ui syncs in: an index.html beside a nested
+// assets/ directory holding the hashed bundle, and the SPA requests that bundle
+// at /assets/<hash>.{js,css}. Because the FS already contains the assets/
+// subtree, the request path maps straight onto it. We deliberately do NOT
+// StripPrefix("/assets/") here: stripping it drops the very directory that holds
+// the hashed bundle, which would 404 every asset and render a blank page.
+func staticAssetHandler(fsys fs.FS) http.Handler {
+	return http.FileServer(http.FS(fsys))
 }
 
 // withSessionToken enforces the per-process session token on every mutating

--- a/internal/console/console.go
+++ b/internal/console/console.go
@@ -10,6 +10,7 @@ package console
 import (
 	"context"
 	"crypto/rand"
+	"crypto/subtle"
 	"embed"
 	"encoding/hex"
 	"encoding/json"
@@ -86,6 +87,10 @@ type Server struct {
 
 	mu             sync.Mutex
 	latestPlanHash string
+
+	// writeMu serializes workspace-mutating handlers (create/update/delete) so
+	// their read-modify-write-validate-rollback sequences cannot interleave.
+	writeMu sync.Mutex
 }
 
 // NewServer builds a console Server: it generates the session token, applies
@@ -198,7 +203,9 @@ func staticAssetHandler(fsys fs.FS) http.Handler {
 func (s *Server) withSessionToken(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if isMutating(r.Method) && strings.HasPrefix(r.URL.Path, "/api/console/") {
-			if r.Header.Get("X-Console-Token") != s.token {
+			provided := r.Header.Get("X-Console-Token")
+			// Constant-time compare so a wrong token cannot be inferred by timing.
+			if subtle.ConstantTimeCompare([]byte(provided), []byte(s.token)) != 1 {
 				writeJSONError(w, http.StatusForbidden, "invalid or missing console session token")
 				return
 			}

--- a/internal/console/console_static_test.go
+++ b/internal/console/console_static_test.go
@@ -1,0 +1,53 @@
+package console
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"testing/fstest"
+)
+
+// TestStaticAssetHandlerServesNestedViteBundle guards the embed path mapping.
+// bin/build-console-ui syncs the Vite dist into internal/console/assets as an
+// index.html beside a nested assets/ directory, and NewServer roots the served
+// FS at that mirror via fs.Sub(assets, "assets"). The SPA requests its bundle at
+// /assets/<hash>.{js,css}; the handler must resolve that onto the nested assets/
+// subtree. A StripPrefix("/assets/") here would drop that directory and 404
+// every bundle (a blank page in the browser), so this asserts the real wiring.
+func TestStaticAssetHandlerServesNestedViteBundle(t *testing.T) {
+	mirror := fstest.MapFS{
+		"index.html":              {Data: []byte("<!doctype html>")},
+		"assets/index-abc123.js":  {Data: []byte("export const x = 1")},
+		"assets/index-abc123.css": {Data: []byte(".x{}")},
+	}
+
+	mux := http.NewServeMux()
+	mux.Handle("GET /assets/", staticAssetHandler(mirror))
+
+	cases := []struct {
+		path string
+		want string
+	}{
+		{"/assets/index-abc123.js", "export const x = 1"},
+		{"/assets/index-abc123.css", ".x{}"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.path, func(t *testing.T) {
+			rec := httptest.NewRecorder()
+			mux.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, tc.path, nil))
+			if rec.Code != http.StatusOK {
+				t.Fatalf("GET %s = %d, want 200 (nested /assets bundle must serve)", tc.path, rec.Code)
+			}
+			if got := rec.Body.String(); got != tc.want {
+				t.Fatalf("GET %s body = %q, want %q", tc.path, got, tc.want)
+			}
+		})
+	}
+
+	// A path that does not exist in the mirror must still 404 cleanly.
+	rec := httptest.NewRecorder()
+	mux.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/assets/missing.js", nil))
+	if rec.Code != http.StatusNotFound {
+		t.Fatalf("GET /assets/missing.js = %d, want 404", rec.Code)
+	}
+}

--- a/internal/console/history.go
+++ b/internal/console/history.go
@@ -1,0 +1,76 @@
+package console
+
+import (
+	"context"
+	"database/sql"
+	"strings"
+
+	"github.com/The-Vibe-Company/companion/internal/state"
+)
+
+// History reads past apply records from the state store. It queries the SQLite
+// applies table directly via the exported *sql.DB.
+type History struct {
+	store *state.Store
+}
+
+// NewHistory wraps a state store for read-only apply history queries.
+func NewHistory(store *state.Store) *History {
+	return &History{store: store}
+}
+
+// List returns up to limit most-recent apply records, newest first. A missing
+// or empty applies table yields an empty slice rather than an error, and a NULL
+// finished_at (an apply still in flight) maps to an empty FinishedAt string.
+func (h *History) List(ctx context.Context, limit int) ([]ApplyHistoryEntry, error) {
+	entries := []ApplyHistoryEntry{}
+	if h == nil || h.store == nil || h.store.DB == nil {
+		return entries, nil
+	}
+	if limit <= 0 {
+		limit = 50
+	}
+
+	rows, err := h.store.DB.QueryContext(
+		ctx,
+		`SELECT id, started_at, finished_at, status
+		 FROM applies
+		 ORDER BY id DESC
+		 LIMIT ?`,
+		limit,
+	)
+	if err != nil {
+		if isMissingTable(err) {
+			return entries, nil
+		}
+		return nil, err
+	}
+	defer rows.Close()
+
+	for rows.Next() {
+		var (
+			entry      ApplyHistoryEntry
+			finishedAt sql.NullString
+		)
+		if err := rows.Scan(&entry.ID, &entry.StartedAt, &finishedAt, &entry.Status); err != nil {
+			return nil, err
+		}
+		if finishedAt.Valid {
+			entry.FinishedAt = finishedAt.String
+		}
+		entries = append(entries, entry)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return entries, nil
+}
+
+// isMissingTable reports whether err is a SQLite "no such table" error, which we
+// treat as an empty history rather than a hard failure.
+func isMissingTable(err error) bool {
+	if err == nil {
+		return false
+	}
+	return strings.Contains(err.Error(), "no such table")
+}

--- a/internal/console/history_test.go
+++ b/internal/console/history_test.go
@@ -1,0 +1,142 @@
+package console
+
+import (
+	"context"
+	"path/filepath"
+	"testing"
+
+	"github.com/The-Vibe-Company/companion/internal/state"
+)
+
+// openTestStore opens a fresh SQLite state store backed by a per-test temp dir.
+func openTestStore(t *testing.T) *state.Store {
+	t.Helper()
+	store, err := state.Open(filepath.Join(t.TempDir(), "state.sqlite"))
+	if err != nil {
+		t.Fatalf("open state: %v", err)
+	}
+	t.Cleanup(func() { store.Close() })
+	return store
+}
+
+func TestHistoryListReturnsAppliesNewestFirst(t *testing.T) {
+	ctx := context.Background()
+	store := openTestStore(t)
+
+	// First apply: finished successfully.
+	firstID, err := store.StartApply(ctx, map[string]any{"changes": 1})
+	if err != nil {
+		t.Fatalf("start first apply: %v", err)
+	}
+	if err := store.FinishApply(ctx, firstID, "succeeded"); err != nil {
+		t.Fatalf("finish first apply: %v", err)
+	}
+
+	// Second apply: finished with failure.
+	secondID, err := store.StartApply(ctx, map[string]any{"changes": 2})
+	if err != nil {
+		t.Fatalf("start second apply: %v", err)
+	}
+	if err := store.FinishApply(ctx, secondID, "failed"); err != nil {
+		t.Fatalf("finish second apply: %v", err)
+	}
+
+	// Third apply: still running (finished_at is NULL).
+	thirdID, err := store.StartApply(ctx, map[string]any{"changes": 3})
+	if err != nil {
+		t.Fatalf("start third apply: %v", err)
+	}
+
+	entries, err := NewHistory(store).List(ctx, 10)
+	if err != nil {
+		t.Fatalf("list history: %v", err)
+	}
+	if len(entries) != 3 {
+		t.Fatalf("expected three entries, got %d: %#v", len(entries), entries)
+	}
+
+	// Newest first: third, second, first.
+	wantIDs := []int64{thirdID, secondID, firstID}
+	wantStatuses := []string{"running", "failed", "succeeded"}
+	for i, entry := range entries {
+		if entry.ID != wantIDs[i] {
+			t.Fatalf("entry %d: expected id %d, got %d (%#v)", i, wantIDs[i], entry.ID, entries)
+		}
+		if entry.Status != wantStatuses[i] {
+			t.Fatalf("entry %d: expected status %q, got %q", i, wantStatuses[i], entry.Status)
+		}
+		if entry.StartedAt == "" {
+			t.Fatalf("entry %d: expected non-empty started_at", i)
+		}
+	}
+
+	// The two finished applies expose a finished_at; the running one does not.
+	if entries[0].FinishedAt != "" {
+		t.Fatalf("running apply should have empty finished_at, got %q", entries[0].FinishedAt)
+	}
+	if entries[1].FinishedAt == "" || entries[2].FinishedAt == "" {
+		t.Fatalf("finished applies should expose finished_at, got %#v", entries)
+	}
+}
+
+func TestHistoryListEmptyStore(t *testing.T) {
+	ctx := context.Background()
+	store := openTestStore(t)
+
+	entries, err := NewHistory(store).List(ctx, 10)
+	if err != nil {
+		t.Fatalf("list empty history: %v", err)
+	}
+	if entries == nil {
+		t.Fatalf("expected non-nil empty slice, got nil")
+	}
+	if len(entries) != 0 {
+		t.Fatalf("expected empty history, got %#v", entries)
+	}
+}
+
+func TestHistoryListRespectsLimit(t *testing.T) {
+	ctx := context.Background()
+	store := openTestStore(t)
+
+	var ids []int64
+	for i := 0; i < 3; i++ {
+		id, err := store.StartApply(ctx, map[string]any{"n": i})
+		if err != nil {
+			t.Fatalf("start apply %d: %v", i, err)
+		}
+		if err := store.FinishApply(ctx, id, "succeeded"); err != nil {
+			t.Fatalf("finish apply %d: %v", i, err)
+		}
+		ids = append(ids, id)
+	}
+
+	entries, err := NewHistory(store).List(ctx, 2)
+	if err != nil {
+		t.Fatalf("list history with limit: %v", err)
+	}
+	if len(entries) != 2 {
+		t.Fatalf("expected limit of two entries, got %d", len(entries))
+	}
+	// Most-recent two, newest first.
+	if entries[0].ID != ids[2] || entries[1].ID != ids[1] {
+		t.Fatalf("expected newest two ids %d,%d, got %d,%d", ids[2], ids[1], entries[0].ID, entries[1].ID)
+	}
+}
+
+func TestHistoryListMissingTableIsEmpty(t *testing.T) {
+	ctx := context.Background()
+	store := openTestStore(t)
+
+	if _, err := store.DB.ExecContext(ctx, `DROP TABLE applies`); err != nil {
+		t.Fatalf("drop applies table: %v", err)
+	}
+
+	entries, err := NewHistory(store).List(ctx, 10)
+	if err != nil {
+		t.Fatalf("missing applies table should not error: %v", err)
+	}
+	if len(entries) != 0 {
+		t.Fatalf("expected empty history for missing table, got %#v", entries)
+	}
+}

--- a/internal/console/runner.go
+++ b/internal/console/runner.go
@@ -17,6 +17,11 @@ const (
 	OpFailed    = "failed"
 )
 
+// maxRetainedOps bounds how many operations the runner keeps for polling via Get.
+// Applies are infrequent and only the most recent matter to the UI, so older
+// operations are evicted to keep memory bounded on a long-lived console process.
+const maxRetainedOps = 100
+
 // OperationRunner serializes apply operations: at most one apply is active at a
 // time. Start launches the supplied run function in a goroutine and tracks its
 // Operation by id; callers poll Get for progress. The injected clock keeps
@@ -34,6 +39,9 @@ type OperationRunner struct {
 	mu     sync.Mutex
 	active bool
 	ops    map[string]*Operation
+	// order records id insertion order so the oldest operations can be evicted
+	// once retention exceeds maxRetainedOps.
+	order []string
 }
 
 // NewOperationRunner builds an OperationRunner. A nil clock defaults to
@@ -86,6 +94,8 @@ func (r *OperationRunner) Start(fn func(ctx context.Context) (changed []string, 
 	}
 	r.active = true
 	r.ops[id] = op
+	r.order = append(r.order, id)
+	r.evictLocked()
 	r.mu.Unlock()
 
 	go r.run(id, fn)
@@ -137,6 +147,17 @@ func (r *OperationRunner) Get(id string) (Operation, bool) {
 		return Operation{}, false
 	}
 	return *op, true
+}
+
+// evictLocked drops the oldest operations once retention exceeds maxRetainedOps.
+// The just-appended id is the active operation, so eviction from the front never
+// removes an in-flight one. The caller must hold r.mu.
+func (r *OperationRunner) evictLocked() {
+	for len(r.order) > maxRetainedOps {
+		oldest := r.order[0]
+		r.order = r.order[1:]
+		delete(r.ops, oldest)
+	}
 }
 
 // randomID returns a short hex operation id from crypto/rand.

--- a/internal/console/runner.go
+++ b/internal/console/runner.go
@@ -1,0 +1,155 @@
+package console
+
+import (
+	"context"
+	"crypto/rand"
+	"encoding/hex"
+	"fmt"
+	"sync"
+	"time"
+)
+
+// Operation states.
+const (
+	OpPending   = "pending"
+	OpRunning   = "running"
+	OpSucceeded = "succeeded"
+	OpFailed    = "failed"
+)
+
+// OperationRunner serializes apply operations: at most one apply is active at a
+// time. Start launches the supplied run function in a goroutine and tracks its
+// Operation by id; callers poll Get for progress. The injected clock keeps
+// timestamps deterministic in tests.
+type OperationRunner struct {
+	clock func() time.Time
+
+	// ctx ties launched operations to the server lifecycle. When the runner is
+	// closed (or the server stops) the context is cancelled and passed to the run
+	// function so long applies can observe cancellation. It is not required to be
+	// cancellable from the API in v1.
+	ctx    context.Context
+	cancel context.CancelFunc
+
+	mu     sync.Mutex
+	active bool
+	ops    map[string]*Operation
+}
+
+// NewOperationRunner builds an OperationRunner. A nil clock defaults to
+// time.Now.
+func NewOperationRunner(clock func() time.Time) *OperationRunner {
+	if clock == nil {
+		clock = time.Now
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	return &OperationRunner{
+		clock:  clock,
+		ctx:    ctx,
+		cancel: cancel,
+		ops:    map[string]*Operation{},
+	}
+}
+
+// Close cancels the lifecycle context shared by in-flight operations. Already
+// recorded operations remain retrievable via Get. It is safe to call multiple
+// times.
+func (r *OperationRunner) Close() {
+	if r.cancel != nil {
+		r.cancel()
+	}
+}
+
+// Start attempts to begin a new apply. It returns ok=false when an apply is
+// already active (the API maps that to 409 Conflict). On success it returns the
+// new operation id and runs fn asynchronously, advancing the operation through
+// running -> succeeded/failed. fn receives a context tied to the runner
+// lifecycle and returns the changed resource addresses, the canonical plan JSON
+// it applied, and any error.
+func (r *OperationRunner) Start(fn func(ctx context.Context) (changed []string, planJSON []byte, err error)) (id string, ok bool) {
+	r.mu.Lock()
+	if r.active {
+		r.mu.Unlock()
+		return "", false
+	}
+
+	id, err := randomID()
+	if err != nil {
+		r.mu.Unlock()
+		return "", false
+	}
+
+	op := &Operation{
+		ID:        id,
+		State:     OpRunning,
+		StartedAt: r.clock(),
+	}
+	r.active = true
+	r.ops[id] = op
+	r.mu.Unlock()
+
+	go r.run(id, fn)
+
+	return id, true
+}
+
+// run executes fn and records the terminal state under the lock. It always
+// clears the active flag so a failed or panicking op never wedges the runner.
+func (r *OperationRunner) run(id string, fn func(ctx context.Context) (changed []string, planJSON []byte, err error)) {
+	var (
+		changed  []string
+		planJSON []byte
+		runErr   error
+	)
+
+	defer func() {
+		r.mu.Lock()
+		defer r.mu.Unlock()
+
+		op := r.ops[id]
+		op.FinishedAt = r.clock()
+		op.Changed = changed
+		if len(planJSON) > 0 {
+			op.PlanJSON = append([]byte(nil), planJSON...)
+		}
+		if rec := recover(); rec != nil {
+			op.State = OpFailed
+			op.Error = panicError(rec)
+		} else if runErr != nil {
+			op.State = OpFailed
+			op.Error = runErr.Error()
+		} else {
+			op.State = OpSucceeded
+		}
+		r.active = false
+	}()
+
+	changed, planJSON, runErr = fn(r.ctx)
+}
+
+// Get returns the tracked operation by id. Finished operations remain
+// retrievable.
+func (r *OperationRunner) Get(id string) (Operation, bool) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	op, ok := r.ops[id]
+	if !ok {
+		return Operation{}, false
+	}
+	return *op, true
+}
+
+// randomID returns a short hex operation id from crypto/rand.
+func randomID() (string, error) {
+	buf := make([]byte, 16)
+	if _, err := rand.Read(buf); err != nil {
+		return "", err
+	}
+	return hex.EncodeToString(buf), nil
+}
+
+// panicError renders a recovered panic value as a string for the operation
+// error field.
+func panicError(rec any) string {
+	return fmt.Sprintf("panic: %v", rec)
+}

--- a/internal/console/runner_test.go
+++ b/internal/console/runner_test.go
@@ -1,0 +1,266 @@
+package console
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"testing"
+	"time"
+)
+
+// waitForState polls the runner until the operation reaches the wanted terminal
+// state or the deadline elapses. Convergence is driven by the runner goroutine
+// writing the terminal state; the deadline is only a failure guard, not the
+// synchronization mechanism, so this never depends on a fixed sleep duration for
+// correctness.
+func waitForState(t *testing.T, r *OperationRunner, id, want string) Operation {
+	t.Helper()
+	deadline := time.Now().Add(2 * time.Second)
+	for {
+		op, ok := r.Get(id)
+		if !ok {
+			t.Fatalf("operation %q not found", id)
+		}
+		if op.State == want {
+			return op
+		}
+		if time.Now().After(deadline) {
+			t.Fatalf("operation %q stuck in state %q, want %q", id, op.State, want)
+		}
+		time.Sleep(time.Millisecond)
+	}
+}
+
+func TestRunnerStartConflict(t *testing.T) {
+	t.Parallel()
+
+	r := NewOperationRunner(nil)
+
+	started := make(chan struct{})
+	release := make(chan struct{})
+
+	// First op signals when it is executing, then blocks until released so the
+	// conflict window is deterministic rather than timing-dependent.
+	id, ok := r.Start(func(ctx context.Context) ([]string, []byte, error) {
+		close(started)
+		<-release
+		return []string{"fly_app.alpha", "tailscale_host.alpha"}, []byte(`{"changes":[]}`), nil
+	})
+	if !ok {
+		t.Fatal("first Start returned ok=false, want true")
+	}
+	if id == "" {
+		t.Fatal("first Start returned empty id")
+	}
+
+	<-started // op is now running and holds the active slot.
+
+	if op, found := r.Get(id); !found || op.State != OpRunning {
+		t.Fatalf("Get(%q) = (%+v, %v), want running", id, op, found)
+	}
+
+	// A second Start must be rejected while the first is active.
+	if id2, ok2 := r.Start(func(ctx context.Context) ([]string, []byte, error) {
+		t.Error("second run function must not execute while an apply is active")
+		return nil, nil, nil
+	}); ok2 || id2 != "" {
+		t.Fatalf("second Start = (%q, %v), want (\"\", false)", id2, ok2)
+	}
+
+	close(release) // let the first op finish.
+
+	op := waitForState(t, r, id, OpSucceeded)
+	if got, want := op.Changed, []string{"fly_app.alpha", "tailscale_host.alpha"}; !equalStrings(got, want) {
+		t.Fatalf("Changed = %v, want %v", got, want)
+	}
+	if string(op.PlanJSON) != `{"changes":[]}` {
+		t.Fatalf("PlanJSON = %s, want %s", op.PlanJSON, `{"changes":[]}`)
+	}
+	jsonRoundTrips(t, op.PlanJSON)
+	if op.FinishedAt.IsZero() {
+		t.Fatal("FinishedAt is zero on a finished op")
+	}
+	if op.Error != "" {
+		t.Fatalf("Error = %q, want empty", op.Error)
+	}
+
+	// Once the active op finished, the runner accepts a new apply.
+	id3, ok3 := r.Start(func(ctx context.Context) ([]string, []byte, error) {
+		return nil, nil, nil
+	})
+	if !ok3 || id3 == "" {
+		t.Fatalf("Start after completion = (%q, %v), want a fresh id and true", id3, ok3)
+	}
+	if id3 == id {
+		t.Fatalf("reused operation id %q", id3)
+	}
+	waitForState(t, r, id3, OpSucceeded)
+}
+
+func TestRunnerStartStates(t *testing.T) {
+	t.Parallel()
+
+	clock := func() time.Time { return testStamp }
+
+	tests := []struct {
+		name      string
+		changed   []string
+		planJSON  []byte
+		runErr    error
+		wantState string
+		wantErr   string
+	}{
+		{
+			name:      "success",
+			changed:   []string{"fly_app.web"},
+			planJSON:  []byte(`{"changes":[{"address":"fly_app.web"}]}`),
+			wantState: OpSucceeded,
+		},
+		{
+			name:      "failure",
+			runErr:    errors.New("apply boom"),
+			wantState: OpFailed,
+			wantErr:   "apply boom",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			r := NewOperationRunner(clock)
+
+			id, ok := r.Start(func(ctx context.Context) ([]string, []byte, error) {
+				return tt.changed, tt.planJSON, tt.runErr
+			})
+			if !ok || id == "" {
+				t.Fatalf("Start = (%q, %v), want id and true", id, ok)
+			}
+
+			op := waitForState(t, r, id, tt.wantState)
+			if !op.StartedAt.Equal(testStamp) {
+				t.Fatalf("StartedAt = %v, want %v (injected clock)", op.StartedAt, testStamp)
+			}
+			if !op.FinishedAt.Equal(testStamp) {
+				t.Fatalf("FinishedAt = %v, want %v (injected clock)", op.FinishedAt, testStamp)
+			}
+			if op.Error != tt.wantErr {
+				t.Fatalf("Error = %q, want %q", op.Error, tt.wantErr)
+			}
+			if !equalStrings(op.Changed, tt.changed) {
+				t.Fatalf("Changed = %v, want %v", op.Changed, tt.changed)
+			}
+			if tt.planJSON != nil && string(op.PlanJSON) != string(tt.planJSON) {
+				t.Fatalf("PlanJSON = %s, want %s", op.PlanJSON, tt.planJSON)
+			}
+			jsonRoundTrips(t, op.PlanJSON)
+			// After a terminal state the active slot is free again.
+			if next, ok := r.Start(func(ctx context.Context) ([]string, []byte, error) {
+				return nil, nil, nil
+			}); !ok || next == "" {
+				t.Fatalf("Start after terminal state = (%q, %v), want a fresh apply", next, ok)
+			}
+		})
+	}
+}
+
+// TestRunnerStartPanicRecovers proves a panicking run function does not wedge the
+// runner: the op is marked failed and the active slot is released.
+func TestRunnerStartPanicRecovers(t *testing.T) {
+	t.Parallel()
+
+	r := NewOperationRunner(nil)
+
+	id, ok := r.Start(func(ctx context.Context) ([]string, []byte, error) {
+		panic("kaboom")
+	})
+	if !ok {
+		t.Fatal("Start returned ok=false, want true")
+	}
+
+	op := waitForState(t, r, id, OpFailed)
+	if op.Error != "panic: kaboom" {
+		t.Fatalf("Error = %q, want %q", op.Error, "panic: kaboom")
+	}
+
+	// The runner is usable again after a panic.
+	id2, ok2 := r.Start(func(ctx context.Context) ([]string, []byte, error) {
+		return nil, nil, nil
+	})
+	if !ok2 || id2 == "" {
+		t.Fatalf("Start after panic = (%q, %v), want a fresh apply", id2, ok2)
+	}
+	waitForState(t, r, id2, OpSucceeded)
+}
+
+// TestRunnerGetUnknown documents the not-found path.
+func TestRunnerGetUnknown(t *testing.T) {
+	t.Parallel()
+
+	r := NewOperationRunner(nil)
+	if op, ok := r.Get("does-not-exist"); ok || op.ID != "" {
+		t.Fatalf("Get(unknown) = (%+v, %v), want (zero, false)", op, ok)
+	}
+}
+
+// TestRunnerCloseCancelsContext proves Close cancels the lifecycle context that
+// in-flight run functions receive.
+func TestRunnerCloseCancelsContext(t *testing.T) {
+	t.Parallel()
+
+	r := NewOperationRunner(nil)
+
+	got := make(chan error, 1)
+	release := make(chan struct{})
+	id, ok := r.Start(func(ctx context.Context) ([]string, []byte, error) {
+		<-release
+		got <- ctx.Err()
+		return nil, nil, ctx.Err()
+	})
+	if !ok {
+		t.Fatal("Start returned ok=false, want true")
+	}
+
+	r.Close()
+	close(release)
+
+	select {
+	case err := <-got:
+		if !errors.Is(err, context.Canceled) {
+			t.Fatalf("run ctx.Err() = %v, want context.Canceled", err)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("run function did not observe cancellation")
+	}
+
+	op := waitForState(t, r, id, OpFailed)
+	if op.Error == "" {
+		t.Fatal("Error is empty on a cancelled op, want context error")
+	}
+}
+
+// equalStrings compares two string slices, treating nil and empty as equal so
+// the success-with-no-changes case is not spuriously different from nil.
+func equalStrings(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
+}
+
+// jsonRoundTrips guards that the recorded PlanJSON stays valid JSON the API can
+// re-emit verbatim.
+func jsonRoundTrips(t *testing.T, raw json.RawMessage) {
+	t.Helper()
+	if len(raw) == 0 {
+		return
+	}
+	var v any
+	if err := json.Unmarshal(raw, &v); err != nil {
+		t.Fatalf("PlanJSON is not valid JSON: %v", err)
+	}
+}

--- a/internal/console/runner_test.go
+++ b/internal/console/runner_test.go
@@ -264,3 +264,29 @@ func jsonRoundTrips(t *testing.T, raw json.RawMessage) {
 		t.Fatalf("PlanJSON is not valid JSON: %v", err)
 	}
 }
+
+// TestRunnerEvictsOldestOperations guards the bounded retention: after more than
+// maxRetainedOps applies, the oldest operations are evicted while the newest stay
+// retrievable, so a long-lived console does not grow ops without bound.
+func TestRunnerEvictsOldestOperations(t *testing.T) {
+	r := NewOperationRunner(nil)
+	ids := make([]string, 0, maxRetainedOps+10)
+	for i := 0; i < maxRetainedOps+10; i++ {
+		id, ok := r.Start(func(ctx context.Context) ([]string, []byte, error) {
+			return nil, nil, nil
+		})
+		if !ok {
+			t.Fatalf("Start %d returned ok=false (runner wedged)", i)
+		}
+		// Wait for completion so active clears before the next Start.
+		waitForState(t, r, id, OpSucceeded)
+		ids = append(ids, id)
+	}
+
+	if _, ok := r.Get(ids[0]); ok {
+		t.Fatalf("oldest operation should have been evicted")
+	}
+	if _, ok := r.Get(ids[len(ids)-1]); !ok {
+		t.Fatalf("newest operation should be retained")
+	}
+}

--- a/internal/console/tomlwriter.go
+++ b/internal/console/tomlwriter.go
@@ -19,6 +19,12 @@ import (
 // Sub-tables use the config.Raw* layer (pointer fields) so unset optional keys
 // are omitted entirely: an all-nil Raw struct marshals to nothing under the
 // `omitempty` tag, keeping generated files minimal and faithful.
+//
+// The struct mirrors workspace.agentFile field-for-field (including the dual
+// vault-connection spellings the loader accepts) so an unmarshal -> mutate ->
+// marshal round-trip preserves EVERY key Companion understands. That fidelity is
+// what makes update and delete non-destructive for hand-authored files that use
+// fields the console form does not surface.
 type agentTOMLFile struct {
 	Agent            agentTOMLTable              `toml:"agent"`
 	Model            config.RawModel             `toml:"model,omitempty"`
@@ -27,25 +33,41 @@ type agentTOMLFile struct {
 	Identity         config.RawIdentity          `toml:"identity,omitempty"`
 	CompanionSoul    config.RawCompanionSoul     `toml:"companion_soul,omitempty"`
 	VaultConnections []config.RawVaultConnection `toml:"vault_connections,omitempty"`
+	// VaultConnectionsAlt captures the singular `[[vault_connection]]` spelling
+	// the loader also accepts, so neither form is dropped on round-trip.
+	VaultConnectionsAlt []config.RawVaultConnection `toml:"vault_connection,omitempty"`
 }
 
-// agentTOMLTable is the [agent] table written by the console. It uses pointer
-// fields so optional keys can be omitted from the generated TOML. IdentityPath
-// maps to the `identity = "..."` shorthand the workspace loader promotes into
-// the [identity] table (see workspace.agentFile.toRawAgent).
+// agentTOMLTable is the [agent] table. It mirrors workspace.rawAgentTable in full
+// (pointer fields so unset keys stay omitted) so that reading an existing agent
+// file and writing it back preserves every [agent] key — not just the handful
+// the console form edits. IdentityPath maps to the `identity = "..."` shorthand
+// the workspace loader promotes into the [identity] table.
 type agentTOMLTable struct {
-	ID                *string `toml:"id"`
-	Runtime           *string `toml:"runtime,omitempty"`
-	Network           *string `toml:"network,omitempty"`
-	ModelProvider     *string `toml:"model_provider,omitempty"`
-	Lifecycle         *string `toml:"lifecycle,omitempty"`
-	Protect           *bool   `toml:"protect,omitempty"`
-	FlyApp            *string `toml:"fly_app,omitempty"`
-	TailscaleHostname *string `toml:"tailscale_hostname,omitempty"`
-	IdentityPath      *string `toml:"identity,omitempty"`
-	Region            *string `toml:"region,omitempty"`
-	Memory            *string `toml:"memory,omitempty"`
-	CPUs              *int    `toml:"cpus,omitempty"`
+	ID                         *string `toml:"id"`
+	Runtime                    *string `toml:"runtime,omitempty"`
+	Network                    *string `toml:"network,omitempty"`
+	ModelProvider              *string `toml:"model_provider,omitempty"`
+	Lifecycle                  *string `toml:"lifecycle,omitempty"`
+	Protect                    *bool   `toml:"protect,omitempty"`
+	FlyApp                     *string `toml:"fly_app,omitempty"`
+	TailscaleHostname          *string `toml:"tailscale_hostname,omitempty"`
+	IdentityPath               *string `toml:"identity,omitempty"`
+	Region                     *string `toml:"region,omitempty"`
+	VolumeName                 *string `toml:"volume_name,omitempty"`
+	VolumeSizeGB               *int    `toml:"volume_size_gb,omitempty"`
+	Memory                     *string `toml:"memory,omitempty"`
+	CPUs                       *int    `toml:"cpus,omitempty"`
+	DashboardMode              *string `toml:"dashboard_mode,omitempty"`
+	DashboardHost              *string `toml:"dashboard_host,omitempty"`
+	DashboardInsecure          *bool   `toml:"dashboard_insecure,omitempty"`
+	DashboardPort              *int    `toml:"dashboard_port,omitempty"`
+	GraniteEnabled             *bool   `toml:"granite_enabled,omitempty"`
+	TailscaleAuthKeySecretName *string `toml:"tailscale_authkey_secret_name,omitempty"`
+	TailscaleAcceptDNS         *bool   `toml:"tailscale_accept_dns,omitempty"`
+	TSExtraArgs                *string `toml:"ts_extra_args,omitempty"`
+	TailscaledExtraArgs        *string `toml:"tailscaled_extra_args,omitempty"`
+	GraniteTemplate            *string `toml:"granite_template,omitempty"`
 }
 
 // Console-managed defaults mirror examples/minimal so a freshly created agent
@@ -98,42 +120,73 @@ func (w *TomlWriter) SoulPath(id string) string {
 	return filepath.Join(w.root, "identities", id, "SOUL.md")
 }
 
-// BuildAgentFile converts an AgentInput into the faithful per-file TOML struct,
-// applying console defaults (mirroring examples/minimal) for omitted optional
-// fields. It validates the id, fly_app, and tailscale_hostname by reusing the
-// config package's normalization+validation rather than duplicating its regex.
-// It does not touch the filesystem.
+// BuildAgentFile converts an AgentInput into a fresh per-file TOML struct for a
+// NEW agent, applying console defaults (mirroring examples/minimal) for omitted
+// optional fields. It does not touch the filesystem.
 func (w *TomlWriter) BuildAgentFile(in AgentInput) (agentTOMLFile, error) {
-	id := strings.TrimSpace(in.ID)
+	var file agentTOMLFile
+	if err := applyInput(&file, in); err != nil {
+		return agentTOMLFile{}, err
+	}
+	return file, nil
+}
+
+// MergeAgentFile loads the existing agents/<id>.toml and overlays the AgentInput
+// projection onto it, PRESERVING every field the console form does not model —
+// volume sizing, dashboard/granite settings, secret-name references, [api_server],
+// [[vault_connections]], and any other [agent] key. This is the update path: the
+// structured form edits the fields it shows without discarding the rest of a
+// hand-authored file. The id is authoritative (callers pass the path id).
+func (w *TomlWriter) MergeAgentFile(id string, in AgentInput) (agentTOMLFile, error) {
 	if err := validateID(id); err != nil {
 		return agentTOMLFile{}, err
 	}
-
-	runtime := firstNonEmpty(in.Runtime, defaultRuntime)
-	network := firstNonEmpty(in.Network, defaultNetwork)
-	modelProvider := firstNonEmpty(in.ModelProvider, defaultModelProvider)
-	lifecycle := firstNonEmpty(in.Lifecycle, defaultLifecycle)
-	flyApp := firstNonEmpty(in.FlyApp, id)
-	tailscaleHostname := firstNonEmpty(in.TailscaleHostname, id)
-
-	// Reuse config validation for the three name-shaped fields. Building a real
-	// one-agent config exercises the same nameRE / lifecycle / provider-shape
-	// checks the loader applies, so the writer rejects exactly what Load would.
-	if err := validateAgentNames(id, flyApp, tailscaleHostname, runtime, network, modelProvider, lifecycle); err != nil {
+	data, err := os.ReadFile(w.AgentPath(id))
+	if err != nil {
+		return agentTOMLFile{}, fmt.Errorf("read agent %s: %w", id, err)
+	}
+	var file agentTOMLFile
+	if err := toml.Unmarshal(data, &file); err != nil {
+		return agentTOMLFile{}, fmt.Errorf("parse agent %s: %w", id, err)
+	}
+	in.ID = id
+	if err := applyInput(&file, in); err != nil {
 		return agentTOMLFile{}, err
 	}
+	return file, nil
+}
 
-	file := agentTOMLFile{
-		Agent: agentTOMLTable{
-			ID:                strPtr(id),
-			Runtime:           strPtr(runtime),
-			Network:           strPtr(network),
-			ModelProvider:     strPtr(modelProvider),
-			Lifecycle:         strPtr(lifecycle),
-			FlyApp:            strPtr(flyApp),
-			TailscaleHostname: strPtr(tailscaleHostname),
-		},
+// applyInput overlays the structured AgentInput fields onto file in place. Core
+// fields fall back to the file's current value, then to the console default, so
+// the overlay is correct for both a fresh struct (create) and an existing one
+// (update). Optional fields are applied only when provided, so an update never
+// wipes a field the form left blank. Name-shaped fields are validated by reusing
+// config.Normalize, so the writer rejects exactly what workspace.Load would.
+func applyInput(file *agentTOMLFile, in AgentInput) error {
+	id := strings.TrimSpace(in.ID)
+	if err := validateID(id); err != nil {
+		return err
 	}
+
+	runtime := firstNonEmpty(in.Runtime, ptrVal(file.Agent.Runtime), defaultRuntime)
+	network := firstNonEmpty(in.Network, ptrVal(file.Agent.Network), defaultNetwork)
+	modelProvider := firstNonEmpty(in.ModelProvider, ptrVal(file.Agent.ModelProvider), defaultModelProvider)
+	lifecycle := firstNonEmpty(in.Lifecycle, ptrVal(file.Agent.Lifecycle), defaultLifecycle)
+	flyApp := firstNonEmpty(in.FlyApp, ptrVal(file.Agent.FlyApp), id)
+	tailscaleHostname := firstNonEmpty(in.TailscaleHostname, ptrVal(file.Agent.TailscaleHostname), id)
+
+	if err := validateAgentNames(id, flyApp, tailscaleHostname, runtime, network, modelProvider, lifecycle); err != nil {
+		return err
+	}
+
+	file.Agent.ID = strPtr(id)
+	file.Agent.Runtime = strPtr(runtime)
+	file.Agent.Network = strPtr(network)
+	file.Agent.ModelProvider = strPtr(modelProvider)
+	file.Agent.Lifecycle = strPtr(lifecycle)
+	file.Agent.FlyApp = strPtr(flyApp)
+	file.Agent.TailscaleHostname = strPtr(tailscaleHostname)
+
 	if v := strings.TrimSpace(in.Region); v != "" {
 		file.Agent.Region = strPtr(v)
 	}
@@ -167,7 +220,7 @@ func (w *TomlWriter) BuildAgentFile(in AgentInput) (agentTOMLFile, error) {
 		file.CompanionSoul.Enabled = boolPtr(*in.CompanionSoulEnabled)
 	}
 
-	return file, nil
+	return nil
 }
 
 // WriteAgent marshals the agent file to agents/<id>.toml, backing up any
@@ -261,6 +314,24 @@ func (w *TomlWriter) RemoveAgent(id string) error {
 	if err := os.Remove(w.AgentPath(id)); err != nil && !os.IsNotExist(err) {
 		return err
 	}
+	return nil
+}
+
+// RemoveSoul deletes identities/<id>/SOUL.md and, when it becomes empty, the
+// identities/<id>/ directory. It rolls back a SOUL.md freshly written for a
+// create that then failed validation (one with no prior backup to restore).
+// Missing files are tolerated.
+func (w *TomlWriter) RemoveSoul(id string) error {
+	if err := validateID(id); err != nil {
+		return err
+	}
+	soul := w.SoulPath(id)
+	if err := os.Remove(soul); err != nil && !os.IsNotExist(err) {
+		return err
+	}
+	// Best-effort: drop the now-empty identities/<id>/ directory. A non-empty
+	// directory makes os.Remove fail, which we intentionally ignore.
+	_ = os.Remove(filepath.Dir(soul))
 	return nil
 }
 
@@ -367,3 +438,12 @@ func firstNonEmpty(values ...string) string {
 func strPtr(v string) *string { return &v }
 func boolPtr(v bool) *bool    { return &v }
 func intPtr(v int) *int       { return &v }
+
+// ptrVal dereferences a *string, returning "" for nil. Used by applyInput to
+// fall back to a file's existing value when the input omits a field.
+func ptrVal(p *string) string {
+	if p == nil {
+		return ""
+	}
+	return *p
+}

--- a/internal/console/tomlwriter.go
+++ b/internal/console/tomlwriter.go
@@ -1,0 +1,369 @@
+package console
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"github.com/pelletier/go-toml/v2"
+
+	"github.com/The-Vibe-Company/companion/internal/config"
+)
+
+// agentTOMLFile mirrors the per-file shape an agents/<id>.toml unmarshals into
+// (see internal/workspace.agentFile). The console marshals this struct back to
+// TOML via pelletier/go-toml/v2 so round-trips stay valid for workspace.Load.
+//
+// Sub-tables use the config.Raw* layer (pointer fields) so unset optional keys
+// are omitted entirely: an all-nil Raw struct marshals to nothing under the
+// `omitempty` tag, keeping generated files minimal and faithful.
+type agentTOMLFile struct {
+	Agent            agentTOMLTable              `toml:"agent"`
+	Model            config.RawModel             `toml:"model,omitempty"`
+	APIServer        config.RawAPIServer         `toml:"api_server,omitempty"`
+	DefaultVault     config.RawDefaultVault      `toml:"default_vault,omitempty"`
+	Identity         config.RawIdentity          `toml:"identity,omitempty"`
+	CompanionSoul    config.RawCompanionSoul     `toml:"companion_soul,omitempty"`
+	VaultConnections []config.RawVaultConnection `toml:"vault_connections,omitempty"`
+}
+
+// agentTOMLTable is the [agent] table written by the console. It uses pointer
+// fields so optional keys can be omitted from the generated TOML. IdentityPath
+// maps to the `identity = "..."` shorthand the workspace loader promotes into
+// the [identity] table (see workspace.agentFile.toRawAgent).
+type agentTOMLTable struct {
+	ID                *string `toml:"id"`
+	Runtime           *string `toml:"runtime,omitempty"`
+	Network           *string `toml:"network,omitempty"`
+	ModelProvider     *string `toml:"model_provider,omitempty"`
+	Lifecycle         *string `toml:"lifecycle,omitempty"`
+	Protect           *bool   `toml:"protect,omitempty"`
+	FlyApp            *string `toml:"fly_app,omitempty"`
+	TailscaleHostname *string `toml:"tailscale_hostname,omitempty"`
+	IdentityPath      *string `toml:"identity,omitempty"`
+	Region            *string `toml:"region,omitempty"`
+	Memory            *string `toml:"memory,omitempty"`
+	CPUs              *int    `toml:"cpus,omitempty"`
+}
+
+// Console-managed defaults mirror examples/minimal so a freshly created agent
+// loads and plans without further editing.
+const (
+	defaultRuntime       = "fly.default"
+	defaultNetwork       = "tailscale.default"
+	defaultModelProvider = "openrouter.default"
+	defaultLifecycle     = "present"
+)
+
+// soulRelPath is the workspace-relative SOUL.md path for an agent identity. It
+// is written into [agent].identity so apply renders the agent SOUL.
+func soulRelPath(id string) string {
+	return path("identities", id, "SOUL.md")
+}
+
+// path joins workspace-relative segments with forward slashes (TOML/path form),
+// independent of the host separator.
+func path(segments ...string) string {
+	return strings.Join(segments, "/")
+}
+
+// TomlWriter performs safe, backup-protected writes of console-managed files
+// (agents/<id>.toml and identities/<id>/SOUL.md) under a workspace root. Before
+// overwriting an existing file it copies the current contents into a timestamped
+// backup directory derived from clock.
+type TomlWriter struct {
+	root  string
+	clock func() time.Time
+}
+
+// NewTomlWriter builds a writer rooted at the workspace directory. A nil clock
+// defaults to time.Now.
+func NewTomlWriter(root string, clock func() time.Time) *TomlWriter {
+	if clock == nil {
+		clock = time.Now
+	}
+	return &TomlWriter{root: root, clock: clock}
+}
+
+// AgentPath returns the absolute path to agents/<id>.toml under the workspace.
+func (w *TomlWriter) AgentPath(id string) string {
+	return filepath.Join(w.root, "agents", id+".toml")
+}
+
+// SoulPath returns the absolute path to identities/<id>/SOUL.md under the
+// workspace.
+func (w *TomlWriter) SoulPath(id string) string {
+	return filepath.Join(w.root, "identities", id, "SOUL.md")
+}
+
+// BuildAgentFile converts an AgentInput into the faithful per-file TOML struct,
+// applying console defaults (mirroring examples/minimal) for omitted optional
+// fields. It validates the id, fly_app, and tailscale_hostname by reusing the
+// config package's normalization+validation rather than duplicating its regex.
+// It does not touch the filesystem.
+func (w *TomlWriter) BuildAgentFile(in AgentInput) (agentTOMLFile, error) {
+	id := strings.TrimSpace(in.ID)
+	if err := validateID(id); err != nil {
+		return agentTOMLFile{}, err
+	}
+
+	runtime := firstNonEmpty(in.Runtime, defaultRuntime)
+	network := firstNonEmpty(in.Network, defaultNetwork)
+	modelProvider := firstNonEmpty(in.ModelProvider, defaultModelProvider)
+	lifecycle := firstNonEmpty(in.Lifecycle, defaultLifecycle)
+	flyApp := firstNonEmpty(in.FlyApp, id)
+	tailscaleHostname := firstNonEmpty(in.TailscaleHostname, id)
+
+	// Reuse config validation for the three name-shaped fields. Building a real
+	// one-agent config exercises the same nameRE / lifecycle / provider-shape
+	// checks the loader applies, so the writer rejects exactly what Load would.
+	if err := validateAgentNames(id, flyApp, tailscaleHostname, runtime, network, modelProvider, lifecycle); err != nil {
+		return agentTOMLFile{}, err
+	}
+
+	file := agentTOMLFile{
+		Agent: agentTOMLTable{
+			ID:                strPtr(id),
+			Runtime:           strPtr(runtime),
+			Network:           strPtr(network),
+			ModelProvider:     strPtr(modelProvider),
+			Lifecycle:         strPtr(lifecycle),
+			FlyApp:            strPtr(flyApp),
+			TailscaleHostname: strPtr(tailscaleHostname),
+		},
+	}
+	if v := strings.TrimSpace(in.Region); v != "" {
+		file.Agent.Region = strPtr(v)
+	}
+	if v := strings.TrimSpace(in.Memory); v != "" {
+		file.Agent.Memory = strPtr(v)
+	}
+	if in.CPUs > 0 {
+		file.Agent.CPUs = intPtr(in.CPUs)
+	}
+
+	// Model: a chosen model goes into [model].default. Mirroring examples/minimal,
+	// the workspace defaults.toml already enables the model + provider, so the
+	// agent file only needs to override the model name when one is supplied.
+	if v := strings.TrimSpace(in.Model); v != "" {
+		file.Model.Default = strPtr(v)
+	}
+
+	// default_vault.name carries the human label the UI edits.
+	if v := strings.TrimSpace(in.VaultName); v != "" {
+		file.DefaultVault.Name = strPtr(v)
+	}
+
+	// A provided soul is written to identities/<id>/SOUL.md and referenced via the
+	// [agent].identity shorthand (promoted to identity.path + enabled on load).
+	if strings.TrimSpace(in.Soul) != "" {
+		file.Agent.IdentityPath = strPtr(soulRelPath(id))
+	}
+
+	// companion_soul toggles the fleet-wide SOUL addition for this agent.
+	if in.CompanionSoulEnabled != nil {
+		file.CompanionSoul.Enabled = boolPtr(*in.CompanionSoulEnabled)
+	}
+
+	return file, nil
+}
+
+// WriteAgent marshals the agent file to agents/<id>.toml, backing up any
+// existing file first. It returns the backup directory used (empty when the
+// target did not previously exist) so the API layer can roll back.
+func (w *TomlWriter) WriteAgent(id string, file agentTOMLFile) (backupDir string, err error) {
+	if err := validateID(id); err != nil {
+		return "", err
+	}
+	data, err := toml.Marshal(file)
+	if err != nil {
+		return "", fmt.Errorf("marshal agent %s: %w", id, err)
+	}
+	return w.writeFile(w.AgentPath(id), data)
+}
+
+// WriteSoul writes identities/<id>/SOUL.md, backing up any existing file first.
+// It returns the backup directory used (empty when the target did not previously
+// exist).
+func (w *TomlWriter) WriteSoul(id, soul string) (backupDir string, err error) {
+	if err := validateID(id); err != nil {
+		return "", err
+	}
+	content := strings.TrimRight(soul, "\n") + "\n"
+	return w.writeFile(w.SoulPath(id), []byte(content))
+}
+
+// SetLifecycleAbsent implements console DELETE semantics: it reads the existing
+// agents/<id>.toml, sets [agent].lifecycle = "absent", and rewrites it (with a
+// backup) WITHOUT removing the file. The agent stays in the workspace so plan
+// renders an explicit destroy. It returns the backup directory used.
+func (w *TomlWriter) SetLifecycleAbsent(id string) (backupDir string, err error) {
+	if err := validateID(id); err != nil {
+		return "", err
+	}
+	target := w.AgentPath(id)
+	data, err := os.ReadFile(target)
+	if err != nil {
+		return "", fmt.Errorf("read agent %s: %w", id, err)
+	}
+	var file agentTOMLFile
+	if err := toml.Unmarshal(data, &file); err != nil {
+		return "", fmt.Errorf("parse agent %s: %w", id, err)
+	}
+	absent := "absent"
+	file.Agent.Lifecycle = &absent
+	out, err := toml.Marshal(file)
+	if err != nil {
+		return "", fmt.Errorf("marshal agent %s: %w", id, err)
+	}
+	return w.writeFile(target, out)
+}
+
+// Restore copies the files saved under backupDir back into the workspace,
+// overwriting current contents. It is used by the API layer to roll back a write
+// that failed post-write validation. A blank backupDir is a no-op.
+func (w *TomlWriter) Restore(backupDir string) error {
+	if strings.TrimSpace(backupDir) == "" {
+		return nil
+	}
+	return filepath.Walk(backupDir, func(p string, info os.FileInfo, err error) error {
+		if err != nil {
+			return err
+		}
+		if info.IsDir() {
+			return nil
+		}
+		rel, err := filepath.Rel(backupDir, p)
+		if err != nil {
+			return err
+		}
+		dest := filepath.Join(w.root, rel)
+		if err := os.MkdirAll(filepath.Dir(dest), 0o755); err != nil {
+			return err
+		}
+		data, err := os.ReadFile(p)
+		if err != nil {
+			return err
+		}
+		return os.WriteFile(dest, data, 0o644)
+	})
+}
+
+// RemoveAgent deletes agents/<id>.toml. It is used by the API layer to roll back
+// a freshly created agent file (one with no prior backup). Missing files are
+// tolerated.
+func (w *TomlWriter) RemoveAgent(id string) error {
+	if err := validateID(id); err != nil {
+		return err
+	}
+	if err := os.Remove(w.AgentPath(id)); err != nil && !os.IsNotExist(err) {
+		return err
+	}
+	return nil
+}
+
+// writeFile writes data to target, first backing up any existing file into a
+// timestamped backup dir under <root>/.companion/backups/<ts>/<relpath>. The
+// returned backupDir is empty when the target did not previously exist.
+func (w *TomlWriter) writeFile(target string, data []byte) (string, error) {
+	backupDir, err := w.backup(target)
+	if err != nil {
+		return "", err
+	}
+	if err := os.MkdirAll(filepath.Dir(target), 0o755); err != nil {
+		return "", err
+	}
+	if err := os.WriteFile(target, data, 0o644); err != nil {
+		return "", err
+	}
+	return backupDir, nil
+}
+
+// backup copies target into <root>/.companion/backups/<ts>/<relpath> when it
+// exists, returning the backup directory (the <ts> root). It returns "" when the
+// target does not exist (nothing to back up).
+func (w *TomlWriter) backup(target string) (string, error) {
+	if _, err := os.Stat(target); err != nil {
+		if os.IsNotExist(err) {
+			return "", nil
+		}
+		return "", err
+	}
+	rel, err := filepath.Rel(w.root, target)
+	if err != nil {
+		return "", err
+	}
+	if strings.HasPrefix(rel, "..") {
+		return "", fmt.Errorf("refusing to back up path outside workspace: %s", target)
+	}
+	ts := backupStamp(w.clock())
+	backupDir := filepath.Join(w.root, ".companion", "backups", ts)
+	dest := filepath.Join(backupDir, rel)
+	if err := os.MkdirAll(filepath.Dir(dest), 0o755); err != nil {
+		return "", err
+	}
+	data, err := os.ReadFile(target)
+	if err != nil {
+		return "", err
+	}
+	if err := os.WriteFile(dest, data, 0o644); err != nil {
+		return "", err
+	}
+	return backupDir, nil
+}
+
+// backupStamp renders a filesystem-safe, sortable timestamp for backup dir
+// names. It is derived from the injected clock so tests get deterministic paths.
+func backupStamp(t time.Time) string {
+	return t.UTC().Format("20060102T150405.000000000Z")
+}
+
+// validateID rejects empty ids and any id that could escape the workspace via
+// path traversal or separators, then defers cosmetic name rules to config.
+func validateID(id string) error {
+	id = strings.TrimSpace(id)
+	if id == "" {
+		return fmt.Errorf("agent id is required")
+	}
+	if id == "." || id == ".." || strings.ContainsAny(id, `/\`) || strings.Contains(id, "..") {
+		return fmt.Errorf("invalid agent id %q: path traversal not allowed", id)
+	}
+	return nil
+}
+
+// validateAgentNames reuses the config package's validation by normalizing a
+// minimal one-agent config. Any name/shape error config.Validate would raise for
+// id, fly_app, or tailscale_hostname surfaces here, so the writer never produces
+// a file the loader would reject for those fields.
+func validateAgentNames(id, flyApp, tailscaleHostname, runtime, network, modelProvider, lifecycle string) error {
+	raw := config.RawConfig{
+		Agents: []config.RawAgent{{
+			ID:                strPtr(id),
+			FlyApp:            strPtr(flyApp),
+			TailscaleHostname: strPtr(tailscaleHostname),
+			Runtime:           strPtr(runtime),
+			Network:           strPtr(network),
+			ModelProvider:     strPtr(modelProvider),
+			Lifecycle:         strPtr(lifecycle),
+		}},
+	}
+	if _, err := config.Normalize(raw); err != nil {
+		return err
+	}
+	return nil
+}
+
+func firstNonEmpty(values ...string) string {
+	for _, v := range values {
+		if s := strings.TrimSpace(v); s != "" {
+			return s
+		}
+	}
+	return ""
+}
+
+func strPtr(v string) *string { return &v }
+func boolPtr(v bool) *bool    { return &v }
+func intPtr(v int) *int       { return &v }

--- a/internal/console/tomlwriter_test.go
+++ b/internal/console/tomlwriter_test.go
@@ -1,0 +1,414 @@
+package console
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/pelletier/go-toml/v2"
+
+	"github.com/The-Vibe-Company/companion/internal/workspace"
+)
+
+// fixedClock returns a deterministic clock for backup-path assertions.
+func fixedClock(t time.Time) func() time.Time {
+	return func() time.Time { return t }
+}
+
+var testStamp = time.Date(2026, 6, 4, 12, 30, 45, 123456789, time.UTC)
+
+// newTestWorkspace lays down a minimal but complete Companion workspace under a
+// fresh temp dir and returns its root. It mirrors examples/minimal so files the
+// console writes re-load through workspace.Load + Validate.
+func newTestWorkspace(t *testing.T) string {
+	t.Helper()
+	root := t.TempDir()
+	writeWS(t, root, "companion.toml", `workspace = "console-test"
+
+[backend.local]
+state = ".companion/state.sqlite"
+
+[load]
+providers = "providers.toml"
+defaults = "defaults.toml"
+webui = "webui.toml"
+agents = "agents/*.toml"
+vaults = "vaults/*.toml"
+`)
+	writeWS(t, root, "providers.toml", `[fly.default]
+region = "cdg"
+token_env = "FLY_API_TOKEN"
+
+[tailscale.default]
+api_key_env = "TAILSCALE_API_KEY"
+auth_key_secret = "TS_AUTHKEY"
+
+[openrouter.default]
+base_url = "https://openrouter.ai/api/v1"
+api_key_env = "OPENROUTER_API_KEY"
+`)
+	writeWS(t, root, "defaults.toml", `[defaults]
+region = "cdg"
+
+[defaults.model]
+enabled = true
+default = "google/gemini-3.5-flash"
+api_key_secret_name = "OPENROUTER_API_KEY"
+api_key_env = "OPENROUTER_API_KEY"
+
+[defaults.default_vault]
+enabled = true
+name = "Default"
+mcp_enabled = true
+mcp_role = "write"
+
+[defaults.companion_soul]
+enabled = true
+text = "Fleet rule: persist durable learnings to Granite."
+`)
+	writeWS(t, root, "webui.toml", `[open_webui]
+enabled = false
+`)
+	return root
+}
+
+func writeWS(t *testing.T, root, name, content string) {
+	t.Helper()
+	p := filepath.Join(root, filepath.FromSlash(name))
+	if err := os.MkdirAll(filepath.Dir(p), 0o755); err != nil {
+		t.Fatalf("mkdir %s: %v", name, err)
+	}
+	if err := os.WriteFile(p, []byte(strings.TrimSpace(content)+"\n"), 0o644); err != nil {
+		t.Fatalf("write %s: %v", name, err)
+	}
+}
+
+// writeAgentInput is the create flow the API layer performs: build the file,
+// write its soul (if any), write the TOML.
+func writeAgentInput(t *testing.T, w *TomlWriter, in AgentInput) {
+	t.Helper()
+	file, err := w.BuildAgentFile(in)
+	if err != nil {
+		t.Fatalf("BuildAgentFile(%s): %v", in.ID, err)
+	}
+	if strings.TrimSpace(in.Soul) != "" {
+		if _, err := w.WriteSoul(in.ID, in.Soul); err != nil {
+			t.Fatalf("WriteSoul(%s): %v", in.ID, err)
+		}
+	}
+	if _, err := w.WriteAgent(in.ID, file); err != nil {
+		t.Fatalf("WriteAgent(%s): %v", in.ID, err)
+	}
+}
+
+func TestTOMLWriterCreateLoadsAndValidates(t *testing.T) {
+	root := newTestWorkspace(t)
+	w := NewTomlWriter(root, fixedClock(testStamp))
+
+	enabled := true
+	writeAgentInput(t, w, AgentInput{
+		ID:                   "alpha-agent",
+		Model:                "anthropic/claude-3.7-sonnet",
+		Region:               "cdg",
+		FlyApp:               "alpha-companion-agent",
+		TailscaleHostname:    "alpha-agent",
+		Soul:                 "You are Alpha. Persist learnings to Granite.",
+		CompanionSoulEnabled: &enabled,
+		VaultName:            "Alpha Vault",
+	})
+
+	// The written file must re-load through the real workspace loader+validator.
+	ws, err := workspace.Load(root)
+	if err != nil {
+		t.Fatalf("workspace.Load after create: %v", err)
+	}
+	if got := len(ws.Config.Agents); got != 1 {
+		t.Fatalf("agent count = %d, want 1", got)
+	}
+	agent := ws.Config.Agents[0]
+	if agent.ID != "alpha-agent" {
+		t.Errorf("agent id = %q, want alpha-agent", agent.ID)
+	}
+	if agent.FlyApp != "alpha-companion-agent" {
+		t.Errorf("fly_app = %q, want alpha-companion-agent", agent.FlyApp)
+	}
+	if agent.Model.Default != "anthropic/claude-3.7-sonnet" {
+		t.Errorf("model.default = %q, want anthropic/claude-3.7-sonnet", agent.Model.Default)
+	}
+	if agent.DefaultVault.Name != "Alpha Vault" {
+		t.Errorf("default_vault.name = %q, want Alpha Vault", agent.DefaultVault.Name)
+	}
+	if !agent.CompanionSoul.Enabled {
+		t.Errorf("companion_soul.enabled = false, want true")
+	}
+	if !agent.Identity.Enabled {
+		t.Errorf("identity.enabled = false, want true (soul provided)")
+	}
+	if agent.Identity.Path != "identities/alpha-agent/SOUL.md" {
+		t.Errorf("identity.path = %q, want identities/alpha-agent/SOUL.md", agent.Identity.Path)
+	}
+
+	// The SOUL.md is on disk for apply to render.
+	soul, err := os.ReadFile(w.SoulPath("alpha-agent"))
+	if err != nil {
+		t.Fatalf("read SOUL.md: %v", err)
+	}
+	if !strings.Contains(string(soul), "You are Alpha.") {
+		t.Errorf("SOUL.md missing expected content: %q", soul)
+	}
+}
+
+func TestTOMLWriterCompanionSoulDisable(t *testing.T) {
+	root := newTestWorkspace(t)
+	w := NewTomlWriter(root, fixedClock(testStamp))
+
+	// The fleet defaults enable companion_soul; the per-agent knob disables it.
+	disabled := false
+	writeAgentInput(t, w, AgentInput{ID: "theta-agent", CompanionSoulEnabled: &disabled})
+
+	ws, err := workspace.Load(root)
+	if err != nil {
+		t.Fatalf("workspace.Load: %v", err)
+	}
+	if ws.Config.Agents[0].CompanionSoul.Enabled {
+		t.Errorf("companion_soul.enabled = true, want false (per-agent disable)")
+	}
+
+	// An agent that says nothing inherits the fleet default (enabled).
+	writeAgentInput(t, w, AgentInput{ID: "iota-agent"})
+	ws2, err := workspace.Load(root)
+	if err != nil {
+		t.Fatalf("workspace.Load: %v", err)
+	}
+	for _, a := range ws2.Config.Agents {
+		if a.ID == "iota-agent" && !a.CompanionSoul.Enabled {
+			t.Errorf("iota-agent companion_soul.enabled = false, want true (inherited default)")
+		}
+	}
+}
+
+func TestTOMLWriterCreateAppliesDefaults(t *testing.T) {
+	root := newTestWorkspace(t)
+	w := NewTomlWriter(root, fixedClock(testStamp))
+
+	// Only id supplied: fly_app/tailscale_hostname/runtime/network/model_provider/
+	// lifecycle must fall back to console defaults that mirror examples/minimal.
+	writeAgentInput(t, w, AgentInput{ID: "beta-agent"})
+
+	ws, err := workspace.Load(root)
+	if err != nil {
+		t.Fatalf("workspace.Load: %v", err)
+	}
+	agent := ws.Config.Agents[0]
+	checks := map[string]string{
+		"runtime":            agent.Runtime,
+		"network":            agent.Network,
+		"model_provider":     agent.ModelProvider,
+		"lifecycle":          agent.Lifecycle,
+		"fly_app":            agent.FlyApp,
+		"tailscale_hostname": agent.TailscaleHostname,
+	}
+	want := map[string]string{
+		"runtime":            "fly.default",
+		"network":            "tailscale.default",
+		"model_provider":     "openrouter.default",
+		"lifecycle":          "present",
+		"fly_app":            "beta-agent",
+		"tailscale_hostname": "beta-agent",
+	}
+	for k, v := range want {
+		if checks[k] != v {
+			t.Errorf("%s = %q, want %q", k, checks[k], v)
+		}
+	}
+}
+
+func TestTOMLWriterUpdateBacksUpBeforeOverwrite(t *testing.T) {
+	root := newTestWorkspace(t)
+	w := NewTomlWriter(root, fixedClock(testStamp))
+
+	writeAgentInput(t, w, AgentInput{ID: "gamma-agent", Memory: "2gb"})
+	original, err := os.ReadFile(w.AgentPath("gamma-agent"))
+	if err != nil {
+		t.Fatalf("read original: %v", err)
+	}
+
+	// First write created the file: no backup expected.
+	file, err := w.BuildAgentFile(AgentInput{ID: "gamma-agent", Memory: "8gb"})
+	if err != nil {
+		t.Fatalf("BuildAgentFile: %v", err)
+	}
+	backupDir, err := w.WriteAgent("gamma-agent", file)
+	if err != nil {
+		t.Fatalf("WriteAgent (overwrite): %v", err)
+	}
+
+	// Overwriting an existing file must produce a deterministic backup path.
+	wantBackupDir := filepath.Join(root, ".companion", "backups", backupStamp(testStamp))
+	if backupDir != wantBackupDir {
+		t.Fatalf("backupDir = %q, want %q", backupDir, wantBackupDir)
+	}
+	backupFile := filepath.Join(backupDir, "agents", "gamma-agent.toml")
+	saved, err := os.ReadFile(backupFile)
+	if err != nil {
+		t.Fatalf("read backup: %v", err)
+	}
+	if string(saved) != string(original) {
+		t.Errorf("backup content mismatch:\n got %q\nwant %q", saved, original)
+	}
+
+	// The live file now reflects the update and still loads.
+	ws, err := workspace.Load(root)
+	if err != nil {
+		t.Fatalf("workspace.Load after update: %v", err)
+	}
+	if ws.Config.Agents[0].Memory != "8gb" {
+		t.Errorf("memory = %q, want 8gb", ws.Config.Agents[0].Memory)
+	}
+}
+
+func TestTOMLWriterDeleteSetsAbsentKeepsFile(t *testing.T) {
+	root := newTestWorkspace(t)
+	w := NewTomlWriter(root, fixedClock(testStamp))
+
+	writeAgentInput(t, w, AgentInput{ID: "delta-agent"})
+
+	backupDir, err := w.SetLifecycleAbsent("delta-agent")
+	if err != nil {
+		t.Fatalf("SetLifecycleAbsent: %v", err)
+	}
+	if backupDir == "" {
+		t.Fatalf("expected a backup when rewriting an existing file")
+	}
+
+	// The file must still exist (delete is soft: lifecycle=absent).
+	target := w.AgentPath("delta-agent")
+	if _, err := os.Stat(target); err != nil {
+		t.Fatalf("agent file must remain after delete: %v", err)
+	}
+
+	ws, err := workspace.Load(root)
+	if err != nil {
+		t.Fatalf("workspace.Load after delete: %v", err)
+	}
+	if got := ws.Config.Agents[0].Lifecycle; got != "absent" {
+		t.Errorf("lifecycle = %q, want absent", got)
+	}
+
+	// Sanity: the raw TOML carries lifecycle = "absent".
+	data, err := os.ReadFile(target)
+	if err != nil {
+		t.Fatalf("read agent: %v", err)
+	}
+	var file agentTOMLFile
+	if err := toml.Unmarshal(data, &file); err != nil {
+		t.Fatalf("unmarshal agent: %v", err)
+	}
+	if file.Agent.Lifecycle == nil || *file.Agent.Lifecycle != "absent" {
+		t.Errorf("[agent].lifecycle in file = %v, want absent", file.Agent.Lifecycle)
+	}
+}
+
+func TestTOMLWriterRejectsInvalidID(t *testing.T) {
+	root := newTestWorkspace(t)
+	w := NewTomlWriter(root, fixedClock(testStamp))
+
+	cases := []struct {
+		name string
+		id   string
+	}{
+		{"empty", ""},
+		{"path traversal", "../escape"},
+		{"slash", "team/agent"},
+		{"dot dot", "a..b"},
+		{"uppercase", "BadAgent"},
+		{"leading hyphen", "-bad"},
+		{"underscore", "bad_agent"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if _, err := w.BuildAgentFile(AgentInput{ID: tc.id}); err == nil {
+				t.Fatalf("BuildAgentFile(%q) = nil error, want rejection", tc.id)
+			}
+		})
+	}
+
+	// No agent file should have been created for the traversal attempt.
+	if _, err := os.Stat(filepath.Join(root, "agents")); err == nil {
+		entries, _ := os.ReadDir(filepath.Join(root, "agents"))
+		if len(entries) != 0 {
+			t.Errorf("invalid ids must not write files, found %d entries", len(entries))
+		}
+	}
+}
+
+func TestTOMLWriterFixedClockDeterministicBackupPath(t *testing.T) {
+	root := newTestWorkspace(t)
+	stamp := time.Date(2026, 1, 2, 3, 4, 5, 0, time.UTC)
+	w := NewTomlWriter(root, fixedClock(stamp))
+
+	writeAgentInput(t, w, AgentInput{ID: "epsilon-agent"})
+	file, err := w.BuildAgentFile(AgentInput{ID: "epsilon-agent", Memory: "1gb"})
+	if err != nil {
+		t.Fatalf("BuildAgentFile: %v", err)
+	}
+	backupDir, err := w.WriteAgent("epsilon-agent", file)
+	if err != nil {
+		t.Fatalf("WriteAgent: %v", err)
+	}
+
+	want := filepath.Join(root, ".companion", "backups", "20260102T030405.000000000Z")
+	if backupDir != want {
+		t.Fatalf("backupDir = %q, want %q", backupDir, want)
+	}
+}
+
+func TestTOMLWriterRestoreRollsBack(t *testing.T) {
+	root := newTestWorkspace(t)
+	w := NewTomlWriter(root, fixedClock(testStamp))
+
+	writeAgentInput(t, w, AgentInput{ID: "zeta-agent", Memory: "2gb"})
+	original, err := os.ReadFile(w.AgentPath("zeta-agent"))
+	if err != nil {
+		t.Fatalf("read original: %v", err)
+	}
+
+	// Overwrite (captures a backup), then restore from it.
+	file, err := w.BuildAgentFile(AgentInput{ID: "zeta-agent", Memory: "16gb"})
+	if err != nil {
+		t.Fatalf("BuildAgentFile: %v", err)
+	}
+	backupDir, err := w.WriteAgent("zeta-agent", file)
+	if err != nil {
+		t.Fatalf("WriteAgent: %v", err)
+	}
+	if err := w.Restore(backupDir); err != nil {
+		t.Fatalf("Restore: %v", err)
+	}
+	restored, err := os.ReadFile(w.AgentPath("zeta-agent"))
+	if err != nil {
+		t.Fatalf("read restored: %v", err)
+	}
+	if string(restored) != string(original) {
+		t.Errorf("after restore content mismatch:\n got %q\nwant %q", restored, original)
+	}
+}
+
+func TestTOMLWriterRemoveAgentRollsBackCreate(t *testing.T) {
+	root := newTestWorkspace(t)
+	w := NewTomlWriter(root, fixedClock(testStamp))
+
+	writeAgentInput(t, w, AgentInput{ID: "eta-agent"})
+	if err := w.RemoveAgent("eta-agent"); err != nil {
+		t.Fatalf("RemoveAgent: %v", err)
+	}
+	if _, err := os.Stat(w.AgentPath("eta-agent")); !os.IsNotExist(err) {
+		t.Fatalf("expected agent file removed, stat err = %v", err)
+	}
+	// Removing a missing file is tolerated.
+	if err := w.RemoveAgent("eta-agent"); err != nil {
+		t.Fatalf("RemoveAgent (missing) = %v, want nil", err)
+	}
+}

--- a/internal/console/tomlwriter_test.go
+++ b/internal/console/tomlwriter_test.go
@@ -412,3 +412,137 @@ func TestTOMLWriterRemoveAgentRollsBackCreate(t *testing.T) {
 		t.Fatalf("RemoveAgent (missing) = %v, want nil", err)
 	}
 }
+
+// richAgentTOML is a hand-authored agent file that uses fields the console form
+// does NOT model (volume sizing, dashboard/granite settings, [api_server],
+// [[vault_connections]]). The writer must preserve all of them across a
+// structured update and a lifecycle=absent delete.
+const richAgentTOML = `[agent]
+id = "rich"
+runtime = "fly.default"
+network = "tailscale.default"
+model_provider = "openrouter.default"
+lifecycle = "present"
+fly_app = "rich-app"
+tailscale_hostname = "rich"
+memory = "2gb"
+volume_size_gb = 7
+dashboard_mode = "serve"
+granite_enabled = true
+ts_extra_args = "--netfilter-mode=off"
+
+[api_server]
+enabled = true
+port = 8642
+
+[[vault_connections]]
+name = "shared"
+mode = "write"
+host = "vault.local"
+`
+
+func writeRawAgent(t *testing.T, w *TomlWriter, id, content string) {
+	t.Helper()
+	p := w.AgentPath(id)
+	if err := os.MkdirAll(filepath.Dir(p), 0o755); err != nil {
+		t.Fatalf("mkdir agents: %v", err)
+	}
+	if err := os.WriteFile(p, []byte(content), 0o644); err != nil {
+		t.Fatalf("write %s: %v", p, err)
+	}
+}
+
+func readFileString(t *testing.T, p string) string {
+	t.Helper()
+	b, err := os.ReadFile(p)
+	if err != nil {
+		t.Fatalf("read %s: %v", p, err)
+	}
+	return string(b)
+}
+
+// preservedKeys are the unmodeled tokens that must survive a console update or
+// delete of richAgentTOML. We assert on key names and distinctive values rather
+// than exact rendering, so the check is spacing/quote-agnostic.
+var preservedKeys = []string{
+	"volume_size_gb", "dashboard_mode", "granite_enabled",
+	"ts_extra_args", "api_server", "8642", "vault_connections", "vault.local",
+}
+
+func TestTOMLWriterUpdatePreservesUnmodeledFields(t *testing.T) {
+	root := t.TempDir()
+	w := NewTomlWriter(root, fixedClock(testStamp))
+	writeRawAgent(t, w, "rich", richAgentTOML)
+
+	// Edit only memory through the structured form.
+	file, err := w.MergeAgentFile("rich", AgentInput{ID: "rich", Memory: "4gb"})
+	if err != nil {
+		t.Fatalf("MergeAgentFile: %v", err)
+	}
+	if _, err := w.WriteAgent("rich", file); err != nil {
+		t.Fatalf("WriteAgent: %v", err)
+	}
+
+	out := readFileString(t, w.AgentPath("rich"))
+	if !strings.Contains(out, "4gb") {
+		t.Fatalf("update did not apply memory=4gb:\n%s", out)
+	}
+	if strings.Contains(out, "2gb") {
+		t.Fatalf("update left the stale memory value:\n%s", out)
+	}
+	for _, want := range preservedKeys {
+		if !strings.Contains(out, want) {
+			t.Fatalf("update dropped unmodeled field %q:\n%s", want, out)
+		}
+	}
+	// The merged file must still parse as a valid agent file.
+	var parsed agentTOMLFile
+	if err := toml.Unmarshal([]byte(out), &parsed); err != nil {
+		t.Fatalf("merged file does not re-parse: %v", err)
+	}
+}
+
+func TestTOMLWriterDeletePreservesUnmodeledFields(t *testing.T) {
+	root := t.TempDir()
+	w := NewTomlWriter(root, fixedClock(testStamp))
+	writeRawAgent(t, w, "rich", richAgentTOML)
+
+	if _, err := w.SetLifecycleAbsent("rich"); err != nil {
+		t.Fatalf("SetLifecycleAbsent: %v", err)
+	}
+
+	out := readFileString(t, w.AgentPath("rich"))
+	if !strings.Contains(out, "absent") {
+		t.Fatalf("delete did not set lifecycle=absent:\n%s", out)
+	}
+	for _, want := range preservedKeys {
+		if !strings.Contains(out, want) {
+			t.Fatalf("delete dropped unmodeled field %q:\n%s", want, out)
+		}
+	}
+}
+
+func TestTOMLWriterRemoveSoulDropsFileAndEmptyDir(t *testing.T) {
+	root := t.TempDir()
+	w := NewTomlWriter(root, fixedClock(testStamp))
+
+	if _, err := w.WriteSoul("gamma", "You are gamma."); err != nil {
+		t.Fatalf("WriteSoul: %v", err)
+	}
+	if _, err := os.Stat(w.SoulPath("gamma")); err != nil {
+		t.Fatalf("soul not written: %v", err)
+	}
+	if err := w.RemoveSoul("gamma"); err != nil {
+		t.Fatalf("RemoveSoul: %v", err)
+	}
+	if _, err := os.Stat(w.SoulPath("gamma")); !os.IsNotExist(err) {
+		t.Fatalf("soul file not removed, stat err = %v", err)
+	}
+	if _, err := os.Stat(filepath.Dir(w.SoulPath("gamma"))); !os.IsNotExist(err) {
+		t.Fatalf("empty identity dir not removed, stat err = %v", err)
+	}
+	// Removing a missing soul is tolerated.
+	if err := w.RemoveSoul("gamma"); err != nil {
+		t.Fatalf("RemoveSoul (missing) = %v, want nil", err)
+	}
+}

--- a/internal/console/types.go
+++ b/internal/console/types.go
@@ -1,0 +1,141 @@
+package console
+
+import (
+	"encoding/json"
+	"time"
+)
+
+// WorkspaceInfo summarizes the loaded workspace for the console UI. Provider
+// credentials are redacted to names + presence only; secret values never leave
+// the process.
+type WorkspaceInfo struct {
+	Name       string         `json:"name"`
+	Root       string         `json:"root"`
+	AgentCount int            `json:"agent_count"`
+	Providers  []ProviderCred `json:"providers"`
+}
+
+// ProviderCred is a redacted provider credential: the environment variable name
+// and whether it is currently present, never the value.
+type ProviderCred struct {
+	Name    string `json:"name"`
+	Present bool   `json:"present"`
+}
+
+// AgentSummary is the list-row view of a fleet agent. The health/fly_state/url/
+// last_deploy fields are enriched from a status snapshot when one is available
+// and otherwise stay zero, so listing never requires live network access.
+type AgentSummary struct {
+	ID                string `json:"id"`
+	Model             string `json:"model"`
+	FlyApp            string `json:"fly_app"`
+	TailscaleHostname string `json:"tailscale_hostname"`
+	Vault             string `json:"vault"`
+	Lifecycle         string `json:"lifecycle"`
+	Health            string `json:"health,omitempty"`
+	FlyState          string `json:"fly_state,omitempty"`
+	URL               string `json:"url,omitempty"`
+	LastDeploy        string `json:"last_deploy,omitempty"`
+}
+
+// AgentDetail is the full single-agent view edited by the console.
+type AgentDetail struct {
+	AgentSummary
+	Region               string   `json:"region"`
+	Memory               string   `json:"memory"`
+	CPUs                 int      `json:"cpus"`
+	Runtime              string   `json:"runtime"`
+	Network              string   `json:"network"`
+	ModelProvider        string   `json:"model_provider"`
+	SoulPreview          string   `json:"soul_preview"`
+	CompanionSoulEnabled bool     `json:"companion_soul_enabled"`
+	VaultConnections     []string `json:"vault_connections"`
+}
+
+// AgentInput is the structured payload the UI sends to create or update an
+// agent. Omitted optional fields fall back to sensible defaults that mirror
+// examples/minimal.
+type AgentInput struct {
+	ID                   string `json:"id"`
+	Name                 string `json:"name"`
+	Model                string `json:"model"`
+	Memory               string `json:"memory"`
+	CPUs                 int    `json:"cpus"`
+	Region               string `json:"region"`
+	TailscaleHostname    string `json:"tailscale_hostname"`
+	FlyApp               string `json:"fly_app"`
+	Runtime              string `json:"runtime"`
+	Network              string `json:"network"`
+	ModelProvider        string `json:"model_provider"`
+	Lifecycle            string `json:"lifecycle"`
+	Soul                 string `json:"soul"`
+	CompanionSoulEnabled *bool  `json:"companion_soul_enabled,omitempty"`
+	VaultName            string `json:"vault_name"`
+}
+
+// PlanChange is one line of a computed plan, redacted to the safe fields the UI
+// renders.
+type PlanChange struct {
+	Kind      string `json:"kind"`
+	Action    string `json:"action"`
+	Address   string `json:"address"`
+	Message   string `json:"message"`
+	Protected bool   `json:"protected"`
+}
+
+// PlanResponse is the result of POST /api/console/plan. Hash is the sha256 of
+// the canonical plan JSON; apply must echo it back to guard against stale plans.
+type PlanResponse struct {
+	Hash    string       `json:"hash"`
+	Text    string       `json:"text"`
+	Changes []PlanChange `json:"changes"`
+}
+
+// ApplyRequest is the body of POST /api/console/apply.
+type ApplyRequest struct {
+	Hash string `json:"hash"`
+}
+
+// ApplyResponse returns the async operation id to poll.
+type ApplyResponse struct {
+	OperationID string `json:"operation_id"`
+}
+
+// OperationStatus is the polled state of an async apply operation.
+type OperationStatus struct {
+	ID               string   `json:"id"`
+	State            string   `json:"state"`
+	StartedAt        string   `json:"started_at,omitempty"`
+	FinishedAt       string   `json:"finished_at,omitempty"`
+	ChangedResources []string `json:"changed_resources"`
+	Error            string   `json:"error,omitempty"`
+}
+
+// ApplyHistoryEntry is a past apply row from the state applies table.
+type ApplyHistoryEntry struct {
+	ID         int64  `json:"id"`
+	StartedAt  string `json:"started_at"`
+	FinishedAt string `json:"finished_at,omitempty"`
+	Status     string `json:"status"`
+}
+
+// LogsResponse returns recent offline state events for an agent. Live Fly/agent
+// task logs are a later Hermes feature.
+type LogsResponse struct {
+	AgentID string   `json:"agent_id"`
+	Lines   []string `json:"lines"`
+	Source  string   `json:"source"`
+	Note    string   `json:"note"`
+}
+
+// Operation is the in-memory record of an async apply tracked by the
+// OperationRunner.
+type Operation struct {
+	ID         string          `json:"id"`
+	State      string          `json:"state"`
+	StartedAt  time.Time       `json:"started_at"`
+	FinishedAt time.Time       `json:"finished_at"`
+	Changed    []string        `json:"changed"`
+	PlanJSON   json.RawMessage `json:"plan_json,omitempty"`
+	Error      string          `json:"error,omitempty"`
+}

--- a/internal/console/types.go
+++ b/internal/console/types.go
@@ -89,6 +89,26 @@ type PlanResponse struct {
 	Hash    string       `json:"hash"`
 	Text    string       `json:"text"`
 	Changes []PlanChange `json:"changes"`
+	// RequiresProtectedConfirm is true when the plan destroys (or is blocked from
+	// destroying) a protected resource, so the UI must collect an explicit
+	// confirmation before apply.
+	RequiresProtectedConfirm bool `json:"requires_protected_confirm"`
+	// RequiresDestroyData is true when the plan destroys a Fly volume, so the UI
+	// must collect a separate persistent-data confirmation.
+	RequiresDestroyData bool `json:"requires_destroy_data"`
+}
+
+// PlanRequest is the optional body of POST /api/console/plan. The destroy
+// confirmations default to false, so an absent body plans safely: protected
+// resources marked for destruction show as blocked rather than being removed.
+type PlanRequest struct {
+	// AllowProtectedDestroy permits destroying resources marked protect=true (the
+	// default for agents); without it a lifecycle="absent" agent's resources are
+	// reported as blocked.
+	AllowProtectedDestroy bool `json:"allow_protected_destroy"`
+	// DestroyData permits destroying persistent data (Fly volumes). The console
+	// always pairs it with a backup-first acknowledgement.
+	DestroyData bool `json:"destroy_data"`
 }
 
 // ApplyRequest is the body of POST /api/console/apply.

--- a/web/.gitignore
+++ b/web/.gitignore
@@ -1,0 +1,3 @@
+node_modules
+dist
+*.local

--- a/web/index.html
+++ b/web/index.html
@@ -1,0 +1,22 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Companion Console</title>
+    <!--
+      Token sentinels. The Go console replaces %%CONSOLE_TOKEN%% with the
+      per-process session token when it serves this file in production. In dev
+      the Vite-served HTML keeps the literal sentinel and the API client falls
+      back to GET /api/console/session.
+    -->
+    <meta name="console-token" content="%%CONSOLE_TOKEN%%" />
+    <script>
+      window.__CONSOLE_TOKEN__ = "%%CONSOLE_TOKEN%%";
+    </script>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/main.tsx"></script>
+  </body>
+</html>

--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -1,0 +1,3730 @@
+{
+  "name": "companion-console",
+  "version": "0.1.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "companion-console",
+      "version": "0.1.0",
+      "license": "MIT",
+      "dependencies": {
+        "react": "^19.0.0",
+        "react-dom": "^19.0.0",
+        "react-router-dom": "^7.1.0"
+      },
+      "devDependencies": {
+        "@tailwindcss/vite": "^4.0.0",
+        "@testing-library/jest-dom": "^6.9.1",
+        "@testing-library/react": "^16.3.2",
+        "@testing-library/user-event": "^14.6.1",
+        "@types/node": "^22.10.0",
+        "@types/react": "^19.0.0",
+        "@types/react-dom": "^19.0.0",
+        "@vitejs/plugin-react": "^4.4.0",
+        "jsdom": "^28.0.0",
+        "tailwindcss": "^4.0.0",
+        "typescript": "^5.9.3",
+        "vite": "^6.3.0",
+        "vitest": "^4.0.18"
+      }
+    },
+    "node_modules/@acemir/cssom": {
+      "version": "0.9.31",
+      "resolved": "https://registry.npmjs.org/@acemir/cssom/-/cssom-0.9.31.tgz",
+      "integrity": "sha512-ZnR3GSaH+/vJ0YlHau21FjfLYjMpYVIzTD8M8vIEQvIGxeOXyXdzCI140rrCY862p/C/BbzWsjc1dgnM9mkoTA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@adobe/css-tools": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/@adobe/css-tools/-/css-tools-4.5.0.tgz",
+      "integrity": "sha512-6OzddxPio9UiWTCemp4N8cYLV2ZN1ncRnV1cVGtve7dhPOtRkleRyx32GQCYSwDYgaHU3USMm84tNsvKzRCa1Q==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@asamuzakjp/css-color": {
+      "version": "5.1.11",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/css-color/-/css-color-5.1.11.tgz",
+      "integrity": "sha512-KVw6qIiCTUQhByfTd78h2yD1/00waTmm9uy/R7Ck/ctUyAPj+AEDLkQIdJW0T8+qGgj3j5bpNKK7Q3G+LedJWg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@asamuzakjp/generational-cache": "^1.0.1",
+        "@csstools/css-calc": "^3.2.0",
+        "@csstools/css-color-parser": "^4.1.0",
+        "@csstools/css-parser-algorithms": "^4.0.0",
+        "@csstools/css-tokenizer": "^4.0.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@asamuzakjp/dom-selector": {
+      "version": "6.8.1",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/dom-selector/-/dom-selector-6.8.1.tgz",
+      "integrity": "sha512-MvRz1nCqW0fsy8Qz4dnLIvhOlMzqDVBabZx6lH+YywFDdjXhMY37SmpV1XFX3JzG5GWHn63j6HX6QPr3lZXHvQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@asamuzakjp/nwsapi": "^2.3.9",
+        "bidi-js": "^1.0.3",
+        "css-tree": "^3.1.0",
+        "is-potential-custom-element-name": "^1.0.1",
+        "lru-cache": "^11.2.6"
+      }
+    },
+    "node_modules/@asamuzakjp/dom-selector/node_modules/lru-cache": {
+      "version": "11.5.1",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.5.1.tgz",
+      "integrity": "sha512-RPimw/7aMdv2oqRrxKwvZXcPfwBrn/JZ2xYcY9Hus/6LaS3VOAKVWKWgNLCFSiOm1ESXinjsDlidVU7JlnCN2A==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": "20 || >=22"
+      }
+    },
+    "node_modules/@asamuzakjp/generational-cache": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/generational-cache/-/generational-cache-1.0.1.tgz",
+      "integrity": "sha512-wajfB8KqzMCN2KGNFdLkReeHncd0AslUSrvHVvvYWuU8ghncRJoA50kT3zP9MVL0+9g4/67H+cdvBskj9THPzg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@asamuzakjp/nwsapi": {
+      "version": "2.3.9",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/nwsapi/-/nwsapi-2.3.9.tgz",
+      "integrity": "sha512-n8GuYSrI9bF7FFZ/SjhwevlHc8xaVlb/7HmHelnc/PZXBD2ZR49NnN9sMMuDdEGPeeRQ5d0hqlSlEpgCX3Wl0Q==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@babel/code-frame": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.29.7.tgz",
+      "integrity": "sha512-Aup7aUOfpbAUg2ROOJN6Iw5f9DMBlzu0mIkm/malLQFN/YQgO48wCj0Kxa3sEHJvPVFg7siR+qRInwXd2qhQKw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-validator-identifier": "^7.29.7",
+        "js-tokens": "^4.0.0",
+        "picocolors": "^1.1.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/compat-data": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.29.7.tgz",
+      "integrity": "sha512-locTkQyKvwIEgBzVrn8693ebc97F2U8ZHjbXwDXJ5Fn2TCpNwTlKcaKLkdHop5c/icOFE7qt7Q9JC5hnKNa6Gg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/core": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.29.7.tgz",
+      "integrity": "sha512-RgHBCvtjbOK2gXSNBNIkNoEc9qoVEtau3hj8gEqKQuL3HZAibKarWFEI3Lfm6EYKkLalOh8eSrj9b+ch9H/VBA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.29.7",
+        "@babel/generator": "^7.29.7",
+        "@babel/helper-compilation-targets": "^7.29.7",
+        "@babel/helper-module-transforms": "^7.29.7",
+        "@babel/helpers": "^7.29.7",
+        "@babel/parser": "^7.29.7",
+        "@babel/template": "^7.29.7",
+        "@babel/traverse": "^7.29.7",
+        "@babel/types": "^7.29.7",
+        "@jridgewell/remapping": "^2.3.5",
+        "convert-source-map": "^2.0.0",
+        "debug": "^4.1.0",
+        "gensync": "^1.0.0-beta.2",
+        "json5": "^2.2.3",
+        "semver": "^6.3.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/babel"
+      }
+    },
+    "node_modules/@babel/generator": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.29.7.tgz",
+      "integrity": "sha512-DkXD5OJQaAQIdZ1bt3UZdEnHAn9Imd3IVBdX03UFe+ony9Ojw5pzr9YVKGDY1jt+Gcn/FnGkNf8r+Vj5NOJWtQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.29.7",
+        "@babel/types": "^7.29.7",
+        "@jridgewell/gen-mapping": "^0.3.12",
+        "@jridgewell/trace-mapping": "^0.3.28",
+        "jsesc": "^3.0.2"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-compilation-targets": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.29.7.tgz",
+      "integrity": "sha512-wem6WaBj4NaVYVdNhLPPVacES6ZJ+KBBfSkTMD3YZxbP3rm3Di85tJU5ljaUNhaOynt+Aj0xruhYuzQBt8n71g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/compat-data": "^7.29.7",
+        "@babel/helper-validator-option": "^7.29.7",
+        "browserslist": "^4.24.0",
+        "lru-cache": "^5.1.1",
+        "semver": "^6.3.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-globals": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-globals/-/helper-globals-7.29.7.tgz",
+      "integrity": "sha512-3nQVUAtvkKH9zahfWgw96Jc/uFOmjACE1kQz82E2lqWmHBgjzbNlsC22nuQTfahmWeQtTq5nQ/4Nnd2A1wj4zA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-module-imports": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.29.7.tgz",
+      "integrity": "sha512-ejHwrQQYcm9xnTivShn2IDOlIzInN34AXskvq9QicvCtEzq1Vzclu/tKF8Jq1Cg8JG2GL6/EmjgsCT7lXepE3g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/traverse": "^7.29.7",
+        "@babel/types": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-module-transforms": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.29.7.tgz",
+      "integrity": "sha512-UPUVSyXbOh627KiCIGQSgwWzGeBKLkaJ9PJEdrngIwMSzxLR4jS4+f1f1jb7VzBbg8nFLaYotvVPFCTqdrmTAg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-module-imports": "^7.29.7",
+        "@babel/helper-validator-identifier": "^7.29.7",
+        "@babel/traverse": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0"
+      }
+    },
+    "node_modules/@babel/helper-plugin-utils": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.29.7.tgz",
+      "integrity": "sha512-G7sHYigPY17oO5SYWnfD/0MTBwVR781S/JI643e/JhUYgVgWE/61SoW3NH9KWUKyKq5LVh3npif99Wkt6j86Jw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-string-parser": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.29.7.tgz",
+      "integrity": "sha512-Pb5ijPrZ89GDH8223L4UP8i6QApWxs04RbPQJTeWDV0/keR2E36MeKnyr6LYmUUvqRRI+Iv87SuF1W6ErINzYw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-validator-identifier": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.29.7.tgz",
+      "integrity": "sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-validator-option": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.29.7.tgz",
+      "integrity": "sha512-N9ZErrD+yW5geCDtBqnOoxmR8+tNKiGuxKlDpuJxfsqpa2dFcexaziGAE/qoHLiDDreVNMupxGmSoNlyvsA3gw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helpers": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.29.7.tgz",
+      "integrity": "sha512-1k2lAGRMfHTcwuNYcCNUmaUffmQv8KWMfh2iJUUeRlwlwH4FdNG7mfPI10NPfLHJFThE4Tyr4mv7kTNZOiPuBg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/template": "^7.29.7",
+        "@babel/types": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/parser": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.7.tgz",
+      "integrity": "sha512-hnORnjP/1P/zFEndoeX+n+t1RwWRJiJpM/jO7FW32Kn9r5+sJB2JWOdYo4L6k78j15eCwY3Gm/7364B1EMwtNg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/types": "^7.29.7"
+      },
+      "bin": {
+        "parser": "bin/babel-parser.js"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-react-jsx-self": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx-self/-/plugin-transform-react-jsx-self-7.29.7.tgz",
+      "integrity": "sha512-TL0hMc9xzy86VD31nUiwzd5otRAcyEPcsegCxolO0PvcXuH1v0kECe/UIznYFihpkvU5wg/jk4v0TTEFfm53fw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-react-jsx-source": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx-source/-/plugin-transform-react-jsx-source-7.29.7.tgz",
+      "integrity": "sha512-06IyK09H3wi4cGbhDBwp5gUGo0IKtnYa8tyTiephirPCK6fbobVGiXMMI5zLQ4aKEYP3wZ3ArU44o+8KMrSG/Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/runtime": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.29.7.tgz",
+      "integrity": "sha512-Nq8OhGWiZIZGV6hLHoyAKLLcJihP/xFeBMGJoUrxTX2psI8dCifzLhZISFb+VWS3wFMRDmCGw5R+dOySCqPLhw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/template": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.29.7.tgz",
+      "integrity": "sha512-puq+Gf35oI24FeN11LkoUQFqv9uwNeWpxXZi/Ji3rRIoKAzKnxRaZ+Gkj0vKS9ZCiTESfng1N9LyOyXvo+m+Gg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.29.7",
+        "@babel/parser": "^7.29.7",
+        "@babel/types": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/traverse": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.29.7.tgz",
+      "integrity": "sha512-EhlfNQtZ+NK22w5BM61ciuiq1m58ed33Wr1Xan//ZRTy6hgjnwyCffRYwzsGXdASJSUJ1guZILsErh1eQcl+zw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.29.7",
+        "@babel/generator": "^7.29.7",
+        "@babel/helper-globals": "^7.29.7",
+        "@babel/parser": "^7.29.7",
+        "@babel/template": "^7.29.7",
+        "@babel/types": "^7.29.7",
+        "debug": "^4.3.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/types": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.7.tgz",
+      "integrity": "sha512-4zBIxpPzowiZpusoFkyGVwakdRJUyuH5PxQ/PrqghfdFWWasvnCdPfQXHrenDai+gyLARulZjZowCOj6fjT4pA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-string-parser": "^7.29.7",
+        "@babel/helper-validator-identifier": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@bramus/specificity": {
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/@bramus/specificity/-/specificity-2.4.2.tgz",
+      "integrity": "sha512-ctxtJ/eA+t+6q2++vj5j7FYX3nRu311q1wfYH3xjlLOsczhlhxAg2FWNUXhpGvAw3BWo1xBcvOV6/YLc2r5FJw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "css-tree": "^3.0.0"
+      },
+      "bin": {
+        "specificity": "bin/cli.js"
+      }
+    },
+    "node_modules/@csstools/color-helpers": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/@csstools/color-helpers/-/color-helpers-6.0.2.tgz",
+      "integrity": "sha512-LMGQLS9EuADloEFkcTBR3BwV/CGHV7zyDxVRtVDTwdI2Ca4it0CCVTT9wCkxSgokjE5Ho41hEPgb8OEUwoXr6Q==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT-0",
+      "engines": {
+        "node": ">=20.19.0"
+      }
+    },
+    "node_modules/@csstools/css-calc": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/@csstools/css-calc/-/css-calc-3.2.1.tgz",
+      "integrity": "sha512-DtdHlgXh5ZkA43cwBcAm+huzgJiwx3ZTWVjBs94kwz2xKqSimDA3lBgCjphYgwgVUMWatSM0pDd8TILB1yrVVg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^4.0.0",
+        "@csstools/css-tokenizer": "^4.0.0"
+      }
+    },
+    "node_modules/@csstools/css-color-parser": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/@csstools/css-color-parser/-/css-color-parser-4.1.1.tgz",
+      "integrity": "sha512-eZ5XOtyhK+mggRafYUWzA0tvaYOFgdY8AkgQiCJF9qNAePnUo/zmsqqYubBBb3sQ8uNUaSKTY9s9klfRaAXL0g==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@csstools/color-helpers": "^6.0.2",
+        "@csstools/css-calc": "^3.2.1"
+      },
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^4.0.0",
+        "@csstools/css-tokenizer": "^4.0.0"
+      }
+    },
+    "node_modules/@csstools/css-parser-algorithms": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-parser-algorithms/-/css-parser-algorithms-4.0.0.tgz",
+      "integrity": "sha512-+B87qS7fIG3L5h3qwJ/IFbjoVoOe/bpOdh9hAjXbvx0o8ImEmUsGXN0inFOnk2ChCFgqkkGFQ+TpM5rbhkKe4w==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "peerDependencies": {
+        "@csstools/css-tokenizer": "^4.0.0"
+      }
+    },
+    "node_modules/@csstools/css-syntax-patches-for-csstree": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@csstools/css-syntax-patches-for-csstree/-/css-syntax-patches-for-csstree-1.1.5.tgz",
+      "integrity": "sha512-oNjBvzLq2GPZtJphCjLqXow/cHySHSgtxvKZb7OqSZ/xHgw6NWNhfad+6AB9cLeVm6eA9d/qMll3JdEHjy6M+A==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT-0",
+      "peerDependencies": {
+        "css-tree": "^3.2.1"
+      },
+      "peerDependenciesMeta": {
+        "css-tree": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@csstools/css-tokenizer": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-tokenizer/-/css-tokenizer-4.0.0.tgz",
+      "integrity": "sha512-QxULHAm7cNu72w97JUNCBFODFaXpbDg+dP8b/oWFAZ2MTRppA3U00Y2L1HqaS4J6yBqxwa/Y3nMBaxVKbB/NsA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.19.0"
+      }
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.25.12.tgz",
+      "integrity": "sha512-Hhmwd6CInZ3dwpuGTF8fJG6yoWmsToE+vYgD4nytZVxcu1ulHpUQRAB1UJ8+N1Am3Mz4+xOByoQoSZf4D+CpkA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.25.12.tgz",
+      "integrity": "sha512-VJ+sKvNA/GE7Ccacc9Cha7bpS8nyzVv0jdVgwNDaR4gDMC/2TTRc33Ip8qrNYUcpkOHUT5OZ0bUcNNVZQ9RLlg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.25.12.tgz",
+      "integrity": "sha512-6AAmLG7zwD1Z159jCKPvAxZd4y/VTO0VkprYy+3N2FtJ8+BQWFXU+OxARIwA46c5tdD9SsKGZ/1ocqBS/gAKHg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.25.12.tgz",
+      "integrity": "sha512-5jbb+2hhDHx5phYR2By8GTWEzn6I9UqR11Kwf22iKbNpYrsmRB18aX/9ivc5cabcUiAT/wM+YIZ6SG9QO6a8kg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.25.12.tgz",
+      "integrity": "sha512-N3zl+lxHCifgIlcMUP5016ESkeQjLj/959RxxNYIthIg+CQHInujFuXeWbWMgnTo4cp5XVHqFPmpyu9J65C1Yg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.25.12.tgz",
+      "integrity": "sha512-HQ9ka4Kx21qHXwtlTUVbKJOAnmG1ipXhdWTmNXiPzPfWKpXqASVcWdnf2bnL73wgjNrFXAa3yYvBSd9pzfEIpA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.25.12.tgz",
+      "integrity": "sha512-gA0Bx759+7Jve03K1S0vkOu5Lg/85dou3EseOGUes8flVOGxbhDDh/iZaoek11Y8mtyKPGF3vP8XhnkDEAmzeg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.25.12.tgz",
+      "integrity": "sha512-TGbO26Yw2xsHzxtbVFGEXBFH0FRAP7gtcPE7P5yP7wGy7cXK2oO7RyOhL5NLiqTlBh47XhmIUXuGciXEqYFfBQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.25.12.tgz",
+      "integrity": "sha512-lPDGyC1JPDou8kGcywY0YILzWlhhnRjdof3UlcoqYmS9El818LLfJJc3PXXgZHrHCAKs/Z2SeZtDJr5MrkxtOw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.25.12.tgz",
+      "integrity": "sha512-8bwX7a8FghIgrupcxb4aUmYDLp8pX06rGh5HqDT7bB+8Rdells6mHvrFHHW2JAOPZUbnjUpKTLg6ECyzvas2AQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.25.12.tgz",
+      "integrity": "sha512-0y9KrdVnbMM2/vG8KfU0byhUN+EFCny9+8g202gYqSSVMonbsCfLjUO+rCci7pM0WBEtz+oK/PIwHkzxkyharA==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.25.12.tgz",
+      "integrity": "sha512-h///Lr5a9rib/v1GGqXVGzjL4TMvVTv+s1DPoxQdz7l/AYv6LDSxdIwzxkrPW438oUXiDtwM10o9PmwS/6Z0Ng==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.25.12.tgz",
+      "integrity": "sha512-iyRrM1Pzy9GFMDLsXn1iHUm18nhKnNMWscjmp4+hpafcZjrr2WbT//d20xaGljXDBYHqRcl8HnxbX6uaA/eGVw==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.25.12.tgz",
+      "integrity": "sha512-9meM/lRXxMi5PSUqEXRCtVjEZBGwB7P/D4yT8UG/mwIdze2aV4Vo6U5gD3+RsoHXKkHCfSxZKzmDssVlRj1QQA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.25.12.tgz",
+      "integrity": "sha512-Zr7KR4hgKUpWAwb1f3o5ygT04MzqVrGEGXGLnj15YQDJErYu/BGg+wmFlIDOdJp0PmB0lLvxFIOXZgFRrdjR0w==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.25.12.tgz",
+      "integrity": "sha512-MsKncOcgTNvdtiISc/jZs/Zf8d0cl/t3gYWX8J9ubBnVOwlk65UIEEvgBORTiljloIWnBzLs4qhzPkJcitIzIg==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.25.12.tgz",
+      "integrity": "sha512-uqZMTLr/zR/ed4jIGnwSLkaHmPjOjJvnm6TVVitAa08SLS9Z0VM8wIRx7gWbJB5/J54YuIMInDquWyYvQLZkgw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.25.12.tgz",
+      "integrity": "sha512-xXwcTq4GhRM7J9A8Gv5boanHhRa/Q9KLVmcyXHCTaM4wKfIpWkdXiMog/KsnxzJ0A1+nD+zoecuzqPmCRyBGjg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.25.12.tgz",
+      "integrity": "sha512-Ld5pTlzPy3YwGec4OuHh1aCVCRvOXdH8DgRjfDy/oumVovmuSzWfnSJg+VtakB9Cm0gxNO9BzWkj6mtO1FMXkQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.25.12.tgz",
+      "integrity": "sha512-fF96T6KsBo/pkQI950FARU9apGNTSlZGsv1jZBAlcLL1MLjLNIWPBkj5NlSz8aAzYKg+eNqknrUJ24QBybeR5A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.25.12.tgz",
+      "integrity": "sha512-MZyXUkZHjQxUvzK7rN8DJ3SRmrVrke8ZyRusHlP+kuwqTcfWLyqMOE3sScPPyeIXN/mDJIfGXvcMqCgYKekoQw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.25.12.tgz",
+      "integrity": "sha512-rm0YWsqUSRrjncSXGA7Zv78Nbnw4XL6/dzr20cyrQf7ZmRcsovpcRBdhD43Nuk3y7XIoW2OxMVvwuRvk9XdASg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.25.12.tgz",
+      "integrity": "sha512-3wGSCDyuTHQUzt0nV7bocDy72r2lI33QL3gkDNGkod22EsYl04sMf0qLb8luNKTOmgF/eDEDP5BFNwoBKH441w==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.25.12.tgz",
+      "integrity": "sha512-rMmLrur64A7+DKlnSuwqUdRKyd3UE7oPJZmnljqEptesKM8wx9J8gx5u0+9Pq0fQQW8vqeKebwNXdfOyP+8Bsg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.25.12.tgz",
+      "integrity": "sha512-HkqnmmBoCbCwxUKKNPBixiWDGCpQGVsrQfJoVGYLPT41XWF8lHuE5N6WhVia2n4o5QK5M4tYr21827fNhi4byQ==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.25.12.tgz",
+      "integrity": "sha512-alJC0uCZpTFrSL0CCDjcgleBXPnCrEAhTBILpeAp7M/OFgoqtAetfBzX0xM00MUsVVPpVjlPuMbREqnZCXaTnA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@exodus/bytes": {
+      "version": "1.15.1",
+      "resolved": "https://registry.npmjs.org/@exodus/bytes/-/bytes-1.15.1.tgz",
+      "integrity": "sha512-S6mL0yNB/Abt9Ei4tq8gDhcczc4S3+vQ4ra7vxnAf+YHC02srtqxKKZghx2Dq6p0e66THKwR6r8N6P95wEty7Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      },
+      "peerDependencies": {
+        "@noble/hashes": "^1.8.0 || ^2.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@noble/hashes": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@jridgewell/gen-mapping": {
+      "version": "0.3.13",
+      "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.13.tgz",
+      "integrity": "sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.0",
+        "@jridgewell/trace-mapping": "^0.3.24"
+      }
+    },
+    "node_modules/@jridgewell/remapping": {
+      "version": "2.3.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/remapping/-/remapping-2.3.5.tgz",
+      "integrity": "sha512-LI9u/+laYG4Ds1TDKSJW2YPrIlcVYOwi2fUC6xB43lueCjgxV4lffOCZCtYFiH6TNOX+tQKXx97T4IKHbhyHEQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/gen-mapping": "^0.3.5",
+        "@jridgewell/trace-mapping": "^0.3.24"
+      }
+    },
+    "node_modules/@jridgewell/resolve-uri": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
+      "integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@jridgewell/sourcemap-codec": {
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+      "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@jridgewell/trace-mapping": {
+      "version": "0.3.31",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.31.tgz",
+      "integrity": "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/resolve-uri": "^3.1.0",
+        "@jridgewell/sourcemap-codec": "^1.4.14"
+      }
+    },
+    "node_modules/@rolldown/pluginutils": {
+      "version": "1.0.0-beta.27",
+      "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.0-beta.27.tgz",
+      "integrity": "sha512-+d0F4MKMCbeVUJwG96uQ4SgAznZNSq93I3V+9NHA4OpvqG8mRCpGdKmK8l/dl02h2CCDHwW2FqilnTyDcAnqjA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@rollup/rollup-android-arm-eabi": {
+      "version": "4.61.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.61.1.tgz",
+      "integrity": "sha512-JnBB8MdXj45cajvTuO5FmPlvFVJRQgvrz1uSEl3NwqFnReAPGwb8EanbGi4z2nRaqLzjJSv5/JmycoTKlRZxHA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-android-arm64": {
+      "version": "4.61.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.61.1.tgz",
+      "integrity": "sha512-Jx2g7iSjw4AOT0HDPHM9RV3GNjRXwybWtSFZiZAYUTjUwjVrYIwq3kBf+LnhqJlzXFAqTAh2F7IGI+O568exPw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-arm64": {
+      "version": "4.61.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.61.1.tgz",
+      "integrity": "sha512-0F1L/Z3Eqv8mT2n3dCpeO8GcTvHvVqkP5/t6DMsn0KzhYVcg+s7Ncl5DS8qjKYEeio6Az0Gt6nyBORay5qIlCA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-x64": {
+      "version": "4.61.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.61.1.tgz",
+      "integrity": "sha512-qLttcH871ujY4YcVfUSShhOw+CsoTatYz8gRbHO7Bb92QH059/P0y5do1KMs41fY0BpD2x4AJH/gID0zFiqVKQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-arm64": {
+      "version": "4.61.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.61.1.tgz",
+      "integrity": "sha512-fUI4RapGE0Oh3mb8mgfvC1O2nU1RpDZUKnDQm3xB1Ipg7C2wTs5Kstz7G2uWK99a8S2yTMq8/P4uycwNa0nJyw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-x64": {
+      "version": "4.61.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.61.1.tgz",
+      "integrity": "sha512-H5YrdvJaDtI/U9/emrD4b++xkvp3y/JvOe4rizHbxvkyMfRS/CiRYdji+Pl8D0brEaNFWUh1drQxgAGIl6Xudw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
+      "version": "4.61.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.61.1.tgz",
+      "integrity": "sha512-Q8CBCCQtDFrYtXoeUXSrnFXKOnyUhx6bz+SkL6A0E7V8kAiCJ5pamq1WtbfpVGhR5TSpXY6ak3avmDc5fHTyJA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-musleabihf": {
+      "version": "4.61.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.61.1.tgz",
+      "integrity": "sha512-nwnhk1581l0FBVellGcVCAT0Oi06onEA3WB53sf01VO3I0UPBkMH9sXONYME2K0ovXcNayJfNtHfm6mpJElatQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-gnu": {
+      "version": "4.61.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.61.1.tgz",
+      "integrity": "sha512-x5Xr49hwt3hdW75UOZm3395YwwzPyauktslv29KpWL/T+vVAzoT3azLcTWv0eMciBNrx+DYjH4paehHoLpPvpg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-musl": {
+      "version": "4.61.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.61.1.tgz",
+      "integrity": "sha512-unMS3H73DpaoPyyEVPjGKleM/s0mkmsauTENpw4INQY8y4+IuLNjkueQ5QCtC0D3N38Y38yhAU8OoZ20S2Tm6w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-gnu": {
+      "version": "4.61.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.61.1.tgz",
+      "integrity": "sha512-zNZzGRnAhwjFEYmvphJRV5XaQGjs62cCmeYYHUT//NbvEnHauw+I85nGG+SiVg5ld4GX8D1IbKIX+ozITQnhMQ==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-musl": {
+      "version": "4.61.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-musl/-/rollup-linux-loong64-musl-4.61.1.tgz",
+      "integrity": "sha512-LdpWGL8X209B2SIvWjqlc8VZgM6PKfontSerGepuldQmHYrAOtnMCXeJkxXGbC+PPZVOuu5czJo7fNV6aeW8rQ==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-gnu": {
+      "version": "4.61.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.61.1.tgz",
+      "integrity": "sha512-EC5kTtNaNGOmbMGqar8dvJy6y/hg99GAwjfBz++pxZhQATXGcRjd6c5en5wcbru0vkRmiMGsQKdMJOOf6sza4g==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-musl": {
+      "version": "4.61.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-musl/-/rollup-linux-ppc64-musl-4.61.1.tgz",
+      "integrity": "sha512-8hiwp6D4acEcNK78I4rP0/XtS1sknWIAMJBPdR4l6zUtyTm5KiTDr5bXmWt4foY7nAN7AThDHgkLIEZOWKbzWw==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-gnu": {
+      "version": "4.61.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.61.1.tgz",
+      "integrity": "sha512-10dh/h/BqA7DuMPWSxkR8uks18FRwnwOEqr5zOTEl+NOwP/OMzKX8OFR/Of9xxDA7D5qef1Nzar5WDD2kCCr1g==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-musl": {
+      "version": "4.61.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.61.1.tgz",
+      "integrity": "sha512-YKJ5lg35DP17gcAOggnihe+APw9HLyj1Xn7gsmGumBJAUDa6NGXNixJzmkWLhcK9TOuuyQjdamzvJefkO7qHZQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-s390x-gnu": {
+      "version": "4.61.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.61.1.tgz",
+      "integrity": "sha512-Mlil5G2Jj6a7B3LWGctg+XPL9vdXYuzCtNXfxOQ0nPjc2m6ueUktocPGH9bnAM0bNRKb/bAWTujUU7IJQdQA+g==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-gnu": {
+      "version": "4.61.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.61.1.tgz",
+      "integrity": "sha512-bVWIOIk6pV01p4CdUbPP7CJ/434z+OooYjDuFcR+44N35YvKUC66G8MGnvcWx5mWKW3g61J+t74l3Kj15Kwn2Q==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-musl": {
+      "version": "4.61.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.61.1.tgz",
+      "integrity": "sha512-qy5pBvZbqNFheBz61R1rzsezjm0J7O2oNGoWtGoY89SZYLUfxAJTBAqDChqAIdB4rCiIbi9nF7yZ83GnNiLwSw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-openbsd-x64": {
+      "version": "4.61.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openbsd-x64/-/rollup-openbsd-x64-4.61.1.tgz",
+      "integrity": "sha512-E83TXjI4zm0+5f2qO+UOudaCYIhYwpJ5jq6YCZNIZ+6CbfhKrkAGezeiASBL9ElxAxFsRS9ZhESv8mfnj6TKeg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-openharmony-arm64": {
+      "version": "4.61.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.61.1.tgz",
+      "integrity": "sha512-fbWnKqVkjrJN38vNe3ahkbk6iejS/3b0Nt7EEtPpE6RBacZcGXNKbzfHN3GUUlXOPghUg0j6XUGrtjX9z1sIvA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-arm64-msvc": {
+      "version": "4.61.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.61.1.tgz",
+      "integrity": "sha512-ArMl38iVAbk0New1ogihQNY6iphLi4ZaRsa037gUzv5yeKPY8TD3Dmy4x2RNC1VztU/uqm+G+/RwFrSka3Oy2g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-ia32-msvc": {
+      "version": "4.61.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.61.1.tgz",
+      "integrity": "sha512-0mYtjHS9ucAbcATycCNK9IGBk/cCe/ma7EmSLGZdsxnOA8cjRIyU04wDpVAD9NiOfLUR9KTxdiO53uOkherqjQ==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-gnu": {
+      "version": "4.61.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.61.1.tgz",
+      "integrity": "sha512-gK1iCEPfpoSG9wfBihXxvBMi8ZfcWffYkEsC/Eih+iFENTaewvNcrEQ69lIOWYO5pePHKLHHO7nq5AILGO/HQQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-msvc": {
+      "version": "4.61.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.61.1.tgz",
+      "integrity": "sha512-X+zaP2x+j4RXGfbp/seSoRHWnPxzApilDszisZxbYH5C/jTxFhCtDNdPGZb9lJyYPs24wGxruPF7Y+sIXt9Gzw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@standard-schema/spec": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
+      "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@tailwindcss/node": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/node/-/node-4.3.0.tgz",
+      "integrity": "sha512-aFb4gUhFOgdh9AXo4IzBEOzBkkAxm9VigwDJnMIYv3lcfXCJVesNfbEaBl4BNgVRyid92AmdviqwBUBRKSeY3g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/remapping": "^2.3.5",
+        "enhanced-resolve": "^5.21.0",
+        "jiti": "^2.6.1",
+        "lightningcss": "1.32.0",
+        "magic-string": "^0.30.21",
+        "source-map-js": "^1.2.1",
+        "tailwindcss": "4.3.0"
+      }
+    },
+    "node_modules/@tailwindcss/oxide": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide/-/oxide-4.3.0.tgz",
+      "integrity": "sha512-F7HZGBeN9I0/AuuJS5PwcD8xayx5ri5GhjYUDBEVYUkexyA/giwbDNjRVrxSezE3T250OU2K/wp/ltWx3UOefg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 20"
+      },
+      "optionalDependencies": {
+        "@tailwindcss/oxide-android-arm64": "4.3.0",
+        "@tailwindcss/oxide-darwin-arm64": "4.3.0",
+        "@tailwindcss/oxide-darwin-x64": "4.3.0",
+        "@tailwindcss/oxide-freebsd-x64": "4.3.0",
+        "@tailwindcss/oxide-linux-arm-gnueabihf": "4.3.0",
+        "@tailwindcss/oxide-linux-arm64-gnu": "4.3.0",
+        "@tailwindcss/oxide-linux-arm64-musl": "4.3.0",
+        "@tailwindcss/oxide-linux-x64-gnu": "4.3.0",
+        "@tailwindcss/oxide-linux-x64-musl": "4.3.0",
+        "@tailwindcss/oxide-wasm32-wasi": "4.3.0",
+        "@tailwindcss/oxide-win32-arm64-msvc": "4.3.0",
+        "@tailwindcss/oxide-win32-x64-msvc": "4.3.0"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-android-arm64": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-android-arm64/-/oxide-android-arm64-4.3.0.tgz",
+      "integrity": "sha512-TJPiq67tKlLuObP6RkwvVGDoxCMBVtDgKkLfa/uyj7/FyxvQwHS+UOnVrXXgbEsfUaMgiVvC4KbJnRr26ho4Ng==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-darwin-arm64": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-darwin-arm64/-/oxide-darwin-arm64-4.3.0.tgz",
+      "integrity": "sha512-oMN/WZRb+SO37BmUElEgeEWuU8E/HXRkiODxJxLe1UTHVXLrdVSgfaJV7pSlhRGMSOiXLuxTIjfsF3wYvz8cgQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-darwin-x64": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-darwin-x64/-/oxide-darwin-x64-4.3.0.tgz",
+      "integrity": "sha512-N6CUmu4a6bKVADfw77p+iw6Yd9Q3OBhe0veaDX+QazfuVYlQsHfDgxBrsjQ/IW+zywL8mTrNd0SdJT/zgtvMdA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-freebsd-x64": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-freebsd-x64/-/oxide-freebsd-x64-4.3.0.tgz",
+      "integrity": "sha512-zDL5hBkQdH5C6MpqbK3gQAgP80tsMwSI26vjOzjJtNCMUo0lFgOItzHKBIupOZNQxt3ouPH7RPhvNhiTfCe5CQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-linux-arm-gnueabihf": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-arm-gnueabihf/-/oxide-linux-arm-gnueabihf-4.3.0.tgz",
+      "integrity": "sha512-R06HdNi7A7OEoMsf6d4tjZ71RCWnZQPHj2mnotSFURjNLdBC+cIgXQ7l81CqeoiQftjf6OOblxXMInMgN2VzMA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-linux-arm64-gnu": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-arm64-gnu/-/oxide-linux-arm64-gnu-4.3.0.tgz",
+      "integrity": "sha512-qTJHELX8jetjhRQHCLilkVLmybpzNQAtaI/gaoVoidn/ufbNDbAo8KlK2J+yPoc8wQxvDxCmh/5lr8nC1+lTbg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-linux-arm64-musl": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-arm64-musl/-/oxide-linux-arm64-musl-4.3.0.tgz",
+      "integrity": "sha512-Z6sukiQsngnWO+l39X4pPbiWT81IC+PLKF+PHxIlyZbGNb9MODfYlXEVlFvej5BOZInWX01kVyzeLvHsXhfczQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-linux-x64-gnu": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-x64-gnu/-/oxide-linux-x64-gnu-4.3.0.tgz",
+      "integrity": "sha512-DRNdQRpSGzRGfARVuVkxvM8Q12nh19l4BF/G7zGA1oe+9wcC6saFBHTISrpIcKzhiXtSrlSrluCfvMuledoCTQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-linux-x64-musl": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-x64-musl/-/oxide-linux-x64-musl-4.3.0.tgz",
+      "integrity": "sha512-Z0IADbDo8bh6I7h2IQMx601AdXBLfFpEdUotft86evd/8ZPflZe9COPO8Q1vw+pfLWIUo9zN/JGZvwuAJqduqg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-wasm32-wasi": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-wasm32-wasi/-/oxide-wasm32-wasi-4.3.0.tgz",
+      "integrity": "sha512-HNZGOUxEmElksYR7S6sC5jTeNGpobAsy9u7Gu0AskJ8/20FR9GqebUyB+HBcU/ax6BHuiuJi+Oda4B+YX6H1yA==",
+      "bundleDependencies": [
+        "@napi-rs/wasm-runtime",
+        "@emnapi/core",
+        "@emnapi/runtime",
+        "@tybys/wasm-util",
+        "@emnapi/wasi-threads",
+        "tslib"
+      ],
+      "cpu": [
+        "wasm32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/core": "^1.10.0",
+        "@emnapi/runtime": "^1.10.0",
+        "@emnapi/wasi-threads": "^1.2.1",
+        "@napi-rs/wasm-runtime": "^1.1.4",
+        "@tybys/wasm-util": "^0.10.1",
+        "tslib": "^2.8.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-win32-arm64-msvc": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-win32-arm64-msvc/-/oxide-win32-arm64-msvc-4.3.0.tgz",
+      "integrity": "sha512-Pe+RPVTi1T+qymuuRpcdvwSVZjnll/f7n8gBxMMh3xLTctMDKqpdfGimbMyioqtLhUYZxdJ9wGNhV7MKHvgZsQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-win32-x64-msvc": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-win32-x64-msvc/-/oxide-win32-x64-msvc-4.3.0.tgz",
+      "integrity": "sha512-Mvrf2kXW/yeW/OTezZlCGOirXRcUuLIBx/5Y12BaPM7wJoryG6dfS/NJL8aBPqtTEx/Vm4T4vKzFUcKDT+TKUA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@tailwindcss/vite": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/vite/-/vite-4.3.0.tgz",
+      "integrity": "sha512-t6J3OrB5Fc0ExuhohouH0fWUGMYL6PTLhW+E7zIk/pdbnJARZDCwjBznFnkh5ynRnIRSI4YjtTH0t6USjJISrw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@tailwindcss/node": "4.3.0",
+        "@tailwindcss/oxide": "4.3.0",
+        "tailwindcss": "4.3.0"
+      },
+      "peerDependencies": {
+        "vite": "^5.2.0 || ^6 || ^7 || ^8"
+      }
+    },
+    "node_modules/@testing-library/dom": {
+      "version": "10.4.1",
+      "resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-10.4.1.tgz",
+      "integrity": "sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@babel/code-frame": "^7.10.4",
+        "@babel/runtime": "^7.12.5",
+        "@types/aria-query": "^5.0.1",
+        "aria-query": "5.3.0",
+        "dom-accessibility-api": "^0.5.9",
+        "lz-string": "^1.5.0",
+        "picocolors": "1.1.1",
+        "pretty-format": "^27.0.2"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@testing-library/jest-dom": {
+      "version": "6.9.1",
+      "resolved": "https://registry.npmjs.org/@testing-library/jest-dom/-/jest-dom-6.9.1.tgz",
+      "integrity": "sha512-zIcONa+hVtVSSep9UT3jZ5rizo2BsxgyDYU7WFD5eICBE7no3881HGeb/QkGfsJs6JTkY1aQhT7rIPC7e+0nnA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@adobe/css-tools": "^4.4.0",
+        "aria-query": "^5.0.0",
+        "css.escape": "^1.5.1",
+        "dom-accessibility-api": "^0.6.3",
+        "picocolors": "^1.1.1",
+        "redent": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=14",
+        "npm": ">=6",
+        "yarn": ">=1"
+      }
+    },
+    "node_modules/@testing-library/jest-dom/node_modules/dom-accessibility-api": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.6.3.tgz",
+      "integrity": "sha512-7ZgogeTnjuHbo+ct10G9Ffp0mif17idi0IyWNVA/wcwcm7NPOD/WEHVP3n7n3MhXqxoIYm8d6MuZohYWIZ4T3w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@testing-library/react": {
+      "version": "16.3.2",
+      "resolved": "https://registry.npmjs.org/@testing-library/react/-/react-16.3.2.tgz",
+      "integrity": "sha512-XU5/SytQM+ykqMnAnvB2umaJNIOsLF3PVv//1Ew4CTcpz0/BRyy/af40qqrt7SjKpDdT1saBMc42CUok5gaw+g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.12.5"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@testing-library/dom": "^10.0.0",
+        "@types/react": "^18.0.0 || ^19.0.0",
+        "@types/react-dom": "^18.0.0 || ^19.0.0",
+        "react": "^18.0.0 || ^19.0.0",
+        "react-dom": "^18.0.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@testing-library/user-event": {
+      "version": "14.6.1",
+      "resolved": "https://registry.npmjs.org/@testing-library/user-event/-/user-event-14.6.1.tgz",
+      "integrity": "sha512-vq7fv0rnt+QTXgPxr5Hjc210p6YKq2kmdziLgnsZGgLJ9e6VAShx1pACLuRjd/AS/sr7phAR58OIIpf0LlmQNw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12",
+        "npm": ">=6"
+      },
+      "peerDependencies": {
+        "@testing-library/dom": ">=7.21.4"
+      }
+    },
+    "node_modules/@types/aria-query": {
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-5.0.4.tgz",
+      "integrity": "sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/@types/babel__core": {
+      "version": "7.20.5",
+      "resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.20.5.tgz",
+      "integrity": "sha512-qoQprZvz5wQFJwMDqeseRXWv3rqMvhgpbXFfVyWhbx9X47POIA6i/+dXefEmZKoAgOaTdaIgNSMqMIU61yRyzA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.20.7",
+        "@babel/types": "^7.20.7",
+        "@types/babel__generator": "*",
+        "@types/babel__template": "*",
+        "@types/babel__traverse": "*"
+      }
+    },
+    "node_modules/@types/babel__generator": {
+      "version": "7.27.0",
+      "resolved": "https://registry.npmjs.org/@types/babel__generator/-/babel__generator-7.27.0.tgz",
+      "integrity": "sha512-ufFd2Xi92OAVPYsy+P4n7/U7e68fex0+Ee8gSG9KX7eo084CWiQ4sdxktvdl0bOPupXtVJPY19zk6EwWqUQ8lg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/types": "^7.0.0"
+      }
+    },
+    "node_modules/@types/babel__template": {
+      "version": "7.4.4",
+      "resolved": "https://registry.npmjs.org/@types/babel__template/-/babel__template-7.4.4.tgz",
+      "integrity": "sha512-h/NUaSyG5EyxBIp8YRxo4RMe2/qQgvyowRwVMzhYhBCONbW8PUsg4lkFMrhgZhUe5z3L3MiLDuvyJ/CaPa2A8A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.1.0",
+        "@babel/types": "^7.0.0"
+      }
+    },
+    "node_modules/@types/babel__traverse": {
+      "version": "7.28.0",
+      "resolved": "https://registry.npmjs.org/@types/babel__traverse/-/babel__traverse-7.28.0.tgz",
+      "integrity": "sha512-8PvcXf70gTDZBgt9ptxJ8elBeBjcLOAcOtoO/mPJjtji1+CdGbHgm77om1GrsPxsiE+uXIpNSK64UYaIwQXd4Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/types": "^7.28.2"
+      }
+    },
+    "node_modules/@types/chai": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
+      "integrity": "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/deep-eql": "*",
+        "assertion-error": "^2.0.1"
+      }
+    },
+    "node_modules/@types/deep-eql": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
+      "integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/estree": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.9.tgz",
+      "integrity": "sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/node": {
+      "version": "22.19.19",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.19.19.tgz",
+      "integrity": "sha512-dyh/xO2Fh5bYrfWaaqGrRQQGkNdmYw6AmaAUvYeUMNTWQtvb796ikLdmTchRmOlOiIJ1TDXfWgVx1QkUlQ6Hew==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~6.21.0"
+      }
+    },
+    "node_modules/@types/react": {
+      "version": "19.2.16",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.16.tgz",
+      "integrity": "sha512-esJiCAnl0kfpNdE69f3So4WJUXy95dLZydX0KwK46riIHDzHM7O9Vtf9xCHW0PXIqvgqNrswl522kA/5yx+F4w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "csstype": "^3.2.2"
+      }
+    },
+    "node_modules/@types/react-dom": {
+      "version": "19.2.3",
+      "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-19.2.3.tgz",
+      "integrity": "sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "^19.2.0"
+      }
+    },
+    "node_modules/@vitejs/plugin-react": {
+      "version": "4.7.0",
+      "resolved": "https://registry.npmjs.org/@vitejs/plugin-react/-/plugin-react-4.7.0.tgz",
+      "integrity": "sha512-gUu9hwfWvvEDBBmgtAowQCojwZmJ5mcLn3aufeCsitijs3+f2NsrPtlAWIR6OPiqljl96GVCUbLe0HyqIpVaoA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/core": "^7.28.0",
+        "@babel/plugin-transform-react-jsx-self": "^7.27.1",
+        "@babel/plugin-transform-react-jsx-source": "^7.27.1",
+        "@rolldown/pluginutils": "1.0.0-beta.27",
+        "@types/babel__core": "^7.20.5",
+        "react-refresh": "^0.17.0"
+      },
+      "engines": {
+        "node": "^14.18.0 || >=16.0.0"
+      },
+      "peerDependencies": {
+        "vite": "^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0"
+      }
+    },
+    "node_modules/@vitest/expect": {
+      "version": "4.1.8",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.8.tgz",
+      "integrity": "sha512-h3nDO677RDLEGlBxyQ5CW8RlMThSKSRLUePLOx09gNIWRL40edgA1GCZSZgf1W55MFAG6/Sw14KeaAnqv0NKdQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@standard-schema/spec": "^1.1.0",
+        "@types/chai": "^5.2.2",
+        "@vitest/spy": "4.1.8",
+        "@vitest/utils": "4.1.8",
+        "chai": "^6.2.2",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/mocker": {
+      "version": "4.1.8",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.1.8.tgz",
+      "integrity": "sha512-LEiN/xe4OSIbKe9HQIp5OC24agGD9J5CnmMgsLohVVoOPWL9a2sBoR6VBx43jQZb7Kr1l4RCuyCJzcAa0+dojw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "4.1.8",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.21"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/pretty-format": {
+      "version": "4.1.8",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.8.tgz",
+      "integrity": "sha512-9GasEBxpZ1VYIpqHf/0+YGg121uSNwCKOJqIrTwWP/TB7DmFCiaBpNl3aPZzoLWfWkuqhbH8vJIVobZkvdo2cA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner": {
+      "version": "4.1.8",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.1.8.tgz",
+      "integrity": "sha512-EmVxeBAfMJvycdjd6Hm+RbFBbA9fKvo0Kx37hNpBYoYeavH3RNsBXWDooR1mgD52dCrxIIuP7UotpfiwOikvcg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/utils": "4.1.8",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot": {
+      "version": "4.1.8",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.1.8.tgz",
+      "integrity": "sha512-acfZboRmAIf05DEKcBQy33VXojFJjtUdLyo7oOmV9kebb2xdU01UknNiPuPZoJZQyO7DF0gZdTGTpeAzET9QPQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.8",
+        "@vitest/utils": "4.1.8",
+        "magic-string": "^0.30.21",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/spy": {
+      "version": "4.1.8",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.1.8.tgz",
+      "integrity": "sha512-6EevtBp6OZOPF7bmz36HrGMeP3txgVSrgebWxHOafDXGkhIzfXK14f8KF6MuFfgXXUeHxmpD3BQxkV00/3s5mA==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/utils": {
+      "version": "4.1.8",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.8.tgz",
+      "integrity": "sha512-uOJamYALNhfJ6iolExyQM40yIQwDqYnkKtQ5VCiSe17E33H0aQ/u+1GlRuz4LZBk6Mm3sg90G9hEbmEt37C1Zg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.8",
+        "convert-source-map": "^2.0.0",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/agent-base": {
+      "version": "7.1.4",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
+      "integrity": "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/ansi-styles": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
+      "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/aria-query": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/aria-query/-/aria-query-5.3.0.tgz",
+      "integrity": "sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "dequal": "^2.0.3"
+      }
+    },
+    "node_modules/assertion-error": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/baseline-browser-mapping": {
+      "version": "2.10.33",
+      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.33.tgz",
+      "integrity": "sha512-bA6+tcSLpz2tIEdDXZPpPTIuxBcC4+w6SieaYyfigIa4h8GlFxbA17v22Vx3JUtuZQj9SgOsnbK+aTBzyDyEuw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "baseline-browser-mapping": "dist/cli.cjs"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/bidi-js": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/bidi-js/-/bidi-js-1.0.3.tgz",
+      "integrity": "sha512-RKshQI1R3YQ+n9YJz2QQ147P66ELpa1FQEg20Dk8oW9t2KgLbpDLLp9aGZ7y8WHSshDknG0bknqGw5/tyCs5tw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "require-from-string": "^2.0.2"
+      }
+    },
+    "node_modules/browserslist": {
+      "version": "4.28.2",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.28.2.tgz",
+      "integrity": "sha512-48xSriZYYg+8qXna9kwqjIVzuQxi+KYWp2+5nCYnYKPTr0LvD89Jqk2Or5ogxz0NUMfIjhh2lIUX/LyX9B4oIg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/browserslist"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/browserslist"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "baseline-browser-mapping": "^2.10.12",
+        "caniuse-lite": "^1.0.30001782",
+        "electron-to-chromium": "^1.5.328",
+        "node-releases": "^2.0.36",
+        "update-browserslist-db": "^1.2.3"
+      },
+      "bin": {
+        "browserslist": "cli.js"
+      },
+      "engines": {
+        "node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
+      }
+    },
+    "node_modules/caniuse-lite": {
+      "version": "1.0.30001793",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001793.tgz",
+      "integrity": "sha512-iwSsYWaCOoh26cV8NwNRViHlrfUvYsHDfRVcbtmw0Kg6PJIZZXwMkj1442FYLBGkeUf1juAsU3DTfxW579mrPA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/browserslist"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/caniuse-lite"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "CC-BY-4.0"
+    },
+    "node_modules/chai": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-6.2.2.tgz",
+      "integrity": "sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/convert-source-map": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
+      "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/cookie": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-1.1.1.tgz",
+      "integrity": "sha512-ei8Aos7ja0weRpFzJnEA9UHJ/7XQmqglbRwnf2ATjcB9Wq874VKH9kfjjirM6UhU2/E5fFYadylyhFldcqSidQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/css-tree": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/css-tree/-/css-tree-3.2.1.tgz",
+      "integrity": "sha512-X7sjQzceUhu1u7Y/ylrRZFU2FS6LRiFVp6rKLPg23y3x3c3DOKAwuXGDp+PAGjh6CSnCjYeAul8pcT8bAl+lSA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mdn-data": "2.27.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12.20.0 || ^14.13.0 || >=15.0.0"
+      }
+    },
+    "node_modules/css.escape": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/css.escape/-/css.escape-1.5.1.tgz",
+      "integrity": "sha512-YUifsXXuknHlUsmlgyY0PKzgPOr7/FjCePfHNt0jxm83wHZi44VDMQ7/fGNkjY3/jV1MC+1CmZbaHzugyeRtpg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/cssstyle": {
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/cssstyle/-/cssstyle-6.2.0.tgz",
+      "integrity": "sha512-Fm5NvhYathRnXNVndkUsCCuR63DCLVVwGOOwQw782coXFi5HhkXdu289l59HlXZBawsyNccXfWRYvLzcDCdDig==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@asamuzakjp/css-color": "^5.0.1",
+        "@csstools/css-syntax-patches-for-csstree": "^1.0.28",
+        "css-tree": "^3.1.0",
+        "lru-cache": "^11.2.6"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/cssstyle/node_modules/lru-cache": {
+      "version": "11.5.1",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.5.1.tgz",
+      "integrity": "sha512-RPimw/7aMdv2oqRrxKwvZXcPfwBrn/JZ2xYcY9Hus/6LaS3VOAKVWKWgNLCFSiOm1ESXinjsDlidVU7JlnCN2A==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": "20 || >=22"
+      }
+    },
+    "node_modules/csstype": {
+      "version": "3.2.3",
+      "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
+      "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/data-urls": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/data-urls/-/data-urls-7.0.0.tgz",
+      "integrity": "sha512-23XHcCF+coGYevirZceTVD7NdJOqVn+49IHyxgszm+JIiHLoB2TkmPtsYkNWT1pvRSGkc35L6NHs0yHkN2SumA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-mimetype": "^5.0.0",
+        "whatwg-url": "^16.0.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
+    "node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/decimal.js": {
+      "version": "10.6.0",
+      "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.6.0.tgz",
+      "integrity": "sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/dequal": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/dequal/-/dequal-2.0.3.tgz",
+      "integrity": "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/detect-libc": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
+      "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/dom-accessibility-api": {
+      "version": "0.5.16",
+      "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.16.tgz",
+      "integrity": "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/electron-to-chromium": {
+      "version": "1.5.367",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.367.tgz",
+      "integrity": "sha512-4Mk/mrynCNQ+atY40D3UpmhLWB6AHMbYMlIrPhHcMF6x0L7O0b052FCAsxw1LlaR++UFuNg3D/A6XCuGDa0guQ==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/enhanced-resolve": {
+      "version": "5.22.2",
+      "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.22.2.tgz",
+      "integrity": "sha512-0rxICaFZ7NQho/sHely2bvOPRP0Eu2B0NZ9zM54YvRvWMn7jfz3DmnOZDR9LlXDdDcqntAVc6Hfy4gr/tdH/Ag==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "graceful-fs": "^4.2.4",
+        "tapable": "^2.3.3"
+      },
+      "engines": {
+        "node": ">=10.13.0"
+      }
+    },
+    "node_modules/entities": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-8.0.0.tgz",
+      "integrity": "sha512-zwfzJecQ/Uej6tusMqwAqU/6KL2XaB2VZ2Jg54Je6ahNBGNH6Ek6g3jjNCF0fG9EWQKGZNddNjU5F1ZQn/sBnA==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
+    "node_modules/es-module-lexer": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.1.0.tgz",
+      "integrity": "sha512-n27zTYMjYu1aj4MjCWzSP7G9r75utsaoc8m61weK+W8JMBGGQybd43GstCXZ3WNmSFtGT9wi59qQTW6mhTR5LQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/esbuild": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.25.12.tgz",
+      "integrity": "sha512-bbPBYYrtZbkt6Os6FiTLCTFxvq4tt3JKall1vRwshA3fdVztsLAatFaZobhkBC8/BrPetoa0oksYoKXoG4ryJg==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.25.12",
+        "@esbuild/android-arm": "0.25.12",
+        "@esbuild/android-arm64": "0.25.12",
+        "@esbuild/android-x64": "0.25.12",
+        "@esbuild/darwin-arm64": "0.25.12",
+        "@esbuild/darwin-x64": "0.25.12",
+        "@esbuild/freebsd-arm64": "0.25.12",
+        "@esbuild/freebsd-x64": "0.25.12",
+        "@esbuild/linux-arm": "0.25.12",
+        "@esbuild/linux-arm64": "0.25.12",
+        "@esbuild/linux-ia32": "0.25.12",
+        "@esbuild/linux-loong64": "0.25.12",
+        "@esbuild/linux-mips64el": "0.25.12",
+        "@esbuild/linux-ppc64": "0.25.12",
+        "@esbuild/linux-riscv64": "0.25.12",
+        "@esbuild/linux-s390x": "0.25.12",
+        "@esbuild/linux-x64": "0.25.12",
+        "@esbuild/netbsd-arm64": "0.25.12",
+        "@esbuild/netbsd-x64": "0.25.12",
+        "@esbuild/openbsd-arm64": "0.25.12",
+        "@esbuild/openbsd-x64": "0.25.12",
+        "@esbuild/openharmony-arm64": "0.25.12",
+        "@esbuild/sunos-x64": "0.25.12",
+        "@esbuild/win32-arm64": "0.25.12",
+        "@esbuild/win32-ia32": "0.25.12",
+        "@esbuild/win32-x64": "0.25.12"
+      }
+    },
+    "node_modules/escalade": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz",
+      "integrity": "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
+    },
+    "node_modules/expect-type": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.3.0.tgz",
+      "integrity": "sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
+    "node_modules/fdir": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
+      "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "peerDependencies": {
+        "picomatch": "^3 || ^4"
+      },
+      "peerDependenciesMeta": {
+        "picomatch": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/gensync": {
+      "version": "1.0.0-beta.2",
+      "resolved": "https://registry.npmjs.org/gensync/-/gensync-1.0.0-beta.2.tgz",
+      "integrity": "sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/graceful-fs": {
+      "version": "4.2.11",
+      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
+      "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/html-encoding-sniffer": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-6.0.0.tgz",
+      "integrity": "sha512-CV9TW3Y3f8/wT0BRFc1/KAVQ3TUHiXmaAb6VW9vtiMFf7SLoMd1PdAc4W3KFOFETBJUb90KatHqlsZMWV+R9Gg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@exodus/bytes": "^1.6.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
+    "node_modules/http-proxy-agent": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-7.0.2.tgz",
+      "integrity": "sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.0",
+        "debug": "^4.3.4"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/https-proxy-agent": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
+      "integrity": "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.2",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/indent-string": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-4.0.0.tgz",
+      "integrity": "sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/is-potential-custom-element-name": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-potential-custom-element-name/-/is-potential-custom-element-name-1.0.1.tgz",
+      "integrity": "sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/jiti": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/jiti/-/jiti-2.7.0.tgz",
+      "integrity": "sha512-AC/7JofJvZGrrneWNaEnJeOLUx+JlGt7tNa0wZiRPT4MY1wmfKjt2+6O2p2uz2+skll8OZZmJMNqeke7kKbNgQ==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "jiti": "lib/jiti-cli.mjs"
+      }
+    },
+    "node_modules/js-tokens": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
+      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/jsdom": {
+      "version": "28.1.0",
+      "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-28.1.0.tgz",
+      "integrity": "sha512-0+MoQNYyr2rBHqO1xilltfDjV9G7ymYGlAUazgcDLQaUf8JDHbuGwsxN6U9qWaElZ4w1B2r7yEGIL3GdeW3Rug==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@acemir/cssom": "^0.9.31",
+        "@asamuzakjp/dom-selector": "^6.8.1",
+        "@bramus/specificity": "^2.4.2",
+        "@exodus/bytes": "^1.11.0",
+        "cssstyle": "^6.0.1",
+        "data-urls": "^7.0.0",
+        "decimal.js": "^10.6.0",
+        "html-encoding-sniffer": "^6.0.0",
+        "http-proxy-agent": "^7.0.2",
+        "https-proxy-agent": "^7.0.6",
+        "is-potential-custom-element-name": "^1.0.1",
+        "parse5": "^8.0.0",
+        "saxes": "^6.0.0",
+        "symbol-tree": "^3.2.4",
+        "tough-cookie": "^6.0.0",
+        "undici": "^7.21.0",
+        "w3c-xmlserializer": "^5.0.0",
+        "webidl-conversions": "^8.0.1",
+        "whatwg-mimetype": "^5.0.0",
+        "whatwg-url": "^16.0.0",
+        "xml-name-validator": "^5.0.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      },
+      "peerDependencies": {
+        "canvas": "^3.0.0"
+      },
+      "peerDependenciesMeta": {
+        "canvas": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/jsesc": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-3.1.0.tgz",
+      "integrity": "sha512-/sM3dO2FOzXjKQhJuo0Q173wf2KOo8t4I8vHy6lF9poUp7bKT0/NHE8fPX23PwfhnykfqnC2xRxOnVw5XuGIaA==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "jsesc": "bin/jsesc"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/json5": {
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz",
+      "integrity": "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "json5": "lib/cli.js"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/lightningcss": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss/-/lightningcss-1.32.0.tgz",
+      "integrity": "sha512-NXYBzinNrblfraPGyrbPoD19C1h9lfI/1mzgWYvXUTe414Gz/X1FD2XBZSZM7rRTrMA8JL3OtAaGifrIKhQ5yQ==",
+      "dev": true,
+      "license": "MPL-2.0",
+      "dependencies": {
+        "detect-libc": "^2.0.3"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      },
+      "optionalDependencies": {
+        "lightningcss-android-arm64": "1.32.0",
+        "lightningcss-darwin-arm64": "1.32.0",
+        "lightningcss-darwin-x64": "1.32.0",
+        "lightningcss-freebsd-x64": "1.32.0",
+        "lightningcss-linux-arm-gnueabihf": "1.32.0",
+        "lightningcss-linux-arm64-gnu": "1.32.0",
+        "lightningcss-linux-arm64-musl": "1.32.0",
+        "lightningcss-linux-x64-gnu": "1.32.0",
+        "lightningcss-linux-x64-musl": "1.32.0",
+        "lightningcss-win32-arm64-msvc": "1.32.0",
+        "lightningcss-win32-x64-msvc": "1.32.0"
+      }
+    },
+    "node_modules/lightningcss-android-arm64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-android-arm64/-/lightningcss-android-arm64-1.32.0.tgz",
+      "integrity": "sha512-YK7/ClTt4kAK0vo6w3X+Pnm0D2cf2vPHbhOXdoNti1Ga0al1P4TBZhwjATvjNwLEBCnKvjJc2jQgHXH0NEwlAg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-darwin-arm64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-darwin-arm64/-/lightningcss-darwin-arm64-1.32.0.tgz",
+      "integrity": "sha512-RzeG9Ju5bag2Bv1/lwlVJvBE3q6TtXskdZLLCyfg5pt+HLz9BqlICO7LZM7VHNTTn/5PRhHFBSjk5lc4cmscPQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-darwin-x64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-darwin-x64/-/lightningcss-darwin-x64-1.32.0.tgz",
+      "integrity": "sha512-U+QsBp2m/s2wqpUYT/6wnlagdZbtZdndSmut/NJqlCcMLTWp5muCrID+K5UJ6jqD2BFshejCYXniPDbNh73V8w==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-freebsd-x64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-freebsd-x64/-/lightningcss-freebsd-x64-1.32.0.tgz",
+      "integrity": "sha512-JCTigedEksZk3tHTTthnMdVfGf61Fky8Ji2E4YjUTEQX14xiy/lTzXnu1vwiZe3bYe0q+SpsSH/CTeDXK6WHig==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm-gnueabihf": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm-gnueabihf/-/lightningcss-linux-arm-gnueabihf-1.32.0.tgz",
+      "integrity": "sha512-x6rnnpRa2GL0zQOkt6rts3YDPzduLpWvwAF6EMhXFVZXD4tPrBkEFqzGowzCsIWsPjqSK+tyNEODUBXeeVHSkw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm64-gnu": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-gnu/-/lightningcss-linux-arm64-gnu-1.32.0.tgz",
+      "integrity": "sha512-0nnMyoyOLRJXfbMOilaSRcLH3Jw5z9HDNGfT/gwCPgaDjnx0i8w7vBzFLFR1f6CMLKF8gVbebmkUN3fa/kQJpQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm64-musl": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-musl/-/lightningcss-linux-arm64-musl-1.32.0.tgz",
+      "integrity": "sha512-UpQkoenr4UJEzgVIYpI80lDFvRmPVg6oqboNHfoH4CQIfNA+HOrZ7Mo7KZP02dC6LjghPQJeBsvXhJod/wnIBg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-x64-gnu": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-gnu/-/lightningcss-linux-x64-gnu-1.32.0.tgz",
+      "integrity": "sha512-V7Qr52IhZmdKPVr+Vtw8o+WLsQJYCTd8loIfpDaMRWGUZfBOYEJeyJIkqGIDMZPwPx24pUMfwSxxI8phr/MbOA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-x64-musl": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-musl/-/lightningcss-linux-x64-musl-1.32.0.tgz",
+      "integrity": "sha512-bYcLp+Vb0awsiXg/80uCRezCYHNg1/l3mt0gzHnWV9XP1W5sKa5/TCdGWaR/zBM2PeF/HbsQv/j2URNOiVuxWg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-win32-arm64-msvc": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-win32-arm64-msvc/-/lightningcss-win32-arm64-msvc-1.32.0.tgz",
+      "integrity": "sha512-8SbC8BR40pS6baCM8sbtYDSwEVQd4JlFTOlaD3gWGHfThTcABnNDBda6eTZeqbofalIJhFx0qKzgHJmcPTnGdw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-win32-x64-msvc": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-win32-x64-msvc/-/lightningcss-win32-x64-msvc-1.32.0.tgz",
+      "integrity": "sha512-Amq9B/SoZYdDi1kFrojnoqPLxYhQ4Wo5XiL8EVJrVsB8ARoC1PWW6VGtT0WKCemjy8aC+louJnjS7U18x3b06Q==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lru-cache": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
+      "integrity": "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "yallist": "^3.0.2"
+      }
+    },
+    "node_modules/lz-string": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/lz-string/-/lz-string-1.5.0.tgz",
+      "integrity": "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "bin": {
+        "lz-string": "bin/bin.js"
+      }
+    },
+    "node_modules/magic-string": {
+      "version": "0.30.21",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
+      "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
+    "node_modules/mdn-data": {
+      "version": "2.27.1",
+      "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.27.1.tgz",
+      "integrity": "sha512-9Yubnt3e8A0OKwxYSXyhLymGW4sCufcLG6VdiDdUGVkPhpqLxlvP5vl1983gQjJl3tqbrM731mjaZaP68AgosQ==",
+      "dev": true,
+      "license": "CC0-1.0"
+    },
+    "node_modules/min-indent": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/min-indent/-/min-indent-1.0.1.tgz",
+      "integrity": "sha512-I9jwMn07Sy/IwOj3zVkVik2JTvgpaykDZEigL6Rx6N9LbMywwUSMtxET+7lVoDLLd3O3IXwJwvuuns8UB/HeAg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/nanoid": {
+      "version": "3.3.12",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.12.tgz",
+      "integrity": "sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "bin": {
+        "nanoid": "bin/nanoid.cjs"
+      },
+      "engines": {
+        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
+    },
+    "node_modules/node-releases": {
+      "version": "2.0.47",
+      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.47.tgz",
+      "integrity": "sha512-Uzmd6LXpouKo8EUK68IjH4+E01w/hXyV3R3g/geCJo+rXLNfh1xucB+LOzYEOQPSiUK3h/xZf0cQGcSsmyL2Og==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/obug": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/obug/-/obug-2.1.2.tgz",
+      "integrity": "sha512-AWGB9WFcRXOQs48Z/udjI5ZcZMHXwX8XPByNpOydgcGsDLIzjGizhoMWJyKAWze7AVW/2W1i+/gPX4YtKe5cyg==",
+      "dev": true,
+      "funding": [
+        "https://github.com/sponsors/sxzz",
+        "https://opencollective.com/debug"
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.20.0"
+      }
+    },
+    "node_modules/parse5": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/parse5/-/parse5-8.0.1.tgz",
+      "integrity": "sha512-z1e/HMG90obSGeidlli3hj7cbocou0/wa5HacvI3ASx34PecNjNQeaHNo5WIZpWofN9kgkqV1q5YvXe3F0FoPw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "entities": "^8.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/inikulin/parse5?sponsor=1"
+      }
+    },
+    "node_modules/pathe": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/picocolors": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/picomatch": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/postcss": {
+      "version": "8.5.15",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.15.tgz",
+      "integrity": "sha512-FfR8sjd4em2T6fb3I2MwAJU7HWVMr9zba+enmQeeWFfCbm+UOC/0X4DS8XtpUTMwWMGbjKYP7xjfNekzyGmB3A==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/postcss"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "nanoid": "^3.3.12",
+        "picocolors": "^1.1.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
+      }
+    },
+    "node_modules/pretty-format": {
+      "version": "27.5.1",
+      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-27.5.1.tgz",
+      "integrity": "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "ansi-regex": "^5.0.1",
+        "ansi-styles": "^5.0.0",
+        "react-is": "^17.0.1"
+      },
+      "engines": {
+        "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
+      }
+    },
+    "node_modules/punycode": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
+      "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/react": {
+      "version": "19.2.7",
+      "resolved": "https://registry.npmjs.org/react/-/react-19.2.7.tgz",
+      "integrity": "sha512-HNe9WslTbXmFK8o8cmwgAeJFSBvt1bPdHCVKtaaV+WlAN36mpT4hcRpwbf3fY56ar2oIXzsBpOAiIRHAdY0OlQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/react-dom": {
+      "version": "19.2.7",
+      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.7.tgz",
+      "integrity": "sha512-t0BRVXvbiE/o20Hfw669rLbMCDWtYZLvmJigy2f0MxsXF+71pxhR3xOkspmsO8h3ZlNzyibAmtCa3l4lYKk6gQ==",
+      "license": "MIT",
+      "dependencies": {
+        "scheduler": "^0.27.0"
+      },
+      "peerDependencies": {
+        "react": "^19.2.7"
+      }
+    },
+    "node_modules/react-is": {
+      "version": "17.0.2",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
+      "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/react-refresh": {
+      "version": "0.17.0",
+      "resolved": "https://registry.npmjs.org/react-refresh/-/react-refresh-0.17.0.tgz",
+      "integrity": "sha512-z6F7K9bV85EfseRCp2bzrpyQ0Gkw1uLoCel9XBVWPg/TjRj94SkJzUTGfOa4bs7iJvBWtQG0Wq7wnI0syw3EBQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/react-router": {
+      "version": "7.17.0",
+      "resolved": "https://registry.npmjs.org/react-router/-/react-router-7.17.0.tgz",
+      "integrity": "sha512-FDELK7rTMlCHO5+reyXsPlmfr7N1F91lPHsWYfMEGQm/KQ+F4JFM8jGoeQDmDvdTs93Fw9aSilH+uKRb4/jXvQ==",
+      "license": "MIT",
+      "dependencies": {
+        "cookie": "^1.0.1",
+        "set-cookie-parser": "^2.6.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=18",
+        "react-dom": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/react-router-dom": {
+      "version": "7.17.0",
+      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-7.17.0.tgz",
+      "integrity": "sha512-fyU2yjGups/hE6Xz0I5ZYbVL8Gx29eCjgpHaRaTaVU+OOAdfRX05KsvyRm0GO8YQwOkhpU3MurW1jyMUJn+zSw==",
+      "license": "MIT",
+      "dependencies": {
+        "react-router": "7.17.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=18",
+        "react-dom": ">=18"
+      }
+    },
+    "node_modules/redent": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/redent/-/redent-3.0.0.tgz",
+      "integrity": "sha512-6tDA8g98We0zd0GvVeMT9arEOnTw9qM03L9cJXaCjrip1OO764RDBLBfrB4cwzNGDj5OA5ioymC9GkizgWJDUg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "indent-string": "^4.0.0",
+        "strip-indent": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/require-from-string": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/rollup": {
+      "version": "4.61.1",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.61.1.tgz",
+      "integrity": "sha512-I4KW6iuRpuu2uHBLraZ1wNZe0DP7lnRha+VJ9tNaYVaVgKhW0aI3h4RYnoRPeql0flHm/Co55b7snEDcOfOJrA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "1.0.9"
+      },
+      "bin": {
+        "rollup": "dist/bin/rollup"
+      },
+      "engines": {
+        "node": ">=18.0.0",
+        "npm": ">=8.0.0"
+      },
+      "optionalDependencies": {
+        "@rollup/rollup-android-arm-eabi": "4.61.1",
+        "@rollup/rollup-android-arm64": "4.61.1",
+        "@rollup/rollup-darwin-arm64": "4.61.1",
+        "@rollup/rollup-darwin-x64": "4.61.1",
+        "@rollup/rollup-freebsd-arm64": "4.61.1",
+        "@rollup/rollup-freebsd-x64": "4.61.1",
+        "@rollup/rollup-linux-arm-gnueabihf": "4.61.1",
+        "@rollup/rollup-linux-arm-musleabihf": "4.61.1",
+        "@rollup/rollup-linux-arm64-gnu": "4.61.1",
+        "@rollup/rollup-linux-arm64-musl": "4.61.1",
+        "@rollup/rollup-linux-loong64-gnu": "4.61.1",
+        "@rollup/rollup-linux-loong64-musl": "4.61.1",
+        "@rollup/rollup-linux-ppc64-gnu": "4.61.1",
+        "@rollup/rollup-linux-ppc64-musl": "4.61.1",
+        "@rollup/rollup-linux-riscv64-gnu": "4.61.1",
+        "@rollup/rollup-linux-riscv64-musl": "4.61.1",
+        "@rollup/rollup-linux-s390x-gnu": "4.61.1",
+        "@rollup/rollup-linux-x64-gnu": "4.61.1",
+        "@rollup/rollup-linux-x64-musl": "4.61.1",
+        "@rollup/rollup-openbsd-x64": "4.61.1",
+        "@rollup/rollup-openharmony-arm64": "4.61.1",
+        "@rollup/rollup-win32-arm64-msvc": "4.61.1",
+        "@rollup/rollup-win32-ia32-msvc": "4.61.1",
+        "@rollup/rollup-win32-x64-gnu": "4.61.1",
+        "@rollup/rollup-win32-x64-msvc": "4.61.1",
+        "fsevents": "~2.3.2"
+      }
+    },
+    "node_modules/saxes": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/saxes/-/saxes-6.0.0.tgz",
+      "integrity": "sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "xmlchars": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=v12.22.7"
+      }
+    },
+    "node_modules/scheduler": {
+      "version": "0.27.0",
+      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.27.0.tgz",
+      "integrity": "sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q==",
+      "license": "MIT"
+    },
+    "node_modules/semver": {
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      }
+    },
+    "node_modules/set-cookie-parser": {
+      "version": "2.7.2",
+      "resolved": "https://registry.npmjs.org/set-cookie-parser/-/set-cookie-parser-2.7.2.tgz",
+      "integrity": "sha512-oeM1lpU/UvhTxw+g3cIfxXHyJRc/uidd3yK1P242gzHds0udQBYzs3y8j4gCCW+ZJ7ad0yctld8RYO+bdurlvw==",
+      "license": "MIT"
+    },
+    "node_modules/siginfo": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/source-map-js": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
+      "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/stackback": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/std-env": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-4.1.0.tgz",
+      "integrity": "sha512-Rq7ybcX2RuC55r9oaPVEW7/xu3tj8u4GeBYHBWCychFtzMIr86A7e3PPEBPT37sHStKX3+TiX/Fr/ACmJLVlLQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/strip-indent": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-3.0.0.tgz",
+      "integrity": "sha512-laJTa3Jb+VQpaC6DseHhF7dXVqHTfJPCRDaEbid/drOhgitgYku/letMUqOXFoWV0zIIUbjpdH2t+tYj4bQMRQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "min-indent": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/symbol-tree": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
+      "integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tailwindcss": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-4.3.0.tgz",
+      "integrity": "sha512-y6nxMGB1nMW9R6k96e5gdIFzcfL/gTJRNaqGes1YvkLnPVXzWgbqFF2yLC0T8G774n24cx3Pe8XrKoniCOAH+Q==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tapable": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/tapable/-/tapable-2.3.3.tgz",
+      "integrity": "sha512-uxc/zpqFg6x7C8vOE7lh6Lbda8eEL9zmVm/PLeTPBRhh1xCgdWaQ+J1CUieGpIfm2HdtsUpRv+HshiasBMcc6A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/webpack"
+      }
+    },
+    "node_modules/tinybench": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+      "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinyexec": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.2.4.tgz",
+      "integrity": "sha512-SHf/r48b7vOrjve9PxJo3MN5v5yuyjHvdUcrQffT3WXMUfnGmHDVbC4k3sHJaJTgZCwpUplIaAo5ANtMyp3YHg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tinyglobby": {
+      "version": "0.2.17",
+      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.17.tgz",
+      "integrity": "sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fdir": "^6.5.0",
+        "picomatch": "^4.0.4"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
+    "node_modules/tinyrainbow": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-3.1.0.tgz",
+      "integrity": "sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/tldts": {
+      "version": "7.4.2",
+      "resolved": "https://registry.npmjs.org/tldts/-/tldts-7.4.2.tgz",
+      "integrity": "sha512-kCwffuaH8ntKtygnWe1b4BJKWiCUH30n5KfoTr6IchcXOwR7chAOFJxFrH3vjANafUYrIA4a7SDL+nn7SiR4Sw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tldts-core": "^7.4.2"
+      },
+      "bin": {
+        "tldts": "bin/cli.js"
+      }
+    },
+    "node_modules/tldts-core": {
+      "version": "7.4.2",
+      "resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-7.4.2.tgz",
+      "integrity": "sha512-nwEyF4vl4RSJjwSjBUmOSxc3BFPoIFdlRthJ6e+5v9P3bHNsoD06UjuqMUspqp7vsEZ1beaHi1km+optiE17yA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tough-cookie": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-6.0.1.tgz",
+      "integrity": "sha512-LktZQb3IeoUWB9lqR5EWTHgW/VTITCXg4D21M+lvybRVdylLrRMnqaIONLVb5mav8vM19m44HIcGq4qASeu2Qw==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "tldts": "^7.0.5"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/tr46": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-6.0.0.tgz",
+      "integrity": "sha512-bLVMLPtstlZ4iMQHpFHTR7GAGj2jxi8Dg0s2h2MafAE4uSWF98FC/3MomU51iQAMf8/qDUbKWf5GxuvvVcXEhw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "punycode": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/undici": {
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.27.1.tgz",
+      "integrity": "sha512-UDdpiex+mzigiyrXrGbiUaF4HzTNhKbh2vRNFaTMzcqmLIPrZxaCtwo/1TMSuWoM1Xz3WiTo9KdgI3kRqYzJGg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.18.1"
+      }
+    },
+    "node_modules/undici-types": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/update-browserslist-db": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.2.3.tgz",
+      "integrity": "sha512-Js0m9cx+qOgDxo0eMiFGEueWztz+d4+M3rGlmKPT+T4IS/jP4ylw3Nwpu6cpTTP8R1MAC1kF4VbdLt3ARf209w==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/browserslist"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/browserslist"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "escalade": "^3.2.0",
+        "picocolors": "^1.1.1"
+      },
+      "bin": {
+        "update-browserslist-db": "cli.js"
+      },
+      "peerDependencies": {
+        "browserslist": ">= 4.21.0"
+      }
+    },
+    "node_modules/vite": {
+      "version": "6.4.3",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-6.4.3.tgz",
+      "integrity": "sha512-NTKlcQjlAK7MlQoyb6LgaqHc8sso/pVyUJYWMws3jg21uTJw/LddqIFPcPqP6PzpgbIcZyKI85sFE4HBrQDA8A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "^0.25.0",
+        "fdir": "^6.4.4",
+        "picomatch": "^4.0.2",
+        "postcss": "^8.5.3",
+        "rollup": "^4.34.9",
+        "tinyglobby": "^0.2.13"
+      },
+      "bin": {
+        "vite": "bin/vite.js"
+      },
+      "engines": {
+        "node": "^18.0.0 || ^20.0.0 || >=22.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/vitejs/vite?sponsor=1"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      },
+      "peerDependencies": {
+        "@types/node": "^18.0.0 || ^20.0.0 || >=22.0.0",
+        "jiti": ">=1.21.0",
+        "less": "*",
+        "lightningcss": "^1.21.0",
+        "sass": "*",
+        "sass-embedded": "*",
+        "stylus": "*",
+        "sugarss": "*",
+        "terser": "^5.16.0",
+        "tsx": "^4.8.1",
+        "yaml": "^2.4.2"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "jiti": {
+          "optional": true
+        },
+        "less": {
+          "optional": true
+        },
+        "lightningcss": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        },
+        "sass-embedded": {
+          "optional": true
+        },
+        "stylus": {
+          "optional": true
+        },
+        "sugarss": {
+          "optional": true
+        },
+        "terser": {
+          "optional": true
+        },
+        "tsx": {
+          "optional": true
+        },
+        "yaml": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vitest": {
+      "version": "4.1.8",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.1.8.tgz",
+      "integrity": "sha512-flY6ScbCIt9HThs+C5HS7jvGOB560DJtk/Z15IQROTA6zEy49Nh8T/dofWTQL+n3vswqn87sbJNiuqw1SDp5Ig==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/expect": "4.1.8",
+        "@vitest/mocker": "4.1.8",
+        "@vitest/pretty-format": "4.1.8",
+        "@vitest/runner": "4.1.8",
+        "@vitest/snapshot": "4.1.8",
+        "@vitest/spy": "4.1.8",
+        "@vitest/utils": "4.1.8",
+        "es-module-lexer": "^2.0.0",
+        "expect-type": "^1.3.0",
+        "magic-string": "^0.30.21",
+        "obug": "^2.1.1",
+        "pathe": "^2.0.3",
+        "picomatch": "^4.0.3",
+        "std-env": "^4.0.0-rc.1",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^1.0.2",
+        "tinyglobby": "^0.2.15",
+        "tinyrainbow": "^3.1.0",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^20.0.0 || ^22.0.0 || >=24.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@opentelemetry/api": "^1.9.0",
+        "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0",
+        "@vitest/browser-playwright": "4.1.8",
+        "@vitest/browser-preview": "4.1.8",
+        "@vitest/browser-webdriverio": "4.1.8",
+        "@vitest/coverage-istanbul": "4.1.8",
+        "@vitest/coverage-v8": "4.1.8",
+        "@vitest/ui": "4.1.8",
+        "happy-dom": "*",
+        "jsdom": "*",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@opentelemetry/api": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser-playwright": {
+          "optional": true
+        },
+        "@vitest/browser-preview": {
+          "optional": true
+        },
+        "@vitest/browser-webdriverio": {
+          "optional": true
+        },
+        "@vitest/coverage-istanbul": {
+          "optional": true
+        },
+        "@vitest/coverage-v8": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        },
+        "vite": {
+          "optional": false
+        }
+      }
+    },
+    "node_modules/w3c-xmlserializer": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/w3c-xmlserializer/-/w3c-xmlserializer-5.0.0.tgz",
+      "integrity": "sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "xml-name-validator": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/webidl-conversions": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-8.0.1.tgz",
+      "integrity": "sha512-BMhLD/Sw+GbJC21C/UgyaZX41nPt8bUTg+jWyDeg7e7YN4xOM05YPSIXceACnXVtqyEw/LMClUQMtMZ+PGGpqQ==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/whatwg-mimetype": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-5.0.0.tgz",
+      "integrity": "sha512-sXcNcHOC51uPGF0P/D4NVtrkjSU2fNsm9iog4ZvZJsL3rjoDAzXZhkm2MWt1y+PUdggKAYVoMAIYcs78wJ51Cw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/whatwg-url": {
+      "version": "16.0.1",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-16.0.1.tgz",
+      "integrity": "sha512-1to4zXBxmXHV3IiSSEInrreIlu02vUOvrhxJJH5vcxYTBDAx51cqZiKdyTxlecdKNSjj8EcxGBxNf6Vg+945gw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@exodus/bytes": "^1.11.0",
+        "tr46": "^6.0.0",
+        "webidl-conversions": "^8.0.1"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
+    "node_modules/why-is-node-running": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+      "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
+      },
+      "bin": {
+        "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/xml-name-validator": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-5.0.0.tgz",
+      "integrity": "sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/xmlchars": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/xmlchars/-/xmlchars-2.2.0.tgz",
+      "integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/yallist": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
+      "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
+      "dev": true,
+      "license": "ISC"
+    }
+  }
+}

--- a/web/package.json
+++ b/web/package.json
@@ -1,0 +1,36 @@
+{
+  "name": "companion-console",
+  "version": "0.1.0",
+  "type": "module",
+  "private": true,
+  "description": "Companion Console — local-admin UI for managing a Companion fleet workspace",
+  "license": "MIT",
+  "author": "The Vibe Company",
+  "scripts": {
+    "dev": "vite",
+    "build": "tsc --noEmit && vite build",
+    "test": "vitest run",
+    "test:watch": "vitest",
+    "typecheck": "tsc --noEmit"
+  },
+  "dependencies": {
+    "react": "^19.0.0",
+    "react-dom": "^19.0.0",
+    "react-router-dom": "^7.1.0"
+  },
+  "devDependencies": {
+    "@tailwindcss/vite": "^4.0.0",
+    "@testing-library/jest-dom": "^6.9.1",
+    "@testing-library/react": "^16.3.2",
+    "@testing-library/user-event": "^14.6.1",
+    "@types/node": "^22.10.0",
+    "@types/react": "^19.0.0",
+    "@types/react-dom": "^19.0.0",
+    "@vitejs/plugin-react": "^4.4.0",
+    "jsdom": "^28.0.0",
+    "tailwindcss": "^4.0.0",
+    "typescript": "^5.9.3",
+    "vite": "^6.3.0",
+    "vitest": "^4.0.18"
+  }
+}

--- a/web/src/App.test.tsx
+++ b/web/src/App.test.tsx
@@ -1,0 +1,31 @@
+import { describe, expect, it } from "vitest";
+import { render, screen, within } from "@testing-library/react";
+import App from "./App.tsx";
+
+/**
+ * App smoke test: mounting the root renders the layout shell and the index
+ * (Agents) page. We assert on accessible landmarks/roles rather than markup so
+ * the test reflects what a screen-reader user perceives.
+ */
+describe("App", () => {
+  it("renders the primary navigation with the four console destinations", () => {
+    render(<App />);
+    const nav = screen.getByRole("navigation", { name: /primary/i });
+    // All four sidebar links are present and reachable.
+    expect(within(nav).getByRole("link", { name: "Agents" })).toBeInTheDocument();
+    expect(within(nav).getByRole("link", { name: "Create" })).toBeInTheDocument();
+    expect(
+      within(nav).getByRole("link", { name: "Plan & Apply" }),
+    ).toBeInTheDocument();
+    expect(within(nav).getByRole("link", { name: "Settings" })).toBeInTheDocument();
+  });
+
+  it("renders the Agents page heading at the index route", () => {
+    render(<App />);
+    expect(
+      screen.getByRole("heading", { level: 1, name: /agents/i }),
+    ).toBeInTheDocument();
+    // The content landmark exists for skip-link / SR navigation.
+    expect(screen.getByRole("main")).toBeInTheDocument();
+  });
+});

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -1,0 +1,14 @@
+/**
+ * Companion Console root.
+ *
+ * Mounts the router (which renders the AppLayout shell + the matched page). The
+ * design tokens and global styles live in index.css; the API client and hooks
+ * provide the data layer the pages consume.
+ */
+
+import { RouterProvider } from "react-router-dom";
+import { router } from "./app/routes";
+
+export default function App() {
+  return <RouterProvider router={router} />;
+}

--- a/web/src/api/client.test.ts
+++ b/web/src/api/client.test.ts
@@ -1,0 +1,265 @@
+/**
+ * Tests for the console API client, focused on the contract that the rest of the
+ * app and the Go server depend on:
+ *
+ *  - mutating calls (POST/PUT/DELETE) send the `X-Console-Token` header;
+ *  - read-only GETs send NO token;
+ *  - non-2xx responses become a ConsoleError carrying status + server message;
+ *  - the dev token fallback hits `GET /api/console/session` when the page has no
+ *    injected token, and caches the result (one fetch for N mutations).
+ *
+ * The network is mocked at the `fetch` boundary; nothing here touches a live
+ * server. Each recorded call is inspected so we assert real request shape, not
+ * just that a function resolved.
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  __resetTokenCacheForTests,
+  apply,
+  ConsoleError,
+  createAgent,
+  deleteAgent,
+  getAgent,
+  getStatus,
+  listAgents,
+  plan,
+  updateAgent,
+} from "./client";
+import type { AgentInput } from "./types";
+
+/** A captured fetch call: the request URL, method, and headers. */
+interface Recorded {
+  url: string;
+  method: string;
+  headers: Headers;
+  body: string | undefined;
+}
+
+/**
+ * Installs a fetch mock returning JSON per a small routing table and records
+ * every call so tests can assert on headers/method. Routes are matched by URL
+ * substring (and optional method).
+ */
+function installFetch(
+  routes: Array<{
+    url: string;
+    method?: string;
+    status?: number;
+    json?: unknown;
+  }>,
+): { calls: Recorded[]; fetchMock: ReturnType<typeof vi.fn> } {
+  const calls: Recorded[] = [];
+  const fetchMock = vi.fn(
+    async (input: RequestInfo | URL, init?: RequestInit) => {
+      const url = typeof input === "string" ? input : input.toString();
+      const method = (init?.method ?? "GET").toUpperCase();
+      calls.push({
+        url,
+        method,
+        headers: new Headers(init?.headers),
+        body: typeof init?.body === "string" ? init.body : undefined,
+      });
+      const route = routes.find(
+        (r) =>
+          url.includes(r.url) &&
+          (r.method ? r.method.toUpperCase() === method : true),
+      );
+      if (!route) {
+        throw new Error(`no mock route for ${method} ${url}`);
+      }
+      const status = route.status ?? 200;
+      const payload = route.json === undefined ? "" : JSON.stringify(route.json);
+      return new Response(payload, {
+        status,
+        headers: { "Content-Type": "application/json" },
+      });
+    },
+  );
+  vi.stubGlobal("fetch", fetchMock);
+  return { calls, fetchMock };
+}
+
+const sampleInput: AgentInput = {
+  id: "agent-one",
+  name: "Agent One",
+  model: "anthropic/claude-3.5",
+  memory: "512mb",
+  cpus: 1,
+  region: "cdg",
+  tailscale_hostname: "agent-one",
+  fly_app: "agent-one",
+  runtime: "fly.default",
+  network: "tailscale.default",
+  model_provider: "openrouter.default",
+  lifecycle: "present",
+  soul: "",
+  companion_soul_enabled: true,
+  vault_name: "memory",
+};
+
+describe("console API client", () => {
+  beforeEach(() => {
+    __resetTokenCacheForTests();
+    // Production-style injected token on the window for the default cases.
+    window.__CONSOLE_TOKEN__ = "prod-token-abc";
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    delete window.__CONSOLE_TOKEN__;
+    // Remove any meta tag a test added.
+    document
+      .querySelectorAll('meta[name="console-token"]')
+      .forEach((el) => el.remove());
+  });
+
+  it("sends no token header on read-only GETs", async () => {
+    const { calls } = installFetch([{ url: "/api/console/agents", json: [] }]);
+    await listAgents();
+    expect(calls).toHaveLength(1);
+    expect(calls[0].method).toBe("GET");
+    expect(calls[0].headers.has("X-Console-Token")).toBe(false);
+  });
+
+  it("encodes the id in single-agent GETs", async () => {
+    const { calls } = installFetch([
+      { url: "/api/console/agents/", json: { id: "a b" } },
+    ]);
+    await getAgent("a b");
+    expect(calls[0].url).toContain("/api/console/agents/a%20b");
+    expect(calls[0].headers.has("X-Console-Token")).toBe(false);
+  });
+
+  it("sends X-Console-Token and a JSON body on POST create", async () => {
+    const { calls } = installFetch([
+      { url: "/api/console/agents", method: "POST", status: 201, json: { id: "agent-one" } },
+    ]);
+    await createAgent(sampleInput);
+    expect(calls).toHaveLength(1);
+    expect(calls[0].method).toBe("POST");
+    expect(calls[0].headers.get("X-Console-Token")).toBe("prod-token-abc");
+    expect(calls[0].headers.get("Content-Type")).toBe("application/json");
+    expect(JSON.parse(calls[0].body as string)).toMatchObject({ id: "agent-one" });
+  });
+
+  it("sends X-Console-Token on PUT update", async () => {
+    const { calls } = installFetch([
+      { url: "/api/console/agents/", method: "PUT", json: { id: "agent-one" } },
+    ]);
+    await updateAgent("agent-one", sampleInput);
+    expect(calls[0].method).toBe("PUT");
+    expect(calls[0].headers.get("X-Console-Token")).toBe("prod-token-abc");
+  });
+
+  it("sends X-Console-Token on DELETE with no body", async () => {
+    const { calls } = installFetch([
+      { url: "/api/console/agents/", method: "DELETE", json: { id: "agent-one", lifecycle: "absent" } },
+    ]);
+    await deleteAgent("agent-one");
+    expect(calls[0].method).toBe("DELETE");
+    expect(calls[0].headers.get("X-Console-Token")).toBe("prod-token-abc");
+    expect(calls[0].body).toBeUndefined();
+  });
+
+  it("echoes the hash in the apply body", async () => {
+    const { calls } = installFetch([
+      { url: "/api/console/apply", method: "POST", status: 202, json: { operation_id: "op1" } },
+    ]);
+    const res = await apply("hash-123");
+    expect(res.operation_id).toBe("op1");
+    expect(JSON.parse(calls[0].body as string)).toEqual({ hash: "hash-123" });
+    expect(calls[0].headers.get("X-Console-Token")).toBe("prod-token-abc");
+  });
+
+  it("throws ConsoleError with the server message on a 4xx", async () => {
+    installFetch([
+      {
+        url: "/api/console/agents",
+        method: "POST",
+        status: 409,
+        json: { error: "agent already exists: agent-one" },
+      },
+    ]);
+    await expect(createAgent(sampleInput)).rejects.toMatchObject({
+      status: 409,
+      message: "agent already exists: agent-one",
+    });
+    await expect(createAgent(sampleInput)).rejects.toBeInstanceOf(ConsoleError);
+  });
+
+  it("throws ConsoleError with status on a 5xx read", async () => {
+    installFetch([
+      { url: "/api/console/agents", status: 500, json: { error: "boom" } },
+    ]);
+    const err = await listAgents().catch((e: unknown) => e);
+    expect(err).toBeInstanceOf(ConsoleError);
+    expect((err as ConsoleError).status).toBe(500);
+    expect((err as ConsoleError).message).toBe("boom");
+  });
+
+  it("surfaces /api/status errors as ConsoleError", async () => {
+    installFetch([{ url: "/api/status", status: 503, json: { error: "no poller" } }]);
+    await expect(getStatus()).rejects.toMatchObject({ status: 503 });
+  });
+
+  describe("dev token fallback", () => {
+    beforeEach(() => {
+      // Simulate the dev environment: no injected token anywhere on the page.
+      __resetTokenCacheForTests();
+      delete window.__CONSOLE_TOKEN__;
+    });
+
+    it("treats the unreplaced %%CONSOLE_TOKEN%% sentinel as absent and fetches /session", async () => {
+      // The dev HTML keeps the literal sentinel; it must NOT be used as a token.
+      window.__CONSOLE_TOKEN__ = "%%CONSOLE_TOKEN%%";
+      const { calls } = installFetch([
+        { url: "/api/console/session", json: { token: "dev-token-xyz" } },
+        { url: "/api/console/plan", method: "POST", json: { hash: "h", text: "", changes: [] } },
+      ]);
+
+      await plan();
+
+      const sessionCall = calls.find((c) => c.url.includes("/session"));
+      const planCall = calls.find((c) => c.url.includes("/plan"));
+      expect(sessionCall).toBeDefined();
+      expect(sessionCall?.method).toBe("GET");
+      expect(planCall?.headers.get("X-Console-Token")).toBe("dev-token-xyz");
+    });
+
+    it("fetches the session token only once across multiple mutations (cached)", async () => {
+      const { calls } = installFetch([
+        { url: "/api/console/session", json: { token: "dev-token-xyz" } },
+        { url: "/api/console/plan", method: "POST", json: { hash: "h", text: "", changes: [] } },
+        { url: "/api/console/apply", method: "POST", status: 202, json: { operation_id: "op" } },
+      ]);
+
+      await plan();
+      await apply("h");
+
+      const sessionCalls = calls.filter((c) => c.url.includes("/session"));
+      expect(sessionCalls).toHaveLength(1);
+      // Both mutations carried the fetched dev token.
+      const tokenedCalls = calls.filter(
+        (c) => c.headers.get("X-Console-Token") === "dev-token-xyz",
+      );
+      expect(tokenedCalls).toHaveLength(2);
+    });
+
+    it("reads the token from the <meta> tag when the window global is absent", async () => {
+      const meta = document.createElement("meta");
+      meta.name = "console-token";
+      meta.content = "meta-token-123";
+      document.head.appendChild(meta);
+
+      const { calls } = installFetch([
+        { url: "/api/console/plan", method: "POST", json: { hash: "h", text: "", changes: [] } },
+      ]);
+      await plan();
+
+      // No /session fetch needed: the meta tag supplied the token.
+      expect(calls.some((c) => c.url.includes("/session"))).toBe(false);
+      expect(calls[0].headers.get("X-Console-Token")).toBe("meta-token-123");
+    });
+  });
+});

--- a/web/src/api/client.ts
+++ b/web/src/api/client.ts
@@ -1,0 +1,277 @@
+/**
+ * Typed client for the Companion Console JSON API.
+ *
+ * Same-origin: every path is under `/api/console` (plus `/api/status`). The
+ * client owns the per-process session-token handshake:
+ *
+ *  - PRODUCTION: the Go server injects the token into the served HTML, both as
+ *    `window.__CONSOLE_TOKEN__` and a `<meta name="console-token">` tag.
+ *  - DEV: the Vite-served HTML keeps the literal `%%CONSOLE_TOKEN%%` sentinel
+ *    (no injection happens through the reverse proxy), so the client falls back
+ *    to the dev-only endpoint `GET /api/console/session` once and caches it.
+ *
+ * The token is sent as `X-Console-Token` on mutating requests (POST/PUT/DELETE)
+ * only; GETs are exempt server-side, so they carry no token. Non-2xx responses
+ * are surfaced as `ConsoleError` carrying the HTTP status and the server's
+ * `{ "error": ... }` message when present.
+ */
+
+import type {
+  AgentDetail,
+  AgentInput,
+  AgentSummary,
+  ApplyHistoryEntry,
+  ApplyResponse,
+  LogsResponse,
+  OperationStatus,
+  PlanResponse,
+  StatusSnapshot,
+  WorkspaceInfo,
+} from "./types";
+
+const API_BASE = "/api/console";
+
+/** The unreplaced sentinel left in dev HTML; treated as "no token present". */
+const TOKEN_SENTINEL = "%%CONSOLE_TOKEN%%";
+
+/**
+ * Error thrown for any non-2xx console API response. `status` is the HTTP
+ * status code; `message` is the server's error string when the body is the
+ * standard `{ "error": "..." }` shape, otherwise a generic status message.
+ */
+export class ConsoleError extends Error {
+  readonly status: number;
+
+  constructor(status: number, message: string) {
+    super(message);
+    this.name = "ConsoleError";
+    this.status = status;
+    // Restore prototype chain for instanceof across transpilation targets.
+    Object.setPrototypeOf(this, ConsoleError.prototype);
+  }
+}
+
+/**
+ * Reads the injected session token from the page (window global first, then the
+ * meta tag), ignoring the unreplaced dev sentinel. Returns null when no real
+ * token is embedded — the dev fallback then fetches one.
+ */
+function tokenFromDocument(): string | null {
+  const fromWindow =
+    typeof window !== "undefined" ? window.__CONSOLE_TOKEN__ : undefined;
+  if (isRealToken(fromWindow)) {
+    return fromWindow as string;
+  }
+  if (typeof document !== "undefined") {
+    const meta = document.querySelector<HTMLMetaElement>(
+      'meta[name="console-token"]',
+    );
+    const fromMeta = meta?.content;
+    if (isRealToken(fromMeta)) {
+      return fromMeta as string;
+    }
+  }
+  return null;
+}
+
+function isRealToken(value: string | undefined | null): boolean {
+  return (
+    typeof value === "string" &&
+    value.length > 0 &&
+    value !== TOKEN_SENTINEL
+  );
+}
+
+// Cached token promise so the dev `/session` fallback is fetched at most once,
+// even under concurrent mutating calls. Stored as a promise (not a value) so
+// callers awaiting in parallel share one in-flight request.
+let tokenPromise: Promise<string> | null = null;
+
+/**
+ * Resolves the session token, caching the result. Prefers the document-injected
+ * token (production); otherwise fetches the dev-only `GET /api/console/session`
+ * endpoint exactly once. A failure here is surfaced as a ConsoleError so the
+ * calling mutation can report "could not obtain a session token".
+ */
+export function getSessionToken(): Promise<string> {
+  const embedded = tokenFromDocument();
+  if (embedded) {
+    return Promise.resolve(embedded);
+  }
+  if (!tokenPromise) {
+    tokenPromise = (async () => {
+      const res = await fetch(`${API_BASE}/session`, {
+        headers: { Accept: "application/json" },
+      });
+      if (!res.ok) {
+        // Don't poison the cache on failure: allow a later retry.
+        tokenPromise = null;
+        throw await toConsoleError(res);
+      }
+      const data = (await res.json()) as { token?: string };
+      const token = data?.token;
+      if (!isRealToken(token)) {
+        tokenPromise = null;
+        throw new ConsoleError(res.status, "console session token unavailable");
+      }
+      return token as string;
+    })();
+  }
+  return tokenPromise;
+}
+
+/**
+ * Test/SSR seam: resets the cached token promise. Exported so tests can isolate
+ * the dev-fallback path between cases. Not used by application code.
+ */
+export function __resetTokenCacheForTests(): void {
+  tokenPromise = null;
+}
+
+/** Builds a ConsoleError from a non-ok Response, reading its error body. */
+async function toConsoleError(res: Response): Promise<ConsoleError> {
+  let message = `request failed with status ${res.status}`;
+  try {
+    const text = await res.text();
+    if (text) {
+      try {
+        const parsed = JSON.parse(text) as { error?: string };
+        if (parsed && typeof parsed.error === "string" && parsed.error) {
+          message = parsed.error;
+        } else {
+          message = text;
+        }
+      } catch {
+        message = text;
+      }
+    }
+  } catch {
+    // Body already consumed or unreadable: keep the generic status message.
+  }
+  return new ConsoleError(res.status, message);
+}
+
+/** Parses a JSON response body, tolerating an empty body as `undefined`. */
+async function parseJSON<T>(res: Response): Promise<T> {
+  const text = await res.text();
+  if (!text) {
+    return undefined as T;
+  }
+  return JSON.parse(text) as T;
+}
+
+/** Performs a read-only GET; no token is attached (GETs are server-exempt). */
+async function getJSON<T>(path: string): Promise<T> {
+  const res = await fetch(`${API_BASE}${path}`, {
+    method: "GET",
+    headers: { Accept: "application/json" },
+  });
+  if (!res.ok) {
+    throw await toConsoleError(res);
+  }
+  return parseJSON<T>(res);
+}
+
+type MutateMethod = "POST" | "PUT" | "DELETE";
+
+/**
+ * Performs a mutating request, attaching the resolved `X-Console-Token` header.
+ * The token is fetched/cached lazily so reads never trigger the handshake.
+ */
+async function mutateJSON<T>(
+  method: MutateMethod,
+  path: string,
+  body?: unknown,
+): Promise<T> {
+  const token = await getSessionToken();
+  const headers: Record<string, string> = {
+    Accept: "application/json",
+    "X-Console-Token": token,
+  };
+  if (body !== undefined) {
+    headers["Content-Type"] = "application/json";
+  }
+  const res = await fetch(`${API_BASE}${path}`, {
+    method,
+    headers,
+    body: body === undefined ? undefined : JSON.stringify(body),
+  });
+  if (!res.ok) {
+    throw await toConsoleError(res);
+  }
+  return parseJSON<T>(res);
+}
+
+// --- Public API surface (imported verbatim by the feature pages) ----------
+
+/** GET /api/console/workspace */
+export function getWorkspace(): Promise<WorkspaceInfo> {
+  return getJSON<WorkspaceInfo>("/workspace");
+}
+
+/** GET /api/console/agents */
+export function listAgents(): Promise<AgentSummary[]> {
+  return getJSON<AgentSummary[]>("/agents");
+}
+
+/** GET /api/console/agents/{id} */
+export function getAgent(id: string): Promise<AgentDetail> {
+  return getJSON<AgentDetail>(`/agents/${encodeURIComponent(id)}`);
+}
+
+/** POST /api/console/agents -> 201 AgentDetail */
+export function createAgent(input: AgentInput): Promise<AgentDetail> {
+  return mutateJSON<AgentDetail>("POST", "/agents", input);
+}
+
+/** PUT /api/console/agents/{id} -> 200 AgentDetail */
+export function updateAgent(id: string, input: AgentInput): Promise<AgentDetail> {
+  return mutateJSON<AgentDetail>(
+    "PUT",
+    `/agents/${encodeURIComponent(id)}`,
+    input,
+  );
+}
+
+/** DELETE /api/console/agents/{id} -> 200 AgentDetail (lifecycle="absent") */
+export function deleteAgent(id: string): Promise<AgentDetail> {
+  return mutateJSON<AgentDetail>("DELETE", `/agents/${encodeURIComponent(id)}`);
+}
+
+/** POST /api/console/plan -> PlanResponse */
+export function plan(): Promise<PlanResponse> {
+  return mutateJSON<PlanResponse>("POST", "/plan");
+}
+
+/** POST /api/console/apply -> 202 ApplyResponse (409 on stale hash / in-flight) */
+export function apply(hash: string): Promise<ApplyResponse> {
+  return mutateJSON<ApplyResponse>("POST", "/apply", { hash });
+}
+
+/** GET /api/console/operations/{id} */
+export function getOperation(id: string): Promise<OperationStatus> {
+  return getJSON<OperationStatus>(`/operations/${encodeURIComponent(id)}`);
+}
+
+/** GET /api/console/applies */
+export function listApplies(): Promise<ApplyHistoryEntry[]> {
+  return getJSON<ApplyHistoryEntry[]>("/applies");
+}
+
+/** GET /api/console/agents/{id}/logs */
+export function getAgentLogs(id: string): Promise<LogsResponse> {
+  return getJSON<LogsResponse>(`/agents/${encodeURIComponent(id)}/logs`);
+}
+
+/** GET /api/status (existing fleet status snapshot; same origin, no /console). */
+export function getStatus(): Promise<StatusSnapshot> {
+  return fetch("/api/status", {
+    method: "GET",
+    headers: { Accept: "application/json" },
+  }).then(async (res) => {
+    if (!res.ok) {
+      throw await toConsoleError(res);
+    }
+    return parseJSON<StatusSnapshot>(res);
+  });
+}

--- a/web/src/api/client.ts
+++ b/web/src/api/client.ts
@@ -24,6 +24,7 @@ import type {
   ApplyResponse,
   LogsResponse,
   OperationStatus,
+  PlanOptions,
   PlanResponse,
   StatusSnapshot,
   WorkspaceInfo,
@@ -238,9 +239,16 @@ export function deleteAgent(id: string): Promise<AgentDetail> {
   return mutateJSON<AgentDetail>("DELETE", `/agents/${encodeURIComponent(id)}`);
 }
 
-/** POST /api/console/plan -> PlanResponse */
-export function plan(): Promise<PlanResponse> {
-  return mutateJSON<PlanResponse>("POST", "/plan");
+/**
+ * POST /api/console/plan -> PlanResponse. The destroy confirmations default to
+ * false, so a plain plan reports protected destructions as blocked. Pass
+ * { allowProtectedDestroy, destroyData } to compute (and later apply) a destroy.
+ */
+export function plan(opts: PlanOptions = {}): Promise<PlanResponse> {
+  return mutateJSON<PlanResponse>("POST", "/plan", {
+    allow_protected_destroy: opts.allowProtectedDestroy ?? false,
+    destroy_data: opts.destroyData ?? false,
+  });
 }
 
 /** POST /api/console/apply -> 202 ApplyResponse (409 on stale hash / in-flight) */

--- a/web/src/api/types.ts
+++ b/web/src/api/types.ts
@@ -1,0 +1,168 @@
+/**
+ * TypeScript DTOs for the Companion Console JSON API.
+ *
+ * These interfaces mirror the Go structs in `internal/console/types.go` and
+ * `internal/status/status.go`. JSON is snake_case on the wire, so the field
+ * names here are deliberately snake_case to match the server exactly — do not
+ * camelCase them. Security note: provider credentials are name + presence only;
+ * a secret value never crosses this boundary.
+ */
+
+/** A redacted provider credential: env var name + whether it is present. */
+export interface ProviderCred {
+  name: string;
+  present: boolean;
+}
+
+/** Workspace summary for the console header / settings view. */
+export interface WorkspaceInfo {
+  name: string;
+  root: string;
+  agent_count: number;
+  providers: ProviderCred[];
+}
+
+/**
+ * List-row view of a fleet agent. The health/fly_state/url/last_deploy fields
+ * are enriched from a live status snapshot when one is available and are
+ * otherwise absent, so listing never requires network access.
+ */
+export interface AgentSummary {
+  id: string;
+  model: string;
+  fly_app: string;
+  tailscale_hostname: string;
+  vault: string;
+  lifecycle: string;
+  health?: string;
+  fly_state?: string;
+  url?: string;
+  last_deploy?: string;
+}
+
+/** Full single-agent view edited by the console. */
+export interface AgentDetail extends AgentSummary {
+  region: string;
+  memory: string;
+  cpus: number;
+  runtime: string;
+  network: string;
+  model_provider: string;
+  soul_preview: string;
+  companion_soul_enabled: boolean;
+  vault_connections: string[];
+}
+
+/**
+ * Structured payload the UI sends to create or update an agent. Omitted
+ * optional fields fall back to server-side defaults that mirror
+ * examples/minimal.
+ */
+export interface AgentInput {
+  id: string;
+  name: string;
+  model: string;
+  memory: string;
+  cpus: number;
+  region: string;
+  tailscale_hostname: string;
+  fly_app: string;
+  runtime: string;
+  network: string;
+  model_provider: string;
+  lifecycle: string;
+  soul: string;
+  companion_soul_enabled: boolean;
+  vault_name: string;
+}
+
+/** Plan change kinds, mirroring the engine's single-character markers. */
+export type PlanChangeKind = "+" | "~" | "-" | "=" | "!";
+
+/** One line of a computed plan, redacted to the safe fields the UI renders. */
+export interface PlanChange {
+  kind: PlanChangeKind | string;
+  action: string;
+  address: string;
+  message: string;
+  protected: boolean;
+}
+
+/** Result of POST /api/console/plan. `hash` must be echoed back to apply. */
+export interface PlanResponse {
+  hash: string;
+  text: string;
+  changes: PlanChange[];
+}
+
+/** Body of POST /api/console/apply. */
+export interface ApplyRequest {
+  hash: string;
+}
+
+/** Response of POST /api/console/apply: the async operation id to poll. */
+export interface ApplyResponse {
+  operation_id: string;
+}
+
+/** Terminal and in-flight states of an async apply operation. */
+export type OperationState = "pending" | "running" | "succeeded" | "failed";
+
+/** Polled state of an async apply operation. */
+export interface OperationStatus {
+  id: string;
+  state: OperationState | string;
+  started_at?: string;
+  finished_at?: string;
+  changed_resources: string[];
+  error?: string;
+}
+
+/** A past apply row from the state applies table. */
+export interface ApplyHistoryEntry {
+  id: number;
+  started_at: string;
+  finished_at?: string;
+  status: string;
+}
+
+/** Recent offline state events for an agent. */
+export interface LogsResponse {
+  agent_id: string;
+  lines: string[];
+  source: string;
+  note: string;
+}
+
+/** Live status of a single fleet service (from the status poller). */
+export interface ServiceStatus {
+  id: string;
+  kind: string;
+  fly_app?: string;
+  host?: string;
+  url?: string;
+  health: string;
+  http_status?: number;
+  online: boolean;
+  machine_state?: string;
+  model?: string;
+  vault?: string;
+  error?: string;
+}
+
+/** Roll-up of service health for the status header. */
+export interface StatusSummary {
+  total: number;
+  healthy: number;
+  degraded: number;
+  down: number;
+}
+
+/** One full poll of the fleet (existing /api/status contract). */
+export interface StatusSnapshot {
+  workspace: string;
+  generated_at: string;
+  services: ServiceStatus[];
+  drift_count: number;
+  summary: StatusSummary;
+}

--- a/web/src/api/types.ts
+++ b/web/src/api/types.ts
@@ -93,6 +93,26 @@ export interface PlanResponse {
   hash: string;
   text: string;
   changes: PlanChange[];
+  /**
+   * True when the plan destroys (or is blocked from destroying) a protected
+   * resource, so the UI must collect an explicit confirmation before apply.
+   */
+  requires_protected_confirm: boolean;
+  /**
+   * True when the plan destroys a Fly volume, so the UI must collect a separate
+   * persistent-data confirmation (the server always backs up first).
+   */
+  requires_destroy_data: boolean;
+}
+
+/**
+ * Optional body of POST /api/console/plan. The destroy confirmations default to
+ * false, so a plain plan reports protected destructions as blocked rather than
+ * performing them.
+ */
+export interface PlanOptions {
+  allowProtectedDestroy?: boolean;
+  destroyData?: boolean;
 }
 
 /** Body of POST /api/console/apply. */

--- a/web/src/app/components/AgentForm.test.tsx
+++ b/web/src/app/components/AgentForm.test.tsx
@@ -1,0 +1,158 @@
+/**
+ * AgentForm tests: the form must (1) block submission and surface a field error
+ * for an invalid agent id, and (2) call onSubmit with the assembled AgentInput
+ * when every required field is valid. We drive it as a user would (typing into
+ * labelled controls, clicking the submit button) and host it in a small stateful
+ * wrapper so the controlled value updates the way the real parent provides it.
+ */
+
+import { describe, expect, it, vi } from "vitest";
+import { useState } from "react";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { AgentForm, emptyAgentInput, validateAgentInput } from "./AgentForm";
+import type { AgentInput } from "../../api/types";
+
+/** Hosts AgentForm with real controlled state so typing mutates the value. */
+function Harness({
+  onSubmit,
+  initial,
+  mode = "create",
+}: {
+  onSubmit: (v: AgentInput) => void;
+  initial?: Partial<AgentInput>;
+  mode?: "create" | "edit";
+}) {
+  const [value, setValue] = useState<AgentInput>({
+    ...emptyAgentInput(),
+    ...initial,
+  });
+  return (
+    <AgentForm
+      value={value}
+      onChange={setValue}
+      onSubmit={onSubmit}
+      submitLabel="Create agent"
+      mode={mode}
+    />
+  );
+}
+
+describe("validateAgentInput", () => {
+  it("rejects ids that violate the contract", () => {
+    const base = emptyAgentInput();
+    expect(validateAgentInput({ ...base, id: "-bad" }, "create").id).toBeTruthy();
+    expect(validateAgentInput({ ...base, id: "bad-" }, "create").id).toBeTruthy();
+    expect(validateAgentInput({ ...base, id: "Bad" }, "create").id).toBeTruthy();
+    expect(validateAgentInput({ ...base, id: "b a" }, "create").id).toBeTruthy();
+    expect(validateAgentInput({ ...base, id: "" }, "create").id).toBeTruthy();
+  });
+
+  it("accepts valid ids and flags missing name/model + bad cpus", () => {
+    const v: AgentInput = { ...emptyAgentInput(), id: "research-agent", cpus: 0 };
+    const errs = validateAgentInput(v, "create");
+    expect(errs.id).toBeUndefined();
+    expect(errs.name).toBeTruthy();
+    expect(errs.model).toBeTruthy();
+    expect(errs.cpus).toBeTruthy();
+  });
+
+  it("ignores the id in edit mode (id is immutable)", () => {
+    const v: AgentInput = {
+      ...emptyAgentInput(),
+      id: "",
+      name: "x",
+      model: "m",
+    };
+    expect(validateAgentInput(v, "edit").id).toBeUndefined();
+  });
+});
+
+describe("AgentForm", () => {
+  it("blocks submit and shows an error for an invalid id", async () => {
+    const user = userEvent.setup();
+    const onSubmit = vi.fn();
+    render(<Harness onSubmit={onSubmit} />);
+
+    // Fill name + model so the ONLY problem is the id.
+    await user.type(screen.getByLabelText(/display name/i), "Research Agent");
+    await user.type(screen.getByLabelText(/^model$/i), "anthropic/claude-3.5");
+    await user.type(screen.getByLabelText(/agent id/i), "Bad_Id");
+
+    await user.click(screen.getByRole("button", { name: /create agent/i }));
+
+    expect(onSubmit).not.toHaveBeenCalled();
+    // The id field reports the contract violation and is marked invalid.
+    const idField = screen.getByLabelText(/agent id/i);
+    expect(idField).toHaveAttribute("aria-invalid", "true");
+    expect(
+      screen.getByText(/lowercase letters, digits and hyphens/i),
+    ).toBeInTheDocument();
+  });
+
+  it("blocks submit when required name/model are empty", async () => {
+    const user = userEvent.setup();
+    const onSubmit = vi.fn();
+    render(<Harness onSubmit={onSubmit} initial={{ id: "valid-agent" }} />);
+
+    await user.click(screen.getByRole("button", { name: /create agent/i }));
+
+    expect(onSubmit).not.toHaveBeenCalled();
+    expect(screen.getByText(/a display name is required/i)).toBeInTheDocument();
+    expect(screen.getByText(/a model is required/i)).toBeInTheDocument();
+  });
+
+  it("calls onSubmit with the assembled input when valid", async () => {
+    const user = userEvent.setup();
+    const onSubmit = vi.fn();
+    render(<Harness onSubmit={onSubmit} />);
+
+    await user.type(screen.getByLabelText(/agent id/i), "research-agent");
+    await user.type(screen.getByLabelText(/display name/i), "Research Agent");
+    await user.type(screen.getByLabelText(/^model$/i), "anthropic/claude-3.5");
+
+    await user.click(screen.getByRole("button", { name: /create agent/i }));
+
+    expect(onSubmit).toHaveBeenCalledTimes(1);
+    const submitted = onSubmit.mock.calls[0][0] as AgentInput;
+    expect(submitted).toMatchObject({
+      id: "research-agent",
+      name: "Research Agent",
+      model: "anthropic/claude-3.5",
+      cpus: 1,
+      // Console defaults are carried through.
+      runtime: "fly.default",
+      network: "tailscale.default",
+      model_provider: "openrouter.default",
+      lifecycle: "present",
+      companion_soul_enabled: true,
+    });
+  });
+
+  it("clears a field error once the user corrects it", async () => {
+    const user = userEvent.setup();
+    const onSubmit = vi.fn();
+    render(<Harness onSubmit={onSubmit} initial={{ id: "valid-agent", model: "m" }} />);
+
+    // Submit with empty name → error appears.
+    await user.click(screen.getByRole("button", { name: /create agent/i }));
+    expect(screen.getByText(/a display name is required/i)).toBeInTheDocument();
+
+    // Typing into the name field clears its error eagerly.
+    await user.type(screen.getByLabelText(/display name/i), "Now Named");
+    expect(
+      screen.queryByText(/a display name is required/i),
+    ).not.toBeInTheDocument();
+  });
+
+  it("makes the id read-only in edit mode", () => {
+    render(
+      <Harness
+        onSubmit={vi.fn()}
+        mode="edit"
+        initial={{ id: "locked-agent", name: "X", model: "m" }}
+      />,
+    );
+    expect(screen.getByLabelText(/agent id/i)).toHaveAttribute("readonly");
+  });
+});

--- a/web/src/app/components/AgentForm.tsx
+++ b/web/src/app/components/AgentForm.tsx
@@ -1,0 +1,372 @@
+/**
+ * AgentForm — the controlled create/edit form for a fleet agent.
+ *
+ * It is fully controlled: the parent owns the `AgentInput` value and receives
+ * `onChange` patches. On submit it runs client-side validation and only calls
+ * `onSubmit(value)` when the input is valid; otherwise it surfaces per-field
+ * errors and moves focus to the first invalid control. The server is the final
+ * authority (it re-validates and rolls back), but catching obvious mistakes
+ * here keeps the round-trip tight.
+ *
+ * Validation rules (mirroring the Companion id contract):
+ *   - id    : must match ^[a-z0-9][a-z0-9-]*[a-z0-9]$ (single-char [a-z0-9] ok)
+ *   - name  : required, non-empty
+ *   - model : required, non-empty
+ *   - cpus  : a positive integer
+ *
+ * In edit mode the id is immutable (it keys the TOML file + state), so the id
+ * field is read-only.
+ */
+
+import { useId, useRef, useState } from "react";
+import type { AgentInput } from "../../api/types";
+import { Button } from "./Button";
+import { TextField } from "./TextField";
+import { SelectField } from "./SelectField";
+import { Toggle } from "./Toggle";
+
+/** The agent id contract shared with the Go workspace loader. */
+export const AGENT_ID_PATTERN = /^[a-z0-9][a-z0-9-]*[a-z0-9]$|^[a-z0-9]$/;
+
+const RUNTIME_OPTIONS = [{ value: "fly.default" }];
+const NETWORK_OPTIONS = [{ value: "tailscale.default" }];
+const PROVIDER_OPTIONS = [{ value: "openrouter.default" }];
+const LIFECYCLE_OPTIONS = [
+  { value: "present", label: "present (deploy)" },
+  { value: "absent", label: "absent (destroy)" },
+];
+
+/** A blank AgentInput with the console defaults that mirror examples/minimal. */
+export function emptyAgentInput(): AgentInput {
+  return {
+    id: "",
+    name: "",
+    model: "",
+    memory: "",
+    cpus: 1,
+    region: "",
+    tailscale_hostname: "",
+    fly_app: "",
+    runtime: "fly.default",
+    network: "tailscale.default",
+    model_provider: "openrouter.default",
+    lifecycle: "present",
+    soul: "",
+    companion_soul_enabled: true,
+    vault_name: "",
+  };
+}
+
+export type AgentFormErrors = Partial<Record<keyof AgentInput, string>>;
+
+/** Pure validator: returns a map of field -> message for any invalid fields. */
+export function validateAgentInput(
+  value: AgentInput,
+  mode: "create" | "edit",
+): AgentFormErrors {
+  const errors: AgentFormErrors = {};
+
+  if (mode === "create") {
+    const id = value.id.trim();
+    if (!id) {
+      errors.id = "An id is required.";
+    } else if (!AGENT_ID_PATTERN.test(id)) {
+      errors.id =
+        "Use lowercase letters, digits and hyphens; must start and end with a letter or digit.";
+    }
+  }
+
+  if (!value.name.trim()) {
+    errors.name = "A display name is required.";
+  }
+  if (!value.model.trim()) {
+    errors.model = "A model is required.";
+  }
+  if (!Number.isInteger(value.cpus) || value.cpus <= 0) {
+    errors.cpus = "CPUs must be a positive whole number.";
+  }
+
+  return errors;
+}
+
+export interface AgentFormProps {
+  value: AgentInput;
+  onChange: (next: AgentInput) => void;
+  onSubmit: (value: AgentInput) => void;
+  submitLabel: string;
+  disabled?: boolean;
+  mode: "create" | "edit";
+}
+
+export function AgentForm({
+  value,
+  onChange,
+  onSubmit,
+  submitLabel,
+  disabled = false,
+  mode,
+}: AgentFormProps) {
+  const [errors, setErrors] = useState<AgentFormErrors>({});
+  const formRef = useRef<HTMLFormElement>(null);
+  const headingId = useId();
+
+  function patch<K extends keyof AgentInput>(key: K, val: AgentInput[K]) {
+    onChange({ ...value, [key]: val });
+    // Clear a field's error as soon as the user edits it.
+    if (errors[key]) {
+      setErrors((prev) => {
+        const next = { ...prev };
+        delete next[key];
+        return next;
+      });
+    }
+  }
+
+  function handleSubmit(e: React.FormEvent) {
+    e.preventDefault();
+    const found = validateAgentInput(value, mode);
+    setErrors(found);
+    if (Object.keys(found).length > 0) {
+      // Move focus to the first invalid control for keyboard/SR users.
+      const first = Object.keys(found)[0];
+      const el = formRef.current?.querySelector<HTMLElement>(
+        `[name="${first}"]`,
+      );
+      el?.focus();
+      return;
+    }
+    onSubmit(value);
+  }
+
+  return (
+    <form
+      ref={formRef}
+      onSubmit={handleSubmit}
+      aria-labelledby={headingId}
+      className="space-y-8"
+      noValidate
+    >
+      <h2 id={headingId} className="sr-only">
+        Agent configuration
+      </h2>
+
+      {/* Identity ------------------------------------------------------- */}
+      <fieldset className="space-y-4" disabled={disabled}>
+        <legend className="text-xs font-semibold tracking-wide text-muted uppercase">
+          Identity
+        </legend>
+        <div className="grid gap-4 sm:grid-cols-2">
+          <TextField
+            name="id"
+            label="Agent id"
+            mono
+            required={mode === "create"}
+            readOnly={mode === "edit"}
+            value={value.id}
+            onChange={(e) => patch("id", e.target.value)}
+            error={errors.id ?? null}
+            hint={
+              mode === "edit"
+                ? "The id is immutable once created."
+                : "Lowercase, digits, hyphens. e.g. research-agent"
+            }
+            placeholder="research-agent"
+            autoComplete="off"
+            spellCheck={false}
+          />
+          <TextField
+            name="name"
+            label="Display name"
+            required
+            value={value.name}
+            onChange={(e) => patch("name", e.target.value)}
+            error={errors.name ?? null}
+            placeholder="Research Agent"
+          />
+        </div>
+        <TextField
+          name="model"
+          label="Model"
+          mono
+          required
+          value={value.model}
+          onChange={(e) => patch("model", e.target.value)}
+          error={errors.model ?? null}
+          hint="OpenRouter model slug, e.g. anthropic/claude-3.5-sonnet"
+          placeholder="anthropic/claude-3.5-sonnet"
+          autoComplete="off"
+          spellCheck={false}
+        />
+        <SelectField
+          name="model_provider"
+          label="Model provider"
+          options={PROVIDER_OPTIONS}
+          value={value.model_provider}
+          onChange={(e) => patch("model_provider", e.target.value)}
+        />
+      </fieldset>
+
+      {/* Runtime -------------------------------------------------------- */}
+      <fieldset className="space-y-4" disabled={disabled}>
+        <legend className="text-xs font-semibold tracking-wide text-muted uppercase">
+          Runtime
+        </legend>
+        <div className="grid gap-4 sm:grid-cols-2">
+          <SelectField
+            name="runtime"
+            label="Runtime"
+            options={RUNTIME_OPTIONS}
+            value={value.runtime}
+            onChange={(e) => patch("runtime", e.target.value)}
+          />
+          <SelectField
+            name="network"
+            label="Network"
+            options={NETWORK_OPTIONS}
+            value={value.network}
+            onChange={(e) => patch("network", e.target.value)}
+          />
+          <TextField
+            name="region"
+            label="Region"
+            mono
+            value={value.region}
+            onChange={(e) => patch("region", e.target.value)}
+            hint="Fly region, e.g. cdg. Blank uses the workspace default."
+            placeholder="cdg"
+            autoComplete="off"
+          />
+          <TextField
+            name="memory"
+            label="Memory"
+            mono
+            value={value.memory}
+            onChange={(e) => patch("memory", e.target.value)}
+            hint="e.g. 512mb, 1gb. Blank uses the default."
+            placeholder="512mb"
+            autoComplete="off"
+          />
+          <TextField
+            name="cpus"
+            label="CPUs"
+            type="number"
+            min={1}
+            step={1}
+            inputMode="numeric"
+            required
+            value={String(value.cpus)}
+            onChange={(e) => patch("cpus", e.target.valueAsNumber || 0)}
+            error={errors.cpus ?? null}
+          />
+          <SelectField
+            name="lifecycle"
+            label="Lifecycle"
+            options={LIFECYCLE_OPTIONS}
+            value={value.lifecycle}
+            onChange={(e) => patch("lifecycle", e.target.value)}
+            hint="absent renders an explicit destroy in the next plan."
+          />
+        </div>
+      </fieldset>
+
+      {/* Networking ----------------------------------------------------- */}
+      <fieldset className="space-y-4" disabled={disabled}>
+        <legend className="text-xs font-semibold tracking-wide text-muted uppercase">
+          Networking & vault
+        </legend>
+        <div className="grid gap-4 sm:grid-cols-2">
+          <TextField
+            name="fly_app"
+            label="Fly app"
+            mono
+            value={value.fly_app}
+            onChange={(e) => patch("fly_app", e.target.value)}
+            hint="Blank derives from the id."
+            placeholder="research-agent"
+            autoComplete="off"
+            spellCheck={false}
+          />
+          <TextField
+            name="tailscale_hostname"
+            label="Tailscale hostname"
+            mono
+            value={value.tailscale_hostname}
+            onChange={(e) => patch("tailscale_hostname", e.target.value)}
+            hint="Blank derives from the id."
+            placeholder="research-agent"
+            autoComplete="off"
+            spellCheck={false}
+          />
+          <TextField
+            name="vault_name"
+            label="Default vault"
+            mono
+            value={value.vault_name}
+            onChange={(e) => patch("vault_name", e.target.value)}
+            hint="Granite vault label this agent writes to."
+            placeholder="memory"
+            autoComplete="off"
+            spellCheck={false}
+          />
+        </div>
+      </fieldset>
+
+      {/* Soul ----------------------------------------------------------- */}
+      <fieldset className="space-y-4" disabled={disabled}>
+        <legend className="text-xs font-semibold tracking-wide text-muted uppercase">
+          Identity & soul
+        </legend>
+        <SoulField
+          value={value.soul}
+          onChange={(v) => patch("soul", v)}
+        />
+        <Toggle
+          label="Append companion soul"
+          checked={value.companion_soul_enabled}
+          onChange={(v) => patch("companion_soul_enabled", v)}
+          hint="Adds the fleet-wide companion SOUL.md (e.g. Granite memory rules) after this agent's identity."
+        />
+      </fieldset>
+
+      <div className="flex items-center justify-end gap-3 border-t border-line pt-5">
+        <Button type="submit" variant="primary" loading={disabled}>
+          {submitLabel}
+        </Button>
+      </div>
+    </form>
+  );
+}
+
+/** A labelled multi-line SOUL.md editor. Split out for readability. */
+function SoulField({
+  value,
+  onChange,
+}: {
+  value: string;
+  onChange: (v: string) => void;
+}) {
+  const id = useId();
+  const hintId = `${id}-hint`;
+  return (
+    <div className="flex flex-col gap-1.5">
+      <label htmlFor={id} className="text-xs font-medium text-muted">
+        SOUL.md
+      </label>
+      <textarea
+        id={id}
+        name="soul"
+        value={value}
+        onChange={(e) => onChange(e.target.value)}
+        aria-describedby={hintId}
+        rows={6}
+        spellCheck={false}
+        placeholder="# Identity&#10;You are a focused research agent…"
+        className="rounded-md border border-line bg-canvas p-3 font-mono text-xs leading-relaxed text-fg placeholder:text-faint focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-accent"
+      />
+      <p id={hintId} className="text-xs text-faint">
+        Optional. Written to the agent&apos;s SOUL.md; leave blank to keep the
+        existing identity.
+      </p>
+    </div>
+  );
+}

--- a/web/src/app/components/AppLayout.tsx
+++ b/web/src/app/components/AppLayout.tsx
@@ -1,0 +1,148 @@
+/**
+ * AppLayout — the console application shell: a fixed sidebar with primary
+ * navigation and a scrolling content region that renders the matched route via
+ * <Outlet/>.
+ *
+ * Navigation is a real <nav> with NavLinks so active state, keyboard focus, and
+ * the current-page indication (aria-current) are correct. The brand mark + the
+ * "local admin" affordance reinforce that this is a single-operator tool.
+ */
+
+import { NavLink, Outlet } from "react-router-dom";
+import type { ReactNode } from "react";
+
+interface NavItem {
+  to: string;
+  label: string;
+  /** Exact match (used for "/" so it isn't active on every route). */
+  end?: boolean;
+  icon: ReactNode;
+}
+
+const NAV: NavItem[] = [
+  { to: "/", label: "Agents", end: true, icon: <AgentsIcon /> },
+  { to: "/agents/new", label: "Create", icon: <PlusIcon /> },
+  { to: "/plan", label: "Plan & Apply", icon: <PlanIcon /> },
+  { to: "/settings", label: "Settings", icon: <GearIcon /> },
+];
+
+export interface AppLayoutProps {
+  /** Optional override of the workspace label shown in the sidebar header. */
+  workspaceName?: string;
+}
+
+export function AppLayout({ workspaceName }: AppLayoutProps) {
+  return (
+    <div className="flex min-h-full bg-canvas text-fg">
+      <a
+        href="#main"
+        className="sr-only focus:not-sr-only focus:absolute focus:left-3 focus:top-3 focus:z-50 focus:rounded-md focus:bg-accent focus:px-3 focus:py-1.5 focus:text-sm focus:text-accent-fg"
+      >
+        Skip to content
+      </a>
+
+      <aside className="flex w-60 shrink-0 flex-col border-r border-line bg-surface">
+        <div className="flex h-14 items-center gap-2.5 border-b border-line px-4">
+          <span
+            aria-hidden="true"
+            className="grid size-7 place-items-center rounded-md bg-accent text-sm font-semibold text-accent-fg"
+          >
+            C
+          </span>
+          <div className="min-w-0">
+            <p className="truncate text-sm font-semibold tracking-tight">
+              Companion
+            </p>
+            {workspaceName && (
+              <p className="truncate text-[11px] text-faint">{workspaceName}</p>
+            )}
+          </div>
+        </div>
+
+        <nav aria-label="Primary" className="flex-1 space-y-0.5 p-2">
+          {NAV.map((item) => (
+            <NavLink
+              key={item.to}
+              to={item.to}
+              end={item.end}
+              className={({ isActive }) =>
+                "flex items-center gap-2.5 rounded-md px-2.5 py-2 text-sm transition-colors " +
+                "focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-accent " +
+                (isActive
+                  ? "bg-surface-raised font-medium text-fg"
+                  : "text-muted hover:bg-surface-raised hover:text-fg")
+              }
+            >
+              <span aria-hidden="true" className="text-faint">
+                {item.icon}
+              </span>
+              {item.label}
+            </NavLink>
+          ))}
+        </nav>
+
+        <div className="border-t border-line px-4 py-3">
+          <span className="text-[11px] text-faint">local admin</span>
+        </div>
+      </aside>
+
+      <div className="flex min-w-0 flex-1 flex-col">
+        <main
+          id="main"
+          className="mx-auto w-full max-w-5xl flex-1 px-6 py-8"
+        >
+          <Outlet />
+        </main>
+      </div>
+    </div>
+  );
+}
+
+/* --- inline icons (decorative; aria-hidden via parent) -------------------- */
+
+function iconProps() {
+  return {
+    width: 16,
+    height: 16,
+    viewBox: "0 0 24 24",
+    fill: "none",
+    stroke: "currentColor",
+    strokeWidth: 1.8,
+    strokeLinecap: "round" as const,
+    strokeLinejoin: "round" as const,
+  };
+}
+
+function AgentsIcon() {
+  return (
+    <svg {...iconProps()}>
+      <rect x="3" y="4" width="18" height="6" rx="1.5" />
+      <rect x="3" y="14" width="18" height="6" rx="1.5" />
+    </svg>
+  );
+}
+
+function PlusIcon() {
+  return (
+    <svg {...iconProps()}>
+      <path d="M12 5v14M5 12h14" />
+    </svg>
+  );
+}
+
+function PlanIcon() {
+  return (
+    <svg {...iconProps()}>
+      <path d="M4 6h16M4 12h10M4 18h7" />
+    </svg>
+  );
+}
+
+function GearIcon() {
+  return (
+    <svg {...iconProps()}>
+      <circle cx="12" cy="12" r="3" />
+      <path d="M19.4 15a1.65 1.65 0 0 0 .33 1.82l.06.06a2 2 0 1 1-2.83 2.83l-.06-.06a1.65 1.65 0 0 0-2.82 1.17V21a2 2 0 1 1-4 0v-.09A1.65 1.65 0 0 0 8 19.4a1.65 1.65 0 0 0-1.82.33l-.06.06a2 2 0 1 1-2.83-2.83l.06-.06A1.65 1.65 0 0 0 3.6 14H3.5a2 2 0 1 1 0-4h.09A1.65 1.65 0 0 0 4.6 8a1.65 1.65 0 0 0-.33-1.82l-.06-.06a2 2 0 1 1 2.83-2.83l.06.06A1.65 1.65 0 0 0 9 3.6h.09A1.65 1.65 0 0 0 10 2v0a2 2 0 1 1 4 0v.09a1.65 1.65 0 0 0 1 1.51 1.65 1.65 0 0 0 1.82-.33l.06-.06a2 2 0 1 1 2.83 2.83l-.06.06A1.65 1.65 0 0 0 20.4 9v.09A1.65 1.65 0 0 0 22 10a2 2 0 1 1 0 4h-.09a1.65 1.65 0 0 0-1.51 1Z" />
+    </svg>
+  );
+}

--- a/web/src/app/components/Badge.tsx
+++ b/web/src/app/components/Badge.tsx
@@ -1,0 +1,62 @@
+/**
+ * Badge — a small, calm status pill. Tones map to the semantic theme colors;
+ * the default `neutral` tone is used for lifecycle/metadata labels. A leading
+ * dot is optional for status-like badges.
+ */
+
+import type { ReactNode } from "react";
+
+export type BadgeTone = "neutral" | "accent" | "ok" | "warn" | "danger";
+
+export interface BadgeProps {
+  tone?: BadgeTone;
+  /** Shows a small leading status dot in the tone color. */
+  dot?: boolean;
+  className?: string;
+  children: ReactNode;
+}
+
+const tones: Record<BadgeTone, { pill: string; dot: string }> = {
+  neutral: {
+    pill: "border-line bg-surface-raised text-muted",
+    dot: "bg-faint",
+  },
+  accent: {
+    pill: "border-accent-muted/40 bg-accent-muted/15 text-accent",
+    dot: "bg-accent",
+  },
+  ok: {
+    pill: "border-ok/30 bg-ok/12 text-ok",
+    dot: "bg-ok",
+  },
+  warn: {
+    pill: "border-warn/30 bg-warn/12 text-warn",
+    dot: "bg-warn",
+  },
+  danger: {
+    pill: "border-danger/30 bg-danger/12 text-danger",
+    dot: "bg-danger",
+  },
+};
+
+export function Badge({
+  tone = "neutral",
+  dot = false,
+  className = "",
+  children,
+}: BadgeProps) {
+  const t = tones[tone];
+  return (
+    <span
+      className={`inline-flex items-center gap-1.5 rounded-md border px-2 py-0.5 text-xs font-medium ${t.pill} ${className}`}
+    >
+      {dot && (
+        <span
+          aria-hidden="true"
+          className={`size-1.5 rounded-full ${t.dot}`}
+        />
+      )}
+      {children}
+    </span>
+  );
+}

--- a/web/src/app/components/Button.tsx
+++ b/web/src/app/components/Button.tsx
@@ -1,0 +1,65 @@
+/**
+ * Button — the single button primitive for the console.
+ *
+ * Variants: primary (accent), secondary (surface), ghost (bare), danger
+ * (destructive). A `loading` flag shows an inline spinner and disables
+ * interaction without removing the button from the tab order's intent (it sets
+ * `aria-busy`). Focus-visible rings come from the global stylesheet.
+ */
+
+import type { ButtonHTMLAttributes, ReactNode } from "react";
+import { Spinner } from "./Spinner";
+
+export type ButtonVariant = "primary" | "secondary" | "ghost" | "danger";
+export type ButtonSize = "sm" | "md";
+
+export interface ButtonProps extends ButtonHTMLAttributes<HTMLButtonElement> {
+  variant?: ButtonVariant;
+  size?: ButtonSize;
+  /** When true, shows a spinner and marks the button busy + disabled. */
+  loading?: boolean;
+  children: ReactNode;
+}
+
+const base =
+  "inline-flex items-center justify-center gap-2 rounded-md font-medium " +
+  "transition-colors disabled:cursor-not-allowed disabled:opacity-50 " +
+  "focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-accent";
+
+const sizes: Record<ButtonSize, string> = {
+  sm: "h-8 px-3 text-xs",
+  md: "h-9 px-4 text-sm",
+};
+
+const variants: Record<ButtonVariant, string> = {
+  primary:
+    "bg-accent text-accent-fg hover:bg-accent-muted focus-visible:outline-accent",
+  secondary:
+    "border border-line bg-surface-raised text-fg hover:border-line-strong hover:bg-surface",
+  ghost: "text-muted hover:bg-surface-raised hover:text-fg",
+  danger: "bg-danger text-white hover:opacity-90 focus-visible:outline-danger",
+};
+
+export function Button({
+  variant = "secondary",
+  size = "md",
+  loading = false,
+  disabled,
+  className = "",
+  children,
+  type = "button",
+  ...rest
+}: ButtonProps) {
+  return (
+    <button
+      type={type}
+      disabled={disabled || loading}
+      aria-busy={loading || undefined}
+      className={`${base} ${sizes[size]} ${variants[variant]} ${className}`}
+      {...rest}
+    >
+      {loading && <Spinner className="size-4" label="Working" />}
+      {children}
+    </button>
+  );
+}

--- a/web/src/app/components/Card.tsx
+++ b/web/src/app/components/Card.tsx
@@ -1,0 +1,53 @@
+/**
+ * Card — a hairline-bordered surface container with optional title/actions
+ * header. Used to group related content (agent detail sections, plan output,
+ * settings panels) on the canvas.
+ */
+
+import type { ReactNode } from "react";
+
+export interface CardProps {
+  /** Optional heading shown in the card header row. */
+  title?: ReactNode;
+  /** Optional secondary text under the title. */
+  description?: ReactNode;
+  /** Optional actions rendered at the right of the header row. */
+  actions?: ReactNode;
+  /** Removes inner padding from the body (for full-bleed content like tables). */
+  bare?: boolean;
+  className?: string;
+  children?: ReactNode;
+}
+
+export function Card({
+  title,
+  description,
+  actions,
+  bare = false,
+  className = "",
+  children,
+}: CardProps) {
+  const hasHeader = title != null || actions != null || description != null;
+  return (
+    <section
+      className={`rounded-md border border-line bg-surface ${className}`}
+    >
+      {hasHeader && (
+        <header className="flex items-start justify-between gap-4 border-b border-line px-4 py-3">
+          <div className="min-w-0">
+            {title != null && (
+              <h2 className="truncate text-sm font-semibold text-fg">{title}</h2>
+            )}
+            {description != null && (
+              <p className="mt-0.5 text-xs text-muted">{description}</p>
+            )}
+          </div>
+          {actions != null && (
+            <div className="flex shrink-0 items-center gap-2">{actions}</div>
+          )}
+        </header>
+      )}
+      <div className={bare ? "" : "p-4"}>{children}</div>
+    </section>
+  );
+}

--- a/web/src/app/components/CodeBlock.tsx
+++ b/web/src/app/components/CodeBlock.tsx
@@ -1,0 +1,42 @@
+/**
+ * CodeBlock — a monospace, scrollable block for preformatted output (plan text,
+ * log lines, soul previews). Preserves whitespace and offers an optional
+ * accessible label. It is read-only display, never an editor.
+ */
+
+import type { ReactNode } from "react";
+
+export interface CodeBlockProps {
+  /** Raw text to render. Newlines are preserved. */
+  children: ReactNode;
+  /** Accessible label for the scroll region (announced as a group). */
+  ariaLabel?: string;
+  /** Caps the height and enables vertical scroll. Defaults to true. */
+  scroll?: boolean;
+  className?: string;
+}
+
+export function CodeBlock({
+  children,
+  ariaLabel,
+  scroll = true,
+  className = "",
+}: CodeBlockProps) {
+  return (
+    <pre
+      // A labelled, focusable group lets keyboard users scroll long output.
+      aria-label={ariaLabel}
+      role={ariaLabel ? "group" : undefined}
+      tabIndex={scroll ? 0 : undefined}
+      className={
+        "overflow-x-auto rounded-md border border-line bg-canvas p-3 " +
+        "font-mono text-xs leading-relaxed whitespace-pre text-muted " +
+        "focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-accent " +
+        (scroll ? "max-h-80 overflow-y-auto " : "") +
+        className
+      }
+    >
+      {children}
+    </pre>
+  );
+}

--- a/web/src/app/components/ConfirmDialog.tsx
+++ b/web/src/app/components/ConfirmDialog.tsx
@@ -1,0 +1,99 @@
+/**
+ * ConfirmDialog — an accessible confirmation modal built on the native
+ * <dialog> element, which gives us focus trapping, Escape-to-close, and the
+ * backdrop for free. Used to gate destructive/irreversible actions (delete an
+ * agent, apply a plan).
+ *
+ * The dialog is rendered only when `open` so its mount/unmount drives the modal
+ * lifecycle; the confirm button can show a pending state while the action runs.
+ */
+
+import type { ReactNode } from "react";
+import { useEffect, useId, useRef } from "react";
+import { Button, type ButtonVariant } from "./Button";
+
+export interface ConfirmDialogProps {
+  open: boolean;
+  title: ReactNode;
+  /** Body content explaining the consequence of confirming. */
+  children?: ReactNode;
+  confirmLabel?: string;
+  cancelLabel?: string;
+  /** Visual tone of the confirm button (danger for destructive actions). */
+  confirmVariant?: ButtonVariant;
+  /** Shows a spinner on confirm and blocks re-clicks while the action runs. */
+  pending?: boolean;
+  onConfirm: () => void;
+  onCancel: () => void;
+}
+
+export function ConfirmDialog({
+  open,
+  title,
+  children,
+  confirmLabel = "Confirm",
+  cancelLabel = "Cancel",
+  confirmVariant = "primary",
+  pending = false,
+  onConfirm,
+  onCancel,
+}: ConfirmDialogProps) {
+  const ref = useRef<HTMLDialogElement>(null);
+  const titleId = useId();
+  const descId = useId();
+
+  // Open/close the native dialog in step with the `open` prop. showModal()
+  // provides the focus trap + inert background; close() restores focus.
+  useEffect(() => {
+    const el = ref.current;
+    if (!el) return;
+    if (open && !el.open) {
+      el.showModal();
+    } else if (!open && el.open) {
+      el.close();
+    }
+  }, [open]);
+
+  if (!open) return null;
+
+  return (
+    <dialog
+      ref={ref}
+      aria-labelledby={titleId}
+      aria-describedby={children ? descId : undefined}
+      // Native <dialog> handles Escape via the "cancel" event.
+      onCancel={(e) => {
+        e.preventDefault();
+        if (!pending) onCancel();
+      }}
+      // Clicking the ::backdrop reports the dialog itself as the target.
+      onClick={(e) => {
+        if (e.target === ref.current && !pending) onCancel();
+      }}
+      className="m-auto w-[min(28rem,calc(100vw-2rem))] rounded-md border border-line bg-surface p-0 text-fg shadow-xl backdrop:bg-black/50"
+    >
+      <div className="p-5">
+        <h2 id={titleId} className="text-base font-semibold">
+          {title}
+        </h2>
+        {children != null && (
+          <div id={descId} className="mt-2 text-sm text-muted">
+            {children}
+          </div>
+        )}
+        <div className="mt-5 flex justify-end gap-2">
+          <Button variant="ghost" onClick={onCancel} disabled={pending}>
+            {cancelLabel}
+          </Button>
+          <Button
+            variant={confirmVariant}
+            onClick={onConfirm}
+            loading={pending}
+          >
+            {confirmLabel}
+          </Button>
+        </div>
+      </div>
+    </dialog>
+  );
+}

--- a/web/src/app/components/EmptyState.tsx
+++ b/web/src/app/components/EmptyState.tsx
@@ -1,0 +1,44 @@
+/**
+ * EmptyState — a calm placeholder for empty lists/sections, with an optional
+ * call-to-action. Every list view renders one of these for its zero case so the
+ * UI never shows a blank region.
+ */
+
+import type { ReactNode } from "react";
+
+export interface EmptyStateProps {
+  title: ReactNode;
+  description?: ReactNode;
+  /** Optional action (typically a Button or link) rendered below the text. */
+  action?: ReactNode;
+  /** Optional decorative icon element. */
+  icon?: ReactNode;
+  className?: string;
+}
+
+export function EmptyState({
+  title,
+  description,
+  action,
+  icon,
+  className = "",
+}: EmptyStateProps) {
+  return (
+    <div
+      className={`flex flex-col items-center justify-center gap-3 rounded-md border border-dashed border-line px-6 py-12 text-center ${className}`}
+    >
+      {icon != null && (
+        <div aria-hidden="true" className="text-faint">
+          {icon}
+        </div>
+      )}
+      <div className="space-y-1">
+        <p className="text-sm font-medium text-fg">{title}</p>
+        {description != null && (
+          <p className="max-w-sm text-xs text-muted">{description}</p>
+        )}
+      </div>
+      {action != null && <div className="mt-1">{action}</div>}
+    </div>
+  );
+}

--- a/web/src/app/components/ErrorBanner.tsx
+++ b/web/src/app/components/ErrorBanner.tsx
@@ -1,0 +1,59 @@
+/**
+ * ErrorBanner — a dismissible, assertive error region.
+ *
+ * Accepts either an Error or a string. Uses `role="alert"` so screen readers
+ * announce failures (failed loads, rejected mutations) immediately. An optional
+ * retry action is rendered inline for recoverable errors.
+ */
+
+import type { ReactNode } from "react";
+import { Button } from "./Button";
+
+export interface ErrorBannerProps {
+  /** The error to display. A ConsoleError's message is shown verbatim. */
+  error: unknown;
+  /** Optional prefix, e.g. "Could not load agents". */
+  title?: ReactNode;
+  /** Optional retry handler; renders a "Retry" button when provided. */
+  onRetry?: () => void;
+  className?: string;
+}
+
+function messageOf(error: unknown): string {
+  if (error == null) return "An unknown error occurred.";
+  if (typeof error === "string") return error;
+  if (error instanceof Error) return error.message;
+  return String(error);
+}
+
+export function ErrorBanner({
+  error,
+  title,
+  onRetry,
+  className = "",
+}: ErrorBannerProps) {
+  return (
+    <div
+      role="alert"
+      className={`flex items-start gap-3 rounded-md border border-danger/40 bg-danger/10 px-4 py-3 ${className}`}
+    >
+      <span
+        aria-hidden="true"
+        className="mt-0.5 grid size-5 shrink-0 place-items-center rounded-full bg-danger/20 text-xs font-bold text-danger"
+      >
+        !
+      </span>
+      <div className="min-w-0 flex-1">
+        {title != null && (
+          <p className="text-sm font-medium text-fg">{title}</p>
+        )}
+        <p className="text-xs break-words text-danger">{messageOf(error)}</p>
+      </div>
+      {onRetry && (
+        <Button size="sm" variant="secondary" onClick={onRetry}>
+          Retry
+        </Button>
+      )}
+    </div>
+  );
+}

--- a/web/src/app/components/HealthBadge.test.tsx
+++ b/web/src/app/components/HealthBadge.test.tsx
@@ -1,0 +1,43 @@
+/**
+ * HealthBadge tests: each known health string maps to its human label and tone,
+ * and unknown/empty values degrade to a neutral "Unknown" pill so a row without
+ * snapshot enrichment still reads cleanly.
+ */
+
+import { describe, expect, it } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { HealthBadge } from "./HealthBadge";
+
+describe("HealthBadge", () => {
+  it("renders 'Healthy' for ok", () => {
+    render(<HealthBadge health="ok" />);
+    const badge = screen.getByText("Healthy");
+    expect(badge).toBeInTheDocument();
+    expect(badge).toHaveClass("text-ok");
+  });
+
+  it("renders 'Degraded' for degraded", () => {
+    render(<HealthBadge health="degraded" />);
+    expect(screen.getByText("Degraded")).toHaveClass("text-warn");
+  });
+
+  it("renders 'Down' for down", () => {
+    render(<HealthBadge health="down" />);
+    expect(screen.getByText("Down")).toHaveClass("text-danger");
+  });
+
+  it("falls back to 'Unknown' for an unrecognized value", () => {
+    render(<HealthBadge health="weird" />);
+    expect(screen.getByText("Unknown")).toBeInTheDocument();
+  });
+
+  it("falls back to 'Unknown' when health is missing", () => {
+    render(<HealthBadge />);
+    expect(screen.getByText("Unknown")).toBeInTheDocument();
+  });
+
+  it("is case-insensitive", () => {
+    render(<HealthBadge health="OK" />);
+    expect(screen.getByText("Healthy")).toBeInTheDocument();
+  });
+});

--- a/web/src/app/components/HealthBadge.tsx
+++ b/web/src/app/components/HealthBadge.tsx
@@ -1,0 +1,42 @@
+/**
+ * HealthBadge — maps a fleet health string to a toned Badge with a status dot.
+ *
+ * The health values come from `internal/status` (ok / degraded / down /
+ * unknown). An empty/unknown value renders a muted "unknown" pill so a row
+ * without snapshot enrichment still reads cleanly.
+ */
+
+import { Badge, type BadgeTone } from "./Badge";
+
+export interface HealthBadgeProps {
+  health?: string;
+  className?: string;
+}
+
+interface HealthView {
+  tone: BadgeTone;
+  label: string;
+}
+
+function viewFor(health: string | undefined): HealthView {
+  switch ((health ?? "").toLowerCase()) {
+    case "ok":
+    case "healthy":
+      return { tone: "ok", label: "Healthy" };
+    case "degraded":
+      return { tone: "warn", label: "Degraded" };
+    case "down":
+      return { tone: "danger", label: "Down" };
+    default:
+      return { tone: "neutral", label: "Unknown" };
+  }
+}
+
+export function HealthBadge({ health, className }: HealthBadgeProps) {
+  const { tone, label } = viewFor(health);
+  return (
+    <Badge tone={tone} dot className={className}>
+      {label}
+    </Badge>
+  );
+}

--- a/web/src/app/components/OperationProgress.tsx
+++ b/web/src/app/components/OperationProgress.tsx
@@ -1,0 +1,103 @@
+/**
+ * OperationProgress — live view of an async apply operation.
+ *
+ * Polls the operation via `useOperation` until it reaches a terminal state, then
+ * fires `onDone(status)` exactly once. Shows the current state, a spinner while
+ * running, the list of changed resource addresses, and any error. This is the
+ * first-class "what is happening right now" surface for an apply.
+ */
+
+import { useEffect, useRef } from "react";
+import { useOperation } from "../hooks";
+import type { OperationStatus } from "../../api/types";
+import { Badge, type BadgeTone } from "./Badge";
+import { Spinner } from "./Spinner";
+import { ErrorBanner } from "./ErrorBanner";
+
+export interface OperationProgressProps {
+  /** The operation id to track, or null when no apply is active. */
+  operationId: string | null;
+  /** Called once when the operation reaches a terminal state. */
+  onDone?: (status: OperationStatus) => void;
+  className?: string;
+}
+
+const STATE_TONE: Record<string, BadgeTone> = {
+  pending: "neutral",
+  running: "accent",
+  succeeded: "ok",
+  failed: "danger",
+};
+
+function isTerminal(state: string | undefined): boolean {
+  return state === "succeeded" || state === "failed";
+}
+
+export function OperationProgress({
+  operationId,
+  onDone,
+  className = "",
+}: OperationProgressProps) {
+  const { data, error } = useOperation(operationId, 1500);
+
+  // Fire onDone exactly once per operation id, when it first goes terminal.
+  const notifiedFor = useRef<string | null>(null);
+  useEffect(() => {
+    if (!data || !operationId) return;
+    if (isTerminal(data.state) && notifiedFor.current !== operationId) {
+      notifiedFor.current = operationId;
+      onDone?.(data);
+    }
+  }, [data, operationId, onDone]);
+
+  if (!operationId) return null;
+
+  const state = data?.state ?? "pending";
+  const running = state === "pending" || state === "running";
+  const changed = data?.changed_resources ?? [];
+
+  return (
+    <div
+      className={`space-y-3 rounded-md border border-line bg-surface p-4 ${className}`}
+      aria-live="polite"
+    >
+      <div className="flex items-center gap-3">
+        {running && <Spinner label="Applying" />}
+        <span className="text-sm font-medium text-fg">Apply</span>
+        <Badge tone={STATE_TONE[state] ?? "neutral"} dot className="ml-auto">
+          {state}
+        </Badge>
+      </div>
+
+      {error && <ErrorBanner error={error} title="Could not read operation status" />}
+
+      {data?.error && (
+        <ErrorBanner error={data.error} title="Apply failed" />
+      )}
+
+      {changed.length > 0 ? (
+        <div>
+          <p className="mb-1.5 text-xs font-medium text-muted">
+            Changed resources ({changed.length})
+          </p>
+          <ul className="space-y-1">
+            {changed.map((addr) => (
+              <li
+                key={addr}
+                className="font-mono text-xs text-fg"
+              >
+                {addr}
+              </li>
+            ))}
+          </ul>
+        </div>
+      ) : (
+        state === "succeeded" && (
+          <p className="text-xs text-muted">
+            Apply completed with no resource changes.
+          </p>
+        )
+      )}
+    </div>
+  );
+}

--- a/web/src/app/components/PageHeader.tsx
+++ b/web/src/app/components/PageHeader.tsx
@@ -1,0 +1,37 @@
+/**
+ * PageHeader — the title block at the top of every page. Renders the page's
+ * primary heading plus optional description and right-aligned actions. Each
+ * page owns exactly one of these so there is a single h1-level landmark.
+ */
+
+import type { ReactNode } from "react";
+
+export interface PageHeaderProps {
+  title: ReactNode;
+  description?: ReactNode;
+  actions?: ReactNode;
+  /** Optional element rendered above the title (e.g. a back link / eyebrow). */
+  eyebrow?: ReactNode;
+}
+
+export function PageHeader({
+  title,
+  description,
+  actions,
+  eyebrow,
+}: PageHeaderProps) {
+  return (
+    <div className="mb-6 flex flex-wrap items-end justify-between gap-4">
+      <div className="min-w-0">
+        {eyebrow != null && <div className="mb-1">{eyebrow}</div>}
+        <h1 className="text-lg font-semibold tracking-tight text-fg">{title}</h1>
+        {description != null && (
+          <p className="mt-1 max-w-prose text-sm text-muted">{description}</p>
+        )}
+      </div>
+      {actions != null && (
+        <div className="flex shrink-0 items-center gap-2">{actions}</div>
+      )}
+    </div>
+  );
+}

--- a/web/src/app/components/PlanDiff.test.tsx
+++ b/web/src/app/components/PlanDiff.test.tsx
@@ -1,0 +1,93 @@
+/**
+ * PlanDiff tests: every change kind must render with a distinct, accessible
+ * treatment (a marker glyph + an SR-readable verb), protected resources must be
+ * flagged, and the empty case must show the "no changes" state. Colour is a
+ * secondary cue, so we assert on the text/role signals a screen reader uses.
+ */
+
+import { describe, expect, it } from "vitest";
+import { render, screen, within } from "@testing-library/react";
+import { PlanDiff } from "./PlanDiff";
+import type { PlanChange } from "../../api/types";
+
+function change(over: Partial<PlanChange>): PlanChange {
+  return {
+    kind: "+",
+    action: "create",
+    address: "fly_app.example",
+    message: "",
+    protected: false,
+    ...over,
+  };
+}
+
+describe("PlanDiff", () => {
+  it("renders a distinct accessible verb for each change kind", () => {
+    const changes: PlanChange[] = [
+      change({ kind: "+", address: "a.create" }),
+      change({ kind: "~", address: "a.update" }),
+      change({ kind: "-", address: "a.destroy" }),
+      change({ kind: "=", address: "a.noop" }),
+      change({ kind: "!", address: "a.blocked" }),
+    ];
+    render(<PlanDiff changes={changes} />);
+
+    const list = screen.getByRole("list", { name: /planned changes/i });
+    const items = within(list).getAllByRole("listitem");
+    expect(items).toHaveLength(5);
+
+    // Each kind exposes its semantic verb and tags the row via data-kind.
+    expect(within(items[0]).getByText("create")).toBeInTheDocument();
+    expect(items[0]).toHaveAttribute("data-kind", "+");
+    expect(within(items[1]).getByText("update")).toBeInTheDocument();
+    expect(items[1]).toHaveAttribute("data-kind", "~");
+    expect(within(items[2]).getByText("destroy")).toBeInTheDocument();
+    expect(items[2]).toHaveAttribute("data-kind", "-");
+    expect(within(items[3]).getByText("no change")).toBeInTheDocument();
+    expect(items[3]).toHaveAttribute("data-kind", "=");
+    expect(within(items[4]).getByText("blocked")).toBeInTheDocument();
+    expect(items[4]).toHaveAttribute("data-kind", "!");
+  });
+
+  it("applies a distinct text colour class per kind", () => {
+    // Distinct styling is part of the contract; assert the colour classes the
+    // component maps each kind to so a regression in the palette is caught.
+    const { rerender } = render(
+      <PlanDiff changes={[change({ kind: "+", message: "" })]} />,
+    );
+    expect(screen.getByText("create")).toHaveClass("text-ok");
+
+    rerender(<PlanDiff changes={[change({ kind: "-", message: "" })]} />);
+    expect(screen.getByText("destroy")).toHaveClass("text-danger");
+
+    rerender(<PlanDiff changes={[change({ kind: "~", message: "" })]} />);
+    expect(screen.getByText("update")).toHaveClass("text-warn");
+
+    rerender(<PlanDiff changes={[change({ kind: "=", message: "" })]} />);
+    expect(screen.getByText("no change")).toHaveClass("text-faint");
+  });
+
+  it("flags protected resources with a badge", () => {
+    render(
+      <PlanDiff
+        changes={[change({ kind: "-", address: "fly_app.prod", protected: true })]}
+      />,
+    );
+    expect(screen.getByText("protected")).toBeInTheDocument();
+  });
+
+  it("shows the message text when present", () => {
+    render(
+      <PlanDiff
+        changes={[change({ kind: "~", message: "memory 256mb -> 512mb" })]}
+      />,
+    );
+    expect(screen.getByText("memory 256mb -> 512mb")).toBeInTheDocument();
+  });
+
+  it("renders an empty state when there are no changes", () => {
+    render(<PlanDiff changes={[]} />);
+    expect(screen.getByText(/no changes/i)).toBeInTheDocument();
+    expect(screen.queryByRole("list")).not.toBeInTheDocument();
+  });
+});

--- a/web/src/app/components/PlanDiff.tsx
+++ b/web/src/app/components/PlanDiff.tsx
@@ -1,0 +1,109 @@
+/**
+ * PlanDiff — renders a computed plan's changes as a legible, color-coded list.
+ *
+ * Each change kind has a distinct marker + color, mirroring the engine's
+ * single-character markers:
+ *   "+" create  → green
+ *   "~" update  → amber
+ *   "-" destroy → red
+ *   "=" no-op    → muted
+ *   "!" error/blocked → red
+ *
+ * Protected resources get an explicit, high-visibility badge so a destroy of a
+ * protected resource is never mistaken for a routine change. Colour is never the
+ * only signal: the marker glyph and an accessible label carry the meaning too.
+ */
+
+import type { PlanChange } from "../../api/types";
+import { Badge } from "./Badge";
+import { EmptyState } from "./EmptyState";
+
+export interface PlanDiffProps {
+  changes: PlanChange[];
+  className?: string;
+}
+
+interface KindView {
+  /** Accessible verb for screen readers. */
+  label: string;
+  /** Text/marker colour class. */
+  color: string;
+  /** Left rail accent. */
+  rail: string;
+}
+
+function viewForKind(kind: string): KindView {
+  switch (kind) {
+    case "+":
+      return { label: "create", color: "text-ok", rail: "bg-ok" };
+    case "~":
+      return { label: "update", color: "text-warn", rail: "bg-warn" };
+    case "-":
+      return { label: "destroy", color: "text-danger", rail: "bg-danger" };
+    case "!":
+      return { label: "blocked", color: "text-danger", rail: "bg-danger" };
+    case "=":
+    default:
+      return { label: "no change", color: "text-faint", rail: "bg-line-strong" };
+  }
+}
+
+export function PlanDiff({ changes, className = "" }: PlanDiffProps) {
+  if (changes.length === 0) {
+    return (
+      <EmptyState
+        title="No changes"
+        description="The workspace matches the recorded state. Nothing to apply."
+        className={className}
+      />
+    );
+  }
+
+  return (
+    <ul
+      aria-label="Planned changes"
+      className={`divide-y divide-line overflow-hidden rounded-md border border-line ${className}`}
+    >
+      {changes.map((change, i) => {
+        const view = viewForKind(change.kind);
+        return (
+          <li
+            key={`${change.address}-${i}`}
+            data-kind={change.kind}
+            className="flex items-start gap-3 bg-surface px-3 py-2"
+          >
+            <span
+              aria-hidden="true"
+              className={`mt-0.5 w-3 shrink-0 self-stretch rounded-full ${view.rail}`}
+            />
+            <span
+              aria-hidden="true"
+              className={`mt-px w-3 shrink-0 text-center font-mono text-sm font-bold ${view.color}`}
+            >
+              {change.kind}
+            </span>
+            <div className="min-w-0 flex-1">
+              <div className="flex flex-wrap items-center gap-2">
+                <span className="font-mono text-xs text-fg">
+                  {change.address}
+                </span>
+                <span className={`text-[11px] font-medium uppercase ${view.color}`}>
+                  <span className="sr-only">Change type: </span>
+                  {view.label}
+                </span>
+                {change.protected && (
+                  <Badge tone="danger">protected</Badge>
+                )}
+              </div>
+              {change.message && (
+                <p className="mt-0.5 text-xs break-words text-muted">
+                  {change.message}
+                </p>
+              )}
+            </div>
+          </li>
+        );
+      })}
+    </ul>
+  );
+}

--- a/web/src/app/components/SelectField.tsx
+++ b/web/src/app/components/SelectField.tsx
@@ -1,0 +1,82 @@
+/**
+ * SelectField — a labelled native <select>.
+ *
+ * Native select keeps keyboard and screen-reader behavior correct for free.
+ * Options are passed as `{ value, label }`; the label defaults to the value.
+ */
+
+import type { ReactNode, SelectHTMLAttributes } from "react";
+import { useId } from "react";
+
+export interface SelectOption {
+  value: string;
+  label?: string;
+}
+
+export interface SelectFieldProps
+  extends Omit<SelectHTMLAttributes<HTMLSelectElement>, "id"> {
+  label: ReactNode;
+  options: SelectOption[];
+  hint?: ReactNode;
+  error?: string | null;
+}
+
+export function SelectField({
+  label,
+  options,
+  hint,
+  error,
+  className = "",
+  required,
+  ...rest
+}: SelectFieldProps) {
+  const id = useId();
+  const hintId = `${id}-hint`;
+  const errorId = `${id}-error`;
+  const describedBy =
+    [hint ? hintId : null, error ? errorId : null].filter(Boolean).join(" ") ||
+    undefined;
+
+  return (
+    <div className={`flex flex-col gap-1.5 ${className}`}>
+      <span className="flex items-center gap-1">
+        <label htmlFor={id} className="text-xs font-medium text-muted">
+          {label}
+        </label>
+        {required && (
+          <span className="text-danger" aria-hidden="true">
+            *
+          </span>
+        )}
+      </span>
+      <select
+        id={id}
+        required={required}
+        aria-invalid={error ? true : undefined}
+        aria-describedby={describedBy}
+        className={
+          "h-9 rounded-md border bg-canvas px-3 text-sm text-fg " +
+          "focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-accent " +
+          (error ? "border-danger" : "border-line")
+        }
+        {...rest}
+      >
+        {options.map((opt) => (
+          <option key={opt.value} value={opt.value}>
+            {opt.label ?? opt.value}
+          </option>
+        ))}
+      </select>
+      {hint && !error && (
+        <p id={hintId} className="text-xs text-faint">
+          {hint}
+        </p>
+      )}
+      {error && (
+        <p id={errorId} className="text-xs text-danger" role="alert">
+          {error}
+        </p>
+      )}
+    </div>
+  );
+}

--- a/web/src/app/components/Spinner.tsx
+++ b/web/src/app/components/Spinner.tsx
@@ -1,0 +1,44 @@
+/**
+ * Spinner — an accessible, reduced-motion-aware loading indicator.
+ *
+ * Renders an SVG ring with `role="status"` and a visually hidden label so
+ * screen readers announce the loading state. The CSS `animate-spin` utility is
+ * neutralized by the global prefers-reduced-motion rule in index.css.
+ */
+
+export interface SpinnerProps {
+  /** Accessible label announced to assistive tech. Defaults to "Loading". */
+  label?: string;
+  /** Tailwind size class for the ring (defaults to a small 1rem ring). */
+  className?: string;
+}
+
+export function Spinner({ label = "Loading", className = "size-4" }: SpinnerProps) {
+  return (
+    <span role="status" className="inline-flex items-center gap-2 text-muted">
+      <svg
+        className={`${className} animate-spin text-current`}
+        viewBox="0 0 24 24"
+        fill="none"
+        aria-hidden="true"
+      >
+        <circle
+          className="opacity-25"
+          cx="12"
+          cy="12"
+          r="10"
+          stroke="currentColor"
+          strokeWidth="3"
+        />
+        <path
+          className="opacity-90"
+          d="M12 2a10 10 0 0 1 10 10"
+          stroke="currentColor"
+          strokeWidth="3"
+          strokeLinecap="round"
+        />
+      </svg>
+      <span className="sr-only">{label}</span>
+    </span>
+  );
+}

--- a/web/src/app/components/TextField.tsx
+++ b/web/src/app/components/TextField.tsx
@@ -1,0 +1,77 @@
+/**
+ * TextField — a labelled text/number input.
+ *
+ * Always renders a real <label> associated to the control by id, an optional
+ * hint, and an optional error message wired via aria-describedby +
+ * aria-invalid. This is the single text-input primitive used by AgentForm and
+ * the settings views.
+ */
+
+import type { InputHTMLAttributes, ReactNode } from "react";
+import { useId } from "react";
+
+export interface TextFieldProps
+  extends Omit<InputHTMLAttributes<HTMLInputElement>, "id"> {
+  label: ReactNode;
+  /** Helper text rendered under the field. */
+  hint?: ReactNode;
+  /** Error message; sets aria-invalid and is announced to AT. */
+  error?: string | null;
+  /** Monospace the input value (ids, hostnames, app names). */
+  mono?: boolean;
+}
+
+export function TextField({
+  label,
+  hint,
+  error,
+  mono = false,
+  className = "",
+  required,
+  ...rest
+}: TextFieldProps) {
+  const id = useId();
+  const hintId = `${id}-hint`;
+  const errorId = `${id}-error`;
+  const describedBy =
+    [hint ? hintId : null, error ? errorId : null].filter(Boolean).join(" ") ||
+    undefined;
+
+  return (
+    <div className={`flex flex-col gap-1.5 ${className}`}>
+      <span className="flex items-center gap-1">
+        <label htmlFor={id} className="text-xs font-medium text-muted">
+          {label}
+        </label>
+        {required && (
+          <span className="text-danger" aria-hidden="true">
+            *
+          </span>
+        )}
+      </span>
+      <input
+        id={id}
+        required={required}
+        aria-invalid={error ? true : undefined}
+        aria-describedby={describedBy}
+        className={
+          "h-9 rounded-md border bg-canvas px-3 text-sm text-fg placeholder:text-faint " +
+          "focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-accent " +
+          (error ? "border-danger " : "border-line ") +
+          (mono ? "font-mono " : "")
+        }
+        {...rest}
+      />
+      {hint && !error && (
+        <p id={hintId} className="text-xs text-faint">
+          {hint}
+        </p>
+      )}
+      {error && (
+        <p id={errorId} className="text-xs text-danger" role="alert">
+          {error}
+        </p>
+      )}
+    </div>
+  );
+}

--- a/web/src/app/components/Toggle.tsx
+++ b/web/src/app/components/Toggle.tsx
@@ -1,0 +1,73 @@
+/**
+ * Toggle — an accessible on/off switch backed by a real checkbox input.
+ *
+ * Using a visually-hidden native checkbox (peer) keeps keyboard toggling (space)
+ * and screen-reader semantics correct for free, while the styled track/thumb is
+ * purely presentational. The label is always associated to the control.
+ */
+
+import type { ReactNode } from "react";
+import { useId } from "react";
+
+export interface ToggleProps {
+  label: ReactNode;
+  checked: boolean;
+  onChange: (checked: boolean) => void;
+  hint?: ReactNode;
+  disabled?: boolean;
+  className?: string;
+}
+
+export function Toggle({
+  label,
+  checked,
+  onChange,
+  hint,
+  disabled = false,
+  className = "",
+}: ToggleProps) {
+  const id = useId();
+  const hintId = `${id}-hint`;
+  return (
+    <div className={`flex items-start gap-3 ${className}`}>
+      <span className="relative inline-flex shrink-0 pt-0.5">
+        <input
+          id={id}
+          type="checkbox"
+          role="switch"
+          checked={checked}
+          disabled={disabled}
+          aria-describedby={hint ? hintId : undefined}
+          onChange={(e) => onChange(e.target.checked)}
+          className="peer sr-only"
+        />
+        <span
+          aria-hidden="true"
+          className={
+            "h-5 w-9 rounded-full border border-line bg-surface-raised transition-colors " +
+            "peer-checked:border-accent peer-checked:bg-accent " +
+            "peer-focus-visible:outline-2 peer-focus-visible:outline-offset-2 peer-focus-visible:outline-accent " +
+            "peer-disabled:opacity-50"
+          }
+        />
+        <span
+          aria-hidden="true"
+          className={
+            "pointer-events-none absolute left-0.5 top-[3px] size-4 rounded-full bg-fg shadow-sm transition-transform " +
+            "peer-checked:translate-x-4"
+          }
+        />
+      </span>
+      <span className="flex flex-col">
+        <label htmlFor={id} className="text-sm text-fg select-none">
+          {label}
+        </label>
+        {hint && (
+          <span id={hintId} className="text-xs text-faint">
+            {hint}
+          </span>
+        )}
+      </span>
+    </div>
+  );
+}

--- a/web/src/app/components/index.ts
+++ b/web/src/app/components/index.ts
@@ -1,0 +1,61 @@
+/**
+ * Barrel for the console component library. Feature pages import named
+ * components from here, e.g. `import { Card, Button, PlanDiff } from
+ * "../app/components"`.
+ */
+
+export { AppLayout } from "./AppLayout";
+export type { AppLayoutProps } from "./AppLayout";
+
+export { PageHeader } from "./PageHeader";
+export type { PageHeaderProps } from "./PageHeader";
+
+export { Card } from "./Card";
+export type { CardProps } from "./Card";
+
+export { Button } from "./Button";
+export type { ButtonProps, ButtonVariant, ButtonSize } from "./Button";
+
+export { TextField } from "./TextField";
+export type { TextFieldProps } from "./TextField";
+
+export { SelectField } from "./SelectField";
+export type { SelectFieldProps, SelectOption } from "./SelectField";
+
+export { Toggle } from "./Toggle";
+export type { ToggleProps } from "./Toggle";
+
+export { Spinner } from "./Spinner";
+export type { SpinnerProps } from "./Spinner";
+
+export { EmptyState } from "./EmptyState";
+export type { EmptyStateProps } from "./EmptyState";
+
+export { ErrorBanner } from "./ErrorBanner";
+export type { ErrorBannerProps } from "./ErrorBanner";
+
+export { ConfirmDialog } from "./ConfirmDialog";
+export type { ConfirmDialogProps } from "./ConfirmDialog";
+
+export { CodeBlock } from "./CodeBlock";
+export type { CodeBlockProps } from "./CodeBlock";
+
+export { Badge } from "./Badge";
+export type { BadgeProps, BadgeTone } from "./Badge";
+
+export { HealthBadge } from "./HealthBadge";
+export type { HealthBadgeProps } from "./HealthBadge";
+
+export { PlanDiff } from "./PlanDiff";
+export type { PlanDiffProps } from "./PlanDiff";
+
+export { OperationProgress } from "./OperationProgress";
+export type { OperationProgressProps } from "./OperationProgress";
+
+export {
+  AgentForm,
+  emptyAgentInput,
+  validateAgentInput,
+  AGENT_ID_PATTERN,
+} from "./AgentForm";
+export type { AgentFormProps, AgentFormErrors } from "./AgentForm";

--- a/web/src/app/hooks.test.tsx
+++ b/web/src/app/hooks.test.tsx
@@ -1,0 +1,166 @@
+/**
+ * Tests for the polling hooks, with the API client mocked so no network is hit.
+ *
+ * The load-bearing behavior is `useOperation`: it must keep polling while an
+ * operation is `running` and then STOP issuing requests the moment it observes a
+ * terminal state (`succeeded`/`failed`). We drive virtual time with fake timers
+ * and assert on the call count of the mocked `getOperation`.
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { act, render, screen, waitFor } from "@testing-library/react";
+import { useOperation, usePolling } from "./hooks";
+import type { OperationStatus } from "../api/types";
+
+// Mock the client module the hooks import from.
+vi.mock("../api/client", () => ({
+  getOperation: vi.fn(),
+  getStatus: vi.fn(),
+}));
+import { getOperation } from "../api/client";
+
+const mockGetOperation = vi.mocked(getOperation);
+
+function op(state: OperationStatus["state"]): OperationStatus {
+  return { id: "op1", state, changed_resources: [] };
+}
+
+/** Renders useOperation and surfaces its state for assertions. */
+function OperationProbe({ id }: { id: string | null }) {
+  const { data, loading } = useOperation(id, 1000);
+  return (
+    <div>
+      <span data-testid="state">{data?.state ?? "none"}</span>
+      <span data-testid="loading">{String(loading)}</span>
+    </div>
+  );
+}
+
+describe("useOperation", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    mockGetOperation.mockReset();
+  });
+
+  afterEach(() => {
+    vi.runOnlyPendingTimers();
+    vi.useRealTimers();
+  });
+
+  it("stops polling once the operation reaches a terminal state", async () => {
+    // running, running, then succeeded — after which polling must cease.
+    mockGetOperation
+      .mockResolvedValueOnce(op("running"))
+      .mockResolvedValueOnce(op("running"))
+      .mockResolvedValueOnce(op("succeeded"))
+      .mockResolvedValue(op("succeeded"));
+
+    render(<OperationProbe id="op1" />);
+
+    // Initial immediate tick.
+    await act(async () => {
+      await Promise.resolve();
+    });
+    expect(mockGetOperation).toHaveBeenCalledTimes(1);
+
+    // Two interval ticks reach the terminal "succeeded".
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(1000);
+    });
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(1000);
+    });
+    expect(mockGetOperation).toHaveBeenCalledTimes(3);
+    expect(screen.getByTestId("state").textContent).toBe("succeeded");
+
+    // Advancing further must NOT issue more requests: the timer was cleared.
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(5000);
+    });
+    expect(mockGetOperation).toHaveBeenCalledTimes(3);
+  });
+
+  it("does not poll when id is null", async () => {
+    render(<OperationProbe id={null} />);
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(3000);
+    });
+    expect(mockGetOperation).not.toHaveBeenCalled();
+    expect(screen.getByTestId("state").textContent).toBe("none");
+    expect(screen.getByTestId("loading").textContent).toBe("false");
+  });
+
+  it("stops immediately when the first observed state is already failed", async () => {
+    mockGetOperation.mockResolvedValue(op("failed"));
+    render(<OperationProbe id="op1" />);
+    await act(async () => {
+      await Promise.resolve();
+    });
+    expect(mockGetOperation).toHaveBeenCalledTimes(1);
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(5000);
+    });
+    // Terminal on the very first tick: no further polls.
+    expect(mockGetOperation).toHaveBeenCalledTimes(1);
+  });
+});
+
+/** Probe for the generic usePolling primitive. */
+function PollingProbe({
+  fn,
+  interval,
+}: {
+  fn: () => Promise<string>;
+  interval: number;
+}) {
+  const { data, error, loading } = usePolling(fn, interval, []);
+  return (
+    <div>
+      <span data-testid="data">{data ?? "null"}</span>
+      <span data-testid="error">{error?.message ?? "none"}</span>
+      <span data-testid="loading">{String(loading)}</span>
+    </div>
+  );
+}
+
+describe("usePolling", () => {
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("exposes data on success and clears the loading flag (real timers)", async () => {
+    const fn = vi.fn().mockResolvedValue("hello");
+    render(<PollingProbe fn={fn} interval={0} />);
+    await waitFor(() =>
+      expect(screen.getByTestId("data").textContent).toBe("hello"),
+    );
+    expect(screen.getByTestId("loading").textContent).toBe("false");
+    expect(screen.getByTestId("error").textContent).toBe("none");
+  });
+
+  it("captures a thrown error into the error slot", async () => {
+    const fn = vi.fn().mockRejectedValue(new Error("kaboom"));
+    render(<PollingProbe fn={fn} interval={0} />);
+    await waitFor(() =>
+      expect(screen.getByTestId("error").textContent).toBe("kaboom"),
+    );
+    expect(screen.getByTestId("loading").textContent).toBe("false");
+  });
+
+  it("repeats on the interval while mounted", async () => {
+    vi.useFakeTimers();
+    const fn = vi.fn().mockResolvedValue("tick");
+    render(<PollingProbe fn={fn} interval={500} />);
+    await act(async () => {
+      await Promise.resolve();
+    });
+    expect(fn).toHaveBeenCalledTimes(1);
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(500);
+    });
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(500);
+    });
+    expect(fn).toHaveBeenCalledTimes(3);
+  });
+});

--- a/web/src/app/hooks.ts
+++ b/web/src/app/hooks.ts
@@ -1,0 +1,179 @@
+/**
+ * Data-fetching hooks for the console.
+ *
+ * `usePolling` is the generic primitive: it calls an async function on an
+ * interval, exposes `{ data, error, loading, refresh }`, and guards against
+ * setting state after unmount or out of order (a slower earlier request never
+ * clobbers a newer result). `useStatus` and `useOperation` build on it.
+ *
+ * `useOperation` stops polling once the operation reaches a terminal state
+ * (`succeeded` / `failed`), so callers can render live apply progress without an
+ * infinite poll loop.
+ */
+
+import { useCallback, useEffect, useRef, useState } from "react";
+import { getOperation, getStatus } from "../api/client";
+import type { OperationStatus, StatusSnapshot } from "../api/types";
+
+/** The shape returned by every polling hook. */
+export interface PollingState<T> {
+  data: T | null;
+  error: Error | null;
+  loading: boolean;
+  /** Triggers an immediate out-of-band refresh and resets the interval. */
+  refresh: () => void;
+}
+
+/**
+ * Polls `fn` every `intervalMs` milliseconds, plus once immediately on mount and
+ * whenever `deps` change. A non-positive interval disables the repeat timer
+ * (single fetch + manual `refresh`). State updates after unmount are dropped.
+ *
+ * `deps` are spread into the effect dependency list; callers pass primitives
+ * (e.g. an id) that should restart polling when they change. `fn` is captured
+ * per render but only re-subscribed when `deps`/`intervalMs` change, so an
+ * inline lambda is fine.
+ */
+export function usePolling<T>(
+  fn: () => Promise<T>,
+  intervalMs: number,
+  deps: ReadonlyArray<unknown> = [],
+): PollingState<T> {
+  const [data, setData] = useState<T | null>(null);
+  const [error, setError] = useState<Error | null>(null);
+  const [loading, setLoading] = useState<boolean>(true);
+
+  // Bump this to force the effect to re-run for a manual refresh.
+  const [nonce, setNonce] = useState(0);
+  const refresh = useCallback(() => setNonce((n) => n + 1), []);
+
+  // Keep the latest fn in a ref so the polling effect does not resubscribe on
+  // every render (callers commonly pass an inline closure).
+  const fnRef = useRef(fn);
+  fnRef.current = fn;
+
+  useEffect(() => {
+    let cancelled = false;
+    // Monotonic guard: only the most recently *started* request may write state.
+    let latest = 0;
+
+    const tick = async () => {
+      const seq = ++latest;
+      try {
+        const result = await fnRef.current();
+        if (cancelled || seq !== latest) return;
+        setData(result);
+        setError(null);
+      } catch (err) {
+        if (cancelled || seq !== latest) return;
+        setError(err instanceof Error ? err : new Error(String(err)));
+      } finally {
+        if (!cancelled && seq === latest) {
+          setLoading(false);
+        }
+      }
+    };
+
+    setLoading(true);
+    void tick();
+
+    if (intervalMs <= 0) {
+      return () => {
+        cancelled = true;
+      };
+    }
+    const handle = setInterval(() => {
+      void tick();
+    }, intervalMs);
+    return () => {
+      cancelled = true;
+      clearInterval(handle);
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [intervalMs, nonce, ...deps]);
+
+  return { data, error, loading, refresh };
+}
+
+/** Polls the fleet status snapshot. Defaults to a 5s interval. */
+export function useStatus(intervalMs = 5000): PollingState<StatusSnapshot> {
+  return usePolling<StatusSnapshot>(() => getStatus(), intervalMs, []);
+}
+
+/** True once an operation has reached a terminal state. */
+function isTerminal(state: string | undefined): boolean {
+  return state === "succeeded" || state === "failed";
+}
+
+/**
+ * Polls a single apply operation until it reaches a terminal state, then stops.
+ * Passing `id === null` disables polling entirely (used before an apply is
+ * started). Defaults to a 1.5s interval while running.
+ *
+ * The hook reads `data.state` each tick; once terminal, it clears its own timer
+ * so no further requests are made even though the component stays mounted.
+ */
+export function useOperation(
+  id: string | null,
+  intervalMs = 1500,
+): PollingState<OperationStatus> {
+  const [data, setData] = useState<OperationStatus | null>(null);
+  const [error, setError] = useState<Error | null>(null);
+  const [loading, setLoading] = useState<boolean>(id != null);
+
+  const [nonce, setNonce] = useState(0);
+  const refresh = useCallback(() => setNonce((n) => n + 1), []);
+
+  useEffect(() => {
+    if (id == null) {
+      // Idle: no operation to track. Clear any prior result/loading.
+      setData(null);
+      setError(null);
+      setLoading(false);
+      return;
+    }
+
+    let cancelled = false;
+    let handle: ReturnType<typeof setInterval> | null = null;
+
+    const stop = () => {
+      if (handle !== null) {
+        clearInterval(handle);
+        handle = null;
+      }
+    };
+
+    const tick = async () => {
+      try {
+        const result = await getOperation(id);
+        if (cancelled) return;
+        setData(result);
+        setError(null);
+        if (isTerminal(result.state)) {
+          // Terminal: stop the timer so we never poll a finished operation.
+          stop();
+        }
+      } catch (err) {
+        if (cancelled) return;
+        setError(err instanceof Error ? err : new Error(String(err)));
+      } finally {
+        if (!cancelled) setLoading(false);
+      }
+    };
+
+    setLoading(true);
+    void tick();
+
+    if (intervalMs > 0) {
+      handle = setInterval(() => {
+        void tick();
+      }, intervalMs);
+    }
+    return () => {
+      cancelled = true;
+      stop();
+    };
+  }, [id, intervalMs, nonce]);
+
+  return { data, error, loading, refresh };
+}

--- a/web/src/app/pages/AgentDetailPage.test.tsx
+++ b/web/src/app/pages/AgentDetailPage.test.tsx
@@ -1,0 +1,355 @@
+/**
+ * AgentDetailPage tests.
+ *
+ * The network is mocked at the client boundary (vi.mock("../../api/client")),
+ * so these assert real page behavior — rendered data, loading/error states, and
+ * the gating + arguments of every mutating flow — without a live server.
+ *
+ * The page renders inside a MemoryRouter seeded at "/agents/:id" with a matching
+ * route so useParams("id") and useNavigate work as in production.
+ */
+
+import { describe, expect, it, vi, beforeEach } from "vitest";
+import { render, screen, waitFor, within } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { MemoryRouter, Route, Routes } from "react-router-dom";
+import AgentDetailPage from "./AgentDetailPage";
+import type {
+  AgentDetail,
+  ApplyResponse,
+  LogsResponse,
+  OperationStatus,
+  PlanResponse,
+} from "../../api/types";
+
+// --- Mock the typed console client at its module boundary ------------------
+// We replace the network-calling functions with spies but keep the real
+// ConsoleError class (the page + tests use `instanceof`/`.message`). getStatus
+// is provided because the hooks module imports it at eval time (unused here).
+vi.mock("../../api/client", async () => {
+  const actual =
+    await vi.importActual<typeof import("../../api/client")>("../../api/client");
+  return {
+    ConsoleError: actual.ConsoleError,
+    getAgent: vi.fn(),
+    updateAgent: vi.fn(),
+    deleteAgent: vi.fn(),
+    getAgentLogs: vi.fn(),
+    plan: vi.fn(),
+    apply: vi.fn(),
+    // Used by useOperation/OperationProgress once an apply starts.
+    getOperation: vi.fn(),
+    getStatus: vi.fn(),
+  };
+});
+
+import * as client from "../../api/client";
+
+const mockGetAgent = vi.mocked(client.getAgent);
+const mockUpdateAgent = vi.mocked(client.updateAgent);
+const mockDeleteAgent = vi.mocked(client.deleteAgent);
+const mockGetAgentLogs = vi.mocked(client.getAgentLogs);
+const mockPlan = vi.mocked(client.plan);
+const mockApply = vi.mocked(client.apply);
+const mockGetOperation = vi.mocked(client.getOperation);
+
+const AGENT_ID = "research-agent";
+
+function makeAgent(overrides: Partial<AgentDetail> = {}): AgentDetail {
+  return {
+    id: AGENT_ID,
+    model: "anthropic/claude-3.5-sonnet",
+    fly_app: "research-agent",
+    tailscale_hostname: "research-agent",
+    vault: "memory",
+    lifecycle: "present",
+    health: "ok",
+    fly_state: "started",
+    url: "https://research-agent.example.ts.net",
+    last_deploy: "2026-06-01T12:00:00Z",
+    region: "cdg",
+    memory: "512mb",
+    cpus: 1,
+    runtime: "fly.default",
+    network: "tailscale.default",
+    model_provider: "openrouter.default",
+    soul_preview: "# Identity\nYou are a focused research agent.",
+    companion_soul_enabled: true,
+    vault_connections: ["shared-research", "team-notes"],
+    ...overrides,
+  };
+}
+
+function makeLogs(overrides: Partial<LogsResponse> = {}): LogsResponse {
+  return {
+    agent_id: AGENT_ID,
+    lines: ["2026-06-01 deploy succeeded", "2026-06-02 health ok"],
+    source: "state-events",
+    note: "Live Fly/agent task logs are a later Hermes feature.",
+    ...overrides,
+  };
+}
+
+/** Renders the page at /agents/:id with a matching route. */
+function renderPage(id = AGENT_ID) {
+  return render(
+    <MemoryRouter initialEntries={[`/agents/${id}`]}>
+      <Routes>
+        <Route path="/agents/:id" element={<AgentDetailPage />} />
+        <Route path="/" element={<div>Agents list</div>} />
+      </Routes>
+    </MemoryRouter>,
+  );
+}
+
+// jsdom implements <dialog> but not its modal methods, which ConfirmDialog
+// drives. Polyfill showModal/close to toggle the `open` property so the dialog
+// mounts and is queryable as a real modal in tests.
+beforeEach(() => {
+  const proto = window.HTMLDialogElement.prototype;
+  if (!proto.showModal) {
+    proto.showModal = function showModal(this: HTMLDialogElement) {
+      this.open = true;
+    };
+  }
+  if (!proto.close) {
+    proto.close = function close(this: HTMLDialogElement) {
+      this.open = false;
+    };
+  }
+});
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  // Sensible default happy-path resolutions; individual tests override.
+  mockGetAgent.mockResolvedValue(makeAgent());
+  mockGetAgentLogs.mockResolvedValue(makeLogs());
+});
+
+describe("AgentDetailPage", () => {
+  it("renders the loaded agent's status, config and granite settings", async () => {
+    renderPage();
+
+    // Heading shows the id (in the PageHeader h1).
+    expect(
+      await screen.findByRole("heading", { level: 1, name: AGENT_ID }),
+    ).toBeInTheDocument();
+
+    // Status facts.
+    expect(screen.getByText("Healthy")).toBeInTheDocument();
+    expect(screen.getByText("started")).toBeInTheDocument();
+
+    // External URL link.
+    const link = screen.getByRole("link", {
+      name: /research-agent\.example\.ts\.net/i,
+    });
+    expect(link).toHaveAttribute(
+      "href",
+      "https://research-agent.example.ts.net",
+    );
+
+    // Edit form is seeded from the detail (model populated, id read-only).
+    expect(screen.getByLabelText(/^model$/i)).toHaveValue(
+      "anthropic/claude-3.5-sonnet",
+    );
+    expect(screen.getByLabelText(/agent id/i)).toHaveAttribute("readonly");
+
+    // SOUL.md preview is shown read-only (CodeBlock group).
+    expect(
+      screen.getByText(/you are a focused research agent/i),
+    ).toBeInTheDocument();
+
+    // Granite: companion soul enabled + read-only vault connections.
+    expect(screen.getByText("enabled")).toBeInTheDocument();
+    expect(screen.getByText("shared-research")).toBeInTheDocument();
+    expect(screen.getByText("team-notes")).toBeInTheDocument();
+  });
+
+  it("shows a spinner while the agent is loading", () => {
+    // A never-resolving promise keeps the page in its loading state.
+    mockGetAgent.mockReturnValue(new Promise<AgentDetail>(() => {}));
+    renderPage();
+    expect(
+      screen.getByText(new RegExp(`loading ${AGENT_ID}`, "i")),
+    ).toBeInTheDocument();
+  });
+
+  it("surfaces a load error with a retry that re-fetches", async () => {
+    const err = new client.ConsoleError(500, "boom");
+    mockGetAgent.mockRejectedValueOnce(err);
+    renderPage();
+
+    const alert = await screen.findByRole("alert");
+    expect(within(alert).getByText("boom")).toBeInTheDocument();
+
+    // Retry triggers a second getAgent; the happy-path default now resolves.
+    await userEvent.click(screen.getByRole("button", { name: /retry/i }));
+    expect(
+      await screen.findByRole("heading", { level: 1, name: AGENT_ID }),
+    ).toBeInTheDocument();
+    expect(mockGetAgent).toHaveBeenCalledTimes(2);
+  });
+
+  it("renders recent activity lines and the offline note", async () => {
+    renderPage();
+    expect(
+      await screen.findByText(/2026-06-01 deploy succeeded/),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText(/live fly\/agent task logs are a later hermes feature/i),
+    ).toBeInTheDocument();
+  });
+
+  it("shows an empty state when there are no recent events", async () => {
+    mockGetAgentLogs.mockResolvedValue(makeLogs({ lines: [] }));
+    renderPage();
+    expect(await screen.findByText(/no recent events/i)).toBeInTheDocument();
+  });
+
+  it("saves edits via updateAgent with the agent id and edited fields", async () => {
+    const user = userEvent.setup();
+    mockUpdateAgent.mockResolvedValue(makeAgent());
+    renderPage();
+
+    // Wait for the form, then change the memory and save.
+    const memory = await screen.findByLabelText(/^memory$/i);
+    await user.clear(memory);
+    await user.type(memory, "1gb");
+
+    await user.click(screen.getByRole("button", { name: /save changes/i }));
+
+    await waitFor(() => expect(mockUpdateAgent).toHaveBeenCalledTimes(1));
+    const [calledId, input] = mockUpdateAgent.mock.calls[0];
+    expect(calledId).toBe(AGENT_ID);
+    expect(input).toMatchObject({
+      id: AGENT_ID,
+      model: "anthropic/claude-3.5-sonnet",
+      memory: "1gb",
+      companion_soul_enabled: true,
+      // soul is intentionally blank so the existing SOUL.md is preserved.
+      soul: "",
+    });
+
+    // Success confirmation appears.
+    expect(
+      await screen.findByText(/saved\. run plan & apply below/i),
+    ).toBeInTheDocument();
+  });
+
+  it("surfaces a save error and does not navigate away", async () => {
+    const user = userEvent.setup();
+    mockUpdateAgent.mockRejectedValue(new client.ConsoleError(400, "bad model"));
+    renderPage();
+
+    await screen.findByRole("button", { name: /save changes/i });
+    await user.click(screen.getByRole("button", { name: /save changes/i }));
+
+    expect(await screen.findByText("bad model")).toBeInTheDocument();
+    // Still on the detail page (heading present).
+    expect(
+      screen.getByRole("heading", { level: 1, name: AGENT_ID }),
+    ).toBeInTheDocument();
+  });
+
+  it("plans, shows the diff, and gates apply behind a confirm dialog", async () => {
+    const user = userEvent.setup();
+    const planResp: PlanResponse = {
+      hash: "sha256:abc123",
+      text: "~ fly_app.research-agent",
+      changes: [
+        {
+          kind: "~",
+          action: "update",
+          address: "fly_app.research-agent",
+          message: "memory 512mb -> 1gb",
+          protected: false,
+        },
+      ],
+    };
+    mockPlan.mockResolvedValue(planResp);
+    const applyResp: ApplyResponse = { operation_id: "op-1" };
+    mockApply.mockResolvedValue(applyResp);
+    const op: OperationStatus = {
+      id: "op-1",
+      state: "succeeded",
+      changed_resources: ["fly_app.research-agent"],
+    };
+    mockGetOperation.mockResolvedValue(op);
+
+    renderPage();
+
+    // Trigger a plan.
+    await user.click(await screen.findByRole("button", { name: /plan changes/i }));
+
+    // The diff renders the change address; apply is now available but NOT yet
+    // called — it must go through the confirm dialog first.
+    expect(
+      await screen.findByText("fly_app.research-agent"),
+    ).toBeInTheDocument();
+    expect(mockApply).not.toHaveBeenCalled();
+
+    // Click Apply -> opens the confirm dialog (still no apply call).
+    await user.click(screen.getByRole("button", { name: /^apply$/i }));
+    const dialog = await screen.findByRole("dialog");
+    expect(
+      within(dialog).getByText(/apply planned changes\?/i),
+    ).toBeInTheDocument();
+    expect(mockApply).not.toHaveBeenCalled();
+
+    // Confirm inside the dialog -> apply(hash) is finally called with the hash.
+    await user.click(within(dialog).getByRole("button", { name: /^apply$/i }));
+    await waitFor(() => expect(mockApply).toHaveBeenCalledTimes(1));
+    expect(mockApply).toHaveBeenCalledWith("sha256:abc123");
+
+    // OperationProgress polls getOperation and shows the changed resource.
+    await waitFor(() => expect(mockGetOperation).toHaveBeenCalledWith("op-1"));
+  });
+
+  it("does not offer apply when the plan has no changes", async () => {
+    const user = userEvent.setup();
+    mockPlan.mockResolvedValue({ hash: "h", text: "", changes: [] });
+    renderPage();
+
+    await user.click(await screen.findByRole("button", { name: /plan changes/i }));
+
+    // Empty diff state appears; no enabled Apply button exists.
+    expect(await screen.findByText(/no changes/i)).toBeInTheDocument();
+    expect(
+      screen.queryByRole("button", { name: /^apply$/i }),
+    ).toBeNull();
+    expect(mockApply).not.toHaveBeenCalled();
+  });
+
+  it("deletes (marks absent) only after confirming, calling deleteAgent", async () => {
+    const user = userEvent.setup();
+    mockDeleteAgent.mockResolvedValue(makeAgent({ lifecycle: "absent" }));
+    renderPage();
+
+    // Open the delete confirm; deleteAgent must not be called yet.
+    await user.click(await screen.findByRole("button", { name: /delete agent/i }));
+    const dialog = await screen.findByRole("dialog");
+    expect(
+      within(dialog).getByText(/mark agent absent\?/i),
+    ).toBeInTheDocument();
+    expect(mockDeleteAgent).not.toHaveBeenCalled();
+
+    // Confirm -> deleteAgent(id) and navigation back to the list.
+    await user.click(within(dialog).getByRole("button", { name: /mark absent/i }));
+    await waitFor(() => expect(mockDeleteAgent).toHaveBeenCalledWith(AGENT_ID));
+    expect(await screen.findByText("Agents list")).toBeInTheDocument();
+  });
+
+  it("can cancel the delete without calling deleteAgent", async () => {
+    const user = userEvent.setup();
+    renderPage();
+
+    await user.click(await screen.findByRole("button", { name: /delete agent/i }));
+    const dialog = await screen.findByRole("dialog");
+    await user.click(within(dialog).getByRole("button", { name: /cancel/i }));
+
+    await waitFor(() =>
+      expect(screen.queryByRole("dialog")).not.toBeInTheDocument(),
+    );
+    expect(mockDeleteAgent).not.toHaveBeenCalled();
+  });
+});

--- a/web/src/app/pages/AgentDetailPage.test.tsx
+++ b/web/src/app/pages/AgentDetailPage.test.tsx
@@ -97,6 +97,7 @@ function renderPage(id = AGENT_ID) {
       <Routes>
         <Route path="/agents/:id" element={<AgentDetailPage />} />
         <Route path="/" element={<div>Agents list</div>} />
+        <Route path="/plan" element={<div>Plan and apply</div>} />
       </Routes>
     </MemoryRouter>,
   );
@@ -265,6 +266,8 @@ describe("AgentDetailPage", () => {
           protected: false,
         },
       ],
+      requires_protected_confirm: false,
+      requires_destroy_data: false,
     };
     mockPlan.mockResolvedValue(planResp);
     const applyResp: ApplyResponse = { operation_id: "op-1" };
@@ -307,7 +310,13 @@ describe("AgentDetailPage", () => {
 
   it("does not offer apply when the plan has no changes", async () => {
     const user = userEvent.setup();
-    mockPlan.mockResolvedValue({ hash: "h", text: "", changes: [] });
+    mockPlan.mockResolvedValue({
+      hash: "h",
+      text: "",
+      changes: [],
+      requires_protected_confirm: false,
+      requires_destroy_data: false,
+    });
     renderPage();
 
     await user.click(await screen.findByRole("button", { name: /plan changes/i }));
@@ -333,10 +342,11 @@ describe("AgentDetailPage", () => {
     ).toBeInTheDocument();
     expect(mockDeleteAgent).not.toHaveBeenCalled();
 
-    // Confirm -> deleteAgent(id) and navigation back to the list.
+    // Confirm -> deleteAgent(id) and navigation to Plan & apply, where the
+    // protected-destroy confirmation actually carries out the destruction.
     await user.click(within(dialog).getByRole("button", { name: /mark absent/i }));
     await waitFor(() => expect(mockDeleteAgent).toHaveBeenCalledWith(AGENT_ID));
-    expect(await screen.findByText("Agents list")).toBeInTheDocument();
+    expect(await screen.findByText("Plan and apply")).toBeInTheDocument();
   });
 
   it("can cancel the delete without calling deleteAgent", async () => {

--- a/web/src/app/pages/AgentDetailPage.tsx
+++ b/web/src/app/pages/AgentDetailPage.tsx
@@ -135,7 +135,9 @@ export default function AgentDetailPage() {
           id={id}
           agent={agent}
           onSaved={refresh}
-          onDeleted={() => navigate("/")}
+          // After marking the agent absent, land on Plan & Apply where the
+          // protected-destroy confirmation actually carries it out.
+          onDeleted={() => navigate("/plan")}
         />
       )}
     </>

--- a/web/src/app/pages/AgentDetailPage.tsx
+++ b/web/src/app/pages/AgentDetailPage.tsx
@@ -1,0 +1,572 @@
+/**
+ * AgentDetailPage — single agent view + edit (route "/agents/:id").
+ *
+ * Loads the agent via getAgent(id) and presents:
+ *   - a status card (HealthBadge, fly_state, url, last_deploy + key facts);
+ *   - an editable AgentForm (mode="edit") that PUTs via updateAgent(id, input);
+ *   - the server-rendered SOUL.md preview as read-only context (CodeBlock), with
+ *     the form's `soul` textarea left blank by default so saving preserves the
+ *     existing SOUL.md (the API only overwrites SOUL.md when `soul` is non-empty);
+ *   - Granite/vault settings: the companion-soul toggle (inside the form) plus a
+ *     read-only list of vault_connections;
+ *   - recent offline state events via getAgentLogs(id) with the offline note;
+ *   - a per-agent Plan & Apply flow (plan() -> PlanDiff -> hash-gated apply());
+ *   - a Delete action gated by ConfirmDialog that calls deleteAgent(id), which
+ *     marks the agent lifecycle="absent" (destroyed on the next apply), not an
+ *     instant delete.
+ *
+ * Security: provider secrets never appear here; only config-derived agent fields
+ * and offline state events are shown.
+ */
+
+import type { ReactNode } from "react";
+import { useCallback, useEffect, useState } from "react";
+import { useNavigate, useParams } from "react-router-dom";
+import {
+  apply as applyPlan,
+  deleteAgent,
+  getAgent,
+  getAgentLogs,
+  plan as runPlan,
+  updateAgent,
+} from "../../api/client";
+import type {
+  AgentDetail,
+  AgentInput,
+  LogsResponse,
+  PlanResponse,
+} from "../../api/types";
+import { usePolling } from "../hooks";
+import {
+  AgentForm,
+  Badge,
+  Button,
+  Card,
+  CodeBlock,
+  ConfirmDialog,
+  EmptyState,
+  ErrorBanner,
+  HealthBadge,
+  OperationProgress,
+  PageHeader,
+  PlanDiff,
+  Spinner,
+} from "../components";
+
+/** Maps an AgentDetail (read view) to the AgentInput the edit form mutates.
+ *
+ * AgentDetail carries no `name` and only a truncated `soul_preview`, so:
+ *  - `name` is seeded from the id (the user can rename in the form);
+ *  - `soul` starts blank so a plain save keeps the existing SOUL.md intact
+ *    (the preview is shown separately, read-only).
+ */
+function detailToInput(detail: AgentDetail): AgentInput {
+  return {
+    id: detail.id,
+    name: detail.id,
+    model: detail.model,
+    memory: detail.memory,
+    cpus: detail.cpus,
+    region: detail.region,
+    tailscale_hostname: detail.tailscale_hostname,
+    fly_app: detail.fly_app,
+    runtime: detail.runtime,
+    network: detail.network,
+    model_provider: detail.model_provider,
+    lifecycle: detail.lifecycle,
+    soul: "",
+    companion_soul_enabled: detail.companion_soul_enabled,
+    vault_name: detail.vault,
+  };
+}
+
+export default function AgentDetailPage() {
+  const { id = "" } = useParams<{ id: string }>();
+  const navigate = useNavigate();
+
+  // Single fetch of the agent detail (interval 0 = load once + manual refresh).
+  const {
+    data: agent,
+    error: loadError,
+    loading,
+    refresh,
+  } = usePolling<AgentDetail>(() => getAgent(id), 0, [id]);
+
+  return (
+    <>
+      <PageHeader
+        eyebrow={
+          <Button
+            size="sm"
+            variant="ghost"
+            onClick={() => navigate("/")}
+            className="-ml-2"
+          >
+            ← All agents
+          </Button>
+        }
+        title={<span className="font-mono">{id || "Agent"}</span>}
+        description="Agent configuration, status, and recent activity."
+        actions={
+          agent ? (
+            <Badge tone={agent.lifecycle === "absent" ? "danger" : "neutral"}>
+              {agent.lifecycle}
+            </Badge>
+          ) : undefined
+        }
+      />
+
+      {loading && !agent && (
+        <div className="py-16">
+          <Spinner label={`Loading ${id}`} />
+        </div>
+      )}
+
+      {loadError && !agent && (
+        <ErrorBanner
+          title={`Could not load agent "${id}"`}
+          error={loadError}
+          onRetry={refresh}
+        />
+      )}
+
+      {agent && (
+        <AgentDetailBody
+          id={id}
+          agent={agent}
+          onSaved={refresh}
+          onDeleted={() => navigate("/")}
+        />
+      )}
+    </>
+  );
+}
+
+interface BodyProps {
+  id: string;
+  agent: AgentDetail;
+  /** Called after a successful edit so the page re-reads the agent. */
+  onSaved: () => void;
+  /** Called after the agent is marked absent (navigates away). */
+  onDeleted: () => void;
+}
+
+function AgentDetailBody({ id, agent, onSaved, onDeleted }: BodyProps) {
+  // Edit form value. Re-seeded whenever the loaded agent identity changes.
+  const [input, setInput] = useState<AgentInput>(() => detailToInput(agent));
+  useEffect(() => {
+    setInput(detailToInput(agent));
+    // Re-seed only on a genuinely new load (id or server-side fields), not on
+    // every keystroke (those flow through onChange below).
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [
+    agent.id,
+    agent.model,
+    agent.memory,
+    agent.cpus,
+    agent.region,
+    agent.lifecycle,
+    agent.companion_soul_enabled,
+  ]);
+
+  const [saving, setSaving] = useState(false);
+  const [saveError, setSaveError] = useState<unknown>(null);
+  const [savedAt, setSavedAt] = useState<number | null>(null);
+
+  const handleSubmit = useCallback(
+    async (value: AgentInput) => {
+      setSaving(true);
+      setSaveError(null);
+      try {
+        await updateAgent(id, value);
+        setSavedAt(Date.now());
+        onSaved();
+      } catch (err) {
+        setSaveError(err);
+      } finally {
+        setSaving(false);
+      }
+    },
+    [id, onSaved],
+  );
+
+  return (
+    <div className="space-y-6">
+      <StatusCard agent={agent} />
+
+      <div className="grid gap-6 lg:grid-cols-3">
+        <div className="space-y-6 lg:col-span-2">
+          <Card
+            title="Configuration"
+            description="Edit and save to rewrite this agent's TOML; the change lands on the next plan & apply."
+          >
+            {saveError != null && (
+              <ErrorBanner
+                title="Could not save changes"
+                error={saveError}
+                className="mb-4"
+              />
+            )}
+            {savedAt != null && saveError == null && !saving && (
+              <div
+                role="status"
+                className="mb-4 rounded-md border border-ok/30 bg-ok/10 px-3 py-2 text-xs text-ok"
+              >
+                Saved. Run plan &amp; apply below to deploy the change.
+              </div>
+            )}
+            <AgentForm
+              value={input}
+              onChange={setInput}
+              onSubmit={handleSubmit}
+              submitLabel="Save changes"
+              disabled={saving}
+              mode="edit"
+            />
+          </Card>
+
+          <SoulPreviewCard preview={agent.soul_preview} />
+        </div>
+
+        <div className="space-y-6">
+          <GraniteCard agent={agent} />
+          <LogsCard id={id} />
+          <PlanApplyCard agentId={id} />
+          <DangerCard id={id} onDeleted={onDeleted} />
+        </div>
+      </div>
+    </div>
+  );
+}
+
+/** Top status strip: health, fly state, deploy time, and a link to the agent. */
+function StatusCard({ agent }: { agent: AgentDetail }) {
+  return (
+    <Card>
+      <dl className="grid gap-4 sm:grid-cols-2 lg:grid-cols-4">
+        <Fact label="Health">
+          <HealthBadge health={agent.health} />
+        </Fact>
+        <Fact label="Fly state">
+          {agent.fly_state ? (
+            <span className="font-mono text-sm text-fg">{agent.fly_state}</span>
+          ) : (
+            <span className="text-sm text-faint">unknown</span>
+          )}
+        </Fact>
+        <Fact label="Model">
+          <span className="font-mono text-sm text-fg">{agent.model || "—"}</span>
+        </Fact>
+        <Fact label="Last deploy">
+          <span className="text-sm text-muted">{agent.last_deploy || "—"}</span>
+        </Fact>
+      </dl>
+      {agent.url && (
+        <div className="mt-4 border-t border-line pt-4">
+          <a
+            href={agent.url}
+            target="_blank"
+            rel="noreferrer"
+            className="inline-flex items-center gap-1.5 font-mono text-xs text-accent hover:underline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-accent"
+          >
+            {agent.url}
+            <span aria-hidden="true">↗</span>
+          </a>
+        </div>
+      )}
+    </Card>
+  );
+}
+
+function Fact({ label, children }: { label: string; children: ReactNode }) {
+  return (
+    <div className="min-w-0">
+      <dt className="text-xs font-medium tracking-wide text-muted uppercase">
+        {label}
+      </dt>
+      <dd className="mt-1 truncate">{children}</dd>
+    </div>
+  );
+}
+
+/** Read-only SOUL.md preview (truncated server-side). */
+function SoulPreviewCard({ preview }: { preview: string }) {
+  return (
+    <Card
+      title="SOUL.md preview"
+      description="A truncated preview of the effective identity. Edit the SOUL.md field above to replace it; leaving it blank keeps the current soul."
+    >
+      {preview.trim() ? (
+        <CodeBlock ariaLabel="SOUL.md preview">{preview}</CodeBlock>
+      ) : (
+        <EmptyState
+          title="No identity soul"
+          description="This agent has no SOUL.md identity, or it is empty."
+        />
+      )}
+    </Card>
+  );
+}
+
+/** Granite vault settings: companion soul state + read-only vault connections. */
+function GraniteCard({ agent }: { agent: AgentDetail }) {
+  const connections = agent.vault_connections ?? [];
+  return (
+    <Card title="Granite & vaults">
+      <div className="space-y-4">
+        <div className="flex items-center justify-between gap-3">
+          <div className="min-w-0">
+            <p className="text-sm text-fg">Companion soul</p>
+            <p className="text-xs text-muted">
+              Fleet-wide SOUL.md appended after this agent&apos;s identity.
+            </p>
+          </div>
+          <Badge tone={agent.companion_soul_enabled ? "ok" : "neutral"} dot>
+            {agent.companion_soul_enabled ? "enabled" : "disabled"}
+          </Badge>
+        </div>
+
+        <div>
+          <p className="mb-1.5 text-xs font-medium tracking-wide text-muted uppercase">
+            Default vault
+          </p>
+          {agent.vault ? (
+            <span className="font-mono text-xs text-fg">{agent.vault}</span>
+          ) : (
+            <span className="text-xs text-faint">none</span>
+          )}
+        </div>
+
+        <div>
+          <p className="mb-1.5 text-xs font-medium tracking-wide text-muted uppercase">
+            Shared vault connections
+          </p>
+          {connections.length > 0 ? (
+            <ul className="flex flex-wrap gap-1.5">
+              {connections.map((vc) => (
+                <li key={vc}>
+                  <Badge tone="accent">{vc}</Badge>
+                </li>
+              ))}
+            </ul>
+          ) : (
+            <p className="text-xs text-faint">
+              No shared vault connections (read-only).
+            </p>
+          )}
+        </div>
+      </div>
+    </Card>
+  );
+}
+
+/** Recent offline state events for the agent. */
+function LogsCard({ id }: { id: string }) {
+  const {
+    data: logs,
+    error,
+    loading,
+    refresh,
+  } = usePolling<LogsResponse>(() => getAgentLogs(id), 0, [id]);
+
+  return (
+    <Card
+      title="Recent activity"
+      actions={
+        <Button size="sm" variant="ghost" onClick={refresh} disabled={loading}>
+          Refresh
+        </Button>
+      }
+    >
+      {loading && !logs && (
+        <div className="py-4">
+          <Spinner label="Loading activity" />
+        </div>
+      )}
+      {error && !logs && (
+        <ErrorBanner title="Could not load activity" error={error} onRetry={refresh} />
+      )}
+      {logs && (
+        <div className="space-y-2">
+          {logs.lines.length > 0 ? (
+            <CodeBlock ariaLabel="Recent state events">
+              {logs.lines.join("\n")}
+            </CodeBlock>
+          ) : (
+            <EmptyState
+              title="No recent events"
+              description="No offline state events have been recorded for this agent yet."
+            />
+          )}
+          {logs.note && (
+            <p className="text-xs text-faint">
+              <span className="font-medium">Note:</span> {logs.note}
+            </p>
+          )}
+        </div>
+      )}
+    </Card>
+  );
+}
+
+type ApplyPhase = "idle" | "planning" | "planned" | "applying";
+
+/** Per-agent plan & apply: plan(), show the diff, then a hash-gated apply(). */
+function PlanApplyCard({ agentId }: { agentId: string }) {
+  const [phase, setPhase] = useState<ApplyPhase>("idle");
+  const [planResult, setPlanResult] = useState<PlanResponse | null>(null);
+  const [error, setError] = useState<unknown>(null);
+  const [confirmOpen, setConfirmOpen] = useState(false);
+  const [operationId, setOperationId] = useState<string | null>(null);
+
+  const handlePlan = useCallback(async () => {
+    setPhase("planning");
+    setError(null);
+    setPlanResult(null);
+    setOperationId(null);
+    try {
+      const result = await runPlan();
+      setPlanResult(result);
+      setPhase("planned");
+    } catch (err) {
+      setError(err);
+      setPhase("idle");
+    }
+  }, []);
+
+  const handleConfirmApply = useCallback(async () => {
+    if (!planResult) return;
+    setPhase("applying");
+    setError(null);
+    try {
+      const res = await applyPlan(planResult.hash);
+      setOperationId(res.operation_id);
+      setConfirmOpen(false);
+    } catch (err) {
+      // A 409 here means the plan went stale (concurrent change / in-flight
+      // apply): drop the diff and ask the user to re-plan.
+      setError(err);
+      setConfirmOpen(false);
+      setPhase("idle");
+      setPlanResult(null);
+    }
+  }, [planResult]);
+
+  const planning = phase === "planning";
+  const applying = phase === "applying";
+
+  return (
+    <Card
+      title="Plan & apply"
+      description="Preview and deploy pending changes for the whole workspace."
+    >
+      <div className="space-y-3">
+        {error != null && (
+          <ErrorBanner title="Plan or apply failed" error={error} />
+        )}
+
+        <Button
+          variant="secondary"
+          onClick={handlePlan}
+          loading={planning}
+          disabled={planning || applying}
+        >
+          {planResult ? "Re-plan" : "Plan changes"}
+        </Button>
+
+        {planResult && (
+          <>
+            <PlanDiff changes={planResult.changes} />
+            {planResult.changes.length > 0 && (
+              <div className="flex items-center justify-end">
+                <Button
+                  variant="primary"
+                  onClick={() => setConfirmOpen(true)}
+                  disabled={applying || operationId != null}
+                >
+                  Apply
+                </Button>
+              </div>
+            )}
+          </>
+        )}
+
+        {operationId && (
+          <OperationProgress
+            operationId={operationId}
+            onDone={() => setPhase("idle")}
+          />
+        )}
+      </div>
+
+      <ConfirmDialog
+        open={confirmOpen}
+        title="Apply planned changes?"
+        confirmLabel="Apply"
+        confirmVariant="primary"
+        pending={applying}
+        onConfirm={handleConfirmApply}
+        onCancel={() => setConfirmOpen(false)}
+      >
+        This deploys the {planResult?.changes.length ?? 0} planned change
+        {planResult?.changes.length === 1 ? "" : "s"} to the live fleet over
+        Tailscale. This affects real Fly resources for{" "}
+        <span className="font-mono">{agentId}</span> and the rest of the
+        workspace.
+      </ConfirmDialog>
+    </Card>
+  );
+}
+
+/** Destructive zone: mark the agent absent (destroyed on next apply). */
+function DangerCard({ id, onDeleted }: { id: string; onDeleted: () => void }) {
+  const [confirmOpen, setConfirmOpen] = useState(false);
+  const [deleting, setDeleting] = useState(false);
+  const [error, setError] = useState<unknown>(null);
+
+  const handleConfirmDelete = useCallback(async () => {
+    setDeleting(true);
+    setError(null);
+    try {
+      await deleteAgent(id);
+      setConfirmOpen(false);
+      onDeleted();
+    } catch (err) {
+      setError(err);
+      setDeleting(false);
+      setConfirmOpen(false);
+    }
+  }, [id, onDeleted]);
+
+  return (
+    <Card title="Danger zone" className="border-danger/30">
+      <div className="space-y-3">
+        {error != null && (
+          <ErrorBanner title="Could not mark agent absent" error={error} />
+        )}
+        <p className="text-xs text-muted">
+          Marks this agent as <span className="font-mono">absent</span>. It is
+          not deleted immediately — the next plan renders an explicit destroy and
+          apply tears it down.
+        </p>
+        <Button variant="danger" onClick={() => setConfirmOpen(true)}>
+          Delete agent
+        </Button>
+      </div>
+
+      <ConfirmDialog
+        open={confirmOpen}
+        title="Mark agent absent?"
+        confirmLabel="Mark absent"
+        confirmVariant="danger"
+        pending={deleting}
+        onConfirm={handleConfirmDelete}
+        onCancel={() => setConfirmOpen(false)}
+      >
+        This sets <span className="font-mono">{id}</span> to lifecycle{" "}
+        <span className="font-mono">absent</span>. The TOML is kept so the next
+        plan shows an explicit destroy; nothing is torn down until you apply.
+      </ConfirmDialog>
+    </Card>
+  );
+}

--- a/web/src/app/pages/AgentsPage.test.tsx
+++ b/web/src/app/pages/AgentsPage.test.tsx
@@ -1,0 +1,229 @@
+/**
+ * AgentsPage tests.
+ *
+ * The network is mocked at the client boundary (`vi.mock("../../api/client")`)
+ * so no real console server or status poller is contacted. We assert on
+ * behavior a user/screen-reader perceives: the agents table renders with
+ * lifecycle/health/url, each row links to the detail route, the live status
+ * snapshot enriches rows by id, support services render in their own section,
+ * and the loading / empty / error states each appear when they should. The
+ * error state's retry must re-invoke the list fetch.
+ */
+
+import { describe, expect, it, vi, beforeEach, type Mock } from "vitest";
+import { render, screen, within } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { MemoryRouter } from "react-router-dom";
+import AgentsPage from "./AgentsPage";
+import type { AgentSummary, StatusSnapshot } from "../../api/types";
+
+// Mock the entire client module: the page calls listAgents() and useStatus()
+// (which calls getStatus()). getOperation is exported only so the hooks module's
+// import resolves under the mock; it is unused by this page.
+vi.mock("../../api/client", () => ({
+  listAgents: vi.fn(),
+  getStatus: vi.fn(),
+  getOperation: vi.fn(),
+}));
+
+import { listAgents, getStatus } from "../../api/client";
+
+const mockListAgents = listAgents as unknown as Mock;
+const mockGetStatus = getStatus as unknown as Mock;
+
+function agent(over: Partial<AgentSummary> = {}): AgentSummary {
+  return {
+    id: "atlas",
+    model: "anthropic/claude-3.5-sonnet",
+    fly_app: "atlas-app",
+    tailscale_hostname: "atlas",
+    vault: "atlas-vault",
+    lifecycle: "present",
+    ...over,
+  };
+}
+
+function emptySnapshot(over: Partial<StatusSnapshot> = {}): StatusSnapshot {
+  return {
+    workspace: "minimal",
+    generated_at: "2026-06-04T00:00:00Z",
+    services: [],
+    drift_count: 0,
+    summary: { total: 0, healthy: 0, degraded: 0, down: 0 },
+    ...over,
+  };
+}
+
+/** A status snapshot that never resolves keeps the page in its loading state. */
+function pending<T>(): Promise<T> {
+  return new Promise<T>(() => {});
+}
+
+function renderPage() {
+  return render(
+    <MemoryRouter>
+      <AgentsPage />
+    </MemoryRouter>,
+  );
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  // Default: a calm, empty status snapshot so useStatus resolves without error.
+  mockGetStatus.mockResolvedValue(emptySnapshot());
+});
+
+describe("AgentsPage", () => {
+  it("shows a loading state before the agents arrive", async () => {
+    mockListAgents.mockReturnValue(pending<AgentSummary[]>());
+    renderPage();
+
+    expect(await screen.findByText(/loading agents/i)).toBeInTheDocument();
+    // No table is rendered yet while the first load is in flight.
+    expect(screen.queryByRole("table")).not.toBeInTheDocument();
+  });
+
+  it("renders a row per agent with lifecycle, health, model and a detail link", async () => {
+    mockListAgents.mockResolvedValue([
+      agent({
+        id: "atlas",
+        lifecycle: "present",
+        health: "ok",
+        fly_state: "started",
+        model: "anthropic/claude-3.5-sonnet",
+        vault: "atlas-vault",
+        url: "https://atlas.example.ts.net",
+        last_deploy: "2026-06-01T12:00:00Z",
+      }),
+      agent({ id: "boreas", lifecycle: "absent", vault: "" }),
+    ]);
+    renderPage();
+
+    // Both agents render as rows.
+    const atlasLink = await screen.findByRole("link", { name: "atlas" });
+    expect(atlasLink).toHaveAttribute("href", "/agents/atlas");
+    const boreasLink = screen.getByRole("link", { name: "boreas" });
+    expect(boreasLink).toHaveAttribute("href", "/agents/boreas");
+
+    // Row content: lifecycle, health badge, fly_state, model.
+    const atlasRow = atlasLink.closest("tr")!;
+    expect(within(atlasRow).getByText("present")).toBeInTheDocument();
+    expect(within(atlasRow).getByText("Healthy")).toBeInTheDocument();
+    expect(within(atlasRow).getByText("started")).toBeInTheDocument();
+    expect(
+      within(atlasRow).getByText("anthropic/claude-3.5-sonnet"),
+    ).toBeInTheDocument();
+
+    // The Tailscale URL renders as an external link showing the host.
+    const urlLink = within(atlasRow).getByRole("link", {
+      name: "atlas.example.ts.net",
+    });
+    expect(urlLink).toHaveAttribute("href", "https://atlas.example.ts.net");
+
+    // The absent agent surfaces its lifecycle distinctly.
+    const boreasRow = boreasLink.closest("tr")!;
+    expect(within(boreasRow).getByText("absent")).toBeInTheDocument();
+  });
+
+  it("enriches an agent row's health/fly_state/url from the status snapshot by id", async () => {
+    // The list row lacks live fields; the snapshot supplies them by matching id.
+    mockListAgents.mockResolvedValue([agent({ id: "atlas" })]);
+    mockGetStatus.mockResolvedValue(
+      emptySnapshot({
+        services: [
+          {
+            id: "atlas",
+            kind: "agent",
+            health: "degraded",
+            online: true,
+            machine_state: "stopped",
+            url: "https://atlas.snapshot.ts.net",
+          },
+        ],
+      }),
+    );
+    renderPage();
+
+    const atlasRow = (await screen.findByRole("link", { name: "atlas" })).closest(
+      "tr",
+    )!;
+    // Health + fly_state came from the snapshot, not the (bare) list row.
+    expect(within(atlasRow).getByText("Degraded")).toBeInTheDocument();
+    expect(within(atlasRow).getByText("stopped")).toBeInTheDocument();
+    expect(
+      within(atlasRow).getByRole("link", { name: "atlas.snapshot.ts.net" }),
+    ).toHaveAttribute("href", "https://atlas.snapshot.ts.net");
+  });
+
+  it("lists support services from the snapshot in their own section, not as agents", async () => {
+    mockListAgents.mockResolvedValue([agent({ id: "atlas" })]);
+    mockGetStatus.mockResolvedValue(
+      emptySnapshot({
+        services: [
+          { id: "atlas", kind: "agent", health: "ok", online: true },
+          {
+            id: "fleet-webui",
+            kind: "openwebui",
+            health: "ok",
+            online: true,
+            url: "https://webui.example.ts.net",
+          },
+        ],
+      }),
+    );
+    renderPage();
+
+    // The support section is a labelled region containing the Open WebUI row.
+    const section = await screen.findByRole("region", {
+      name: /support services/i,
+    });
+    expect(within(section).getByText("fleet-webui")).toBeInTheDocument();
+    expect(within(section).getByText("Open WebUI")).toBeInTheDocument();
+    expect(
+      within(section).getByRole("link", { name: "webui.example.ts.net" }),
+    ).toHaveAttribute("href", "https://webui.example.ts.net");
+
+    // The agent-kind service did NOT leak into the support section.
+    expect(within(section).queryByText("atlas")).not.toBeInTheDocument();
+  });
+
+  it("renders an empty state with a create call-to-action when there are no agents", async () => {
+    mockListAgents.mockResolvedValue([]);
+    renderPage();
+
+    expect(await screen.findByText(/no agents yet/i)).toBeInTheDocument();
+    const cta = screen.getByRole("link", { name: /create an agent/i });
+    expect(cta).toHaveAttribute("href", "/agents/new");
+    // No table in the empty case.
+    expect(screen.queryByRole("table")).not.toBeInTheDocument();
+  });
+
+  it("shows an error banner with a working retry when the list fails", async () => {
+    mockListAgents
+      .mockRejectedValueOnce(new Error("boom: agents unavailable"))
+      .mockResolvedValueOnce([agent({ id: "atlas" })]);
+    renderPage();
+
+    const alert = await screen.findByRole("alert");
+    expect(within(alert).getByText(/boom: agents unavailable/i)).toBeInTheDocument();
+    expect(mockListAgents).toHaveBeenCalledTimes(1);
+
+    // Retrying re-invokes the fetch and recovers to the table.
+    await userEvent.click(within(alert).getByRole("button", { name: /retry/i }));
+
+    expect(await screen.findByRole("link", { name: "atlas" })).toBeInTheDocument();
+    expect(screen.queryByRole("alert")).not.toBeInTheDocument();
+    expect(mockListAgents).toHaveBeenCalledTimes(2);
+  });
+
+  it("always offers a New agent action that navigates to the create route", async () => {
+    mockListAgents.mockResolvedValue([agent({ id: "atlas" })]);
+    renderPage();
+
+    // Wait for content so the header action is settled.
+    await screen.findByRole("link", { name: "atlas" });
+    expect(
+      screen.getByRole("link", { name: /new agent/i }),
+    ).toHaveAttribute("href", "/agents/new");
+  });
+});

--- a/web/src/app/pages/AgentsPage.tsx
+++ b/web/src/app/pages/AgentsPage.tsx
@@ -1,0 +1,363 @@
+/**
+ * AgentsPage — fleet agent list (route "/").
+ *
+ * Lists the workspace's agents in a dense table (lifecycle, health, Fly state,
+ * model, vault, Tailscale URL, last deploy) with each row linking to the agent
+ * detail view. Below the agents, any non-agent support services from the live
+ * status snapshot (Open WebUI, the dashboard) are surfaced in their own section.
+ *
+ * Data comes from two sources that are merged here:
+ *   - `listAgents()` is the config-derived source of truth (always available,
+ *     no live network). Its rows already carry health/fly_state/url when the
+ *     server had a snapshot at request time.
+ *   - `useStatus()` polls the live fleet snapshot; we use it to enrich each
+ *     agent row by id (health / fly_state / url) when the list row is missing
+ *     those fields, and to populate the support-services section.
+ *
+ * Every list state is handled: loading (spinner), error (retryable banner), and
+ * empty (a call-to-action to create the first agent).
+ */
+
+import type { ReactNode } from "react";
+import { Link } from "react-router-dom";
+import { listAgents } from "../../api/client";
+import type { AgentSummary, ServiceStatus } from "../../api/types";
+import { usePolling, useStatus } from "../hooks";
+import {
+  Badge,
+  Card,
+  EmptyState,
+  ErrorBanner,
+  HealthBadge,
+  PageHeader,
+  Spinner,
+} from "../components";
+
+/** Shared primary-action styling for links rendered as accent buttons. */
+const PRIMARY_LINK_CLASS =
+  "inline-flex h-9 items-center justify-center gap-2 rounded-md bg-accent " +
+  "px-4 text-sm font-medium text-accent-fg transition-colors hover:bg-accent-muted " +
+  "focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-accent";
+
+/** Agents change rarely; poll the config-derived list on a calm interval. */
+const AGENTS_POLL_MS = 15000;
+
+export default function AgentsPage() {
+  const {
+    data: agents,
+    error,
+    loading,
+    refresh,
+  } = usePolling<AgentSummary[]>(() => listAgents(), AGENTS_POLL_MS);
+
+  // Live snapshot is best-effort enrichment; its own failure must not blank the
+  // page, so we read only its data and ignore its error/loading here.
+  const { data: status } = useStatus();
+  const serviceById = indexServices(status?.services);
+  const supportServices = (status?.services ?? []).filter(
+    (svc) => !isAgentKind(svc.kind),
+  );
+
+  return (
+    <>
+      <PageHeader
+        title="Agents"
+        description="Your fleet's agents, their health, and lifecycle."
+        actions={
+          // Render the primary action as a real <a>-backed Link so it is
+          // keyboard- and screen-reader-operable as a navigation control.
+          <Link to="/agents/new" className={PRIMARY_LINK_CLASS}>
+            New agent
+          </Link>
+        }
+      />
+
+      <AgentsSection
+        agents={agents}
+        loading={loading}
+        error={error}
+        onRetry={refresh}
+        serviceById={serviceById}
+      />
+
+      <SupportSection services={supportServices} />
+    </>
+  );
+}
+
+/* --- Agents table -------------------------------------------------------- */
+
+interface AgentsSectionProps {
+  agents: AgentSummary[] | null;
+  loading: boolean;
+  error: Error | null;
+  onRetry: () => void;
+  serviceById: Map<string, ServiceStatus>;
+}
+
+function AgentsSection({
+  agents,
+  loading,
+  error,
+  onRetry,
+  serviceById,
+}: AgentsSectionProps) {
+  // Error wins over a stale list so failures are never silently hidden.
+  if (error) {
+    return (
+      <ErrorBanner
+        title="Could not load agents"
+        error={error}
+        onRetry={onRetry}
+      />
+    );
+  }
+
+  // Initial load (no data yet): show a spinner, not an empty table.
+  if (loading && agents === null) {
+    return (
+      <Card>
+        <div className="flex items-center justify-center py-12">
+          <Spinner label="Loading agents" className="size-5" />
+        </div>
+      </Card>
+    );
+  }
+
+  const rows = agents ?? [];
+  if (rows.length === 0) {
+    return (
+      <EmptyState
+        title="No agents yet"
+        description="Create your first agent to start building out the fleet."
+        action={
+          <Link to="/agents/new" className={PRIMARY_LINK_CLASS}>
+            Create an agent
+          </Link>
+        }
+      />
+    );
+  }
+
+  return (
+    <Card bare title="Fleet agents" description={`${rows.length} configured`}>
+      <div className="overflow-x-auto">
+        <table className="w-full border-collapse text-sm">
+          <caption className="sr-only">Fleet agents</caption>
+          <thead>
+            <tr className="border-b border-line text-left text-xs text-muted">
+              <Th>Agent</Th>
+              <Th>Lifecycle</Th>
+              <Th>Health</Th>
+              <Th>Fly state</Th>
+              <Th>Model</Th>
+              <Th>Vault</Th>
+              <Th>URL</Th>
+              <Th>Last deploy</Th>
+            </tr>
+          </thead>
+          <tbody>
+            {rows.map((agent) => (
+              <AgentRow
+                key={agent.id}
+                agent={enrichAgent(agent, serviceById.get(agent.id))}
+              />
+            ))}
+          </tbody>
+        </table>
+      </div>
+    </Card>
+  );
+}
+
+function AgentRow({ agent }: { agent: AgentSummary }) {
+  return (
+    <tr className="border-b border-line/60 last:border-0 hover:bg-surface-raised/60">
+      <td className="px-3 py-2.5">
+        <Link
+          to={`/agents/${encodeURIComponent(agent.id)}`}
+          className="font-medium text-fg underline-offset-2 hover:text-accent hover:underline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-accent"
+        >
+          {agent.id}
+        </Link>
+      </td>
+      <td className="px-3 py-2.5">
+        <LifecycleBadge lifecycle={agent.lifecycle} />
+      </td>
+      <td className="px-3 py-2.5">
+        <HealthBadge health={agent.health} />
+      </td>
+      <td className="px-3 py-2.5 text-muted">
+        <Mono value={agent.fly_state} />
+      </td>
+      <td className="px-3 py-2.5 text-muted">
+        <Mono value={agent.model} />
+      </td>
+      <td className="px-3 py-2.5 text-muted">
+        {agent.vault ? <Mono value={agent.vault} /> : <Dash />}
+      </td>
+      <td className="px-3 py-2.5">
+        {agent.url ? (
+          <a
+            href={agent.url}
+            target="_blank"
+            rel="noreferrer"
+            className="text-accent underline-offset-2 hover:underline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-accent"
+          >
+            {hostOf(agent.url)}
+          </a>
+        ) : (
+          <Dash />
+        )}
+      </td>
+      <td className="px-3 py-2.5 text-muted">
+        {agent.last_deploy ? <Mono value={agent.last_deploy} /> : <Dash />}
+      </td>
+    </tr>
+  );
+}
+
+/* --- Support services ---------------------------------------------------- */
+
+function SupportSection({ services }: { services: ServiceStatus[] }) {
+  if (services.length === 0) {
+    return null;
+  }
+  return (
+    <section className="mt-8" aria-labelledby="support-services-heading">
+      <h2
+        id="support-services-heading"
+        className="mb-3 text-sm font-semibold text-fg"
+      >
+        Support services
+      </h2>
+      <Card bare>
+        <div className="overflow-x-auto">
+          <table className="w-full border-collapse text-sm">
+            <caption className="sr-only">Support services</caption>
+            <thead>
+              <tr className="border-b border-line text-left text-xs text-muted">
+                <Th>Service</Th>
+                <Th>Kind</Th>
+                <Th>Health</Th>
+                <Th>URL</Th>
+              </tr>
+            </thead>
+            <tbody>
+              {services.map((svc) => (
+                <tr
+                  key={svc.id}
+                  className="border-b border-line/60 last:border-0 hover:bg-surface-raised/60"
+                >
+                  <td className="px-3 py-2.5 font-medium text-fg">{svc.id}</td>
+                  <td className="px-3 py-2.5">
+                    <Badge tone="neutral">{labelForKind(svc.kind)}</Badge>
+                  </td>
+                  <td className="px-3 py-2.5">
+                    <HealthBadge health={svc.health} />
+                  </td>
+                  <td className="px-3 py-2.5">
+                    {svc.url ? (
+                      <a
+                        href={svc.url}
+                        target="_blank"
+                        rel="noreferrer"
+                        className="text-accent underline-offset-2 hover:underline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-accent"
+                      >
+                        {hostOf(svc.url)}
+                      </a>
+                    ) : (
+                      <Dash />
+                    )}
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      </Card>
+    </section>
+  );
+}
+
+/* --- Local presentational + data helpers --------------------------------- */
+
+function Th({ children }: { children: ReactNode }) {
+  return <th className="px-3 py-2 font-medium">{children}</th>;
+}
+
+function Mono({ value }: { value?: string }) {
+  if (!value) return <Dash />;
+  return <span className="font-mono text-xs text-muted">{value}</span>;
+}
+
+function Dash() {
+  return (
+    <span className="text-faint" aria-hidden="true">
+      —
+    </span>
+  );
+}
+
+/** Lifecycle pill: present is calm/neutral, absent (pending destroy) is danger. */
+function LifecycleBadge({ lifecycle }: { lifecycle: string }) {
+  const absent = lifecycle === "absent";
+  return (
+    <Badge tone={absent ? "danger" : "neutral"}>{lifecycle || "unknown"}</Badge>
+  );
+}
+
+/** Builds a by-id lookup of snapshot services for O(1) enrichment. */
+function indexServices(
+  services: ServiceStatus[] | undefined,
+): Map<string, ServiceStatus> {
+  const map = new Map<string, ServiceStatus>();
+  for (const svc of services ?? []) {
+    map.set(svc.id, svc);
+  }
+  return map;
+}
+
+/**
+ * Enriches a config-derived agent row with live snapshot fields by id, filling
+ * only the values the list row lacks. The server already enriches when it has a
+ * snapshot, so this covers the case where the live poll is fresher than the list
+ * response.
+ */
+function enrichAgent(
+  agent: AgentSummary,
+  svc: ServiceStatus | undefined,
+): AgentSummary {
+  if (!svc) return agent;
+  return {
+    ...agent,
+    health: agent.health ?? svc.health,
+    fly_state: agent.fly_state ?? svc.machine_state,
+    url: agent.url ?? svc.url,
+  };
+}
+
+/** Status snapshot kind for fleet agents (vs. support services). */
+function isAgentKind(kind: string): boolean {
+  return kind === "agent";
+}
+
+function labelForKind(kind: string): string {
+  switch (kind) {
+    case "openwebui":
+      return "Open WebUI";
+    case "dashboard":
+      return "Dashboard";
+    default:
+      return kind || "service";
+  }
+}
+
+/** Renders a friendlier host label for a URL, falling back to the raw value. */
+function hostOf(url: string): string {
+  try {
+    return new URL(url).host;
+  } catch {
+    return url;
+  }
+}

--- a/web/src/app/pages/CreateAgentPage.test.tsx
+++ b/web/src/app/pages/CreateAgentPage.test.tsx
@@ -1,0 +1,299 @@
+/**
+ * CreateAgentPage tests.
+ *
+ * These exercise the wizard's real, observable behavior end-to-end with the
+ * console client mocked at its module boundary (so no network, no live server):
+ *
+ *  - the template step seeds the form and advances to Configure;
+ *  - the form's own validation gates Configure → Review (an invalid id never
+ *    advances and never calls createAgent);
+ *  - "Create & plan" calls createAgent(input) with the assembled input, then
+ *    plan(), and renders the resulting PlanDiff + the plan hash;
+ *  - APPLY IS GATED: the Apply button is disabled until the explicit
+ *    "I reviewed the plan" confirmation is ticked, after which apply(hash) is
+ *    called with the current plan hash and live progress streams to success;
+ *  - a ConsoleError from createAgent is surfaced inline (the error path).
+ *
+ * The whole client module is mocked so getOperation (reached transitively via
+ * OperationProgress → useOperation) is deterministic too.
+ */
+
+import { describe, expect, it, vi, beforeEach } from "vitest";
+import { render, screen, waitFor, within } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { MemoryRouter, Routes, Route } from "react-router-dom";
+
+import CreateAgentPage from "./CreateAgentPage";
+import type {
+  AgentDetail,
+  ApplyResponse,
+  OperationStatus,
+  PlanResponse,
+} from "../../api/types";
+
+// Mock the client at the boundary. Every page/component path that talks to the
+// API (including OperationProgress → useOperation → getOperation) resolves to
+// these spies.
+vi.mock("../../api/client", () => ({
+  ConsoleError: class ConsoleError extends Error {
+    status: number;
+    constructor(status: number, message: string) {
+      super(message);
+      this.name = "ConsoleError";
+      this.status = status;
+    }
+  },
+  createAgent: vi.fn(),
+  plan: vi.fn(),
+  apply: vi.fn(),
+  getOperation: vi.fn(),
+}));
+
+import {
+  ConsoleError,
+  apply,
+  createAgent,
+  getOperation,
+  plan,
+} from "../../api/client";
+
+const createAgentMock = vi.mocked(createAgent);
+const planMock = vi.mocked(plan);
+const applyMock = vi.mocked(apply);
+const getOperationMock = vi.mocked(getOperation);
+
+function detail(over: Partial<AgentDetail> = {}): AgentDetail {
+  return {
+    id: "research-agent",
+    model: "google/gemini-3.5-flash",
+    fly_app: "research-agent",
+    tailscale_hostname: "research-agent",
+    vault: "memory",
+    lifecycle: "present",
+    region: "cdg",
+    memory: "512mb",
+    cpus: 1,
+    runtime: "fly.default",
+    network: "tailscale.default",
+    model_provider: "openrouter.default",
+    soul_preview: "",
+    companion_soul_enabled: true,
+    vault_connections: [],
+    ...over,
+  };
+}
+
+function planResponse(over: Partial<PlanResponse> = {}): PlanResponse {
+  return {
+    hash: "abcdef0123456789",
+    text: "+ fly_app.research-agent will be created",
+    changes: [
+      {
+        kind: "+",
+        action: "create",
+        address: "fly_app.research-agent",
+        message: "create the agent app",
+        protected: false,
+      },
+    ],
+    ...over,
+  };
+}
+
+function operation(state: OperationStatus["state"]): OperationStatus {
+  return {
+    id: "op-1",
+    state,
+    started_at: "2026-06-04T00:00:00Z",
+    finished_at: state === "succeeded" ? "2026-06-04T00:01:00Z" : undefined,
+    changed_resources:
+      state === "succeeded" ? ["fly_app.research-agent"] : [],
+  };
+}
+
+function renderPage() {
+  return render(
+    <MemoryRouter initialEntries={["/agents/new"]}>
+      <Routes>
+        <Route path="/agents/new" element={<CreateAgentPage />} />
+        <Route path="/agents/:id" element={<div>Agent detail page</div>} />
+      </Routes>
+    </MemoryRouter>,
+  );
+}
+
+/** Walks template → configure → fills the form → review. Returns the user. */
+async function fillToReview(
+  user: ReturnType<typeof userEvent.setup>,
+  id = "research-agent",
+) {
+  await user.click(screen.getByRole("button", { name: /standard agent/i }));
+  // Now on Configure: fill id + name (model is seeded by the template).
+  await user.type(screen.getByLabelText(/agent id/i), id);
+  await user.type(screen.getByLabelText(/display name/i), "Research Agent");
+  await user.click(
+    screen.getByRole("button", { name: /review configuration/i }),
+  );
+}
+
+beforeEach(() => {
+  createAgentMock.mockReset();
+  planMock.mockReset();
+  applyMock.mockReset();
+  getOperationMock.mockReset();
+});
+
+describe("CreateAgentPage", () => {
+  it("seeds the form from the chosen template and advances to configure", async () => {
+    const user = userEvent.setup();
+    renderPage();
+
+    expect(
+      screen.getByRole("heading", { name: /choose a starting template/i }),
+    ).toBeInTheDocument();
+
+    await user.click(screen.getByRole("button", { name: /standard agent/i }));
+
+    // Configure step: the model field is pre-filled from the template.
+    expect(
+      screen.getByRole("heading", { name: /configure the agent/i }),
+    ).toBeInTheDocument();
+    expect(screen.getByLabelText(/^model$/i)).toHaveValue(
+      "google/gemini-3.5-flash",
+    );
+    expect(screen.getByLabelText(/memory/i)).toHaveValue("512mb");
+  });
+
+  it("blocks advancing to review (and never creates) when the id is invalid", async () => {
+    const user = userEvent.setup();
+    renderPage();
+
+    await user.click(screen.getByRole("button", { name: /standard agent/i }));
+    await user.type(screen.getByLabelText(/display name/i), "Research Agent");
+    await user.type(screen.getByLabelText(/agent id/i), "Bad_Id");
+    await user.click(
+      screen.getByRole("button", { name: /review configuration/i }),
+    );
+
+    // Stayed on configure; the id is flagged; createAgent was never called.
+    expect(
+      screen.getByText(/lowercase letters, digits and hyphens/i),
+    ).toBeInTheDocument();
+    expect(screen.getByLabelText(/agent id/i)).toHaveAttribute(
+      "aria-invalid",
+      "true",
+    );
+    expect(createAgentMock).not.toHaveBeenCalled();
+  });
+
+  it("on Create & plan: calls createAgent(input) then plan(), and renders the diff + hash", async () => {
+    createAgentMock.mockResolvedValue(detail());
+    planMock.mockResolvedValue(planResponse());
+
+    const user = userEvent.setup();
+    renderPage();
+
+    await fillToReview(user);
+
+    // Review step shows the assembled input.
+    expect(
+      screen.getByRole("heading", { name: /review configuration/i }),
+    ).toBeInTheDocument();
+    expect(screen.getByText("research-agent")).toBeInTheDocument();
+
+    await user.click(screen.getByRole("button", { name: /create & plan/i }));
+
+    // createAgent was called with the assembled input; plan followed.
+    await waitFor(() => expect(createAgentMock).toHaveBeenCalledTimes(1));
+    expect(createAgentMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        id: "research-agent",
+        name: "Research Agent",
+        model: "google/gemini-3.5-flash",
+        memory: "512mb",
+        cpus: 1,
+        lifecycle: "present",
+      }),
+    );
+    await waitFor(() => expect(planMock).toHaveBeenCalledTimes(1));
+
+    // The plan diff renders the create change and the (truncated) hash.
+    const planList = await screen.findByRole("list", {
+      name: /planned changes/i,
+    });
+    expect(
+      within(planList).getByText("fly_app.research-agent"),
+    ).toBeInTheDocument();
+    expect(within(planList).getByText("create")).toBeInTheDocument();
+    expect(screen.getByText("abcdef012345")).toBeInTheDocument(); // hash.slice(0,12)
+  });
+
+  it("gates Apply behind the explicit confirmation, then calls apply(hash) and streams to success", async () => {
+    createAgentMock.mockResolvedValue(detail());
+    planMock.mockResolvedValue(planResponse());
+    applyMock.mockResolvedValue({ operation_id: "op-1" } satisfies ApplyResponse);
+    // The operation is already terminal on the first poll, so useOperation
+    // resolves and stops without depending on interval timing.
+    getOperationMock.mockResolvedValue(operation("succeeded"));
+
+    const user = userEvent.setup();
+    renderPage();
+
+    await fillToReview(user);
+    await user.click(screen.getByRole("button", { name: /create & plan/i }));
+
+    // Wait for the plan to render, surfacing the Apply card.
+    await screen.findByRole("list", { name: /planned changes/i });
+
+    // The Apply button exists but is DISABLED until the confirmation is ticked.
+    const applyButton = screen.getByRole("button", { name: /apply plan/i });
+    expect(applyButton).toBeDisabled();
+
+    // Clicking while disabled must not call apply.
+    await user.click(applyButton);
+    expect(applyMock).not.toHaveBeenCalled();
+
+    // Tick the explicit "I reviewed the plan" confirmation → button enables.
+    await user.click(
+      screen.getByRole("switch", { name: /i reviewed the plan/i }),
+    );
+    expect(applyButton).toBeEnabled();
+
+    await user.click(applyButton);
+
+    // apply() called with the exact plan hash from the plan response.
+    await waitFor(() => expect(applyMock).toHaveBeenCalledTimes(1));
+    expect(applyMock).toHaveBeenCalledWith("abcdef0123456789");
+
+    // Progress streams to a terminal success state and offers the agent link.
+    await waitFor(() =>
+      expect(getOperationMock).toHaveBeenCalledWith("op-1"),
+    );
+    const viewLink = await screen.findByRole("button", {
+      name: /view research-agent/i,
+    });
+    expect(viewLink).toBeInTheDocument();
+  });
+
+  it("surfaces a ConsoleError from createAgent inline and offers a retry", async () => {
+    createAgentMock.mockRejectedValue(
+      new ConsoleError(400, "workspace validation failed: bad model"),
+    );
+
+    const user = userEvent.setup();
+    renderPage();
+
+    await fillToReview(user);
+    await user.click(screen.getByRole("button", { name: /create & plan/i }));
+
+    // The error is announced and plan() was never reached.
+    const alert = await screen.findByRole("alert");
+    expect(alert).toHaveTextContent(/workspace validation failed: bad model/i);
+    expect(planMock).not.toHaveBeenCalled();
+
+    // No plan ⇒ no Apply control is rendered at all.
+    expect(
+      screen.queryByRole("button", { name: /apply plan/i }),
+    ).not.toBeInTheDocument();
+  });
+});

--- a/web/src/app/pages/CreateAgentPage.test.tsx
+++ b/web/src/app/pages/CreateAgentPage.test.tsx
@@ -96,6 +96,8 @@ function planResponse(over: Partial<PlanResponse> = {}): PlanResponse {
         protected: false,
       },
     ],
+    requires_protected_confirm: false,
+    requires_destroy_data: false,
     ...over,
   };
 }

--- a/web/src/app/pages/CreateAgentPage.tsx
+++ b/web/src/app/pages/CreateAgentPage.tsx
@@ -1,0 +1,587 @@
+/**
+ * CreateAgentPage — the new-agent wizard (route "/agents/new").
+ *
+ * A linear, four-stage flow that takes an operator from an empty form to a
+ * deployed agent without ever skipping the safety rails Companion cares about:
+ *
+ *   1. Template  — seed AgentInput defaults (mirroring examples/minimal) so the
+ *                  common shapes ("Standard agent", "Memory-heavy") are one click.
+ *   2. Configure — the shared AgentForm; its own client-side validation gates
+ *                  advancing to review (we reuse its onSubmit as "next").
+ *   3. Review    — a read-only summary of the assembled AgentInput.
+ *   4. Plan      — createAgent(input) then plan(); render the PlanDiff + hash.
+ *                  The Apply button stays DISABLED until the operator ticks an
+ *                  explicit "I reviewed the plan" confirmation; on apply we call
+ *                  apply(hash) and stream OperationProgress to a terminal state,
+ *                  then offer a link to the freshly created agent.
+ *
+ * Security/UX: no secret values are ever shown (providers live in Settings);
+ * every failure path surfaces a ConsoleError inline via ErrorBanner; the apply
+ * is irreversible-by-intent and therefore gated behind the explicit checkbox.
+ */
+
+import { useState } from "react";
+import { Link, useNavigate } from "react-router-dom";
+import { apply, createAgent, plan } from "../../api/client";
+import type {
+  AgentDetail,
+  AgentInput,
+  OperationStatus,
+  PlanResponse,
+} from "../../api/types";
+import {
+  AgentForm,
+  Badge,
+  Button,
+  Card,
+  CodeBlock,
+  emptyAgentInput,
+  ErrorBanner,
+  OperationProgress,
+  PageHeader,
+  PlanDiff,
+  Spinner,
+  Toggle,
+} from "../components";
+
+/** The wizard stages, in order. */
+type Step = "template" | "configure" | "review" | "plan";
+
+const STEP_ORDER: Step[] = ["template", "configure", "review", "plan"];
+
+const STEP_LABELS: Record<Step, string> = {
+  template: "Template",
+  configure: "Configure",
+  review: "Review",
+  plan: "Plan & apply",
+};
+
+/**
+ * A starting template: a label, blurb, and the AgentInput overrides it applies
+ * on top of `emptyAgentInput()`. Defaults mirror examples/minimal so a fresh
+ * agent lands on sensible, valid shapes.
+ */
+interface Template {
+  id: string;
+  name: string;
+  description: string;
+  patch: Partial<AgentInput>;
+}
+
+const TEMPLATES: Template[] = [
+  {
+    id: "standard",
+    name: "Standard agent",
+    description:
+      "A balanced general-purpose agent. 1 CPU, 512mb, cdg region — mirrors examples/minimal.",
+    patch: {
+      model: "google/gemini-3.5-flash",
+      memory: "512mb",
+      cpus: 1,
+      region: "cdg",
+      companion_soul_enabled: true,
+    },
+  },
+  {
+    id: "memory-heavy",
+    name: "Memory-heavy",
+    description:
+      "For long-context or retrieval-heavy work. 2 CPUs, 2gb, with the companion soul appended.",
+    patch: {
+      model: "google/gemini-3.5-flash",
+      memory: "2gb",
+      cpus: 2,
+      region: "cdg",
+      companion_soul_enabled: true,
+    },
+  },
+];
+
+export default function CreateAgentPage() {
+  const navigate = useNavigate();
+
+  const [step, setStep] = useState<Step>("template");
+  const [templateId, setTemplateId] = useState<string | null>(null);
+  const [input, setInput] = useState<AgentInput>(emptyAgentInput());
+
+  // Plan stage state.
+  const [planResult, setPlanResult] = useState<PlanResponse | null>(null);
+  const [created, setCreated] = useState<AgentDetail | null>(null);
+  const [planPending, setPlanPending] = useState(false);
+  const [planError, setPlanError] = useState<unknown>(null);
+
+  // Apply stage state.
+  const [reviewed, setReviewed] = useState(false);
+  const [applyPending, setApplyPending] = useState(false);
+  const [applyError, setApplyError] = useState<unknown>(null);
+  const [operationId, setOperationId] = useState<string | null>(null);
+  const [finished, setFinished] = useState<OperationStatus | null>(null);
+
+  /** Pick a template, seed the form, and advance to Configure. */
+  function chooseTemplate(template: Template) {
+    setTemplateId(template.id);
+    setInput({ ...emptyAgentInput(), ...template.patch });
+    setStep("configure");
+  }
+
+  /**
+   * AgentForm.onSubmit only fires when the form's own client-side validation
+   * passes, so this is the gate from Configure → Review.
+   */
+  function handleConfigured(value: AgentInput) {
+    setInput(value);
+    setStep("review");
+  }
+
+  /**
+   * Create the agent, then immediately compute a plan. Both run on entering the
+   * Plan stage. A ConsoleError from either call (e.g. a 400 validation
+   * rejection) is captured and shown inline.
+   */
+  async function createThenPlan() {
+    setPlanPending(true);
+    setPlanError(null);
+    setPlanResult(null);
+    try {
+      const detail = await createAgent(input);
+      setCreated(detail);
+      const planned = await plan();
+      setPlanResult(planned);
+    } catch (err) {
+      setPlanError(err);
+    } finally {
+      setPlanPending(false);
+    }
+  }
+
+  /** Advance to the Plan stage and kick off create + plan. */
+  function goToPlan() {
+    setStep("plan");
+    void createThenPlan();
+  }
+
+  /**
+   * Apply the reviewed plan. Guarded by `reviewed` (the explicit confirmation)
+   * and a present plan hash. On success we hold the operation id so
+   * OperationProgress can stream the apply to completion.
+   */
+  async function handleApply() {
+    if (!planResult || !reviewed) return;
+    setApplyPending(true);
+    setApplyError(null);
+    try {
+      const res = await apply(planResult.hash);
+      setOperationId(res.operation_id);
+    } catch (err) {
+      setApplyError(err);
+    } finally {
+      setApplyPending(false);
+    }
+  }
+
+  const agentId = created?.id ?? input.id;
+
+  return (
+    <>
+      <PageHeader
+        title="Create agent"
+        description="Define a task-optimized agent, review the exact plan, then apply it to the fleet."
+        eyebrow={
+          <Link
+            to="/"
+            className="text-xs font-medium text-muted hover:text-fg focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-accent"
+          >
+            ← Back to agents
+          </Link>
+        }
+      />
+
+      <Stepper current={step} />
+
+      <div className="mt-6 space-y-6">
+        {step === "template" && (
+          <TemplateStep selected={templateId} onChoose={chooseTemplate} />
+        )}
+
+        {step === "configure" && (
+          <Card
+            title="Configure the agent"
+            description="Fields are validated before you can continue."
+          >
+            <AgentForm
+              value={input}
+              onChange={setInput}
+              onSubmit={handleConfigured}
+              submitLabel="Review configuration"
+              mode="create"
+            />
+            <div className="mt-4 flex justify-start">
+              <Button variant="ghost" onClick={() => setStep("template")}>
+                ← Back to templates
+              </Button>
+            </div>
+          </Card>
+        )}
+
+        {step === "review" && (
+          <ReviewStep
+            input={input}
+            onBack={() => setStep("configure")}
+            onConfirm={goToPlan}
+          />
+        )}
+
+        {step === "plan" && (
+          <PlanStep
+            agentId={agentId}
+            pending={planPending}
+            error={planError}
+            plan={planResult}
+            created={created}
+            reviewed={reviewed}
+            onReviewedChange={setReviewed}
+            applyPending={applyPending}
+            applyError={applyError}
+            operationId={operationId}
+            finished={finished}
+            onRetryPlan={createThenPlan}
+            onApply={handleApply}
+            onDone={setFinished}
+            onViewAgent={() => navigate(`/agents/${encodeURIComponent(agentId)}`)}
+          />
+        )}
+      </div>
+    </>
+  );
+}
+
+/* -------------------------------------------------------------------------- */
+/* Step indicator                                                              */
+/* -------------------------------------------------------------------------- */
+
+function Stepper({ current }: { current: Step }) {
+  const currentIndex = STEP_ORDER.indexOf(current);
+  return (
+    <ol
+      aria-label="Progress"
+      className="flex flex-wrap items-center gap-x-2 gap-y-1 text-xs"
+    >
+      {STEP_ORDER.map((s, i) => {
+        const state =
+          i < currentIndex ? "done" : i === currentIndex ? "current" : "upcoming";
+        return (
+          <li key={s} className="flex items-center gap-2">
+            <span
+              aria-current={state === "current" ? "step" : undefined}
+              className={
+                "inline-flex items-center gap-1.5 rounded-md px-2 py-1 font-medium " +
+                (state === "current"
+                  ? "bg-accent-muted/15 text-accent"
+                  : state === "done"
+                    ? "text-fg"
+                    : "text-faint")
+              }
+            >
+              <span
+                aria-hidden="true"
+                className={
+                  "grid size-4 place-items-center rounded-full text-[10px] " +
+                  (state === "upcoming"
+                    ? "border border-line text-faint"
+                    : "bg-accent text-accent-fg")
+                }
+              >
+                {state === "done" ? "✓" : i + 1}
+              </span>
+              {STEP_LABELS[s]}
+            </span>
+            {i < STEP_ORDER.length - 1 && (
+              <span aria-hidden="true" className="text-faint">
+                →
+              </span>
+            )}
+          </li>
+        );
+      })}
+    </ol>
+  );
+}
+
+/* -------------------------------------------------------------------------- */
+/* Step 1 — template                                                           */
+/* -------------------------------------------------------------------------- */
+
+function TemplateStep({
+  selected,
+  onChoose,
+}: {
+  selected: string | null;
+  onChoose: (template: Template) => void;
+}) {
+  return (
+    <Card
+      title="Choose a starting template"
+      description="Templates seed sensible defaults. You can change every field in the next step."
+    >
+      <ul className="grid gap-3 sm:grid-cols-2">
+        {TEMPLATES.map((template) => {
+          const isSelected = selected === template.id;
+          return (
+            <li key={template.id}>
+              <button
+                type="button"
+                onClick={() => onChoose(template)}
+                aria-pressed={isSelected}
+                className={
+                  "flex h-full w-full flex-col items-start gap-1 rounded-md border p-4 text-left transition-colors " +
+                  "focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-accent " +
+                  (isSelected
+                    ? "border-accent bg-accent-muted/10"
+                    : "border-line bg-surface hover:border-line-strong hover:bg-surface-raised")
+                }
+              >
+                <span className="text-sm font-semibold text-fg">
+                  {template.name}
+                </span>
+                <span className="text-xs text-muted">{template.description}</span>
+              </button>
+            </li>
+          );
+        })}
+      </ul>
+    </Card>
+  );
+}
+
+/* -------------------------------------------------------------------------- */
+/* Step 3 — review                                                             */
+/* -------------------------------------------------------------------------- */
+
+/** One row in the review summary. Blank values render as a muted placeholder. */
+function SummaryRow({
+  label,
+  value,
+  mono = false,
+}: {
+  label: string;
+  value: string;
+  mono?: boolean;
+}) {
+  const empty = value.trim() === "";
+  return (
+    <div className="flex items-baseline justify-between gap-4 py-1.5">
+      <dt className="text-xs text-muted">{label}</dt>
+      <dd
+        className={
+          "text-right text-xs " +
+          (empty ? "text-faint italic" : "text-fg ") +
+          (mono && !empty ? "font-mono" : "")
+        }
+      >
+        {empty ? "default" : value}
+      </dd>
+    </div>
+  );
+}
+
+function ReviewStep({
+  input,
+  onBack,
+  onConfirm,
+}: {
+  input: AgentInput;
+  onBack: () => void;
+  onConfirm: () => void;
+}) {
+  return (
+    <Card
+      title="Review configuration"
+      description="This is exactly what will be written to the workspace. Nothing is applied yet."
+    >
+      <dl className="divide-y divide-line">
+        <SummaryRow label="Agent id" value={input.id} mono />
+        <SummaryRow label="Display name" value={input.name} />
+        <SummaryRow label="Model" value={input.model} mono />
+        <SummaryRow label="Model provider" value={input.model_provider} mono />
+        <SummaryRow label="Memory" value={input.memory} mono />
+        <SummaryRow label="CPUs" value={String(input.cpus)} mono />
+        <SummaryRow label="Region" value={input.region} mono />
+        <SummaryRow label="Runtime" value={input.runtime} mono />
+        <SummaryRow label="Network" value={input.network} mono />
+        <SummaryRow label="Fly app" value={input.fly_app} mono />
+        <SummaryRow
+          label="Tailscale hostname"
+          value={input.tailscale_hostname}
+          mono
+        />
+        <SummaryRow label="Default vault" value={input.vault_name} mono />
+        <SummaryRow label="Lifecycle" value={input.lifecycle} mono />
+        <div className="flex items-baseline justify-between gap-4 py-1.5">
+          <dt className="text-xs text-muted">Companion soul</dt>
+          <dd className="text-right text-xs">
+            <Badge tone={input.companion_soul_enabled ? "accent" : "neutral"}>
+              {input.companion_soul_enabled ? "appended" : "disabled"}
+            </Badge>
+          </dd>
+        </div>
+      </dl>
+
+      {input.soul.trim() !== "" && (
+        <div className="mt-4">
+          <p className="mb-1.5 text-xs font-medium text-muted">SOUL.md</p>
+          <CodeBlock ariaLabel="SOUL.md preview">{input.soul}</CodeBlock>
+        </div>
+      )}
+
+      <div className="mt-6 flex items-center justify-between gap-3 border-t border-line pt-5">
+        <Button variant="ghost" onClick={onBack}>
+          ← Edit configuration
+        </Button>
+        <Button variant="primary" onClick={onConfirm}>
+          Create &amp; plan
+        </Button>
+      </div>
+    </Card>
+  );
+}
+
+/* -------------------------------------------------------------------------- */
+/* Step 4 — plan & apply                                                       */
+/* -------------------------------------------------------------------------- */
+
+interface PlanStepProps {
+  agentId: string;
+  pending: boolean;
+  error: unknown;
+  plan: PlanResponse | null;
+  created: AgentDetail | null;
+  reviewed: boolean;
+  onReviewedChange: (checked: boolean) => void;
+  applyPending: boolean;
+  applyError: unknown;
+  operationId: string | null;
+  finished: OperationStatus | null;
+  onRetryPlan: () => void;
+  onApply: () => void;
+  onDone: (status: OperationStatus) => void;
+  onViewAgent: () => void;
+}
+
+function PlanStep({
+  agentId,
+  pending,
+  error,
+  plan,
+  created,
+  reviewed,
+  onReviewedChange,
+  applyPending,
+  applyError,
+  operationId,
+  finished,
+  onRetryPlan,
+  onApply,
+  onDone,
+  onViewAgent,
+}: PlanStepProps) {
+  // Once the apply has started, the plan is locked in: hide the gate and show
+  // live progress instead.
+  const applyStarted = operationId !== null;
+  const succeeded = finished?.state === "succeeded";
+
+  return (
+    <div className="space-y-6">
+      <Card
+        title="Plan"
+        description="The agent file was written; this is the change Companion will apply."
+        actions={
+          plan ? (
+            <Badge tone="accent" className="font-mono" data-testid="plan-hash">
+              {plan.hash.slice(0, 12)}
+            </Badge>
+          ) : undefined
+        }
+      >
+        {pending && (
+          <div className="flex items-center gap-3 py-6 text-sm text-muted">
+            <Spinner label="Creating agent and computing plan" />
+            <span>Creating {agentId} and computing the plan…</span>
+          </div>
+        )}
+
+        {!pending && error != null && (
+          <ErrorBanner
+            error={error}
+            title="Could not create the agent or compute a plan"
+            onRetry={onRetryPlan}
+          />
+        )}
+
+        {!pending && error == null && plan && (
+          <div className="space-y-3">
+            {created && (
+              <p className="text-xs text-muted">
+                Created{" "}
+                <span className="font-mono text-fg">{created.id}</span>. Review
+                the plan below before applying.
+              </p>
+            )}
+            <PlanDiff changes={plan.changes} />
+            {plan.changes.length > 0 && (
+              <details className="rounded-md border border-line bg-surface">
+                <summary className="cursor-pointer px-3 py-2 text-xs font-medium text-muted select-none">
+                  Raw plan text
+                </summary>
+                <div className="px-3 pb-3">
+                  <CodeBlock ariaLabel="Raw plan text">{plan.text}</CodeBlock>
+                </div>
+              </details>
+            )}
+          </div>
+        )}
+      </Card>
+
+      {/* Apply gate + progress. Only meaningful once a plan exists. */}
+      {!pending && error == null && plan && (
+        <Card title="Apply">
+          {!applyStarted ? (
+            <div className="space-y-4">
+              <Toggle
+                label="I reviewed the plan above"
+                checked={reviewed}
+                onChange={onReviewedChange}
+                hint="Apply mutates the fleet. Confirm you have read the planned changes before continuing."
+              />
+
+              {applyError != null && (
+                <ErrorBanner error={applyError} title="Apply could not start" />
+              )}
+
+              <div className="flex items-center justify-end gap-3 border-t border-line pt-4">
+                <Button
+                  variant="primary"
+                  onClick={onApply}
+                  disabled={!reviewed}
+                  loading={applyPending}
+                >
+                  Apply plan
+                </Button>
+              </div>
+            </div>
+          ) : (
+            <div className="space-y-4">
+              <OperationProgress operationId={operationId} onDone={onDone} />
+              {succeeded && (
+                <div className="flex items-center justify-end gap-3 border-t border-line pt-4">
+                  <Button variant="primary" onClick={onViewAgent}>
+                    View {agentId} →
+                  </Button>
+                </div>
+              )}
+            </div>
+          )}
+        </Card>
+      )}
+    </div>
+  );
+}

--- a/web/src/app/pages/NotFoundPage.tsx
+++ b/web/src/app/pages/NotFoundPage.tsx
@@ -1,0 +1,28 @@
+/**
+ * NotFoundPage — fallback for unmatched routes, rendered inside the layout so
+ * navigation stays available. Named export (it is not one of the five primary
+ * page stubs the Feature Pages step owns).
+ */
+
+import { Link } from "react-router-dom";
+import { EmptyState, PageHeader } from "../components";
+
+export function NotFoundPage() {
+  return (
+    <>
+      <PageHeader title="Not found" />
+      <EmptyState
+        title="This page does not exist"
+        description="The route you followed has no matching view."
+        action={
+          <Link
+            to="/"
+            className="rounded-md bg-accent px-3 py-1.5 text-sm font-medium text-accent-fg focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-accent"
+          >
+            Back to agents
+          </Link>
+        }
+      />
+    </>
+  );
+}

--- a/web/src/app/pages/PlanApplyPage.test.tsx
+++ b/web/src/app/pages/PlanApplyPage.test.tsx
@@ -1,0 +1,294 @@
+/**
+ * PlanApplyPage tests.
+ *
+ * The whole point of this page is a safe, explicit two-stage mutate flow, so the
+ * tests drive it the way an operator would and assert the load-bearing behavior:
+ *
+ *  - the apply history list renders (and shows its empty state when there is no
+ *    history);
+ *  - "Run plan" calls `plan()` and renders the diff + the plan hash;
+ *  - "Apply" is GATED: disabled until the explicit confirmation toggle is ticked;
+ *  - confirming + applying calls `apply()` with the EXACT plan hash, then renders
+ *    live operation progress (changed resources) and refreshes the history;
+ *  - a 409 from apply surfaces a distinct "plan is no longer current" prompt to
+ *    re-run plan, not a generic failure.
+ *
+ * The network is mocked at the client boundary (`vi.mock('../../api/client')`),
+ * so nothing here touches a live console server or provider. The page is hosted
+ * in a MemoryRouter because it is normally rendered inside the router outlet.
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { render, screen, waitFor, within } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { MemoryRouter } from "react-router-dom";
+import { ConsoleError } from "../../api/client";
+import type {
+  ApplyHistoryEntry,
+  ApplyResponse,
+  OperationStatus,
+  PlanResponse,
+} from "../../api/types";
+import PlanApplyPage from "./PlanApplyPage";
+
+// Mock the entire client module: the page imports plan/apply/listApplies from
+// here, and OperationProgress/useOperation import getOperation from the same
+// module, so this one mock covers the full flow. ConsoleError is preserved as
+// the real class so `instanceof` checks in the page still work.
+vi.mock("../../api/client", async () => {
+  const actual = await vi.importActual<typeof import("../../api/client")>(
+    "../../api/client",
+  );
+  return {
+    ...actual,
+    plan: vi.fn(),
+    apply: vi.fn(),
+    listApplies: vi.fn(),
+    getOperation: vi.fn(),
+  };
+});
+
+// Import the mocked functions after registering the mock so the typed handles
+// point at the vi.fn() instances.
+import { apply, getOperation, listApplies, plan } from "../../api/client";
+
+const mockPlan = vi.mocked(plan);
+const mockApply = vi.mocked(apply);
+const mockListApplies = vi.mocked(listApplies);
+const mockGetOperation = vi.mocked(getOperation);
+
+function planResponse(over: Partial<PlanResponse> = {}): PlanResponse {
+  return {
+    hash: "abc123def456",
+    text: "fly_app.research-agent will be created",
+    changes: [
+      {
+        kind: "+",
+        action: "create",
+        address: "fly_app.research-agent",
+        message: "create app",
+        protected: false,
+      },
+    ],
+    ...over,
+  };
+}
+
+function historyEntry(over: Partial<ApplyHistoryEntry> = {}): ApplyHistoryEntry {
+  return {
+    id: 7,
+    started_at: "2026-06-04T10:00:00Z",
+    finished_at: "2026-06-04T10:01:00Z",
+    status: "succeeded",
+    ...over,
+  };
+}
+
+function operationStatus(over: Partial<OperationStatus> = {}): OperationStatus {
+  return {
+    id: "op-1",
+    state: "succeeded",
+    changed_resources: [],
+    ...over,
+  };
+}
+
+function renderPage() {
+  return render(
+    <MemoryRouter>
+      <PlanApplyPage />
+    </MemoryRouter>,
+  );
+}
+
+beforeEach(() => {
+  // Sensible defaults; individual tests override as needed.
+  mockListApplies.mockResolvedValue([]);
+  mockPlan.mockResolvedValue(planResponse());
+  mockApply.mockResolvedValue({ operation_id: "op-1" } satisfies ApplyResponse);
+  // Default: an apply operation that is already terminal on first poll, so the
+  // first (immediate) tick of useOperation reaches a terminal state without
+  // needing timers.
+  mockGetOperation.mockResolvedValue(
+    operationStatus({ changed_resources: ["fly_app.research-agent"] }),
+  );
+});
+
+afterEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("PlanApplyPage", () => {
+  it("shows the empty plan state and an empty apply history on first load", async () => {
+    renderPage();
+
+    // No plan computed yet.
+    expect(screen.getByText(/no plan yet/i)).toBeInTheDocument();
+    // History resolved to [] -> its empty state, not an error.
+    expect(await screen.findByText(/no applies yet/i)).toBeInTheDocument();
+    // The apply Card only appears once there is a plan.
+    expect(
+      screen.queryByRole("button", { name: /apply plan/i }),
+    ).not.toBeInTheDocument();
+  });
+
+  it("renders the apply history newest-first with status", async () => {
+    mockListApplies.mockResolvedValue([
+      historyEntry({ id: 9, status: "succeeded" }),
+      historyEntry({ id: 8, status: "failed" }),
+    ]);
+    renderPage();
+
+    const list = await screen.findByRole("list", { name: /recent applies/i });
+    const rows = within(list).getAllByRole("listitem");
+    expect(rows).toHaveLength(2);
+    expect(within(rows[0]).getByText("#9")).toBeInTheDocument();
+    expect(within(rows[0]).getByText("succeeded")).toBeInTheDocument();
+    expect(within(rows[1]).getByText("#8")).toBeInTheDocument();
+    expect(within(rows[1]).getByText("failed")).toBeInTheDocument();
+  });
+
+  it("surfaces an apply-history load error with a retry", async () => {
+    mockListApplies.mockRejectedValueOnce(new Error("boom"));
+    renderPage();
+
+    const alert = await screen.findByRole("alert");
+    expect(
+      within(alert).getByText(/could not load apply history/i),
+    ).toBeInTheDocument();
+
+    // Retrying re-calls listApplies; the second call resolves and the list shows.
+    mockListApplies.mockResolvedValue([historyEntry({ id: 3 })]);
+    await userEvent.click(within(alert).getByRole("button", { name: /retry/i }));
+    expect(
+      await screen.findByRole("list", { name: /recent applies/i }),
+    ).toBeInTheDocument();
+  });
+
+  it("runs a plan and renders the diff and the plan hash", async () => {
+    const user = userEvent.setup();
+    renderPage();
+
+    await user.click(screen.getByRole("button", { name: /run plan/i }));
+
+    expect(mockPlan).toHaveBeenCalledTimes(1);
+    // The diff renders the change address...
+    expect(
+      await screen.findByText("fly_app.research-agent"),
+    ).toBeInTheDocument();
+    // ...and the plan hash is shown so the apply guard is visible.
+    expect(screen.getByTestId("plan-hash")).toHaveTextContent("abc123def456");
+  });
+
+  it("surfaces a plan failure with a retry and no diff", async () => {
+    mockPlan.mockRejectedValueOnce(new ConsoleError(502, "provider unavailable"));
+    const user = userEvent.setup();
+    renderPage();
+
+    await user.click(screen.getByRole("button", { name: /^run plan$/i }));
+
+    const alert = await screen.findByRole("alert");
+    expect(within(alert).getByText(/plan failed/i)).toBeInTheDocument();
+    expect(within(alert).getByText(/provider unavailable/i)).toBeInTheDocument();
+    // The apply card never appeared because there is no plan.
+    expect(
+      screen.queryByRole("button", { name: /apply plan/i }),
+    ).not.toBeInTheDocument();
+  });
+
+  it("gates apply behind the confirmation toggle", async () => {
+    const user = userEvent.setup();
+    renderPage();
+
+    await user.click(screen.getByRole("button", { name: /run plan/i }));
+    await screen.findByText("fly_app.research-agent");
+
+    const applyButton = screen.getByRole("button", { name: /apply plan/i });
+    // Disabled until the operator explicitly confirms.
+    expect(applyButton).toBeDisabled();
+    expect(mockApply).not.toHaveBeenCalled();
+
+    await user.click(screen.getByRole("switch"));
+    expect(applyButton).toBeEnabled();
+  });
+
+  it("applies with the exact plan hash and renders live operation progress", async () => {
+    const user = userEvent.setup();
+    renderPage();
+
+    await user.click(screen.getByRole("button", { name: /run plan/i }));
+    await screen.findByText("fly_app.research-agent");
+
+    await user.click(screen.getByRole("switch"));
+    await user.click(screen.getByRole("button", { name: /apply plan/i }));
+
+    // apply() is called with the hash from the plan response — the staleness guard.
+    expect(mockApply).toHaveBeenCalledTimes(1);
+    expect(mockApply).toHaveBeenCalledWith("abc123def456");
+
+    // OperationProgress polls getOperation and renders the terminal state plus
+    // the changed resource address.
+    expect(await screen.findByText("succeeded")).toBeInTheDocument();
+    expect(
+      await screen.findByText("fly_app.research-agent", {
+        selector: "li",
+      }),
+    ).toBeInTheDocument();
+    expect(mockGetOperation).toHaveBeenCalledWith("op-1");
+
+    // Completing an apply refreshes the history (listApplies called again:
+    // once on mount, once after completion).
+    await waitFor(() =>
+      expect(mockListApplies.mock.calls.length).toBeGreaterThanOrEqual(2),
+    );
+  });
+
+  it("shows a distinct stale-plan prompt on a 409 apply conflict", async () => {
+    mockApply.mockRejectedValueOnce(
+      new ConsoleError(409, "stale plan: re-run plan and apply the current hash"),
+    );
+    const user = userEvent.setup();
+    renderPage();
+
+    await user.click(screen.getByRole("button", { name: /run plan/i }));
+    await screen.findByText("fly_app.research-agent");
+
+    await user.click(screen.getByRole("switch"));
+    await user.click(screen.getByRole("button", { name: /apply plan/i }));
+
+    // The 409 is treated as "plan went stale", not a generic failure, and the
+    // recovery action re-runs plan.
+    const alert = await screen.findByRole("alert");
+    expect(
+      within(alert).getByText(/no longer current/i),
+    ).toBeInTheDocument();
+    expect(within(alert).getByText(/re-run plan/i)).toBeInTheDocument();
+
+    // No operation progress is shown because apply never returned an id.
+    expect(mockGetOperation).not.toHaveBeenCalled();
+
+    // The retry button on the conflict banner re-runs plan.
+    mockPlan.mockClear();
+    await user.click(within(alert).getByRole("button", { name: /retry/i }));
+    expect(mockPlan).toHaveBeenCalledTimes(1);
+  });
+
+  it("re-running plan resets the confirmation gate", async () => {
+    const user = userEvent.setup();
+    renderPage();
+
+    await user.click(screen.getByRole("button", { name: /run plan/i }));
+    await screen.findByText("fly_app.research-agent");
+
+    // Confirm, then re-run plan: the toggle must reset so apply is re-gated.
+    await user.click(screen.getByRole("switch"));
+    expect(screen.getByRole("switch")).toBeChecked();
+
+    await user.click(screen.getByRole("button", { name: /re-run plan/i }));
+
+    await waitFor(() =>
+      expect(screen.getByRole("button", { name: /apply plan/i })).toBeDisabled(),
+    );
+    expect(screen.getByRole("switch")).not.toBeChecked();
+  });
+});

--- a/web/src/app/pages/PlanApplyPage.test.tsx
+++ b/web/src/app/pages/PlanApplyPage.test.tsx
@@ -27,6 +27,7 @@ import type {
   ApplyHistoryEntry,
   ApplyResponse,
   OperationStatus,
+  PlanOptions,
   PlanResponse,
 } from "../../api/types";
 import PlanApplyPage from "./PlanApplyPage";
@@ -70,6 +71,8 @@ function planResponse(over: Partial<PlanResponse> = {}): PlanResponse {
         protected: false,
       },
     ],
+    requires_protected_confirm: false,
+    requires_destroy_data: false,
     ...over,
   };
 }
@@ -290,5 +293,76 @@ describe("PlanApplyPage", () => {
       expect(screen.getByRole("button", { name: /apply plan/i })).toBeDisabled(),
     );
     expect(screen.getByRole("switch")).not.toBeChecked();
+  });
+
+  it("gates a protected destroy behind the destroy confirmations, then applies", async () => {
+    // Model the backend: with no destroy flag the protected resources are
+    // blocked; once allowProtectedDestroy is set they become real deletes.
+    mockPlan.mockImplementation(async (opts?: PlanOptions) => {
+      const allow = opts?.allowProtectedDestroy ?? false;
+      return planResponse({
+        hash: allow ? "destroy-hash" : "blocked-hash",
+        text: "destroy example-agent",
+        changes: [
+          {
+            kind: allow ? "-" : "!",
+            action: allow ? "delete" : "blocked",
+            address: "fly_app.example-agent",
+            message: "",
+            protected: true,
+          },
+          {
+            kind: allow ? "-" : "!",
+            action: allow ? "delete" : "blocked",
+            address: "fly_volume.agent_data.example-agent",
+            message: "",
+            protected: true,
+          },
+        ],
+        requires_protected_confirm: true,
+        requires_destroy_data: true,
+      });
+    });
+
+    const user = userEvent.setup();
+    renderPage();
+
+    await user.click(screen.getByRole("button", { name: /run plan/i }));
+    await screen.findByText("fly_app.example-agent");
+
+    const applyButton = () =>
+      screen.getByRole("button", { name: /apply plan/i });
+
+    // The danger zone appears (its protected-destroy switch) and apply is blocked.
+    expect(
+      screen.getByRole("switch", { name: /destroy protected resources/i }),
+    ).toBeInTheDocument();
+    expect(applyButton()).toBeDisabled();
+
+    // "I understand" alone is not enough while protected resources are blocked.
+    await user.click(
+      screen.getByRole("switch", { name: /applies changes to the live fleet/i }),
+    );
+    expect(applyButton()).toBeDisabled();
+
+    // Allow protected destroy: re-plans to real deletes, but the volume still
+    // needs the persistent-data confirmation, so apply stays disabled.
+    await user.click(
+      screen.getByRole("switch", { name: /destroy protected resources/i }),
+    );
+    await waitFor(() => expect(applyButton()).toBeDisabled());
+
+    // Allow persistent-data destruction, then re-confirm (re-planning reset the
+    // gate) — every confirmation is now satisfied.
+    await user.click(screen.getByRole("switch", { name: /persistent data/i }));
+    await user.click(
+      screen.getByRole("switch", { name: /applies changes to the live fleet/i }),
+    );
+
+    await waitFor(() => expect(applyButton()).toBeEnabled());
+    await user.click(applyButton());
+
+    // Apply uses the confirmed-plan hash — the destroy plan the operator saw.
+    expect(mockApply).toHaveBeenCalledWith("destroy-hash");
   });
 });

--- a/web/src/app/pages/PlanApplyPage.tsx
+++ b/web/src/app/pages/PlanApplyPage.tsx
@@ -1,0 +1,370 @@
+/**
+ * PlanApplyPage — plan + apply workflow (route "/plan").
+ *
+ * The flow is deliberately two-staged and explicit, because applying mutates a
+ * real fleet:
+ *
+ *   1. "Run plan" calls `plan()` and renders the computed PlanDiff, the human
+ *      plan text, and the plan hash. The hash is the apply guard.
+ *   2. Apply is gated behind an explicit confirmation toggle AND a current plan.
+ *      Confirming + clicking "Apply" calls `apply(hash)`; the returned operation
+ *      id drives <OperationProgress/>, which polls until terminal and lists the
+ *      changed resources.
+ *   3. "Recent applies" shows the workspace apply history (newest first) and
+ *      refreshes once an apply completes.
+ *
+ * A 409 from apply means the plan went stale (the workspace changed, or another
+ * apply is in flight). We surface that distinctly with a prompt to re-run plan,
+ * since a blind retry of the same hash would just 409 again.
+ *
+ * This page only consumes the shared App Core surface (client + hooks +
+ * components); it adds no shared primitives and does not touch the router.
+ */
+
+import { useCallback, useState } from "react";
+import { apply, ConsoleError, listApplies, plan } from "../../api/client";
+import type {
+  ApplyHistoryEntry,
+  OperationStatus,
+  PlanResponse,
+} from "../../api/types";
+import {
+  Badge,
+  Button,
+  Card,
+  CodeBlock,
+  EmptyState,
+  ErrorBanner,
+  OperationProgress,
+  PageHeader,
+  PlanDiff,
+  Spinner,
+  Toggle,
+  type BadgeTone,
+} from "../components";
+import { usePolling } from "../hooks";
+
+/** Map an apply-history status string to a calm status tone. */
+function applyStatusTone(status: string): BadgeTone {
+  switch (status.toLowerCase()) {
+    case "succeeded":
+    case "success":
+    case "applied":
+    case "ok":
+      return "ok";
+    case "failed":
+    case "error":
+      return "danger";
+    case "running":
+    case "pending":
+    case "in_progress":
+      return "accent";
+    default:
+      return "neutral";
+  }
+}
+
+/** True for a ConsoleError carrying HTTP 409 (stale plan / apply in flight). */
+function isConflict(err: unknown): err is ConsoleError {
+  return err instanceof ConsoleError && err.status === 409;
+}
+
+/** Short, monospace presentation of the plan hash with an explicit label. */
+function PlanHash({ hash }: { hash: string }) {
+  return (
+    <div className="flex items-center gap-2">
+      <span className="text-xs font-medium text-muted">Plan hash</span>
+      <code
+        className="rounded bg-canvas px-1.5 py-0.5 font-mono text-xs text-fg"
+        data-testid="plan-hash"
+      >
+        {hash}
+      </code>
+    </div>
+  );
+}
+
+export default function PlanApplyPage() {
+  // --- Plan state ---------------------------------------------------------
+  const [planResult, setPlanResult] = useState<PlanResponse | null>(null);
+  const [planError, setPlanError] = useState<unknown>(null);
+  const [planning, setPlanning] = useState(false);
+
+  // --- Apply state --------------------------------------------------------
+  const [confirmed, setConfirmed] = useState(false);
+  const [applying, setApplying] = useState(false);
+  const [applyError, setApplyError] = useState<unknown>(null);
+  const [operationId, setOperationId] = useState<string | null>(null);
+
+  // --- Apply history (polled, refreshed on completion) --------------------
+  const {
+    data: applies,
+    error: appliesError,
+    loading: appliesLoading,
+    refresh: refreshApplies,
+  } = usePolling<ApplyHistoryEntry[]>(() => listApplies(), 0, []);
+
+  const runPlan = useCallback(async () => {
+    setPlanning(true);
+    setPlanError(null);
+    // A fresh plan invalidates any prior apply intent: the old hash is stale,
+    // so reset the confirmation gate, the apply error, and any tracked op.
+    setConfirmed(false);
+    setApplyError(null);
+    setOperationId(null);
+    try {
+      const result = await plan();
+      setPlanResult(result);
+    } catch (err) {
+      setPlanError(err);
+      setPlanResult(null);
+    } finally {
+      setPlanning(false);
+    }
+  }, []);
+
+  const runApply = useCallback(async () => {
+    if (!planResult || !confirmed) return;
+    setApplying(true);
+    setApplyError(null);
+    setOperationId(null);
+    try {
+      const res = await apply(planResult.hash);
+      setOperationId(res.operation_id);
+    } catch (err) {
+      setApplyError(err);
+    } finally {
+      setApplying(false);
+    }
+  }, [planResult, confirmed]);
+
+  // When an apply reaches a terminal state, refresh the history so the new row
+  // appears, and drop the confirmation gate so a further apply is deliberate.
+  const handleApplyDone = useCallback(
+    (_status: OperationStatus) => {
+      setConfirmed(false);
+      refreshApplies();
+    },
+    [refreshApplies],
+  );
+
+  const hasPlan = planResult !== null;
+  const hasChanges = (planResult?.changes.length ?? 0) > 0;
+  // Apply is only meaningful with a current plan, an explicit confirmation, and
+  // no apply already in flight (button or tracked operation).
+  const applyDisabled =
+    !hasPlan || !confirmed || applying || operationId !== null;
+
+  return (
+    <>
+      <PageHeader
+        title="Plan & apply"
+        description="Preview changes against recorded state, then apply them."
+        actions={
+          <Button
+            variant="primary"
+            onClick={() => void runPlan()}
+            loading={planning}
+          >
+            {hasPlan ? "Re-run plan" : "Run plan"}
+          </Button>
+        }
+      />
+
+      <div className="space-y-6">
+        {/* Plan output --------------------------------------------------- */}
+        <Card
+          title="Plan"
+          description="A dry run of the changes Companion would make."
+          actions={hasPlan ? <PlanHash hash={planResult.hash} /> : undefined}
+        >
+          {planError ? (
+            <ErrorBanner
+              title="Plan failed"
+              error={planError}
+              onRetry={() => void runPlan()}
+            />
+          ) : planning && !hasPlan ? (
+            <div className="flex items-center gap-2 py-6 text-sm text-muted">
+              <Spinner label="Running plan" />
+              <span>Computing plan…</span>
+            </div>
+          ) : !hasPlan ? (
+            <EmptyState
+              title="No plan yet"
+              description="Use “Run plan” above to preview what would change before applying."
+            />
+          ) : (
+            <div className="space-y-4">
+              <PlanDiff changes={planResult.changes} />
+              {planResult.text.trim() !== "" && (
+                <details className="group">
+                  <summary className="cursor-pointer text-xs font-medium text-muted select-none hover:text-fg">
+                    Plan output
+                  </summary>
+                  <CodeBlock
+                    ariaLabel="Plan output"
+                    className="mt-2"
+                  >
+                    {planResult.text}
+                  </CodeBlock>
+                </details>
+              )}
+            </div>
+          )}
+        </Card>
+
+        {/* Apply --------------------------------------------------------- */}
+        {hasPlan && (
+          <Card
+            title="Apply"
+            description="Confirm to apply the plan above to the live fleet."
+          >
+            <div className="space-y-4">
+              {isConflict(applyError) ? (
+                <ErrorBanner
+                  title="Plan is no longer current"
+                  error={applyError}
+                  onRetry={() => void runPlan()}
+                />
+              ) : applyError ? (
+                <ErrorBanner
+                  title="Apply failed"
+                  error={applyError}
+                  onRetry={() => void runApply()}
+                />
+              ) : null}
+
+              {!hasChanges && (
+                <p className="text-xs text-muted">
+                  This plan makes no changes. Applying is a safe no-op.
+                </p>
+              )}
+
+              <Toggle
+                label="I understand this applies changes to the live fleet."
+                hint="Required before applying."
+                checked={confirmed}
+                onChange={setConfirmed}
+                disabled={applying || operationId !== null}
+              />
+
+              <div className="flex items-center gap-3">
+                <Button
+                  variant="danger"
+                  onClick={() => void runApply()}
+                  disabled={applyDisabled}
+                  loading={applying}
+                >
+                  Apply plan
+                </Button>
+                {!confirmed && operationId === null && (
+                  <span className="text-xs text-faint">
+                    Tick the confirmation to enable apply.
+                  </span>
+                )}
+              </div>
+
+              {operationId !== null && (
+                <OperationProgress
+                  operationId={operationId}
+                  onDone={handleApplyDone}
+                />
+              )}
+            </div>
+          </Card>
+        )}
+
+        {/* Recent applies ------------------------------------------------ */}
+        <Card
+          title="Recent applies"
+          description="History of apply runs for this workspace."
+          actions={
+            <Button
+              size="sm"
+              variant="ghost"
+              onClick={refreshApplies}
+              loading={appliesLoading && applies !== null}
+            >
+              Refresh
+            </Button>
+          }
+          bare
+        >
+          <RecentApplies
+            entries={applies}
+            error={appliesError}
+            loading={appliesLoading}
+            onRetry={refreshApplies}
+          />
+        </Card>
+      </div>
+    </>
+  );
+}
+
+/** The "Recent applies" body: loading, error, empty, and list states. */
+function RecentApplies({
+  entries,
+  error,
+  loading,
+  onRetry,
+}: {
+  entries: ApplyHistoryEntry[] | null;
+  error: Error | null;
+  loading: boolean;
+  onRetry: () => void;
+}) {
+  if (error && entries === null) {
+    return (
+      <div className="p-4">
+        <ErrorBanner
+          title="Could not load apply history"
+          error={error}
+          onRetry={onRetry}
+        />
+      </div>
+    );
+  }
+  if (loading && entries === null) {
+    return (
+      <div className="flex items-center gap-2 p-4 text-sm text-muted">
+        <Spinner label="Loading apply history" />
+        <span>Loading history…</span>
+      </div>
+    );
+  }
+  if (!entries || entries.length === 0) {
+    return (
+      <EmptyState
+        className="m-4 border-0"
+        title="No applies yet"
+        description="Apply a plan and the run will be recorded here."
+      />
+    );
+  }
+
+  return (
+    <ul aria-label="Recent applies" className="divide-y divide-line">
+      {entries.map((entry) => (
+        <li
+          key={entry.id}
+          className="flex items-center justify-between gap-4 px-4 py-3"
+        >
+          <div className="min-w-0">
+            <div className="flex items-center gap-2">
+              <span className="font-mono text-xs text-fg">#{entry.id}</span>
+              <Badge tone={applyStatusTone(entry.status)} dot>
+                {entry.status}
+              </Badge>
+            </div>
+            <p className="mt-0.5 text-xs text-muted">
+              Started {entry.started_at}
+              {entry.finished_at ? ` · finished ${entry.finished_at}` : ""}
+            </p>
+          </div>
+        </li>
+      ))}
+    </ul>
+  );
+}

--- a/web/src/app/pages/PlanApplyPage.tsx
+++ b/web/src/app/pages/PlanApplyPage.tsx
@@ -96,6 +96,12 @@ export default function PlanApplyPage() {
   const [applyError, setApplyError] = useState<unknown>(null);
   const [operationId, setOperationId] = useState<string | null>(null);
 
+  // --- Destroy confirmations (drive the plan request) ---------------------
+  // Off by default, so a plain plan reports protected destructions as blocked
+  // rather than performing them. Toggling either re-plans with the new scope.
+  const [allowProtectedDestroy, setAllowProtectedDestroy] = useState(false);
+  const [destroyData, setDestroyData] = useState(false);
+
   // --- Apply history (polled, refreshed on completion) --------------------
   const {
     data: applies,
@@ -104,24 +110,46 @@ export default function PlanApplyPage() {
     refresh: refreshApplies,
   } = usePolling<ApplyHistoryEntry[]>(() => listApplies(), 0, []);
 
-  const runPlan = useCallback(async () => {
-    setPlanning(true);
-    setPlanError(null);
-    // A fresh plan invalidates any prior apply intent: the old hash is stale,
-    // so reset the confirmation gate, the apply error, and any tracked op.
-    setConfirmed(false);
-    setApplyError(null);
-    setOperationId(null);
-    try {
-      const result = await plan();
-      setPlanResult(result);
-    } catch (err) {
-      setPlanError(err);
-      setPlanResult(null);
-    } finally {
-      setPlanning(false);
-    }
-  }, []);
+  const runPlan = useCallback(
+    async (flags?: { allowProtectedDestroy: boolean; destroyData: boolean }) => {
+      const effective = flags ?? { allowProtectedDestroy, destroyData };
+      setPlanning(true);
+      setPlanError(null);
+      // A fresh plan invalidates any prior apply intent: the old hash is stale,
+      // so reset the confirmation gate, the apply error, and any tracked op.
+      setConfirmed(false);
+      setApplyError(null);
+      setOperationId(null);
+      try {
+        const result = await plan(effective);
+        setPlanResult(result);
+      } catch (err) {
+        setPlanError(err);
+        setPlanResult(null);
+      } finally {
+        setPlanning(false);
+      }
+    },
+    [allowProtectedDestroy, destroyData],
+  );
+
+  // Toggling a destroy confirmation re-plans immediately with the new scope, so
+  // the rendered diff (and the hash apply is bound to) always reflect exactly
+  // what apply will do.
+  const onToggleProtected = useCallback(
+    (next: boolean) => {
+      setAllowProtectedDestroy(next);
+      void runPlan({ allowProtectedDestroy: next, destroyData });
+    },
+    [runPlan, destroyData],
+  );
+  const onToggleDestroyData = useCallback(
+    (next: boolean) => {
+      setDestroyData(next);
+      void runPlan({ allowProtectedDestroy, destroyData: next });
+    },
+    [runPlan, allowProtectedDestroy],
+  );
 
   const runApply = useCallback(async () => {
     if (!planResult || !confirmed) return;
@@ -150,10 +178,20 @@ export default function PlanApplyPage() {
 
   const hasPlan = planResult !== null;
   const hasChanges = (planResult?.changes.length ?? 0) > 0;
-  // Apply is only meaningful with a current plan, an explicit confirmation, and
-  // no apply already in flight (button or tracked operation).
+  const hasBlocked = (planResult?.changes ?? []).some((c) => c.kind === "!");
+  const needsProtected = planResult?.requires_protected_confirm ?? false;
+  const needsData = planResult?.requires_destroy_data ?? false;
+  // A destructive plan is "ready" once every required confirmation is given and
+  // the plan no longer reports blocked resources.
+  const destroyReady =
+    !hasBlocked &&
+    (!needsProtected || allowProtectedDestroy) &&
+    (!needsData || destroyData);
+  // Apply is only meaningful with a current plan, an explicit confirmation, no
+  // apply already in flight, and — for destructive plans — every destroy
+  // confirmation satisfied.
   const applyDisabled =
-    !hasPlan || !confirmed || applying || operationId !== null;
+    !hasPlan || !confirmed || applying || operationId !== null || !destroyReady;
 
   return (
     <>
@@ -214,6 +252,38 @@ export default function PlanApplyPage() {
           )}
         </Card>
 
+        {/* Destroy confirmation ------------------------------------------ */}
+        {hasPlan && needsProtected && (
+          <Card
+            title="Destroy confirmation"
+            description="This plan removes protected resources. Confirm explicitly to unblock them."
+          >
+            <div className="space-y-4 rounded-md border border-danger/40 bg-danger/10 px-4 py-3">
+              <p className="text-xs text-danger">
+                Protected resources (Fly app, volume, secrets, config, rollout)
+                are blocked by default. Destroying them is irreversible — to back
+                out, set the agent’s lifecycle back to “present” and re-plan.
+              </p>
+              <Toggle
+                label="Destroy protected resources"
+                hint="Allows removing resources marked protect = true."
+                checked={allowProtectedDestroy}
+                onChange={onToggleProtected}
+                disabled={planning || applying || operationId !== null}
+              />
+              {needsData && (
+                <Toggle
+                  label="Also destroy persistent data (Fly volumes)"
+                  hint="A backup is taken before the volume is removed."
+                  checked={destroyData}
+                  onChange={onToggleDestroyData}
+                  disabled={planning || applying || operationId !== null}
+                />
+              )}
+            </div>
+          </Card>
+        )}
+
         {/* Apply --------------------------------------------------------- */}
         {hasPlan && (
           <Card
@@ -258,9 +328,11 @@ export default function PlanApplyPage() {
                 >
                   Apply plan
                 </Button>
-                {!confirmed && operationId === null && (
+                {operationId === null && !applying && applyDisabled && (
                   <span className="text-xs text-faint">
-                    Tick the confirmation to enable apply.
+                    {!destroyReady
+                      ? "Resolve the destroy confirmations above to enable apply."
+                      : "Tick the confirmation to enable apply."}
                   </span>
                 )}
               </div>

--- a/web/src/app/pages/SettingsPage.test.tsx
+++ b/web/src/app/pages/SettingsPage.test.tsx
@@ -1,0 +1,194 @@
+/**
+ * SettingsPage tests.
+ *
+ * The page is the read-only Workspace Settings view. We mock the API client at
+ * its module boundary (never the network/a live server) and assert observable
+ * behavior:
+ *
+ *  - the workspace summary (name / root / agent count) renders from the DTO;
+ *  - each provider renders as NAME + a Present/Missing badge — and crucially the
+ *    UI never surfaces a secret value (it must not invent one, since the DTO
+ *    carries none);
+ *  - the loading, empty-providers, and error (with retry) states each render;
+ *  - retry re-invokes getWorkspace.
+ *
+ * No routing hooks are used by this page, so it is rendered directly.
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { render, screen, waitFor, within } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+
+// Mock the client boundary: the page imports `getWorkspace` from "../../api/client".
+vi.mock("../../api/client", () => ({
+  getWorkspace: vi.fn(),
+}));
+
+import SettingsPage from "./SettingsPage";
+import { getWorkspace } from "../../api/client";
+import type { WorkspaceInfo } from "../../api/types";
+
+const mockedGetWorkspace = vi.mocked(getWorkspace);
+
+/** Builds a WorkspaceInfo fixture with overridable fields. */
+function workspace(over: Partial<WorkspaceInfo> = {}): WorkspaceInfo {
+  return {
+    name: "demo-fleet",
+    root: "/home/op/.local/fleets/demo",
+    agent_count: 3,
+    providers: [
+      { name: "OPENROUTER_API_KEY", present: true },
+      { name: "ANTHROPIC_API_KEY", present: false },
+    ],
+    ...over,
+  };
+}
+
+beforeEach(() => {
+  mockedGetWorkspace.mockReset();
+});
+
+afterEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("SettingsPage", () => {
+  it("renders the workspace summary from the loaded info", async () => {
+    mockedGetWorkspace.mockResolvedValue(workspace());
+    render(<SettingsPage />);
+
+    // The page heading is always present.
+    expect(
+      screen.getByRole("heading", { level: 1, name: /settings/i }),
+    ).toBeInTheDocument();
+
+    // Workspace fields appear once the data resolves.
+    expect(await screen.findByText("demo-fleet")).toBeInTheDocument();
+    expect(
+      screen.getByText("/home/op/.local/fleets/demo"),
+    ).toBeInTheDocument();
+    // agent_count is rendered (alongside an "Agents" label).
+    const agentsTerm = screen.getByText("Agents");
+    const agentsRow = agentsTerm.closest("div");
+    expect(agentsRow).not.toBeNull();
+    expect(within(agentsRow as HTMLElement).getByText("3")).toBeInTheDocument();
+
+    expect(mockedGetWorkspace).toHaveBeenCalledTimes(1);
+  });
+
+  it("shows a loading indicator before the workspace resolves", async () => {
+    // A never-resolving promise keeps the page in its loading state.
+    let resolve: (w: WorkspaceInfo) => void = () => {};
+    mockedGetWorkspace.mockReturnValue(
+      new Promise<WorkspaceInfo>((r) => {
+        resolve = r;
+      }),
+    );
+    render(<SettingsPage />);
+
+    // The status spinner announces loading while pending. Its label is in a
+    // visually-hidden span, so assert on the live region's text content.
+    const status = screen.getByRole("status");
+    expect(status).toHaveTextContent(/loading workspace settings/i);
+    // Nothing has rendered yet from the (absent) data.
+    expect(screen.queryByText(/providers/i)).not.toBeInTheDocument();
+
+    // Resolve and confirm the loading indicator gives way to content.
+    resolve(workspace());
+    expect(await screen.findByText("demo-fleet")).toBeInTheDocument();
+    expect(screen.queryByRole("status")).not.toBeInTheDocument();
+  });
+
+  it("lists each provider as name + a Present/Missing badge, never a value", async () => {
+    mockedGetWorkspace.mockResolvedValue(
+      workspace({
+        providers: [
+          { name: "OPENROUTER_API_KEY", present: true },
+          { name: "ANTHROPIC_API_KEY", present: false },
+        ],
+      }),
+    );
+    render(<SettingsPage />);
+
+    // Provider names are shown as row headers in the providers table.
+    const presentRow = (await screen.findByText("OPENROUTER_API_KEY")).closest(
+      "tr",
+    ) as HTMLElement;
+    const missingRow = screen
+      .getByText("ANTHROPIC_API_KEY")
+      .closest("tr") as HTMLElement;
+
+    expect(presentRow).not.toBeNull();
+    expect(missingRow).not.toBeNull();
+
+    // The present credential shows "Present"; the absent one shows "Missing".
+    expect(within(presentRow).getByText(/present/i)).toBeInTheDocument();
+    expect(within(presentRow).queryByText(/missing/i)).not.toBeInTheDocument();
+    expect(within(missingRow).getByText(/missing/i)).toBeInTheDocument();
+    expect(within(missingRow).queryByText(/present/i)).not.toBeInTheDocument();
+
+    // Each provider row's visible text is exactly its name plus its status —
+    // no secret value is rendered. (Defends the "name + present only" contract.)
+    expect(presentRow.textContent).toBe("OPENROUTER_API_KEYPresent");
+    expect(missingRow.textContent).toBe("ANTHROPIC_API_KEYMissing");
+  });
+
+  it("never renders a provider secret value even if one were present on the object", async () => {
+    // The typed DTO has no value field, but a careless implementation might read
+    // an unexpected property. Smuggle a secret-shaped extra field and assert it
+    // is nowhere in the DOM.
+    const SECRET = "sk-or-v1-SUPERSECRETVALUE";
+    const sneaky = {
+      name: "OPENROUTER_API_KEY",
+      present: true,
+      // Extra, non-contract field that must never be displayed.
+      value: SECRET,
+    } as unknown as WorkspaceInfo["providers"][number];
+
+    mockedGetWorkspace.mockResolvedValue(
+      workspace({ providers: [sneaky] }),
+    );
+    render(<SettingsPage />);
+
+    await screen.findByText("OPENROUTER_API_KEY");
+    expect(screen.queryByText(SECRET)).not.toBeInTheDocument();
+    expect(document.body.textContent).not.toContain(SECRET);
+  });
+
+  it("renders an empty state when the workspace has no providers", async () => {
+    mockedGetWorkspace.mockResolvedValue(workspace({ providers: [] }));
+    render(<SettingsPage />);
+
+    // Workspace summary still renders…
+    expect(await screen.findByText("demo-fleet")).toBeInTheDocument();
+    // …and the providers section shows its empty placeholder instead of a table.
+    // Match the exact title (the description also contains the phrase).
+    expect(
+      screen.getByText("No provider credentials"),
+    ).toBeInTheDocument();
+    expect(screen.queryByRole("table")).not.toBeInTheDocument();
+  });
+
+  it("shows an error banner with a working retry on load failure", async () => {
+    // First call fails, second (after retry) succeeds. A plain Error is enough:
+    // ErrorBanner renders any Error's message, and the page surfaces it.
+    mockedGetWorkspace
+      .mockRejectedValueOnce(new Error("workspace load failed"))
+      .mockResolvedValueOnce(workspace());
+
+    const user = userEvent.setup();
+    render(<SettingsPage />);
+
+    // The alert surfaces the server's message.
+    const alert = await screen.findByRole("alert");
+    expect(within(alert).getByText(/could not load workspace settings/i)).toBeInTheDocument();
+    expect(within(alert).getByText(/workspace load failed/i)).toBeInTheDocument();
+
+    // Retrying re-invokes the client and renders the recovered data.
+    await user.click(screen.getByRole("button", { name: /retry/i }));
+
+    expect(await screen.findByText("demo-fleet")).toBeInTheDocument();
+    await waitFor(() => expect(mockedGetWorkspace).toHaveBeenCalledTimes(2));
+    expect(screen.queryByRole("alert")).not.toBeInTheDocument();
+  });
+});

--- a/web/src/app/pages/SettingsPage.tsx
+++ b/web/src/app/pages/SettingsPage.tsx
@@ -1,0 +1,166 @@
+/**
+ * SettingsPage — workspace details + provider credential status (route
+ * "/settings").
+ *
+ * Loads {@link getWorkspace} and renders two read-only panels:
+ *
+ *  1. A workspace summary (name, root, agent count).
+ *  2. A providers table listing each credential as **name + presence only**.
+ *     Provider secret VALUES never cross the API boundary (the DTO carries no
+ *     value field) and this view must never invent one — every provider row
+ *     shows just its name and a Present / Missing badge.
+ *
+ * Editing workspace defaults is a later milestone; v1 is intentionally
+ * view-only, called out with an inline note.
+ */
+
+import { getWorkspace } from "../../api/client";
+import type { ProviderCred, WorkspaceInfo } from "../../api/types";
+import { usePolling } from "../hooks";
+import {
+  Badge,
+  Card,
+  EmptyState,
+  ErrorBanner,
+  PageHeader,
+  Spinner,
+} from "../components";
+
+export default function SettingsPage() {
+  // Settings is near-static, so fetch once on mount with manual refresh
+  // (a non-positive interval disables the repeat timer in usePolling).
+  const { data, error, loading, refresh } = usePolling<WorkspaceInfo>(
+    () => getWorkspace(),
+    0,
+  );
+
+  return (
+    <>
+      <PageHeader
+        title="Settings"
+        description="Workspace details and provider credential status."
+      />
+
+      {/* Error takes precedence so a failed load is announced and retryable. */}
+      {error && (
+        <ErrorBanner
+          title="Could not load workspace settings"
+          error={error}
+          onRetry={refresh}
+          className="mb-6"
+        />
+      )}
+
+      {/* First load with nothing yet: show a single status spinner. */}
+      {loading && !data && !error && (
+        <div className="flex justify-center py-16">
+          <Spinner label="Loading workspace settings" className="size-6" />
+        </div>
+      )}
+
+      {data && (
+        <div className="space-y-6">
+          <WorkspaceSummary workspace={data} />
+          <ProvidersPanel providers={data.providers} />
+        </div>
+      )}
+    </>
+  );
+}
+
+/** A single label/value row in the workspace summary description list. */
+function SummaryRow({ label, value }: { label: string; value: string }) {
+  return (
+    <div className="flex flex-col gap-1 px-4 py-3 sm:flex-row sm:items-baseline sm:gap-4">
+      <dt className="w-40 shrink-0 text-xs font-medium tracking-wide text-muted uppercase">
+        {label}
+      </dt>
+      <dd className="min-w-0 font-mono text-sm break-words text-fg">{value}</dd>
+    </div>
+  );
+}
+
+function WorkspaceSummary({ workspace }: { workspace: WorkspaceInfo }) {
+  return (
+    <Card
+      title="Workspace"
+      description="The loaded Companion workspace this console manages."
+      bare
+    >
+      <dl className="divide-y divide-line">
+        <SummaryRow label="Name" value={workspace.name} />
+        <SummaryRow label="Root" value={workspace.root} />
+        <SummaryRow label="Agents" value={String(workspace.agent_count)} />
+      </dl>
+    </Card>
+  );
+}
+
+/** Present / Missing pill for a single credential — status only, no value. */
+function PresenceBadge({ present }: { present: boolean }) {
+  return present ? (
+    <Badge tone="ok" dot>
+      Present
+    </Badge>
+  ) : (
+    <Badge tone="warn" dot>
+      Missing
+    </Badge>
+  );
+}
+
+function ProvidersPanel({ providers }: { providers: ProviderCred[] }) {
+  return (
+    <Card
+      title="Providers"
+      description="Credential environment variables, shown by name and presence only. Secret values are never read by the console."
+      bare
+    >
+      {providers.length === 0 ? (
+        <div className="p-4">
+          <EmptyState
+            title="No provider credentials"
+            description="This workspace declares no provider credentials yet. Add an OpenRouter or other provider to your workspace configuration to see it here."
+          />
+        </div>
+      ) : (
+        <table className="w-full text-sm">
+          <caption className="sr-only">
+            Provider credentials and whether each is present
+          </caption>
+          <thead>
+            <tr className="border-b border-line text-left">
+              <th
+                scope="col"
+                className="px-4 py-2 text-xs font-medium tracking-wide text-muted uppercase"
+              >
+                Provider
+              </th>
+              <th
+                scope="col"
+                className="px-4 py-2 text-right text-xs font-medium tracking-wide text-muted uppercase"
+              >
+                Status
+              </th>
+            </tr>
+          </thead>
+          <tbody className="divide-y divide-line">
+            {providers.map((p) => (
+              <tr key={p.name}>
+                <th
+                  scope="row"
+                  className="px-4 py-3 text-left font-mono text-sm font-normal break-words text-fg"
+                >
+                  {p.name}
+                </th>
+                <td className="px-4 py-3 text-right">
+                  <PresenceBadge present={p.present} />
+                </td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      )}
+    </Card>
+  );
+}

--- a/web/src/app/routes.tsx
+++ b/web/src/app/routes.tsx
@@ -1,0 +1,37 @@
+/**
+ * Route table for the console.
+ *
+ * A single root layout (AppLayout) wraps all pages and renders the matched page
+ * through its <Outlet/>. App Core wires the 5 routes to stub page components;
+ * the Feature Pages step fleshes the pages out without changing this table.
+ *
+ *   "/"            → AgentsPage
+ *   "/agents/new"  → CreateAgentPage
+ *   "/agents/:id"  → AgentDetailPage
+ *   "/plan"        → PlanApplyPage
+ *   "/settings"    → SettingsPage
+ */
+
+import { createBrowserRouter } from "react-router-dom";
+import { AppLayout } from "./components";
+import AgentsPage from "./pages/AgentsPage";
+import CreateAgentPage from "./pages/CreateAgentPage";
+import AgentDetailPage from "./pages/AgentDetailPage";
+import PlanApplyPage from "./pages/PlanApplyPage";
+import SettingsPage from "./pages/SettingsPage";
+import { NotFoundPage } from "./pages/NotFoundPage";
+
+export const router = createBrowserRouter([
+  {
+    path: "/",
+    element: <AppLayout />,
+    children: [
+      { index: true, element: <AgentsPage /> },
+      { path: "agents/new", element: <CreateAgentPage /> },
+      { path: "agents/:id", element: <AgentDetailPage /> },
+      { path: "plan", element: <PlanApplyPage /> },
+      { path: "settings", element: <SettingsPage /> },
+      { path: "*", element: <NotFoundPage /> },
+    ],
+  },
+]);

--- a/web/src/index.css
+++ b/web/src/index.css
@@ -1,0 +1,83 @@
+@import "tailwindcss";
+
+/*
+  Companion Console theme.
+
+  Dark-mode-first, neutral slate surfaces with a single indigo/violet accent.
+  Tokens live here as CSS variables and are surfaced to Tailwind via @theme so
+  utilities like `bg-surface`, `text-muted`, `border-line`, and `text-accent`
+  stay consistent and there are no scattered inline hex values.
+*/
+
+@theme {
+  --font-sans:
+    "Inter", ui-sans-serif, system-ui, -apple-system, "Segoe UI", Roboto,
+    Helvetica, Arial, sans-serif;
+  --font-mono:
+    ui-monospace, "SF Mono", "JetBrains Mono", Menlo, Monaco, "Cascadia Code",
+    monospace;
+
+  /* Neutral slate surfaces (dark-first). */
+  --color-canvas: oklch(0.16 0.012 265);
+  --color-surface: oklch(0.2 0.014 265);
+  --color-surface-raised: oklch(0.24 0.016 265);
+  --color-line: oklch(0.32 0.014 265);
+  --color-line-strong: oklch(0.42 0.016 265);
+
+  --color-fg: oklch(0.96 0.005 265);
+  --color-muted: oklch(0.72 0.012 265);
+  --color-faint: oklch(0.56 0.012 265);
+
+  /* Single accent: indigo/violet. */
+  --color-accent: oklch(0.62 0.17 277);
+  --color-accent-fg: oklch(0.98 0.01 277);
+  --color-accent-muted: oklch(0.5 0.13 277);
+
+  /* Semantic states. */
+  --color-ok: oklch(0.72 0.16 156);
+  --color-warn: oklch(0.78 0.15 78);
+  --color-danger: oklch(0.64 0.2 25);
+
+  --radius-md: 0.5rem;
+}
+
+@layer base {
+  :root {
+    color-scheme: dark;
+  }
+
+  html,
+  body,
+  #root {
+    height: 100%;
+  }
+
+  body {
+    margin: 0;
+    background-color: var(--color-canvas);
+    color: var(--color-fg);
+    font-family: var(--font-sans);
+    font-synthesis-weight: none;
+    text-rendering: optimizeLegibility;
+    -webkit-font-smoothing: antialiased;
+  }
+
+  /* Visible, accent-colored focus ring for keyboard users. */
+  :focus-visible {
+    outline: 2px solid var(--color-accent);
+    outline-offset: 2px;
+    border-radius: 2px;
+  }
+
+  /* Honor reduced-motion for any transitions/animations we add. */
+  @media (prefers-reduced-motion: reduce) {
+    *,
+    *::before,
+    *::after {
+      animation-duration: 0.01ms !important;
+      animation-iteration-count: 1 !important;
+      transition-duration: 0.01ms !important;
+      scroll-behavior: auto !important;
+    }
+  }
+}

--- a/web/src/main.tsx
+++ b/web/src/main.tsx
@@ -1,0 +1,15 @@
+import { StrictMode } from "react";
+import { createRoot } from "react-dom/client";
+import App from "./App.tsx";
+import "./index.css";
+
+const container = document.getElementById("root");
+if (!container) {
+  throw new Error('Companion Console: #root element not found in document');
+}
+
+createRoot(container).render(
+  <StrictMode>
+    <App />
+  </StrictMode>,
+);

--- a/web/src/test-setup.ts
+++ b/web/src/test-setup.ts
@@ -1,0 +1,100 @@
+// Vitest setup for jsdom-based component tests.
+//
+// - Registers @testing-library/jest-dom matchers (toBeInTheDocument, etc.).
+// - Auto-cleans the React tree between tests.
+// - Provides a fetch mock helper so tests assert behavior at the network
+//   boundary and never hit a live server.
+
+import "@testing-library/jest-dom/vitest";
+import { afterEach, beforeEach, vi } from "vitest";
+import { cleanup } from "@testing-library/react";
+
+afterEach(() => {
+  cleanup();
+});
+
+// jsdom does not implement matchMedia; several components read it (e.g. for
+// prefers-reduced-motion). Provide an inert, non-matching stub.
+beforeEach(() => {
+  if (typeof window !== "undefined" && !window.matchMedia) {
+    Object.defineProperty(window, "matchMedia", {
+      writable: true,
+      configurable: true,
+      value: (query: string): MediaQueryList =>
+        ({
+          matches: false,
+          media: query,
+          onchange: null,
+          addListener: () => {},
+          removeListener: () => {},
+          addEventListener: () => {},
+          removeEventListener: () => {},
+          dispatchEvent: () => false,
+        }) as unknown as MediaQueryList,
+    });
+  }
+});
+
+/**
+ * A single recorded fetch interaction: a matcher against the request and the
+ * Response (or factory) to return when it matches.
+ */
+export interface FetchRoute {
+  method?: string;
+  /** Substring or RegExp matched against the request URL. */
+  url: string | RegExp;
+  /** Status code for the synthesized JSON response. Defaults to 200. */
+  status?: number;
+  /** JSON body, or a function computing it from the parsed request. */
+  body?: unknown | ((req: { url: string; method: string; body: unknown }) => unknown);
+}
+
+/**
+ * Installs a `globalThis.fetch` mock that resolves the first matching route.
+ * Returns the vi mock so tests can assert on calls. Unmatched requests reject
+ * with a descriptive error to surface missing stubs loudly.
+ *
+ * Tests own the network: every component test that performs I/O must stub it
+ * here rather than reaching a real console server or provider.
+ */
+export function mockFetch(routes: FetchRoute[]): ReturnType<typeof vi.fn> {
+  const fn = vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+    const url = typeof input === "string" ? input : input.toString();
+    const method = (init?.method ?? "GET").toUpperCase();
+    const route = routes.find((r) => {
+      if (r.method && r.method.toUpperCase() !== method) return false;
+      return typeof r.url === "string" ? url.includes(r.url) : r.url.test(url);
+    });
+    if (!route) {
+      throw new Error(`mockFetch: no route for ${method} ${url}`);
+    }
+    let parsedBody: unknown;
+    if (typeof init?.body === "string") {
+      try {
+        parsedBody = JSON.parse(init.body);
+      } catch {
+        parsedBody = init.body;
+      }
+    }
+    const payload =
+      typeof route.body === "function"
+        ? (route.body as (req: { url: string; method: string; body: unknown }) => unknown)({
+            url,
+            method,
+            body: parsedBody,
+          })
+        : route.body;
+    const status = route.status ?? 200;
+    return new Response(payload === undefined ? null : JSON.stringify(payload), {
+      status,
+      headers: { "Content-Type": "application/json" },
+    });
+  });
+  vi.stubGlobal("fetch", fn);
+  return fn;
+}
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+  vi.restoreAllMocks();
+});

--- a/web/src/vite-env.d.ts
+++ b/web/src/vite-env.d.ts
@@ -1,0 +1,8 @@
+/// <reference types="vite/client" />
+
+// The Go console injects the per-process session token into the served HTML.
+// In production it is available on the window; in dev the API client falls back
+// to the `GET /api/console/session` endpoint.
+interface Window {
+  __CONSOLE_TOKEN__?: string;
+}

--- a/web/tsconfig.json
+++ b/web/tsconfig.json
@@ -1,0 +1,29 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "useDefineForClassFields": true,
+    "lib": ["ES2022", "DOM", "DOM.Iterable"],
+    "module": "ESNext",
+    "skipLibCheck": true,
+
+    /* Bundler mode */
+    "moduleResolution": "bundler",
+    "allowImportingTsExtensions": true,
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "moduleDetection": "force",
+    "noEmit": true,
+    "jsx": "react-jsx",
+
+    /* Strictness */
+    "strict": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "noFallthroughCasesInSwitch": true,
+    "noUncheckedSideEffectImports": true,
+    "exactOptionalPropertyTypes": false,
+
+    "types": ["vitest/globals", "node", "@testing-library/jest-dom"]
+  },
+  "include": ["src", "vite.config.ts", "vitest.config.ts"]
+}

--- a/web/vite.config.ts
+++ b/web/vite.config.ts
@@ -1,0 +1,27 @@
+import { defineConfig } from "vite";
+import react from "@vitejs/plugin-react";
+import tailwindcss from "@tailwindcss/vite";
+
+// The console dev UI runs on :5173. The Go console (started with
+// `companion console --workspace examples/minimal --dev-ui http://127.0.0.1:5173`)
+// reverse-proxies `/` and `/assets` here, while this dev server proxies the API
+// (`/api`) and health (`/healthz`) back to the Go console on :8788. That keeps the
+// browser on a single origin and lets the dev-only token endpoint
+// (`GET /api/console/session`) resolve the session token.
+export default defineConfig({
+  plugins: [react(), tailwindcss()],
+  server: {
+    port: 5173,
+    strictPort: true,
+    proxy: {
+      "/api": "http://127.0.0.1:8788",
+      "/healthz": "http://127.0.0.1:8788",
+    },
+  },
+  build: {
+    outDir: "dist",
+    // Keep %%CONSOLE_TOKEN%% sentinels verbatim in the emitted index.html so the
+    // Go server can inject the per-process session token at serve time.
+    emptyOutDir: true,
+  },
+});

--- a/web/vitest.config.ts
+++ b/web/vitest.config.ts
@@ -1,0 +1,16 @@
+import { defineConfig } from "vitest/config";
+import react from "@vitejs/plugin-react";
+
+export default defineConfig({
+  plugins: [react()],
+  test: {
+    globals: true,
+    environment: "jsdom",
+    setupFiles: ["src/test-setup.ts"],
+    include: ["src/**/*.test.ts", "src/**/*.test.tsx"],
+    // React 19.2+ only exports `act` from its development build. Forcing
+    // NODE_ENV=test makes jsdom load react.development so @testing-library's
+    // act() wrapping works.
+    env: { NODE_ENV: "test" },
+  },
+});


### PR DESCRIPTION
## Companion Web Console v1

Implements the **Companion Web Console** plan: a self-hosted, local/Tailscale-admin web console to create, edit, deploy, and monitor Hermes agents without touching TOML by hand. TOML stays canonical — the console is a product interface over the existing CLI/workspace/plan/apply engine, not a replacement. The archived legacy UI is untouched.

Built and verified as two phases (each landed green independently).

### `feat(console)` backend — `9e404e06`
New `companion console` command (separate from the read-only `dashboard`) serving a JSON API + embedded UI shell over the existing engine.

- **API** under `/api/console`: `workspace`, `agents` (list/get/create/update/delete), `plan`, `apply`, `operations/{id}`, `applies`, `agents/{id}/logs`, plus the existing `/api/status`.
- **Session token (CSRF / local-admin guard):** a per-process token is injected into the served UI; every mutating request must carry `X-Console-Token`. GETs are exempt. Not user auth.
- **TOML-first writes:** create/update write `agents/<id>.toml` (+ `identities/<id>/SOUL.md`) with **timestamped backups** under `.companion/backups/`, then **load + validate**, rolling back on failure. `DELETE` sets `lifecycle = "absent"` — never a silent destroy.
- **Safe apply:** single-active-apply operation runner with async tracking; `plan` returns a hash and `apply` rejects a **stale hash** or a **concurrent apply** with `409`.
- **History** from the SQLite `applies` table.
- **31 tests** (httptest + `execx.FakeRunner` + `t.TempDir`): redaction, backups, lifecycle-absent, stale-hash, conflict, rollback, offline logs. No live providers.

### `feat(console)` frontend — `50d8ed9d`
React/Vite SPA in `web/`, embedded into the Go binary via `//go:embed`.

- Vite + React 19 + TypeScript (strict) + Tailwind 4 + Vitest. Typed API client with token handling (`window.__CONSOLE_TOKEN__` in prod, `GET /api/console/session` fallback in dev) and `X-Console-Token` on mutations.
- **Pages:** agent list (agents first, support services second) · create-agent wizard (template → form → review → **plan diff → explicit confirm → apply → follow operation**) · agent detail/edit with SOUL.md, vault settings and recent logs · global plan/apply with operation progress + history · workspace settings showing providers **redacted** (name + present only).
- **77 tests** across 11 files (forms, plan-confirmation gating, status rendering, token-on-mutation, redaction).

### Build / embed model
`bin/build-console-ui` builds the SPA and syncs it into the embed dir for production images. A committed **placeholder** `index.html` keeps a bare `go build ./...` (and `go install`) green without a Node toolchain; the built bundles are gitignored. For UI dev: run Vite and start `companion console --dev-ui http://127.0.0.1:5173`.

### Verification (all green)
- `go build ./...`, `go vet ./...`, `gofmt`, `go test ./...`, `go test -race ./internal/console/...`
- `go run ./cmd/companion validate` on `examples/minimal` **and** `examples/webui`
- Frontend `tsc --noEmit`, `vite build`, `vitest` (77/77)
- **End-to-end smoke** of the real binary against `examples/minimal`: `/healthz` 200; `/` serves the SPA with the session token injected via sentinel; `/api/console/workspace` returns providers redacted (names only); `/api/console/agents` lists offline; `POST` without token → `403`; dev `/api/console/session` → `404` when `--dev-ui` is unset.
- CI: new `web` job (`npm ci` + typecheck + build + vitest) added; `bin/build-console-ui` added to the shell-syntax gate.

### Deferred follow-ups (intentionally out of this PR)
- **`Dockerfile.console`** — the console is a local/Tailscale admin tool that edits the workspace and runs apply; a remote-deploy image needs real design (workspace mounting, write access, provider creds) rather than a copy of `Dockerfile.dashboard`.
- **Playwright smoke** — vitest coverage was deemed sufficient for v1; a single happy-path browser smoke against a mocked backend can follow.
- **Constant-time token comparison** (`crypto/subtle`) — minor hardening for a localhost/Tailscale tool.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
