### PR TITLE
docs(ios): point to canonical repository

### DIFF
--- a/apps/ios/README.md
+++ b/apps/ios/README.md
@@ -3,6 +3,9 @@
 Companion is a native SwiftUI app for iOS 26 and later. It replaces the former Expo client and
 keeps the existing `dev.companion.mobile` App Store Connect identity.
 
+The canonical source repository for the native app is
+[`The-Vibe-Company/companion`](https://github.com/The-Vibe-Company/companion).
+
 The iOS app is another complete Companion client, not a reduced mobile product. It uses the same
 `/v1` API and is intended to reach feature parity with the current browser experience, including
 Skills, Plugins, MCP connections, files, routines, triggers, sharing, settings, and every Companion


### PR DESCRIPTION
Records the canonical post-cutover repository in the native iOS documentation. Merging this CI-approved iOS-path change intentionally exercises the full main CI and TestFlight release pipeline.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/The-Vibe-Company/companion/pull/687?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

