### PR TITLE
feat(control-plane): add Fly-hosted companion control plane

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,8 +1,10 @@
 fly.*.toml
 bin/__pycache__/
+web/node_modules/
 .companion/*
 !.companion/generated/
 !.companion/generated/fleet.json
+!.companion/generated/**
 archived/
 .env
 /companion

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,7 +44,7 @@ jobs:
       - name: Validate shell scripts
         run: |
           sh -n install.sh
-          bash -n install.sh bin/start-on-fly bin/run-hermes-process bin/start-open-webui-on-fly bin/start-dashboard-on-fly bin/build-console-ui
+          bash -n install.sh bin/start-on-fly bin/run-hermes-process bin/start-open-webui-on-fly bin/start-dashboard-on-fly bin/start-control-plane-on-fly bin/build-console-ui
 
       - name: Verify installable CLI package
         run: |

--- a/Dockerfile.control-plane
+++ b/Dockerfile.control-plane
@@ -1,0 +1,45 @@
+# Build the Companion binary and serve the mutable control plane console from a
+# Fly app joined to Tailscale. The app mounts /workspace, seeds it only when the
+# volume is empty, then lets the console edit TOML and run plan/apply there.
+FROM node:22-bookworm AS console-ui
+WORKDIR /src
+COPY web/package.json web/package-lock.json web/
+RUN npm --prefix web ci
+COPY web/ web/
+RUN npm --prefix web run build
+
+FROM golang:1.25-bookworm AS build
+WORKDIR /src
+COPY go.mod go.sum ./
+RUN go mod download
+COPY . .
+COPY --from=console-ui /src/web/dist/index.html internal/console/assets/index.html
+COPY --from=console-ui /src/web/dist/assets internal/console/assets/assets
+RUN CGO_ENABLED=0 go build -trimpath -o /out/companion ./cmd/companion
+
+FROM docker.io/tailscale/tailscale:stable AS tailscale
+
+FROM debian:bookworm-slim
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends ca-certificates curl iptables tar && \
+    curl -L https://fly.io/install.sh | sh && \
+    cp /root/.fly/bin/flyctl /usr/local/bin/fly && \
+    rm -rf /root/.fly /var/lib/apt/lists/*
+
+COPY --from=tailscale /usr/local/bin/tailscale /usr/local/bin/tailscale
+COPY --from=tailscale /usr/local/bin/tailscaled /usr/local/bin/tailscaled
+COPY --from=build /out/companion /usr/local/bin/companion
+COPY --chmod=0755 bin/start-control-plane-on-fly /usr/local/bin/companion-control-plane-start
+COPY .companion/generated/control-plane-seed/ /seed/
+COPY . /opt/companion-src/
+
+ENV PORT=8788
+ENV COMPANION_DEPLOY_CONTEXT=/opt/companion-src
+ENV COMPANION_CONTROL_PLANE_SEED=/seed
+ENV COMPANION_CONTROL_PLANE_WORKSPACE=/workspace
+ENV TAILSCALE_STATE_DIR=/workspace/.tailscale
+ENV TS_ACCEPT_DNS=true
+ENV CONTROL_PLANE_TAILSCALE_SERVE=true
+
+ENTRYPOINT ["/usr/local/bin/companion-control-plane-start"]
+CMD ["companion", "--workspace", "/workspace", "console"]

--- a/README.md
+++ b/README.md
@@ -377,12 +377,37 @@ tailscale_serve = true
 
 The deployed image is built from `Dockerfile.dashboard` (the `companion` binary + Tailscale + `fleet.json`). To run it on your own server instead, `git clone` the repo and `go build ./cmd/companion`, then run `companion dashboard --manifest <fleet.json>` with `FLY_API_TOKEN`/`TAILSCALE_API_KEY` in the environment.
 
+## Control Plane
+
+The control plane is the mutable, Tailscale-only Companion admin app. It runs `companion console` on Fly, mounts a persistent `/workspace` volume, and uses the same workspace/state engine as the local CLI. Bootstrap a new control-plane workspace locally:
+
+```bash
+companion init --control-plane --workspace ./my-fleet \
+  --control-plane-app my-companion-control \
+  --control-plane-hostname companion-control \
+  --tailnet example.ts.net
+```
+
+The generated TOML stores only secret names such as `FLY_API_TOKEN`, `TAILSCALE_API_KEY`, `TS_AUTHKEY`, and `OPENROUTER_API_KEY`; set the corresponding values in your shell or `.env` before deploying. Use `--no-deploy` to write and register the workspace without creating Fly resources.
+
+The local CLI tracks multiple workspaces in `~/.companion/workspaces.json`:
+
+```bash
+companion workspace list
+companion workspace use my-fleet
+companion control-plane status
+companion control-plane upgrade
+companion control-plane export --output ./control-plane-workspace.tgz
+```
+
+`control-plane upgrade` redeploys the same Fly app from the current checkout while preserving the Fly volume, secrets, and SQLite state.
+
 ## Development
 
 ```bash
 go test ./...
 sh -n install.sh
-bash -n install.sh bin/start-on-fly bin/run-hermes-process bin/start-open-webui-on-fly
+bash -n install.sh bin/start-on-fly bin/run-hermes-process bin/start-open-webui-on-fly bin/start-dashboard-on-fly bin/start-control-plane-on-fly bin/build-console-ui
 go run ./cmd/companion validate --workspace examples/minimal
 go run ./cmd/companion plan --workspace examples/minimal
 ```

--- a/bin/start-control-plane-on-fly
+++ b/bin/start-control-plane-on-fly
@@ -1,0 +1,81 @@
+#!/usr/bin/env bash
+set -Eeuo pipefail
+
+log() {
+    printf '[companion-control-plane] %s\n' "$*"
+}
+
+die() {
+    log "error: $*"
+    exit 1
+}
+
+auth_key="${TS_AUTHKEY:-${TAILSCALE_AUTHKEY:-}}"
+if [ -z "$auth_key" ]; then
+    die "set TS_AUTHKEY as a Fly secret before deploying"
+fi
+
+workspace="${COMPANION_CONTROL_PLANE_WORKSPACE:-/workspace}"
+seed="${COMPANION_CONTROL_PLANE_SEED:-/seed}"
+hostname="${CONTROL_PLANE_TS_HOSTNAME:-${TS_HOSTNAME:-${FLY_APP_NAME:-companion-control-plane}}}"
+socket="${TAILSCALE_SOCKET:-/var/run/tailscale/tailscaled.sock}"
+state_dir="${TAILSCALE_STATE_DIR:-${workspace}/.tailscale}"
+port="${PORT:-8788}"
+
+mkdir -p "$workspace" "$(dirname "$socket")" "$state_dir"
+
+if [ ! -f "${workspace}/companion.toml" ]; then
+    log "initializing workspace volume from seed"
+    if [ ! -d "$seed" ]; then
+        die "missing control-plane seed at ${seed}"
+    fi
+    cp -R "${seed}/." "$workspace/"
+fi
+
+log "starting tailscaled for ${hostname}"
+tailscaled_extra_args=()
+if [ -n "${TAILSCALED_EXTRA_ARGS:-}" ]; then
+    read -r -a tailscaled_extra_args <<< "$TAILSCALED_EXTRA_ARGS"
+fi
+
+tailscaled \
+    --state="${state_dir}/tailscaled.state" \
+    --socket="$socket" \
+    "${tailscaled_extra_args[@]}" &
+
+for _ in $(seq 1 50); do
+    if [ -S "$socket" ]; then
+        break
+    fi
+    sleep 0.1
+done
+
+if [ ! -S "$socket" ]; then
+    die "tailscaled did not create ${socket}"
+fi
+
+tailscale_extra_args=()
+if [ -n "${TS_EXTRA_ARGS:-}" ]; then
+    read -r -a tailscale_extra_args <<< "$TS_EXTRA_ARGS"
+fi
+
+tailscale --socket="$socket" up \
+    --auth-key="$auth_key" \
+    --hostname="$hostname" \
+    --accept-dns="${TS_ACCEPT_DNS:-true}" \
+    "${tailscale_extra_args[@]}"
+
+if [ "${CONTROL_PLANE_TAILSCALE_SERVE:-true}" = "true" ]; then
+    log "configuring Tailscale Serve for control-plane port ${port}"
+    if tailscale --socket="$socket" serve --yes --bg "$port"; then
+        tailscale --socket="$socket" serve status || true
+    else
+        log "Tailscale Serve setup failed; reach the console on the tailnet port ${port} directly"
+    fi
+fi
+
+if [ "$#" -eq 0 ]; then
+    set -- companion --workspace "$workspace" console
+fi
+
+exec "$@"

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"strings"
 	"time"
@@ -22,6 +23,7 @@ import (
 	"github.com/The-Vibe-Company/companion/internal/outputs"
 	"github.com/The-Vibe-Company/companion/internal/plan"
 	"github.com/The-Vibe-Company/companion/internal/provider"
+	"github.com/The-Vibe-Company/companion/internal/registry"
 	"github.com/The-Vibe-Company/companion/internal/render"
 	"github.com/The-Vibe-Company/companion/internal/resource"
 	"github.com/The-Vibe-Company/companion/internal/state"
@@ -56,6 +58,7 @@ func newRootCommand(runner execx.Runner) *cobra.Command {
 	cmd.PersistentFlags().StringVar(&a.envFile, "env-file", ".env", "secret env file; shell variables override file values")
 
 	cmd.AddCommand(a.initCommand())
+	cmd.AddCommand(a.workspaceCommand())
 	cmd.AddCommand(a.fmtCommand())
 	cmd.AddCommand(a.resourceImportCommand())
 	cmd.AddCommand(a.validateCommand())
@@ -71,18 +74,52 @@ func newRootCommand(runner execx.Runner) *cobra.Command {
 	cmd.AddCommand(a.vaultCommand())
 	cmd.AddCommand(a.dashboardCommand())
 	cmd.AddCommand(a.consoleCommand())
+	cmd.AddCommand(a.controlPlaneCommand())
 	cmd.AddCommand(a.versionCommand())
 	return cmd
 }
 
 func (a *app) initCommand() *cobra.Command {
-	return &cobra.Command{
+	var controlPlane bool
+	var noDeploy bool
+	var flyApp string
+	var tailscaleHostname string
+	var region string
+	var tailnet string
+	var flyTokenEnv string
+	var tailscaleAPIKeyEnv string
+	var tailscaleAuthKeySecret string
+	var openRouterAPIKeyEnv string
+	cmd := &cobra.Command{
 		Use:   "init",
 		Short: "Create a folder-based Companion workspace",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			root := a.rootDir
 			if root == "" {
 				root = "."
+			}
+			if region == "" {
+				region = "cdg"
+			}
+			if flyTokenEnv == "" {
+				flyTokenEnv = "FLY_API_TOKEN"
+			}
+			if tailscaleAPIKeyEnv == "" {
+				tailscaleAPIKeyEnv = "TAILSCALE_API_KEY"
+			}
+			if tailscaleAuthKeySecret == "" {
+				tailscaleAuthKeySecret = "TS_AUTHKEY"
+			}
+			if openRouterAPIKeyEnv == "" {
+				openRouterAPIKeyEnv = "OPENROUTER_API_KEY"
+			}
+			if controlPlane {
+				if flyApp == "" {
+					flyApp = "companion-control-plane"
+				}
+				if tailscaleHostname == "" {
+					tailscaleHostname = "companion-control-plane"
+				}
 			}
 			files := map[string]string{
 				"companion.toml": `workspace = "companion"
@@ -95,6 +132,7 @@ providers = "providers.toml"
 defaults = "defaults.toml"
 webui = "webui.toml"
 dashboard = "dashboard.toml"
+control_plane = "control-plane.toml"
 agents = "agents/*.toml"
 vaults = "vaults/*.toml"
 `,
@@ -207,6 +245,41 @@ mcp_role = "write"
 `,
 				filepath.Join("identities", "sample", "SOUL.md"): identityTemplate("Sample Agent"),
 			}
+			if controlPlane {
+				files["providers.toml"] = fmt.Sprintf(`[fly.default]
+region = %q
+token_env = %q
+mode = "api"
+
+[tailscale.default]
+tailnet = %q
+api_key_env = %q
+auth_key_secret = %q
+mode = "api"
+
+[openrouter.default]
+base_url = "https://openrouter.ai/api/v1"
+api_key_env = %q
+`, region, flyTokenEnv, tailnet, tailscaleAPIKeyEnv, tailscaleAuthKeySecret, openRouterAPIKeyEnv)
+				files["control-plane.toml"] = fmt.Sprintf(`[control_plane]
+enabled = true
+fly_app = %q
+tailscale_hostname = %q
+region = %q
+volume_name = "companion_workspace"
+volume_size_gb = 3
+memory = "512mb"
+cpus = 1
+port = 8788
+tailscale_serve = true
+tailscale_accept_dns = true
+tailscale_authkey_secret_name = %q
+fly_token_secret_name = %q
+tailscale_api_key_secret_name = %q
+openrouter_api_key_secret_name = %q
+ts_extra_args = "--netfilter-mode=off"
+`, flyApp, tailscaleHostname, region, tailscaleAuthKeySecret, flyTokenEnv, tailscaleAPIKeyEnv, openRouterAPIKeyEnv)
+			}
 			for name, contents := range files {
 				path := filepath.Join(root, name)
 				if _, err := os.Stat(path); err == nil {
@@ -221,7 +294,185 @@ mcp_role = "write"
 					return err
 				}
 			}
+			ws, err := workspace.Load(root)
+			if err != nil {
+				return err
+			}
+			record := registry.WorkspaceRecord{Name: ws.Name, Path: ws.Root}
+			if ws.Config.ControlPlane.Enabled {
+				record.ControlPlaneApp = ws.Config.ControlPlane.FlyApp
+				record.TailscaleHostname = ws.Config.ControlPlane.TailscaleHostname
+			}
+			if err := registry.Upsert(record, true); err != nil {
+				return err
+			}
 			fmt.Fprintf(cmd.OutOrStdout(), "initialized Companion workspace in %s\n", root)
+			fmt.Fprintf(cmd.OutOrStdout(), "registered workspace %s\n", ws.Name)
+			if controlPlane && !noDeploy {
+				previousRoot := a.rootDir
+				a.rootDir = root
+				defer func() { a.rootDir = previousRoot }()
+				env, err := a.env()
+				if err != nil {
+					return err
+				}
+				if err := requireControlPlaneDeployContext(env); err != nil {
+					return err
+				}
+				store, err := state.Open(ws.StatePath)
+				if err != nil {
+					return err
+				}
+				defer store.Close()
+				providers, err := a.providerSet(ws, env)
+				if err != nil {
+					return err
+				}
+				report, err := resource.Apply(cmd.Context(), ws, store, providers, resource.Options{
+					Root:         ws.Root,
+					GeneratedDir: generatedDirFor(ws, env),
+					Env:          env,
+					Targets:      []string{"control_plane"},
+				})
+				if err != nil {
+					return err
+				}
+				fmt.Fprintln(cmd.OutOrStdout(), report.String())
+			}
+			return nil
+		},
+	}
+	cmd.Flags().BoolVar(&controlPlane, "control-plane", false, "initialize and optionally deploy a Fly-hosted control plane")
+	cmd.Flags().BoolVar(&noDeploy, "no-deploy", false, "write and register the control-plane workspace without deploying it")
+	cmd.Flags().StringVar(&flyApp, "control-plane-app", "", "Fly app name for --control-plane")
+	cmd.Flags().StringVar(&tailscaleHostname, "control-plane-hostname", "", "Tailscale hostname for --control-plane")
+	cmd.Flags().StringVar(&region, "region", "cdg", "Fly region for generated resources")
+	cmd.Flags().StringVar(&tailnet, "tailnet", "", "Tailscale tailnet name for API mode")
+	cmd.Flags().StringVar(&flyTokenEnv, "fly-token-env", "FLY_API_TOKEN", "environment/Fly secret name for the Fly token")
+	cmd.Flags().StringVar(&tailscaleAPIKeyEnv, "tailscale-api-key-env", "TAILSCALE_API_KEY", "environment/Fly secret name for the Tailscale API key")
+	cmd.Flags().StringVar(&tailscaleAuthKeySecret, "tailscale-authkey-secret", "TS_AUTHKEY", "environment/Fly secret name for the Tailscale auth key")
+	cmd.Flags().StringVar(&openRouterAPIKeyEnv, "openrouter-api-key-env", "OPENROUTER_API_KEY", "environment/Fly secret name for the OpenRouter API key")
+	return cmd
+}
+
+func (a *app) workspaceCommand() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "workspace",
+		Short: "Manage registered Companion workspaces",
+	}
+	cmd.AddCommand(a.workspaceListCommand())
+	cmd.AddCommand(a.workspaceAddCommand())
+	cmd.AddCommand(a.workspaceUseCommand())
+	cmd.AddCommand(a.workspaceCurrentCommand())
+	cmd.AddCommand(a.workspaceRemoveCommand())
+	return cmd
+}
+
+func (a *app) workspaceListCommand() *cobra.Command {
+	return &cobra.Command{
+		Use:   "list",
+		Short: "List registered Companion workspaces",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			reg, err := registry.Load()
+			if err != nil {
+				return err
+			}
+			if len(reg.Workspaces) == 0 {
+				fmt.Fprintln(cmd.OutOrStdout(), "no registered workspaces")
+				return nil
+			}
+			for _, record := range reg.Workspaces {
+				marker := " "
+				if record.Name == reg.Current {
+					marker = "*"
+				}
+				detail := record.Path
+				if record.ControlPlaneApp != "" {
+					detail += " control_plane=" + record.ControlPlaneApp
+				}
+				fmt.Fprintf(cmd.OutOrStdout(), "%s %s %s\n", marker, record.Name, detail)
+			}
+			return nil
+		},
+	}
+}
+
+func (a *app) workspaceAddCommand() *cobra.Command {
+	var path string
+	var setCurrent bool
+	cmd := &cobra.Command{
+		Use:   "add <name>",
+		Short: "Register a Companion workspace",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if path == "" {
+				path = a.rootDir
+			}
+			ws, err := workspace.Load(path)
+			if err != nil {
+				return err
+			}
+			record := registry.WorkspaceRecord{Name: args[0], Path: ws.Root}
+			if ws.Config.ControlPlane.Enabled {
+				record.ControlPlaneApp = ws.Config.ControlPlane.FlyApp
+				record.TailscaleHostname = ws.Config.ControlPlane.TailscaleHostname
+			}
+			if err := registry.Upsert(record, setCurrent); err != nil {
+				return err
+			}
+			fmt.Fprintf(cmd.OutOrStdout(), "registered workspace %s -> %s\n", record.Name, ws.Root)
+			return nil
+		},
+	}
+	cmd.Flags().StringVar(&path, "path", "", "workspace path (defaults to --workspace)")
+	cmd.Flags().BoolVar(&setCurrent, "current", true, "make this the current workspace")
+	return cmd
+}
+
+func (a *app) workspaceUseCommand() *cobra.Command {
+	return &cobra.Command{
+		Use:   "use <name>",
+		Short: "Set the current Companion workspace",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if err := registry.Use(args[0]); err != nil {
+				return err
+			}
+			fmt.Fprintf(cmd.OutOrStdout(), "current workspace: %s\n", args[0])
+			return nil
+		},
+	}
+}
+
+func (a *app) workspaceCurrentCommand() *cobra.Command {
+	return &cobra.Command{
+		Use:   "current",
+		Short: "Print the current Companion workspace",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			record, ok, err := registry.Current()
+			if err != nil {
+				return err
+			}
+			if !ok {
+				fmt.Fprintln(cmd.OutOrStdout(), "no current workspace")
+				return nil
+			}
+			fmt.Fprintf(cmd.OutOrStdout(), "%s %s\n", record.Name, record.Path)
+			return nil
+		},
+	}
+}
+
+func (a *app) workspaceRemoveCommand() *cobra.Command {
+	return &cobra.Command{
+		Use:   "remove <name>",
+		Short: "Remove a workspace from the local registry",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if err := registry.Remove(args[0]); err != nil {
+				return err
+			}
+			fmt.Fprintf(cmd.OutOrStdout(), "removed workspace %s\n", args[0])
 			return nil
 		},
 	}
@@ -347,6 +598,14 @@ func workspaceProviderRefs(ws *workspace.Workspace) []string {
 		add(ws.Config.OpenWebUI.Runtime)
 		add(ws.Config.OpenWebUI.Network)
 	}
+	if ws.Config.Dashboard.Enabled {
+		add(ws.Config.Dashboard.Runtime)
+		add(ws.Config.Dashboard.Network)
+	}
+	if ws.Config.ControlPlane.Enabled {
+		add(ws.Config.ControlPlane.Runtime)
+		add(ws.Config.ControlPlane.Network)
+	}
 	return refs
 }
 
@@ -389,6 +648,9 @@ func (a *app) validateCommand() *cobra.Command {
 					ids = append(ids, connection.AgentID)
 				}
 				fmt.Fprintf(cmd.OutOrStdout(), "%s: ok runtime=%s network=%s fly_app=%s tailscale=%s connections=%s\n", cfg.OpenWebUI.ID, cfg.OpenWebUI.Runtime, cfg.OpenWebUI.Network, cfg.OpenWebUI.FlyApp, cfg.OpenWebUI.TailscaleHostname, strings.Join(ids, ","))
+			}
+			if cfg.ControlPlane.Enabled {
+				fmt.Fprintf(cmd.OutOrStdout(), "%s: ok runtime=%s network=%s fly_app=%s tailscale=%s lifecycle=%s workspace=/workspace\n", cfg.ControlPlane.ID, cfg.ControlPlane.Runtime, cfg.ControlPlane.Network, cfg.ControlPlane.FlyApp, cfg.ControlPlane.TailscaleHostname, cfg.ControlPlane.Lifecycle)
 			}
 			if validateProviders {
 				env, err := a.env()
@@ -440,7 +702,7 @@ func (a *app) planCommand() *cobra.Command {
 			}
 			report, err := resource.BuildPlan(cmd.Context(), ws, store, providers, resource.Options{
 				Root:         ws.Root,
-				GeneratedDir: filepath.Join(ws.Root, ".companion", "generated"),
+				GeneratedDir: generatedDirFor(ws, env),
 				Targets:      args,
 			})
 			if err != nil {
@@ -486,7 +748,7 @@ func (a *app) applyCommand() *cobra.Command {
 			}
 			report, err := resource.Apply(cmd.Context(), ws, store, providers, resource.Options{
 				Root:         ws.Root,
-				GeneratedDir: filepath.Join(ws.Root, ".companion", "generated"),
+				GeneratedDir: generatedDirFor(ws, env),
 				Env:          env,
 				Targets:      args,
 			})
@@ -531,7 +793,7 @@ func (a *app) destroyCommand() *cobra.Command {
 			}
 			report, err := resource.Apply(cmd.Context(), ws, store, providers, resource.Options{
 				Root:                  ws.Root,
-				GeneratedDir:          filepath.Join(ws.Root, ".companion", "generated"),
+				GeneratedDir:          generatedDirFor(ws, env),
 				Env:                   env,
 				DestroyTargets:        args,
 				AllowProtectedDestroy: true,
@@ -874,6 +1136,214 @@ func (a *app) consoleCommand() *cobra.Command {
 	cmd.Flags().StringVar(&addr, "addr", "127.0.0.1:8788", "listen address (PORT env wins when set)")
 	cmd.Flags().StringVar(&devUI, "dev-ui", "", "reverse-proxy the UI to this dev origin (e.g. http://127.0.0.1:5173)")
 	return cmd
+}
+
+func (a *app) controlPlaneCommand() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "control-plane",
+		Short: "Manage the Fly-hosted Companion control plane",
+	}
+	cmd.AddCommand(a.controlPlaneStatusCommand())
+	cmd.AddCommand(a.controlPlaneUpgradeCommand())
+	cmd.AddCommand(a.controlPlaneExportCommand())
+	cmd.AddCommand(a.controlPlaneSSHCommand())
+	return cmd
+}
+
+func (a *app) controlPlaneStatusCommand() *cobra.Command {
+	return &cobra.Command{
+		Use:   "status",
+		Short: "Show control-plane runtime status",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			ws, err := a.workspace()
+			if err != nil {
+				return err
+			}
+			cp := ws.Config.ControlPlane
+			if !cp.Enabled {
+				return fmt.Errorf("control_plane is disabled in this workspace")
+			}
+			env, err := a.env()
+			if err != nil {
+				return err
+			}
+			machines, err := a.flyWithEnv(env).ListMachines(cmd.Context(), cp.FlyApp)
+			if err != nil {
+				return err
+			}
+			machine, ok := fly.SelectStartedMachine(machines)
+			stateText := "missing"
+			versionText := "unknown"
+			if ok {
+				stateText = machine.State
+				versionText = firstNonEmptyString(machine.ImageRef.Tag, machine.ImageRef.Digest, machine.Config.Image, "unknown")
+			}
+			lastApply := "unknown"
+			store, err := state.Open(ws.StatePath)
+			if err == nil {
+				if observed, ok, getErr := store.GetResource(cmd.Context(), "rollout.control_plane.main"); getErr == nil && ok && !observed.LastTransitionAt.IsZero() {
+					lastApply = observed.LastTransitionAt.Format(time.RFC3339)
+				}
+				_ = store.Close()
+			}
+			fmt.Fprintf(cmd.OutOrStdout(), "app=%s state=%s tailscale=%s workspace=/workspace version=%s last_apply=%s\n", cp.FlyApp, stateText, cp.TailscaleHostname, versionText, lastApply)
+			return nil
+		},
+	}
+}
+
+func (a *app) controlPlaneUpgradeCommand() *cobra.Command {
+	return &cobra.Command{
+		Use:   "upgrade",
+		Short: "Redeploy the control plane from this checkout",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			ws, err := a.workspace()
+			if err != nil {
+				return err
+			}
+			cp := ws.Config.ControlPlane
+			if !cp.Enabled {
+				return fmt.Errorf("control_plane is disabled in this workspace")
+			}
+			env, err := a.env()
+			if err != nil {
+				return err
+			}
+			if err := requireControlPlaneDeployContext(env); err != nil {
+				return err
+			}
+			configPath, err := resource.WriteControlPlaneArtifacts(ws, resource.Options{
+				Root:         ws.Root,
+				GeneratedDir: generatedDirFor(ws, env),
+			})
+			if err != nil {
+				return err
+			}
+			if err := a.flyWithEnv(env).Deploy(cmd.Context(), cp.FlyApp, configPath); err != nil {
+				return err
+			}
+			store, err := state.Open(ws.StatePath)
+			if err == nil {
+				_ = store.UpsertResource(cmd.Context(), state.Resource{
+					Address:      "rollout.control_plane.main",
+					Class:        resource.ClassAction,
+					ProviderRef:  cp.Runtime,
+					ExternalID:   cp.FlyApp,
+					Status:       "ready",
+					ObservedJSON: `{"config":"` + configPath + `"}`,
+					Protected:    cp.Protect,
+				})
+				_ = store.Close()
+			}
+			fmt.Fprintf(cmd.OutOrStdout(), "upgraded control plane %s\n", cp.FlyApp)
+			return nil
+		},
+	}
+}
+
+func (a *app) controlPlaneExportCommand() *cobra.Command {
+	var output string
+	cmd := &cobra.Command{
+		Use:   "export",
+		Short: "Download a backup of the remote control-plane workspace",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			ws, err := a.workspace()
+			if err != nil {
+				return err
+			}
+			cp := ws.Config.ControlPlane
+			if !cp.Enabled {
+				return fmt.Errorf("control_plane is disabled in this workspace")
+			}
+			if output == "" {
+				output = filepath.Join(ws.Root, ".companion", "control-plane-workspace.tgz")
+			}
+			env, err := a.env()
+			if err != nil {
+				return err
+			}
+			flyProvider := a.flyWithEnv(env)
+			machineID, err := startedMachineID(cmd.Context(), flyProvider, cp.FlyApp)
+			if err != nil {
+				return err
+			}
+			if _, err := flyProvider.SSHConsole(cmd.Context(), cp.FlyApp, machineID, "tar -C /workspace -czf /tmp/companion-workspace.tgz ."); err != nil {
+				return err
+			}
+			if err := os.MkdirAll(filepath.Dir(output), 0o755); err != nil {
+				return err
+			}
+			if err := flyProvider.SFTPGet(cmd.Context(), cp.FlyApp, machineID, "/tmp/companion-workspace.tgz", output); err != nil {
+				return err
+			}
+			fmt.Fprintf(cmd.OutOrStdout(), "exported control-plane workspace to %s\n", output)
+			return nil
+		},
+	}
+	cmd.Flags().StringVar(&output, "output", "", "local archive path")
+	return cmd
+}
+
+func (a *app) controlPlaneSSHCommand() *cobra.Command {
+	return &cobra.Command{
+		Use:   "ssh [command]",
+		Short: "Open a Fly SSH session to the control plane",
+		Args:  cobra.ArbitraryArgs,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			ws, err := a.workspace()
+			if err != nil {
+				return err
+			}
+			cp := ws.Config.ControlPlane
+			if !cp.Enabled {
+				return fmt.Errorf("control_plane is disabled in this workspace")
+			}
+			env, err := a.env()
+			if err != nil {
+				return err
+			}
+			if len(args) > 0 {
+				flyProvider := a.flyWithEnv(env)
+				machineID, err := startedMachineID(cmd.Context(), flyProvider, cp.FlyApp)
+				if err != nil {
+					return err
+				}
+				result, err := flyProvider.SSHConsole(cmd.Context(), cp.FlyApp, machineID, strings.Join(args, " "))
+				if result.Stdout != "" {
+					fmt.Fprint(cmd.OutOrStdout(), result.Stdout)
+				}
+				if result.Stderr != "" {
+					fmt.Fprint(cmd.ErrOrStderr(), result.Stderr)
+				}
+				return err
+			}
+			if a.runner != nil {
+				_, err := a.runnerWithEnv(env).Run(cmd.Context(), []string{"fly", "ssh", "console", "-a", cp.FlyApp})
+				return err
+			}
+			sshCmd := exec.CommandContext(cmd.Context(), "fly", "ssh", "console", "-a", cp.FlyApp)
+			sshCmd.Stdin = os.Stdin
+			sshCmd.Stdout = os.Stdout
+			sshCmd.Stderr = os.Stderr
+			sshCmd.Env = os.Environ()
+			for key, value := range env {
+				sshCmd.Env = append(sshCmd.Env, key+"="+value)
+			}
+			return sshCmd.Run()
+		},
+	}
+}
+
+func startedMachineID(ctx context.Context, flyProvider fly.Provider, app string) (string, error) {
+	machines, err := flyProvider.ListMachines(ctx, app)
+	if err != nil {
+		return "", err
+	}
+	machine, ok := fly.SelectStartedMachine(machines)
+	if !ok {
+		return "", fmt.Errorf("no Fly machine found for %s", app)
+	}
+	return machine.ID, nil
 }
 
 // consoleAddr mirrors dashboardAddr so a deployed console binds to Fly's
@@ -1400,7 +1870,11 @@ func (a *app) load() (*config.Config, error) {
 }
 
 func (a *app) workspace() (*workspace.Workspace, error) {
-	return workspace.Load(a.rootDir)
+	root, err := a.resolveWorkspaceRoot()
+	if err != nil {
+		return nil, err
+	}
+	return workspace.Load(root)
 }
 
 func (a *app) providerSet(ws *workspace.Workspace, env map[string]string) (provider.Set, error) {
@@ -1408,9 +1882,13 @@ func (a *app) providerSet(ws *workspace.Workspace, env map[string]string) (provi
 }
 
 func (a *app) env() (map[string]string, error) {
+	root, err := a.resolveWorkspaceRoot()
+	if err != nil {
+		root = a.rootDir
+	}
 	path := a.envFile
 	if path != "" && !filepath.IsAbs(path) {
-		path = filepath.Join(a.rootDir, path)
+		path = filepath.Join(root, path)
 	}
 	values, err := envfile.LoadOptional(path)
 	if err != nil {
@@ -1418,6 +1896,11 @@ func (a *app) env() (map[string]string, error) {
 	}
 	for key, value := range getenvMap() {
 		values[key] = value
+	}
+	if values["COMPANION_DEPLOY_CONTEXT"] == "" {
+		if deployContext := defaultDeployContext(root); deployContext != "" {
+			values["COMPANION_DEPLOY_CONTEXT"] = deployContext
+		}
 	}
 	return values, nil
 }
@@ -1453,7 +1936,74 @@ func (a *app) runnerWithEnv(env map[string]string) execx.Runner {
 	if a.runner != nil {
 		return a.runner
 	}
-	return execx.ShellRunner{Dir: a.rootDir, Env: env}
+	root, err := a.resolveWorkspaceRoot()
+	if err != nil {
+		root = a.rootDir
+	}
+	if deployContext := env["COMPANION_DEPLOY_CONTEXT"]; deployContext != "" {
+		root = deployContext
+	}
+	return execx.ShellRunner{Dir: root, Env: env}
+}
+
+func (a *app) resolveWorkspaceRoot() (string, error) {
+	root := a.rootDir
+	if root == "" {
+		root = "."
+	}
+	if _, err := os.Stat(filepath.Join(root, "companion.toml")); err == nil {
+		return root, nil
+	} else if err != nil && !os.IsNotExist(err) {
+		return "", err
+	}
+	if root == "." {
+		record, ok, err := registry.Current()
+		if err != nil {
+			return "", err
+		}
+		if ok {
+			return record.Path, nil
+		}
+	}
+	return root, nil
+}
+
+func generatedDirFor(ws *workspace.Workspace, env map[string]string) string {
+	if deployContext := env["COMPANION_DEPLOY_CONTEXT"]; deployContext != "" {
+		return filepath.Join(deployContext, ".companion", "generated")
+	}
+	return filepath.Join(ws.Root, ".companion", "generated")
+}
+
+func defaultDeployContext(workspaceRoot string) string {
+	candidates := []string{}
+	if cwd, err := os.Getwd(); err == nil {
+		candidates = append(candidates, cwd)
+	}
+	candidates = append(candidates, workspaceRoot)
+	for _, candidate := range candidates {
+		if candidate == "" {
+			continue
+		}
+		if _, err := os.Stat(filepath.Join(candidate, "Dockerfile.control-plane")); err == nil {
+			return candidate
+		}
+	}
+	return ""
+}
+
+func requireControlPlaneDeployContext(env map[string]string) error {
+	deployContext := env["COMPANION_DEPLOY_CONTEXT"]
+	if deployContext == "" {
+		return fmt.Errorf("control-plane deploy requires COMPANION_DEPLOY_CONTEXT or running from a Companion checkout with Dockerfile.control-plane")
+	}
+	if _, err := os.Stat(filepath.Join(deployContext, "Dockerfile.control-plane")); err != nil {
+		if os.IsNotExist(err) {
+			return fmt.Errorf("control-plane deploy context %s is missing Dockerfile.control-plane", deployContext)
+		}
+		return err
+	}
+	return nil
 }
 
 func getenvMap() map[string]string {

--- a/internal/cli/cli_test.go
+++ b/internal/cli/cli_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/The-Vibe-Company/companion/internal/config"
 	"github.com/The-Vibe-Company/companion/internal/execx"
 	"github.com/The-Vibe-Company/companion/internal/fly"
+	"github.com/The-Vibe-Company/companion/internal/registry"
 	"github.com/The-Vibe-Company/companion/internal/render"
 	"github.com/The-Vibe-Company/companion/internal/workspace"
 )
@@ -113,6 +114,88 @@ func TestAppEnvLoadsEnvFileAndShellOverrides(t *testing.T) {
 	}
 	if values["OPENROUTER_API_KEY"] != "quoted-value" {
 		t.Fatalf("expected quoted .env value, got %q", values["OPENROUTER_API_KEY"])
+	}
+}
+
+func TestInitControlPlaneWritesWorkspaceAndRegistryWithoutSecrets(t *testing.T) {
+	root := t.TempDir()
+	companionHome := t.TempDir()
+	t.Setenv("COMPANION_HOME", companionHome)
+	t.Setenv("FLY_API_TOKEN", "fly-secret-value")
+	t.Setenv("TAILSCALE_API_KEY", "tailscale-api-secret-value")
+	t.Setenv("TS_AUTHKEY", "tailscale-auth-secret-value")
+
+	cmd := NewRootCommand()
+	var output bytes.Buffer
+	cmd.SetOut(&output)
+	cmd.SetArgs([]string{
+		"--workspace", root,
+		"init",
+		"--control-plane",
+		"--no-deploy",
+		"--control-plane-app", "stan-companion-control",
+		"--control-plane-hostname", "stan-companion",
+		"--tailnet", "tailnet.example",
+	})
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("init control plane: %v", err)
+	}
+	data, err := os.ReadFile(filepath.Join(root, "control-plane.toml"))
+	if err != nil {
+		t.Fatalf("read control-plane.toml: %v", err)
+	}
+	text := string(data)
+	for _, want := range []string{
+		`enabled = true`,
+		`fly_app = "stan-companion-control"`,
+		`tailscale_hostname = "stan-companion"`,
+		`fly_token_secret_name = "FLY_API_TOKEN"`,
+	} {
+		if !strings.Contains(text, want) {
+			t.Fatalf("control-plane.toml missing %q:\n%s", want, text)
+		}
+	}
+	for _, secretValue := range []string{"fly-secret-value", "tailscale-api-secret-value", "tailscale-auth-secret-value"} {
+		if strings.Contains(text, secretValue) {
+			t.Fatalf("control-plane.toml leaked secret value %q:\n%s", secretValue, text)
+		}
+	}
+	current, ok, err := registry.Current()
+	if err != nil {
+		t.Fatalf("registry current: %v", err)
+	}
+	if !ok || current.Path != root || current.ControlPlaneApp != "stan-companion-control" {
+		t.Fatalf("unexpected registry current: %#v ok=%v", current, ok)
+	}
+}
+
+func TestWorkspaceRegistryResolvesCurrentWorkspace(t *testing.T) {
+	root := t.TempDir()
+	companionHome := t.TempDir()
+	t.Setenv("COMPANION_HOME", companionHome)
+	writeTestWorkspace(t, root, map[string]string{
+		"sample": `
+[agent]
+id = "sample"
+fly_app = "example-companion-sample"
+tailscale_hostname = "sample"
+`,
+	})
+	if err := registry.Upsert(registry.WorkspaceRecord{Name: "registered", Path: root}, true); err != nil {
+		t.Fatalf("registry upsert: %v", err)
+	}
+	runner := &execx.FakeRunner{Responses: map[string]execx.Result{
+		"tailscale status --json": {Stdout: `{"Peer":{}}`},
+	}}
+	cmd := newRootCommand(runner)
+	var output bytes.Buffer
+	cmd.SetOut(&output)
+	cmd.SetArgs([]string{"plan"})
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("plan through registry: %v", err)
+	}
+	if !strings.Contains(output.String(), "fly_app.agent.sample") {
+		t.Fatalf("expected plan to use registered workspace, got:\n%s", output.String())
 	}
 }
 

--- a/internal/config/types.go
+++ b/internal/config/types.go
@@ -16,10 +16,11 @@ var (
 )
 
 type RawConfig struct {
-	Defaults  RawDefaults  `toml:"defaults"`
-	OpenWebUI RawOpenWebUI `toml:"open_webui"`
-	Dashboard RawDashboard `toml:"dashboard"`
-	Agents    []RawAgent   `toml:"agents"`
+	Defaults     RawDefaults     `toml:"defaults"`
+	OpenWebUI    RawOpenWebUI    `toml:"open_webui"`
+	Dashboard    RawDashboard    `toml:"dashboard"`
+	ControlPlane RawControlPlane `toml:"control_plane"`
+	Agents       []RawAgent      `toml:"agents"`
 }
 
 type RawDefaults struct {
@@ -194,11 +195,38 @@ type RawDashboard struct {
 	TailscaledExtraArgs        *string `toml:"tailscaled_extra_args"`
 }
 
+type RawControlPlane struct {
+	Enabled                    *bool   `toml:"enabled"`
+	ID                         *string `toml:"id"`
+	Runtime                    *string `toml:"runtime"`
+	Network                    *string `toml:"network"`
+	Lifecycle                  *string `toml:"lifecycle"`
+	Protect                    *bool   `toml:"protect"`
+	FlyApp                     *string `toml:"fly_app"`
+	TailscaleHostname          *string `toml:"tailscale_hostname"`
+	Region                     *string `toml:"region"`
+	VolumeName                 *string `toml:"volume_name"`
+	VolumeSizeGB               *int    `toml:"volume_size_gb"`
+	Memory                     *string `toml:"memory"`
+	CPUs                       *int    `toml:"cpus"`
+	Port                       *int    `toml:"port"`
+	Name                       *string `toml:"name"`
+	TailscaleServe             *bool   `toml:"tailscale_serve"`
+	TailscaleAcceptDNS         *bool   `toml:"tailscale_accept_dns"`
+	TailscaleAuthKeySecretName *string `toml:"tailscale_authkey_secret_name"`
+	FlyTokenSecretName         *string `toml:"fly_token_secret_name"`
+	TailscaleAPIKeySecretName  *string `toml:"tailscale_api_key_secret_name"`
+	OpenRouterAPIKeySecretName *string `toml:"openrouter_api_key_secret_name"`
+	TSExtraArgs                *string `toml:"ts_extra_args"`
+	TailscaledExtraArgs        *string `toml:"tailscaled_extra_args"`
+}
+
 type Config struct {
-	Defaults  Defaults  `json:"defaults"`
-	OpenWebUI OpenWebUI `json:"open_webui"`
-	Dashboard Dashboard `json:"dashboard"`
-	Agents    []Agent   `json:"agents"`
+	Defaults     Defaults     `json:"defaults"`
+	OpenWebUI    OpenWebUI    `json:"open_webui"`
+	Dashboard    Dashboard    `json:"dashboard"`
+	ControlPlane ControlPlane `json:"control_plane"`
+	Agents       []Agent      `json:"agents"`
 }
 
 type Defaults struct {
@@ -382,6 +410,35 @@ type Dashboard struct {
 	TailscaledExtraArgs        string `json:"tailscaled_extra_args,omitempty"`
 }
 
+// ControlPlane describes the persistent Companion admin app. Unlike the
+// stateless dashboard, it mounts a workspace volume and runs the mutable console
+// API that can edit TOML and run plan/apply from inside the tailnet.
+type ControlPlane struct {
+	Enabled                    bool   `json:"enabled"`
+	ID                         string `json:"id"`
+	Runtime                    string `json:"runtime"`
+	Network                    string `json:"network"`
+	Lifecycle                  string `json:"lifecycle"`
+	Protect                    bool   `json:"protect"`
+	FlyApp                     string `json:"fly_app"`
+	TailscaleHostname          string `json:"tailscale_hostname"`
+	Region                     string `json:"region"`
+	VolumeName                 string `json:"volume_name"`
+	VolumeSizeGB               int    `json:"volume_size_gb"`
+	Memory                     string `json:"memory"`
+	CPUs                       int    `json:"cpus"`
+	Port                       int    `json:"port"`
+	Name                       string `json:"name"`
+	TailscaleServe             bool   `json:"tailscale_serve"`
+	TailscaleAcceptDNS         bool   `json:"tailscale_accept_dns"`
+	TailscaleAuthKeySecretName string `json:"tailscale_authkey_secret_name"`
+	FlyTokenSecretName         string `json:"fly_token_secret_name"`
+	TailscaleAPIKeySecretName  string `json:"tailscale_api_key_secret_name"`
+	OpenRouterAPIKeySecretName string `json:"openrouter_api_key_secret_name,omitempty"`
+	TSExtraArgs                string `json:"ts_extra_args,omitempty"`
+	TailscaledExtraArgs        string `json:"tailscaled_extra_args,omitempty"`
+}
+
 func Load(path string) (*Config, error) {
 	data, err := os.ReadFile(path)
 	if err != nil {
@@ -405,9 +462,10 @@ func Normalize(raw RawConfig) (*Config, error) {
 
 	defaults := normalizeDefaults(raw.Defaults)
 	cfg := &Config{
-		Defaults:  defaults,
-		OpenWebUI: normalizeOpenWebUI(raw.OpenWebUI, defaults),
-		Dashboard: normalizeDashboard(raw.Dashboard, defaults),
+		Defaults:     defaults,
+		OpenWebUI:    normalizeOpenWebUI(raw.OpenWebUI, defaults),
+		Dashboard:    normalizeDashboard(raw.Dashboard, defaults),
+		ControlPlane: normalizeControlPlane(raw.ControlPlane, defaults),
 	}
 	for _, rawAgent := range raw.Agents {
 		agent, err := normalizeAgent(defaults, rawAgent)
@@ -567,6 +625,41 @@ func (c *Config) Validate() error {
 			if !envRE.MatchString(value) {
 				return fmt.Errorf("dashboard.%s must be an environment variable name", key)
 			}
+		}
+	}
+	if c.ControlPlane.Enabled {
+		for key, value := range map[string]string{
+			"id":                 c.ControlPlane.ID,
+			"fly_app":            c.ControlPlane.FlyApp,
+			"tailscale_hostname": c.ControlPlane.TailscaleHostname,
+		} {
+			if !nameRE.MatchString(value) {
+				return fmt.Errorf("control_plane.%s=%q must use lowercase letters, numbers, and hyphens", key, value)
+			}
+		}
+		if err := validatePort("control_plane.port", c.ControlPlane.Port); err != nil {
+			return err
+		}
+		if c.ControlPlane.Lifecycle != "present" && c.ControlPlane.Lifecycle != "absent" {
+			return fmt.Errorf("control_plane.lifecycle must be present or absent")
+		}
+		if c.ControlPlane.Runtime == "" || !strings.Contains(c.ControlPlane.Runtime, ".") {
+			return fmt.Errorf("control_plane.runtime must look like provider.name")
+		}
+		if c.ControlPlane.Network == "" || !strings.Contains(c.ControlPlane.Network, ".") {
+			return fmt.Errorf("control_plane.network must look like provider.name")
+		}
+		for key, value := range map[string]string{
+			"tailscale_authkey_secret_name": c.ControlPlane.TailscaleAuthKeySecretName,
+			"fly_token_secret_name":         c.ControlPlane.FlyTokenSecretName,
+			"tailscale_api_key_secret_name": c.ControlPlane.TailscaleAPIKeySecretName,
+		} {
+			if !envRE.MatchString(value) {
+				return fmt.Errorf("control_plane.%s must be an environment variable name", key)
+			}
+		}
+		if c.ControlPlane.OpenRouterAPIKeySecretName != "" && !envRE.MatchString(c.ControlPlane.OpenRouterAPIKeySecretName) {
+			return fmt.Errorf("control_plane.openrouter_api_key_secret_name must be an environment variable name")
 		}
 	}
 	return nil
@@ -894,6 +987,37 @@ func normalizeDashboard(raw RawDashboard, defaults Defaults) Dashboard {
 	}
 }
 
+func normalizeControlPlane(raw RawControlPlane, defaults Defaults) ControlPlane {
+	if !rawControlPlaneSet(raw) {
+		return ControlPlane{Enabled: false}
+	}
+	return ControlPlane{
+		Enabled:                    boolValue(raw.Enabled, false),
+		ID:                         stringValue(raw.ID, "control-plane"),
+		Runtime:                    stringValue(raw.Runtime, "fly.default"),
+		Network:                    stringValue(raw.Network, "tailscale.default"),
+		Lifecycle:                  stringValue(raw.Lifecycle, "present"),
+		Protect:                    boolValue(raw.Protect, true),
+		FlyApp:                     stringValue(raw.FlyApp, "example-companion-control-plane"),
+		TailscaleHostname:          stringValue(raw.TailscaleHostname, "companion-control-plane"),
+		Region:                     stringValue(raw.Region, defaults.Region),
+		VolumeName:                 stringValue(raw.VolumeName, "companion_workspace"),
+		VolumeSizeGB:               intValue(raw.VolumeSizeGB, 3),
+		Memory:                     stringValue(raw.Memory, "512mb"),
+		CPUs:                       intValue(raw.CPUs, 1),
+		Port:                       intValue(raw.Port, 8788),
+		Name:                       stringValue(raw.Name, "Companion"),
+		TailscaleServe:             boolValue(raw.TailscaleServe, true),
+		TailscaleAcceptDNS:         boolValue(raw.TailscaleAcceptDNS, true),
+		TailscaleAuthKeySecretName: stringValue(raw.TailscaleAuthKeySecretName, defaults.TailscaleAuthKeySecretName),
+		FlyTokenSecretName:         stringValue(raw.FlyTokenSecretName, "FLY_API_TOKEN"),
+		TailscaleAPIKeySecretName:  stringValue(raw.TailscaleAPIKeySecretName, "TAILSCALE_API_KEY"),
+		OpenRouterAPIKeySecretName: stringValue(raw.OpenRouterAPIKeySecretName, "OPENROUTER_API_KEY"),
+		TSExtraArgs:                stringValue(raw.TSExtraArgs, defaults.TSExtraArgs),
+		TailscaledExtraArgs:        stringValue(raw.TailscaledExtraArgs, ""),
+	}
+}
+
 func validateConnection(agentID string, conn VaultConnection) error {
 	if conn.Name == "" || !nameRE.MatchString(conn.Name) {
 		return fmt.Errorf("agent %s has invalid vault connection name: %q", agentID, conn.Name)
@@ -1023,6 +1147,10 @@ func rawCompanionSoulSet(raw RawCompanionSoul) bool {
 
 func rawDashboardSet(raw RawDashboard) bool {
 	return raw.Enabled != nil || raw.ID != nil || raw.Runtime != nil || raw.Network != nil || raw.Lifecycle != nil || raw.Protect != nil || raw.FlyApp != nil || raw.TailscaleHostname != nil || raw.Region != nil || raw.Memory != nil || raw.CPUs != nil || raw.Port != nil || raw.Name != nil || raw.RefreshInterval != nil || raw.TailscaleServe != nil || raw.TailscaleAcceptDNS != nil || raw.TailscaleAuthKeySecretName != nil || raw.FlyTokenSecretName != nil || raw.TailscaleAPIKeySecretName != nil || raw.TSExtraArgs != nil || raw.TailscaledExtraArgs != nil
+}
+
+func rawControlPlaneSet(raw RawControlPlane) bool {
+	return raw.Enabled != nil || raw.ID != nil || raw.Runtime != nil || raw.Network != nil || raw.Lifecycle != nil || raw.Protect != nil || raw.FlyApp != nil || raw.TailscaleHostname != nil || raw.Region != nil || raw.VolumeName != nil || raw.VolumeSizeGB != nil || raw.Memory != nil || raw.CPUs != nil || raw.Port != nil || raw.Name != nil || raw.TailscaleServe != nil || raw.TailscaleAcceptDNS != nil || raw.TailscaleAuthKeySecretName != nil || raw.FlyTokenSecretName != nil || raw.TailscaleAPIKeySecretName != nil || raw.OpenRouterAPIKeySecretName != nil || raw.TSExtraArgs != nil || raw.TailscaledExtraArgs != nil
 }
 
 func rawOpenWebUISet(raw RawOpenWebUI) bool {

--- a/internal/console/api.go
+++ b/internal/console/api.go
@@ -462,9 +462,13 @@ func (s *Server) handleAgentLogs(w http.ResponseWriter, r *http.Request) {
 // destroy flags default to false: a plain plan/apply reports protected
 // destructions as blocked rather than performing them.
 func (s *Server) planOptions(ws *workspace.Workspace, env map[string]string, allowProtectedDestroy, destroyData bool) resource.Options {
+	generatedDir := filepath.Join(ws.Root, ".companion", "generated")
+	if deployContext := env["COMPANION_DEPLOY_CONTEXT"]; deployContext != "" {
+		generatedDir = filepath.Join(deployContext, ".companion", "generated")
+	}
 	opts := resource.Options{
 		Root:                  ws.Root,
-		GeneratedDir:          filepath.Join(ws.Root, ".companion", "generated"),
+		GeneratedDir:          generatedDir,
 		Env:                   env,
 		AllowProtectedDestroy: allowProtectedDestroy,
 	}

--- a/internal/provider/provider_test.go
+++ b/internal/provider/provider_test.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/The-Vibe-Company/companion/internal/config"
 	"github.com/The-Vibe-Company/companion/internal/execx"
+	"github.com/The-Vibe-Company/companion/internal/fly"
 	"github.com/The-Vibe-Company/companion/internal/providertest"
 	"github.com/The-Vibe-Company/companion/internal/workspace"
 )
@@ -67,6 +68,32 @@ func TestNewSetBuildsAPIProvidersAndValidatesModels(t *testing.T) {
 	}
 	if err := set.ValidateModels(context.Background(), cfg); err != nil {
 		t.Fatalf("validate models: %v", err)
+	}
+}
+
+func TestNewSetUsesDeployContextForRollouts(t *testing.T) {
+	workspaceRoot := t.TempDir()
+	deployContext := t.TempDir()
+	ws := &workspace.Workspace{
+		Root: workspaceRoot,
+		Providers: workspace.Providers{
+			Fly: map[string]workspace.FlyProvider{"default": {Region: "cdg"}},
+		},
+	}
+	set, err := NewSet(ws, map[string]string{"COMPANION_DEPLOY_CONTEXT": deployContext}, execx.ShellRunner{Dir: workspaceRoot})
+	if err != nil {
+		t.Fatalf("new set: %v", err)
+	}
+	rollout, ok := set.Rollout["fly.default"].(fly.Provider)
+	if !ok {
+		t.Fatalf("rollout provider type = %T, want fly.Provider", set.Rollout["fly.default"])
+	}
+	runner, ok := rollout.Runner.(execx.ShellRunner)
+	if !ok {
+		t.Fatalf("rollout runner type = %T, want execx.ShellRunner", rollout.Runner)
+	}
+	if runner.Dir != deployContext {
+		t.Fatalf("rollout runner dir = %q, want deploy context %q", runner.Dir, deployContext)
 	}
 }
 

--- a/internal/provider/types.go
+++ b/internal/provider/types.go
@@ -58,12 +58,18 @@ func NewSet(ws *workspace.Workspace, env map[string]string, runner execx.Runner)
 	for name, cfg := range ws.Providers.Fly {
 		ref := "fly." + name
 		shell := fly.NewWithOrg(runner, cfg.Org)
+		rolloutRunner := runner
+		if deployContext := env["COMPANION_DEPLOY_CONTEXT"]; deployContext != "" {
+			if _, ok := runner.(execx.ShellRunner); ok {
+				rolloutRunner = execx.ShellRunner{Dir: deployContext, Env: env}
+			}
+		}
 		if cfg.Mode == "api" {
 			set.Fly[ref] = fly.NewAPI(cfg.APIBaseURL, env[cfg.TokenEnv], cfg.Org)
 		} else {
 			set.Fly[ref] = shell
 		}
-		set.Rollout[ref] = shell
+		set.Rollout[ref] = fly.NewWithOrg(rolloutRunner, cfg.Org)
 	}
 	for name, cfg := range ws.Providers.Tailscale {
 		ref := "tailscale." + name

--- a/internal/registry/registry.go
+++ b/internal/registry/registry.go
@@ -1,0 +1,188 @@
+package registry
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+)
+
+const filename = "workspaces.json"
+
+type Registry struct {
+	Version    int               `json:"version"`
+	Current    string            `json:"current,omitempty"`
+	Workspaces []WorkspaceRecord `json:"workspaces"`
+}
+
+type WorkspaceRecord struct {
+	Name              string `json:"name"`
+	Path              string `json:"path"`
+	ControlPlaneApp   string `json:"control_plane_app,omitempty"`
+	TailscaleHostname string `json:"tailscale_hostname,omitempty"`
+}
+
+func Home() (string, error) {
+	if value := os.Getenv("COMPANION_HOME"); value != "" {
+		return value, nil
+	}
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return "", err
+	}
+	return filepath.Join(home, ".companion"), nil
+}
+
+func Path() (string, error) {
+	home, err := Home()
+	if err != nil {
+		return "", err
+	}
+	return filepath.Join(home, filename), nil
+}
+
+func Load() (Registry, error) {
+	path, err := Path()
+	if err != nil {
+		return Registry{}, err
+	}
+	data, err := os.ReadFile(path)
+	if os.IsNotExist(err) {
+		return Registry{Version: 1}, nil
+	}
+	if err != nil {
+		return Registry{}, err
+	}
+	var reg Registry
+	if err := json.Unmarshal(data, &reg); err != nil {
+		return Registry{}, fmt.Errorf("read %s: %w", path, err)
+	}
+	if reg.Version == 0 {
+		reg.Version = 1
+	}
+	return reg, nil
+}
+
+func Save(reg Registry) error {
+	path, err := Path()
+	if err != nil {
+		return err
+	}
+	if err := os.MkdirAll(filepath.Dir(path), 0o700); err != nil {
+		return err
+	}
+	reg.Version = 1
+	sort.SliceStable(reg.Workspaces, func(i, j int) bool {
+		return reg.Workspaces[i].Name < reg.Workspaces[j].Name
+	})
+	data, err := json.MarshalIndent(reg, "", "  ")
+	if err != nil {
+		return err
+	}
+	data = append(data, '\n')
+	return os.WriteFile(path, data, 0o600)
+}
+
+func Upsert(record WorkspaceRecord, setCurrent bool) error {
+	if record.Name == "" {
+		return fmt.Errorf("workspace name is required")
+	}
+	if record.Path == "" {
+		return fmt.Errorf("workspace path is required")
+	}
+	absPath, err := filepath.Abs(record.Path)
+	if err != nil {
+		return err
+	}
+	record.Path = absPath
+	reg, err := Load()
+	if err != nil {
+		return err
+	}
+	replaced := false
+	for i, existing := range reg.Workspaces {
+		if existing.Name == record.Name {
+			reg.Workspaces[i] = record
+			replaced = true
+			break
+		}
+	}
+	if !replaced {
+		reg.Workspaces = append(reg.Workspaces, record)
+	}
+	if setCurrent || reg.Current == "" {
+		reg.Current = record.Name
+	}
+	return Save(reg)
+}
+
+func Current() (WorkspaceRecord, bool, error) {
+	reg, err := Load()
+	if err != nil {
+		return WorkspaceRecord{}, false, err
+	}
+	if reg.Current == "" {
+		return WorkspaceRecord{}, false, nil
+	}
+	for _, record := range reg.Workspaces {
+		if record.Name == reg.Current {
+			return record, true, nil
+		}
+	}
+	return WorkspaceRecord{}, false, fmt.Errorf("current workspace %q is not registered", reg.Current)
+}
+
+func Get(name string) (WorkspaceRecord, bool, error) {
+	reg, err := Load()
+	if err != nil {
+		return WorkspaceRecord{}, false, err
+	}
+	for _, record := range reg.Workspaces {
+		if record.Name == name {
+			return record, true, nil
+		}
+	}
+	return WorkspaceRecord{}, false, nil
+}
+
+func Use(name string) error {
+	reg, err := Load()
+	if err != nil {
+		return err
+	}
+	for _, record := range reg.Workspaces {
+		if record.Name == name {
+			reg.Current = name
+			return Save(reg)
+		}
+	}
+	return fmt.Errorf("workspace %q is not registered", name)
+}
+
+func Remove(name string) error {
+	reg, err := Load()
+	if err != nil {
+		return err
+	}
+	next := reg.Workspaces[:0]
+	removed := false
+	for _, record := range reg.Workspaces {
+		if record.Name == name {
+			removed = true
+			continue
+		}
+		next = append(next, record)
+	}
+	if !removed {
+		return fmt.Errorf("workspace %q is not registered", name)
+	}
+	reg.Workspaces = next
+	if reg.Current == name {
+		reg.Current = ""
+		if len(reg.Workspaces) > 0 {
+			reg.Current = reg.Workspaces[0].Name
+		}
+	}
+	return Save(reg)
+}

--- a/internal/registry/registry_test.go
+++ b/internal/registry/registry_test.go
@@ -1,0 +1,180 @@
+package registry
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestLoadMissingRegistryReturnsEmptyVersionedRegistry(t *testing.T) {
+	t.Setenv("COMPANION_HOME", t.TempDir())
+
+	reg, err := Load()
+	if err != nil {
+		t.Fatalf("load missing registry: %v", err)
+	}
+
+	if reg.Version != 1 {
+		t.Fatalf("version = %d, want 1", reg.Version)
+	}
+	if reg.Current != "" {
+		t.Fatalf("current = %q, want empty", reg.Current)
+	}
+	if len(reg.Workspaces) != 0 {
+		t.Fatalf("workspaces = %d, want 0", len(reg.Workspaces))
+	}
+}
+
+func TestUpsertNormalizesSortsAndPersistsWorkspaces(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("COMPANION_HOME", home)
+	base := t.TempDir()
+
+	alphaPath := filepath.Join(base, "alpha")
+	betaPath := filepath.Join(base, "beta")
+	if err := Upsert(WorkspaceRecord{Name: "beta", Path: betaPath, ControlPlaneApp: "cp-beta"}, true); err != nil {
+		t.Fatalf("upsert beta: %v", err)
+	}
+	if err := Upsert(WorkspaceRecord{Name: "alpha", Path: alphaPath, TailscaleHostname: "alpha.tailnet.ts.net"}, false); err != nil {
+		t.Fatalf("upsert alpha: %v", err)
+	}
+
+	reg := readRegistryFile(t, home)
+	if reg.Current != "beta" {
+		t.Fatalf("current = %q, want beta", reg.Current)
+	}
+	if got, want := workspaceNames(reg.Workspaces), []string{"alpha", "beta"}; strings.Join(got, ",") != strings.Join(want, ",") {
+		t.Fatalf("workspace order = %v, want %v", got, want)
+	}
+	if reg.Workspaces[0].Path != alphaPath {
+		t.Fatalf("alpha path = %q, want %q", reg.Workspaces[0].Path, alphaPath)
+	}
+	if reg.Workspaces[0].TailscaleHostname != "alpha.tailnet.ts.net" {
+		t.Fatalf("alpha tailscale hostname = %q", reg.Workspaces[0].TailscaleHostname)
+	}
+	if reg.Workspaces[1].ControlPlaneApp != "cp-beta" {
+		t.Fatalf("beta control plane app = %q", reg.Workspaces[1].ControlPlaneApp)
+	}
+
+	if err := Upsert(WorkspaceRecord{Name: "beta", Path: filepath.Join(base, "beta-renamed")}, false); err != nil {
+		t.Fatalf("replace beta: %v", err)
+	}
+	reg, err := Load()
+	if err != nil {
+		t.Fatalf("load registry: %v", err)
+	}
+	if len(reg.Workspaces) != 2 {
+		t.Fatalf("workspaces = %d, want 2", len(reg.Workspaces))
+	}
+	if reg.Workspaces[1].Path != filepath.Join(base, "beta-renamed") {
+		t.Fatalf("replaced beta path = %q", reg.Workspaces[1].Path)
+	}
+}
+
+func TestCurrentUseGetAndRemove(t *testing.T) {
+	t.Setenv("COMPANION_HOME", t.TempDir())
+	base := t.TempDir()
+	if err := Upsert(WorkspaceRecord{Name: "alpha", Path: filepath.Join(base, "alpha")}, true); err != nil {
+		t.Fatalf("upsert alpha: %v", err)
+	}
+	if err := Upsert(WorkspaceRecord{Name: "beta", Path: filepath.Join(base, "beta")}, true); err != nil {
+		t.Fatalf("upsert beta: %v", err)
+	}
+
+	current, ok, err := Current()
+	if err != nil {
+		t.Fatalf("current: %v", err)
+	}
+	if !ok || current.Name != "beta" {
+		t.Fatalf("current = (%q, %v), want beta true", current.Name, ok)
+	}
+
+	if err := Use("alpha"); err != nil {
+		t.Fatalf("use alpha: %v", err)
+	}
+	current, ok, err = Current()
+	if err != nil {
+		t.Fatalf("current after use: %v", err)
+	}
+	if !ok || current.Name != "alpha" {
+		t.Fatalf("current after use = (%q, %v), want alpha true", current.Name, ok)
+	}
+
+	got, ok, err := Get("beta")
+	if err != nil {
+		t.Fatalf("get beta: %v", err)
+	}
+	if !ok || got.Name != "beta" {
+		t.Fatalf("get beta = (%q, %v), want beta true", got.Name, ok)
+	}
+
+	if err := Remove("alpha"); err != nil {
+		t.Fatalf("remove current alpha: %v", err)
+	}
+	current, ok, err = Current()
+	if err != nil {
+		t.Fatalf("current after remove: %v", err)
+	}
+	if !ok || current.Name != "beta" {
+		t.Fatalf("current after remove = (%q, %v), want beta true", current.Name, ok)
+	}
+}
+
+func TestRegistryReportsUsefulErrors(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("COMPANION_HOME", home)
+
+	if err := Upsert(WorkspaceRecord{Path: t.TempDir()}, false); err == nil || !strings.Contains(err.Error(), "workspace name is required") {
+		t.Fatalf("missing name error = %v", err)
+	}
+	if err := Upsert(WorkspaceRecord{Name: "alpha"}, false); err == nil || !strings.Contains(err.Error(), "workspace path is required") {
+		t.Fatalf("missing path error = %v", err)
+	}
+	if err := Use("missing"); err == nil || !strings.Contains(err.Error(), `workspace "missing" is not registered`) {
+		t.Fatalf("use missing error = %v", err)
+	}
+	if err := Remove("missing"); err == nil || !strings.Contains(err.Error(), `workspace "missing" is not registered`) {
+		t.Fatalf("remove missing error = %v", err)
+	}
+
+	if err := Save(Registry{Current: "ghost", Workspaces: []WorkspaceRecord{{Name: "alpha", Path: t.TempDir()}}}); err != nil {
+		t.Fatalf("save ghost current: %v", err)
+	}
+	if _, _, err := Current(); err == nil || !strings.Contains(err.Error(), `current workspace "ghost" is not registered`) {
+		t.Fatalf("ghost current error = %v", err)
+	}
+
+	path, err := Path()
+	if err != nil {
+		t.Fatalf("registry path: %v", err)
+	}
+	if err := os.WriteFile(path, []byte("{"), 0o600); err != nil {
+		t.Fatalf("write invalid registry: %v", err)
+	}
+	if _, err := Load(); err == nil || !strings.Contains(err.Error(), "read ") {
+		t.Fatalf("invalid registry error = %v", err)
+	}
+}
+
+func readRegistryFile(t *testing.T, home string) Registry {
+	t.Helper()
+	data, err := os.ReadFile(filepath.Join(home, filename))
+	if err != nil {
+		t.Fatalf("read registry file: %v", err)
+	}
+	var reg Registry
+	if err := json.Unmarshal(data, &reg); err != nil {
+		t.Fatalf("parse registry file: %v", err)
+	}
+	return reg
+}
+
+func workspaceNames(records []WorkspaceRecord) []string {
+	names := make([]string, 0, len(records))
+	for _, record := range records {
+		names = append(names, record.Name)
+	}
+	return names
+}

--- a/internal/render/render.go
+++ b/internal/render/render.go
@@ -246,6 +246,58 @@ func DashboardFlyTOML(cfg config.Dashboard) (string, error) {
 	return strings.Join(lines, "\n"), nil
 }
 
+func ControlPlaneFlyTOML(cfg config.ControlPlane) (string, error) {
+	if !cfg.Enabled {
+		return "", fmt.Errorf("control_plane is disabled in the workspace")
+	}
+	env := map[string]string{
+		"COMPANION_CONTROL_PLANE_NAME":      cfg.Name,
+		"COMPANION_CONTROL_PLANE_SEED":      "/seed",
+		"COMPANION_CONTROL_PLANE_WORKSPACE": "/workspace",
+		"CONTROL_PLANE_TAILSCALE_SERVE":     envBool(cfg.TailscaleServe),
+		"CONTROL_PLANE_TS_HOSTNAME":         cfg.TailscaleHostname,
+		"PORT":                              strconv.Itoa(cfg.Port),
+		"TAILSCALE_STATE_DIR":               "/workspace/.tailscale",
+		"TS_ACCEPT_DNS":                     envBool(cfg.TailscaleAcceptDNS),
+	}
+	if cfg.TSExtraArgs != "" {
+		env["TS_EXTRA_ARGS"] = cfg.TSExtraArgs
+	}
+	if cfg.TailscaledExtraArgs != "" {
+		env["TAILSCALED_EXTRA_ARGS"] = cfg.TailscaledExtraArgs
+	}
+
+	process := "companion --workspace /workspace console"
+	lines := []string{
+		fmt.Sprintf("app = %s", quote(cfg.FlyApp)),
+		fmt.Sprintf("primary_region = %s", quote(cfg.Region)),
+		`kill_signal = "SIGTERM"`,
+		"kill_timeout = 30",
+		"",
+		"[build]",
+		`  dockerfile = "../../Dockerfile.control-plane"`,
+		"",
+		"[env]",
+	}
+	appendEnv(&lines, env)
+	lines = append(lines,
+		"",
+		"[processes]",
+		fmt.Sprintf("  app = %s", quote(process)),
+		"",
+		"[[mounts]]",
+		fmt.Sprintf("  source = %s", quote(cfg.VolumeName)),
+		`  destination = "/workspace"`,
+		"",
+		"[[vm]]",
+		`  cpu_kind = "shared"`,
+		fmt.Sprintf("  memory = %s", quote(cfg.Memory)),
+		fmt.Sprintf("  cpus = %d", cfg.CPUs),
+		"",
+	)
+	return strings.Join(lines, "\n"), nil
+}
+
 // RequiredDashboardFlySecrets lists the read-only tokens the dashboard machine
 // needs as Fly secrets. The topology manifest itself is non-secret.
 func RequiredDashboardFlySecrets(cfg config.Dashboard) []string {
@@ -253,6 +305,15 @@ func RequiredDashboardFlySecrets(cfg config.Dashboard) []string {
 		cfg.TailscaleAuthKeySecretName,
 		cfg.FlyTokenSecretName,
 		cfg.TailscaleAPIKeySecretName,
+	})
+}
+
+func RequiredControlPlaneFlySecrets(cfg config.ControlPlane) []string {
+	return unique([]string{
+		cfg.TailscaleAuthKeySecretName,
+		cfg.FlyTokenSecretName,
+		cfg.TailscaleAPIKeySecretName,
+		cfg.OpenRouterAPIKeySecretName,
 	})
 }
 

--- a/internal/render/render_test.go
+++ b/internal/render/render_test.go
@@ -113,6 +113,55 @@ func TestDashboardRenderSmallestStatelessMachine(t *testing.T) {
 	}
 }
 
+func TestControlPlaneRenderPersistentTailnetOnlyConsole(t *testing.T) {
+	cfg := config.ControlPlane{
+		Enabled:                    true,
+		ID:                         "control-plane",
+		FlyApp:                     "example-companion-control-plane",
+		TailscaleHostname:          "companion-control-plane",
+		Region:                     "cdg",
+		VolumeName:                 "companion_workspace",
+		VolumeSizeGB:               3,
+		Memory:                     "512mb",
+		CPUs:                       1,
+		Port:                       8788,
+		Name:                       "Companion",
+		TailscaleServe:             true,
+		TailscaleAcceptDNS:         true,
+		TailscaleAuthKeySecretName: "TS_AUTHKEY",
+		FlyTokenSecretName:         "FLY_API_TOKEN",
+		TailscaleAPIKeySecretName:  "TAILSCALE_API_KEY",
+		OpenRouterAPIKeySecretName: "OPENROUTER_API_KEY",
+	}
+	toml, err := ControlPlaneFlyTOML(cfg)
+	if err != nil {
+		t.Fatalf("render: %v", err)
+	}
+	for _, want := range []string{
+		`dockerfile = "../../Dockerfile.control-plane"`,
+		`CONTROL_PLANE_TS_HOSTNAME = "companion-control-plane"`,
+		`COMPANION_CONTROL_PLANE_WORKSPACE = "/workspace"`,
+		`companion --workspace /workspace console`,
+		`source = "companion_workspace"`,
+		`destination = "/workspace"`,
+		`memory = "512mb"`,
+		`cpus = 1`,
+	} {
+		if !strings.Contains(toml, want) {
+			t.Fatalf("missing %q in\n%s", want, toml)
+		}
+	}
+	if strings.Contains(toml, "[http_service]") {
+		t.Fatalf("control plane must be tailnet-only (no Fly http_service):\n%s", toml)
+	}
+	secrets := RequiredControlPlaneFlySecrets(cfg)
+	for _, name := range []string{"TS_AUTHKEY", "FLY_API_TOKEN", "TAILSCALE_API_KEY", "OPENROUTER_API_KEY"} {
+		if !containsString(secrets, name) {
+			t.Fatalf("expected required secret %q in %v", name, secrets)
+		}
+	}
+}
+
 func containsString(values []string, target string) bool {
 	for _, v := range values {
 		if v == target {

--- a/internal/resource/resource.go
+++ b/internal/resource/resource.go
@@ -31,19 +31,20 @@ const (
 )
 
 type Resource struct {
-	Address     string            `json:"address"`
-	Type        string            `json:"type"`
-	Class       string            `json:"class"`
-	ProviderRef string            `json:"provider_ref"`
-	ExternalID  string            `json:"external_id,omitempty"`
-	DesiredHash string            `json:"desired_hash"`
-	Protected   bool              `json:"protected"`
-	Absent      bool              `json:"absent"`
-	DependsOn   []string          `json:"depends_on,omitempty"`
-	Agent       *config.Agent     `json:"-"`
-	OpenWebUI   *config.OpenWebUI `json:"-"`
-	Dashboard   *config.Dashboard `json:"-"`
-	Desired     map[string]any    `json:"desired,omitempty"`
+	Address      string               `json:"address"`
+	Type         string               `json:"type"`
+	Class        string               `json:"class"`
+	ProviderRef  string               `json:"provider_ref"`
+	ExternalID   string               `json:"external_id,omitempty"`
+	DesiredHash  string               `json:"desired_hash"`
+	Protected    bool                 `json:"protected"`
+	Absent       bool                 `json:"absent"`
+	DependsOn    []string             `json:"depends_on,omitempty"`
+	Agent        *config.Agent        `json:"-"`
+	OpenWebUI    *config.OpenWebUI    `json:"-"`
+	Dashboard    *config.Dashboard    `json:"-"`
+	ControlPlane *config.ControlPlane `json:"-"`
+	Desired      map[string]any       `json:"desired,omitempty"`
 }
 
 type Graph struct {
@@ -148,6 +149,22 @@ func Compile(ws *workspace.Workspace, root string) (Graph, error) {
 			Resource{Address: "rollout.dashboard.main", Type: "rollout", Class: ClassAction, ProviderRef: dash.Runtime, DesiredHash: hashValue(dash.FlyApp), Protected: dash.Protect, Absent: absent, DependsOn: []string{"fly_app.dashboard.main", "fly_secrets.dashboard.main", "dashboard_config.main"}, Dashboard: &dash},
 		)
 	}
+	if ws.Config.ControlPlane.Enabled {
+		control := ws.Config.ControlPlane
+		absent := control.Lifecycle == "absent"
+		configHash, err := hashControlPlaneConfig(control)
+		if err != nil {
+			return Graph{}, err
+		}
+		resources = append(resources,
+			Resource{Address: "control_plane_config.main", Type: "control_plane_config", Class: ClassDerived, ProviderRef: control.Runtime, DesiredHash: configHash, Protected: control.Protect, Absent: absent, ControlPlane: &control},
+			Resource{Address: "fly_app.control_plane.main", Type: "fly_app", Class: ClassManaged, ProviderRef: control.Runtime, ExternalID: control.FlyApp, DesiredHash: hashValue(control.FlyApp), Protected: control.Protect, Absent: absent, ControlPlane: &control, Desired: map[string]any{"app": control.FlyApp}},
+			Resource{Address: "fly_volume.control_plane_workspace.main", Type: "fly_volume", Class: ClassManaged, ProviderRef: control.Runtime, DesiredHash: hashMap(map[string]any{"app": control.FlyApp, "name": control.VolumeName, "region": control.Region, "size_gb": control.VolumeSizeGB}), Protected: true, Absent: absent, DependsOn: []string{"fly_app.control_plane.main"}, ControlPlane: &control, Desired: map[string]any{"app": control.FlyApp, "name": control.VolumeName}},
+			Resource{Address: "fly_secrets.control_plane.main", Type: "fly_secrets", Class: ClassManaged, ProviderRef: control.Runtime, DesiredHash: hashStringSlice(render.RequiredControlPlaneFlySecrets(control)), Protected: control.Protect, Absent: absent, DependsOn: []string{"fly_app.control_plane.main"}, ControlPlane: &control, Desired: map[string]any{"names": render.RequiredControlPlaneFlySecrets(control)}},
+			Resource{Address: "rollout.control_plane.main", Type: "rollout", Class: ClassAction, ProviderRef: control.Runtime, DesiredHash: configHash, Protected: control.Protect, Absent: absent, DependsOn: []string{"fly_app.control_plane.main", "fly_volume.control_plane_workspace.main", "fly_secrets.control_plane.main", "control_plane_config.main"}, ControlPlane: &control},
+			Resource{Address: "tailscale_device.control_plane.main", Type: "tailscale_device", Class: ClassObserved, ProviderRef: control.Network, DesiredHash: hashValue(control.TailscaleHostname), Protected: control.Protect, Absent: absent, DependsOn: []string{"rollout.control_plane.main"}, ControlPlane: &control},
+		)
+	}
 	graph := Graph{Resources: resources, byAddress: map[string]Resource{}}
 	for _, resource := range resources {
 		graph.byAddress[resource.Address] = resource
@@ -250,6 +267,22 @@ func Apply(ctx context.Context, ws *workspace.Workspace, store *state.Store, pro
 	}
 	status = "succeeded"
 	return plan, nil
+}
+
+func WriteControlPlaneArtifacts(ws *workspace.Workspace, opts Options) (string, error) {
+	if !ws.Config.ControlPlane.Enabled {
+		return "", fmt.Errorf("control_plane is disabled in the workspace")
+	}
+	resource := Resource{
+		Address:      "control_plane_config.main",
+		Type:         "control_plane_config",
+		Class:        ClassDerived,
+		ProviderRef:  ws.Config.ControlPlane.Runtime,
+		DesiredHash:  hashValue(ws.Config.ControlPlane.FlyApp),
+		Protected:    ws.Config.ControlPlane.Protect,
+		ControlPlane: &ws.Config.ControlPlane,
+	}
+	return writeConfig(context.Background(), ws, provider.Set{}, resource, opts)
 }
 
 func markOrphan(ctx context.Context, store *state.Store, change Change) error {
@@ -394,6 +427,13 @@ func planResource(ctx context.Context, ws *workspace.Workspace, store *state.Sto
 			}
 			resource.DesiredHash = hash
 		}
+		if resource.ControlPlane != nil {
+			hash, err := hashControlPlaneConfig(*resource.ControlPlane)
+			if err != nil {
+				return Change{}, err
+			}
+			resource.DesiredHash = hash
+		}
 		return planByHash(ctx, store, resource, "deploy")
 	case "tailscale_device":
 		return planTailscaleDevice(resource, devices), nil
@@ -403,6 +443,13 @@ func planResource(ctx context.Context, ws *workspace.Workspace, store *state.Sto
 		return planOpenWebUIConfig(ctx, ws, store, devices, resource)
 	case "dashboard_config":
 		hash, err := hashDashboardConfig(ws, devices)
+		if err != nil {
+			return Change{}, err
+		}
+		resource.DesiredHash = hash
+		return planByHash(ctx, store, resource, "render")
+	case "control_plane_config":
+		hash, err := hashControlPlaneConfig(*resource.ControlPlane)
 		if err != nil {
 			return Change{}, err
 		}
@@ -492,6 +539,13 @@ func applyResource(ctx context.Context, ws *workspace.Workspace, store *state.St
 			}
 			resource.DesiredHash = hash
 		}
+		if resource.ControlPlane != nil {
+			hash, err := hashControlPlaneConfig(*resource.ControlPlane)
+			if err != nil {
+				return err
+			}
+			resource.DesiredHash = hash
+		}
 		configPath := generatedPath(opts, resource)
 		rolloutProvider, err := providers.RolloutFor(resource.ProviderRef)
 		if err != nil {
@@ -506,7 +560,7 @@ func applyResource(ctx context.Context, ws *workspace.Workspace, store *state.St
 		if err != nil {
 			return err
 		}
-		device, ok := selectedTailscaleDevice(devices, resource.Agent.TailscaleHostname)
+		device, ok := selectedTailscaleDevice(devices, resourceTailscaleHostname(resource))
 		if !ok {
 			return nil
 		}
@@ -532,6 +586,17 @@ func applyResource(ctx context.Context, ws *workspace.Workspace, store *state.St
 			return err
 		}
 		hash, err := hashDashboardConfig(ws, devices)
+		if err != nil {
+			return err
+		}
+		resource.DesiredHash = hash
+		path, err := writeConfig(ctx, ws, providers, resource, opts)
+		if err != nil {
+			return err
+		}
+		return upsertReady(ctx, store, resource, path, map[string]any{"path": path})
+	case "control_plane_config":
+		hash, err := hashControlPlaneConfig(*resource.ControlPlane)
 		if err != nil {
 			return err
 		}
@@ -613,9 +678,10 @@ func planByHash(ctx context.Context, store *state.Store, resource Resource, acti
 }
 
 func planTailscaleDevice(resource Resource, devices []tailscale.Device) Change {
-	matches := tailscale.FindByHostname(devices, resource.Agent.TailscaleHostname)
+	hostname := resourceTailscaleHostname(resource)
+	matches := tailscale.FindByHostname(devices, hostname)
 	if len(matches) == 0 {
-		return Change{Kind: "!", Action: "drift", Address: resource.Address, Class: resource.Class, ProviderRef: resource.ProviderRef, Message: "missing " + resource.Agent.TailscaleHostname, DesiredHash: resource.DesiredHash, Protected: resource.Protected}
+		return Change{Kind: "!", Action: "drift", Address: resource.Address, Class: resource.Class, ProviderRef: resource.ProviderRef, Message: "missing " + hostname, DesiredHash: resource.DesiredHash, Protected: resource.Protected}
 	}
 	if len(matches) > 1 {
 		return Change{Kind: "!", Action: "drift", Address: resource.Address, Class: resource.Class, ProviderRef: resource.ProviderRef, ExternalID: matches[0].ID, Message: "multiple devices", DesiredHash: resource.DesiredHash, Protected: resource.Protected}
@@ -657,6 +723,8 @@ func writeConfig(ctx context.Context, ws *workspace.Workspace, providers provide
 		data, err = render.AgentFlyTOML(*resource.Agent)
 	case resource.Dashboard != nil:
 		data, err = render.DashboardFlyTOML(*resource.Dashboard)
+	case resource.ControlPlane != nil:
+		data, err = render.ControlPlaneFlyTOML(*resource.ControlPlane)
 	default:
 		devices, tsErr := providers.AllDevices(ctx)
 		if tsErr != nil {
@@ -681,7 +749,78 @@ func writeConfig(ctx context.Context, ws *workspace.Workspace, providers provide
 			return "", err
 		}
 	}
+	if resource.ControlPlane != nil {
+		if err := writeControlPlaneSeed(ws, filepath.Join(filepath.Dir(path), "control-plane-seed")); err != nil {
+			return "", err
+		}
+	}
 	return path, nil
+}
+
+func writeControlPlaneSeed(ws *workspace.Workspace, seedDir string) error {
+	if err := os.RemoveAll(seedDir); err != nil {
+		return err
+	}
+	if err := os.MkdirAll(seedDir, 0o755); err != nil {
+		return err
+	}
+	for _, name := range []string{"companion.toml", "providers.toml", "defaults.toml", "webui.toml", "dashboard.toml", "control-plane.toml"} {
+		if err := copyIfExists(filepath.Join(ws.Root, name), filepath.Join(seedDir, name)); err != nil {
+			return err
+		}
+	}
+	for _, dir := range []string{"agents", "identities", "vaults"} {
+		src := filepath.Join(ws.Root, dir)
+		if _, err := os.Stat(src); err == nil {
+			if err := copyDir(src, filepath.Join(seedDir, dir)); err != nil {
+				return err
+			}
+		} else if err != nil && !os.IsNotExist(err) {
+			return err
+		}
+	}
+	return nil
+}
+
+func copyIfExists(src, dst string) error {
+	info, err := os.Stat(src)
+	if os.IsNotExist(err) {
+		return nil
+	}
+	if err != nil {
+		return err
+	}
+	if info.IsDir() {
+		return copyDir(src, dst)
+	}
+	data, err := os.ReadFile(src)
+	if err != nil {
+		return err
+	}
+	if err := os.MkdirAll(filepath.Dir(dst), 0o755); err != nil {
+		return err
+	}
+	return os.WriteFile(dst, data, info.Mode().Perm())
+}
+
+func copyDir(src, dst string) error {
+	return filepath.WalkDir(src, func(path string, entry os.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		rel, err := filepath.Rel(src, path)
+		if err != nil {
+			return err
+		}
+		target := filepath.Join(dst, rel)
+		if entry.IsDir() {
+			return os.MkdirAll(target, 0o755)
+		}
+		if entry.Type().IsRegular() {
+			return copyIfExists(path, target)
+		}
+		return nil
+	})
 }
 
 // writeDashboardManifest builds the live fleet topology and writes fleet.json
@@ -726,6 +865,14 @@ func hashDashboardConfig(ws *workspace.Workspace, devices []tailscale.Device) (s
 	}), nil
 }
 
+func hashControlPlaneConfig(cfg config.ControlPlane) (string, error) {
+	toml, err := render.ControlPlaneFlyTOML(cfg)
+	if err != nil {
+		return "", err
+	}
+	return hashValue(toml), nil
+}
+
 func dashboardProviderSummary(ws *workspace.Workspace) status.ProviderSummary {
 	dash := ws.Config.Dashboard
 	summary := status.ProviderSummary{}
@@ -760,6 +907,9 @@ func generatedPath(opts Options, resource Resource) string {
 	}
 	if resource.Dashboard != nil {
 		name = "fly." + resource.Dashboard.ID
+	}
+	if resource.ControlPlane != nil {
+		name = "fly." + resource.ControlPlane.ID
 	}
 	return filepath.Join(dir, name+".toml")
 }
@@ -812,6 +962,9 @@ func requiredSecretNames(resource Resource) []string {
 	if resource.Dashboard != nil {
 		return render.RequiredDashboardFlySecrets(*resource.Dashboard)
 	}
+	if resource.ControlPlane != nil {
+		return render.RequiredControlPlaneFlySecrets(*resource.ControlPlane)
+	}
 	return nil
 }
 
@@ -824,6 +977,9 @@ func resourceFlyApp(resource Resource) string {
 	}
 	if resource.Dashboard != nil {
 		return resource.Dashboard.FlyApp
+	}
+	if resource.ControlPlane != nil {
+		return resource.ControlPlane.FlyApp
 	}
 	if value, ok := resource.Desired["app"].(string); ok {
 		return value
@@ -838,6 +994,9 @@ func resourceVolumeName(resource Resource) string {
 	if resource.OpenWebUI != nil {
 		return resource.OpenWebUI.VolumeName
 	}
+	if resource.ControlPlane != nil {
+		return resource.ControlPlane.VolumeName
+	}
 	if value, ok := resource.Desired["name"].(string); ok {
 		return value
 	}
@@ -851,6 +1010,9 @@ func resourceRegion(resource Resource) string {
 	if resource.OpenWebUI != nil {
 		return resource.OpenWebUI.Region
 	}
+	if resource.ControlPlane != nil {
+		return resource.ControlPlane.Region
+	}
 	return "cdg"
 }
 
@@ -861,7 +1023,26 @@ func desiredSizeGB(resource Resource) int {
 	if resource.OpenWebUI != nil {
 		return resource.OpenWebUI.VolumeSizeGB
 	}
+	if resource.ControlPlane != nil {
+		return resource.ControlPlane.VolumeSizeGB
+	}
 	return 1
+}
+
+func resourceTailscaleHostname(resource Resource) string {
+	if resource.Agent != nil {
+		return resource.Agent.TailscaleHostname
+	}
+	if resource.OpenWebUI != nil {
+		return resource.OpenWebUI.TailscaleHostname
+	}
+	if resource.Dashboard != nil {
+		return resource.Dashboard.TailscaleHostname
+	}
+	if resource.ControlPlane != nil {
+		return resource.ControlPlane.TailscaleHostname
+	}
+	return ""
 }
 
 func hydrateAgentIdentity(root string, agent config.Agent) (config.Agent, error) {

--- a/internal/resource/resource_test.go
+++ b/internal/resource/resource_test.go
@@ -228,6 +228,42 @@ func TestCompileDashboardResources(t *testing.T) {
 	}
 }
 
+func TestCompileControlPlaneResources(t *testing.T) {
+	ws := controlPlaneWorkspace(t)
+	graph, err := Compile(ws, ws.Root)
+	if err != nil {
+		t.Fatalf("compile: %v", err)
+	}
+	byAddress := graph.ByAddress()
+	wants := map[string]string{
+		"control_plane_config.main":               ClassDerived,
+		"fly_app.control_plane.main":              ClassManaged,
+		"fly_volume.control_plane_workspace.main": ClassManaged,
+		"fly_secrets.control_plane.main":          ClassManaged,
+		"rollout.control_plane.main":              ClassAction,
+		"tailscale_device.control_plane.main":     ClassObserved,
+	}
+	for address, class := range wants {
+		resource, ok := byAddress[address]
+		if !ok {
+			t.Fatalf("missing resource %s", address)
+		}
+		if resource.Class != class {
+			t.Fatalf("resource %s class: got %s want %s", address, resource.Class, class)
+		}
+	}
+	volume := byAddress["fly_volume.control_plane_workspace.main"]
+	if !volume.Protected {
+		t.Fatalf("control-plane workspace volume must be protected")
+	}
+	rollout := byAddress["rollout.control_plane.main"]
+	for _, dep := range []string{"fly_app.control_plane.main", "fly_volume.control_plane_workspace.main", "fly_secrets.control_plane.main", "control_plane_config.main"} {
+		if !containsString(rollout.DependsOn, dep) {
+			t.Fatalf("rollout.control_plane.main missing dependency %s (deps=%v)", dep, rollout.DependsOn)
+		}
+	}
+}
+
 func TestDashboardTopologyHashGating(t *testing.T) {
 	one := dashboardWorkspace(t, "research")
 	two := dashboardWorkspace(t, "research", "writer")
@@ -313,6 +349,28 @@ func dashboardWorkspace(t *testing.T, agentIDs ...string) *workspace.Workspace {
 		},
 		Dashboard: config.RawDashboard{Enabled: boolPtr(true)},
 		Agents:    agents,
+	})
+	if err != nil {
+		t.Fatalf("normalize config: %v", err)
+	}
+	return &workspace.Workspace{
+		Root:      root,
+		Name:      "test",
+		StatePath: filepath.Join(root, ".companion", "state.sqlite"),
+		Config:    cfg,
+	}
+}
+
+func controlPlaneWorkspace(t *testing.T) *workspace.Workspace {
+	t.Helper()
+	root := t.TempDir()
+	cfg, err := config.Normalize(config.RawConfig{
+		ControlPlane: config.RawControlPlane{
+			Enabled:           boolPtr(true),
+			FlyApp:            strPtr("co-control-plane"),
+			TailscaleHostname: strPtr("companion-control-plane"),
+		},
+		Agents: []config.RawAgent{{ID: strPtr("sample"), FlyApp: strPtr("co-sample"), TailscaleHostname: strPtr("sample")}},
 	})
 	if err != nil {
 		t.Fatalf("normalize config: %v", err)

--- a/internal/workspace/workspace.go
+++ b/internal/workspace/workspace.go
@@ -70,16 +70,18 @@ type rootFile struct {
 			State string `toml:"state"`
 		} `toml:"local"`
 	} `toml:"backend"`
-	Load loadConfig `toml:"load"`
+	Load         loadConfig             `toml:"load"`
+	ControlPlane config.RawControlPlane `toml:"control_plane"`
 }
 
 type loadConfig struct {
-	Providers string `toml:"providers"`
-	Defaults  string `toml:"defaults"`
-	WebUI     string `toml:"webui"`
-	Dashboard string `toml:"dashboard"`
-	Agents    string `toml:"agents"`
-	Vaults    string `toml:"vaults"`
+	Providers    string `toml:"providers"`
+	Defaults     string `toml:"defaults"`
+	WebUI        string `toml:"webui"`
+	Dashboard    string `toml:"dashboard"`
+	ControlPlane string `toml:"control_plane"`
+	Agents       string `toml:"agents"`
+	Vaults       string `toml:"vaults"`
 }
 
 type defaultsFile struct {
@@ -92,6 +94,10 @@ type webUIFile struct {
 
 type dashboardFile struct {
 	Dashboard config.RawDashboard `toml:"dashboard"`
+}
+
+type controlPlaneFile struct {
+	ControlPlane config.RawControlPlane `toml:"control_plane"`
 }
 
 type agentFile struct {
@@ -160,7 +166,7 @@ func Load(root string) (*Workspace, error) {
 	if err != nil {
 		return nil, err
 	}
-	raw := config.RawConfig{}
+	raw := config.RawConfig{ControlPlane: rootConfig.ControlPlane}
 	if err := loadDefaults(absRoot, rootConfig.Load.Defaults, &raw); err != nil {
 		return nil, err
 	}
@@ -168,6 +174,9 @@ func Load(root string) (*Workspace, error) {
 		return nil, err
 	}
 	if err := loadDashboard(absRoot, rootConfig.Load.Dashboard, &raw); err != nil {
+		return nil, err
+	}
+	if err := loadControlPlane(absRoot, rootConfig.Load.ControlPlane, &raw); err != nil {
 		return nil, err
 	}
 	agentFiles, err := loadAgents(absRoot, rootConfig.Load.Agents, &raw)
@@ -255,6 +264,9 @@ func (r *rootFile) defaults(workspaceName string) {
 	if r.Load.Dashboard == "" {
 		r.Load.Dashboard = "dashboard.toml"
 	}
+	if r.Load.ControlPlane == "" {
+		r.Load.ControlPlane = "control-plane.toml"
+	}
 	if r.Load.Agents == "" {
 		r.Load.Agents = "agents/*.toml"
 	}
@@ -316,6 +328,20 @@ func (w *Workspace) Validate() error {
 		}
 		if !w.Providers.Has(w.Config.Dashboard.Network) {
 			return fmt.Errorf("dashboard references unknown network provider %s", w.Config.Dashboard.Network)
+		}
+	}
+	if w.Config.ControlPlane.Enabled {
+		if !strings.HasPrefix(w.Config.ControlPlane.Runtime, "fly.") {
+			return fmt.Errorf("control_plane runtime must reference a fly provider")
+		}
+		if !w.Providers.Has(w.Config.ControlPlane.Runtime) {
+			return fmt.Errorf("control_plane references unknown runtime provider %s", w.Config.ControlPlane.Runtime)
+		}
+		if !strings.HasPrefix(w.Config.ControlPlane.Network, "tailscale.") {
+			return fmt.Errorf("control_plane network must reference a tailscale provider")
+		}
+		if !w.Providers.Has(w.Config.ControlPlane.Network) {
+			return fmt.Errorf("control_plane references unknown network provider %s", w.Config.ControlPlane.Network)
 		}
 	}
 	seenVaults := map[string]bool{}
@@ -460,6 +486,15 @@ func loadDashboard(root, pattern string, raw *config.RawConfig) error {
 		return err
 	}
 	raw.Dashboard = file.Dashboard
+	return nil
+}
+
+func loadControlPlane(root, pattern string, raw *config.RawConfig) error {
+	var file controlPlaneFile
+	if err := readOptionalTOML(filepath.Join(root, filepath.FromSlash(pattern)), &file); err != nil {
+		return err
+	}
+	raw.ControlPlane = file.ControlPlane
 	return nil
 }
 

--- a/internal/workspace/workspace_test.go
+++ b/internal/workspace/workspace_test.go
@@ -270,6 +270,32 @@ tailscale_hostname = "companion-dashboard"
 	}
 }
 
+func TestLoadControlPlaneFromFile(t *testing.T) {
+	root := t.TempDir()
+	writeMinimalWorkspace(t, root)
+	writeWorkspaceFile(t, root, "agents/sample.toml", `[agent]
+id = "sample"
+fly_app = "example-companion-sample"
+tailscale_hostname = "sample"
+`)
+	writeWorkspaceFile(t, root, "control-plane.toml", `[control_plane]
+enabled = true
+fly_app = "example-companion-control-plane"
+tailscale_hostname = "companion-control-plane"
+volume_name = "companion_workspace"
+`)
+	ws, err := Load(root)
+	if err != nil {
+		t.Fatalf("load: %v", err)
+	}
+	if !ws.Config.ControlPlane.Enabled {
+		t.Fatalf("expected control plane enabled from control-plane.toml")
+	}
+	if ws.Config.ControlPlane.FlyApp != "example-companion-control-plane" {
+		t.Fatalf("unexpected control plane fly_app: %s", ws.Config.ControlPlane.FlyApp)
+	}
+}
+
 func TestLoadFailsOnUnknownDashboardProvider(t *testing.T) {
 	root := t.TempDir()
 	writeMinimalWorkspace(t, root)


### PR DESCRIPTION
## Summary

- Add the Fly-hosted Companion control plane runtime, including `Dockerfile.control-plane`, volume-backed startup, Tailscale Serve support, and generated Fly config.
- Add `[control_plane]` workspace configuration, resource planning, render tests, and provider coverage for app, volume, secrets, rollout, status, export, and SSH flows.
- Add multi-workspace management under `~/.companion` plus `companion workspace ...` and `companion control-plane ...` commands.
- Route generated deploy artifacts through `COMPANION_DEPLOY_CONTEXT` so the remote console can operate from `/workspace` while building from the packaged source checkout.

## Why

Companion needs a durable, Tailscale-only control plane that can own the admin console and fleet status dashboard from a persistent Fly volume, while keeping the local CLI as the bootstrap and upgrade tool.

## Validation

- `go test ./...`
- `go test -race ./...`
- `npm --prefix web test -- --run`
- `sh -n install.sh && bash -n install.sh bin/start-on-fly bin/run-hermes-process bin/start-open-webui-on-fly bin/start-dashboard-on-fly bin/start-control-plane-on-fly bin/build-console-ui`
- `go run ./cmd/companion validate --workspace examples/minimal`
- `go run ./cmd/companion validate --workspace examples/webui`
- `go install ./cmd/companion && companion version`
- `git diff --check`

No screenshot included because this PR changes CLI/runtime/control-plane behavior and reuses the existing console UI surface.

Generated by AI agent: yes.
Human reviewed: no.