### PR TITLE
docs(repo): record companion cutover

### DIFF
--- a/docs/repository-cutover.md
+++ b/docs/repository-cutover.md
@@ -1,0 +1,10 @@
+# Repository cutover
+
+On 31 August 2026, `The-Vibe-Company/companion` adopted the code tree from
+`The-Vibe-Company/companion-v2` at commit
+`9f3b9c63ea4e405d65c9a128b4e04de8af802fe7`.
+
+The cutover commit is `587eedf7a7c766923c8a8e4f630a4a03c214097f`. It keeps the established
+`companion` repository identity, history, stars, forks, issues, and releases while making this
+repository the canonical source for the current product. The former `companion-v2` repository is
+retained as a source archive.


### PR DESCRIPTION
Records the one-time companion-v2 code cutover and establishes the new incremental CI baseline. No product code changes.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/The-Vibe-Company/companion/pull/677?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

