### PR TITLE
fix(runtime): reduce noisy Sentry runtime events

### DIFF
--- a/apps/runtime/src/sentry.test.ts
+++ b/apps/runtime/src/sentry.test.ts
@@ -1,6 +1,10 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { RuntimeLogRecord, RuntimeProcessLog } from "@companion/companion-runtime";
-import { captureRuntimeException, createSentryRuntimeProcessLog } from "./sentry";
+import {
+  captureRuntimeException,
+  createSentryRuntimeProcessLog,
+  SENTRY_RUNTIME_ERROR_COOLDOWN_MS,
+} from "./sentry";
 
 type RuntimeLogCapture = (
   level: "info" | "warn" | "error",
@@ -17,7 +21,7 @@ describe("runtime Sentry process log", () => {
     vi.clearAllMocks();
   });
 
-  it("keeps the JSON sink and mirrors warnings and errors", () => {
+  it("keeps every JSON record but mirrors only errors", () => {
     const base: RuntimeProcessLog = {
       error: vi.fn(),
       warn: vi.fn(),
@@ -33,12 +37,12 @@ describe("runtime Sentry process log", () => {
 
     expect(base.warn).toHaveBeenCalledWith(warning);
     expect(base.error).toHaveBeenCalledWith(failure);
-    expect(capture).toHaveBeenNthCalledWith(1, "warn", warning.event, JSON.stringify(warning));
-    expect(capture).toHaveBeenNthCalledWith(2, "error", failure.event, JSON.stringify(failure));
+    expect(capture).toHaveBeenCalledWith("error", failure.event, JSON.stringify(failure));
+    expect(capture).toHaveBeenCalledTimes(1);
   });
 
-  it("passes timing records to the Sentry capture boundary", () => {
-    const base: RuntimeProcessLog = { error() {}, warn() {}, info() {} };
+  it("keeps failed provider timings in JSON without creating Sentry issues", () => {
+    const base: RuntimeProcessLog = { error() {}, warn() {}, info: vi.fn() };
     const capture = vi.fn();
     const log = createSentryRuntimeProcessLog(base, capture);
     const timing = record("runtime.box.provider_call", { ok: false });
@@ -47,8 +51,31 @@ describe("runtime Sentry process log", () => {
     log.info(timing);
     log.info(success);
 
-    expect(capture).toHaveBeenCalledWith("info", timing.event, JSON.stringify(timing));
-    expect(capture).toHaveBeenCalledTimes(1);
+    expect(base.info).toHaveBeenNthCalledWith(1, timing);
+    expect(base.info).toHaveBeenNthCalledWith(2, success);
+    expect(capture).not.toHaveBeenCalled();
+  });
+
+  it("rate-limits repeated errors by runtime event while preserving distinct groups", () => {
+    const base: RuntimeProcessLog = { error: vi.fn(), warn() {}, info() {} };
+    const capture = vi.fn();
+    let current = 1_000;
+    const log = createSentryRuntimeProcessLog(base, capture, () => current);
+    const fenceLost = record("runtime.work.fence_lost");
+    const claimLoop = record("runtime.claim_loop.error");
+
+    log.error(fenceLost);
+    current += SENTRY_RUNTIME_ERROR_COOLDOWN_MS - 1;
+    log.error(fenceLost);
+    log.error(claimLoop);
+    current += 1;
+    log.error(fenceLost);
+
+    expect(base.error).toHaveBeenCalledTimes(4);
+    expect(capture).toHaveBeenCalledTimes(3);
+    expect(capture).toHaveBeenNthCalledWith(1, "error", fenceLost.event, JSON.stringify(fenceLost));
+    expect(capture).toHaveBeenNthCalledWith(2, "error", claimLoop.event, JSON.stringify(claimLoop));
+    expect(capture).toHaveBeenNthCalledWith(3, "error", fenceLost.event, JSON.stringify(fenceLost));
   });
 
   it("expurgates records before sending them to the telemetry capture boundary", () => {

--- a/apps/runtime/src/sentry.ts
+++ b/apps/runtime/src/sentry.ts
@@ -49,6 +49,14 @@ type RuntimeLogCapture = (
   expurgatedRecord: string,
 ) => void;
 
+/**
+ * Sentry is the alerting boundary; the JSON process log remains the complete diagnostic stream.
+ * Keep one repeated error group visible without turning a tight runtime retry/takeover loop into an
+ * event storm. This is deliberately process-local: replicas remain independent and a deploy may
+ * emit one fresh event per key.
+ */
+export const SENTRY_RUNTIME_ERROR_COOLDOWN_MS = 15 * 60_000;
+
 function captureRuntimeLog(
   level: "info" | "warn" | "error",
   event: string,
@@ -71,23 +79,27 @@ function captureRecord(capture: RuntimeLogCapture, level: "info" | "warn" | "err
   capture(level, event, expurgatedRecord);
 }
 
-/** Mirror every expurgated warning/error and failed timing record into Sentry. */
+/** Mirror expurgated errors into Sentry, at most once per runtime event key per cooldown. */
 export function createSentryRuntimeProcessLog(
   log: RuntimeProcessLog,
   capture: RuntimeLogCapture = captureRuntimeLog,
+  now: () => number = Date.now,
 ): RuntimeProcessLog {
+  const lastCapturedAt = new Map<string, number>();
   return {
     error(record) {
       log.error(record);
+      const previous = lastCapturedAt.get(record.event);
+      const current = now();
+      if (previous !== undefined && current - previous < SENTRY_RUNTIME_ERROR_COOLDOWN_MS) return;
+      lastCapturedAt.set(record.event, current);
       captureRecord(capture, "error", record);
     },
     warn(record) {
       log.warn(record);
-      captureRecord(capture, "warn", record);
     },
     info(record) {
       log.info(record);
-      if (record.ok === false) captureRecord(capture, "info", record);
     },
   };
 }

--- a/docs/companions-runtime.md
+++ b/docs/companions-runtime.md
@@ -1346,12 +1346,14 @@ fell back to exec;
 comparison. Neither may ever contain the hosted URL, the proxy token, the bearer, or any response
 payload.
 
-When `SENTRY_DSN` is configured, every expurgated runtime warning/error record and every structured
-timing record with `ok: false` is mirrored to Sentry with stable `runtime.event` and `operation`
-tags. API 5xx failures, worker supervisor/claim failures, web request failures, and process startup
-failures use the same operation-tagged grouping discipline. Before-send sanitizers remove request
-bodies, headers, cookies, and OAuth/query material; runtime records are expurgated before they are
-mirrored. Provider payloads and plaintext credentials never enter these capture paths.
+When `SENTRY_DSN` is configured, expurgated runtime error records are mirrored to Sentry with stable
+`runtime.event` and `operation` tags, at most once per event key every 15 minutes in each runtime
+process. Runtime warnings and structured timings—including failed provider-call timings—remain in
+the complete JSON process log without becoming individual Sentry events. API 5xx failures, worker
+supervisor/claim failures, web request failures, and process startup failures use the same
+operation-tagged grouping discipline. Before-send sanitizers remove request bodies, headers,
+cookies, and OAuth/query material; runtime records are expurgated before they are mirrored. Provider
+payloads and plaintext credentials never enter these capture paths.
 
 Acceptance bounds:
 

--- a/packages/companion-runtime/src/engine.test.ts
+++ b/packages/companion-runtime/src/engine.test.ts
@@ -2106,9 +2106,15 @@ describe("RuntimeEngine attempts", () => {
     const claim = attemptClaim();
     const store = new MemoryRuntimeStore({ authorization: attemptAuthorization(claim) });
     const ports = fakePorts(store);
+    const records: Record<string, unknown>[] = [];
     const engine = new RuntimeEngine(engineDependencies({
       store,
       ports,
+      log: {
+        error(record) { records.push({ level: "error", ...record }); },
+        warn(record) { records.push({ level: "warn", ...record }); },
+        info(record) { records.push({ level: "info", ...record }); },
+      },
       materialProvider: {
         getMaterial: async () => {
           store.renewReturnsNull = true;
@@ -2123,6 +2129,11 @@ describe("RuntimeEngine attempts", () => {
     // terminal the new holder cannot see, so abandoning is still the only safe move.
     expect(result.outcome).toBe("fence_lost");
     expect(store.settlements).toEqual([]);
+    expect(records).toEqual([expect.objectContaining({
+      level: "warn",
+      event: "runtime.work.fence_lost",
+      reason: "lease_fence_lost",
+    })]);
   });
 
   it("abandons when the harvest commit itself is indeterminate", async () => {
@@ -2758,6 +2769,34 @@ describe("RuntimeEngine process error logs", () => {
           message: "settings claim has an impossible nullable shape",
         })],
       }),
+    })]);
+  });
+
+  it("keeps a rejected successful settlement at error severity", async () => {
+    const claim = attemptClaim({
+      checkpoint: "agent_settled",
+      checkpointSequence: 8n,
+      attemptStatus: "running",
+      turnStatus: "running",
+      dispatchState: "accepted",
+      eventCursor: 4n,
+      inactivityDeadlineAt: new Date("2026-08-16T12:10:00.000Z"),
+    });
+    const store = new MemoryRuntimeStore({
+      authorization: attemptAuthorization(claim),
+      material: attemptMaterial({ hasVisibleOutput: true }),
+    });
+    store.settle = async () => false;
+    const captured = capturingLog();
+    const engine = new RuntimeEngine(engineDependencies({ store, log: captured.log }));
+
+    const result = await engine.execute(claim);
+
+    expect(result.outcome).toBe("fence_lost");
+    expect(captured.records).toEqual([expect.objectContaining({
+      level: "error",
+      event: "runtime.work.fence_lost",
+      reason: "settle_rejected",
     })]);
   });
 });

--- a/packages/companion-runtime/src/engine.ts
+++ b/packages/companion-runtime/src/engine.ts
@@ -151,6 +151,11 @@ export class RuntimeEngine {
           outcome: "fence_lost",
           reason: error instanceof LeaseRenewalError ? "lease_renewal_failed" : "lease_fence_lost",
           thrown: error,
+          // A rejected stale fence is the safety mechanism working: the replacement executor owns
+          // recovery and this holder must abandon without settlement. A renewal failure is still an
+          // error because it means the heartbeat exhausted its lease runway without an authoritative
+          // takeover result.
+          level: error instanceof LeaseFenceLostError ? "warn" : "error",
         });
         return this.#result(claim, "fence_lost");
       }


### PR DESCRIPTION
## Summary

- Keep the complete structured runtime stream in JSON logs, while forwarding only error-level records to Sentry.
- Rate-limit repeated Sentry errors once per `runtime.event` key every 15 minutes per process.
- Treat a confirmed stale lease fence as an expected warning, while preserving error severity for renewal-runway exhaustion and rejected settlements.

## Issue analysis

### COMPANION-RUNTIME-3 — `runtime.work.fence_lost`

**Root cause:** The production signature (`starting` unchanged, Box ready, Pi idle) matches the older material-lookup path treating a null result from cross-joined authorization definers as proof that the fence moved. That produced a release/reclaim loop on the 30-second lease TTL. Current main already revalidates the live fence before classifying a null material lookup, so the 30-second TTL and 10-second heartbeat are not the fault. A genuinely moved fence must still abandon without settling or replaying; the replacement executor owns recovery.

**Change:** Confirmed stale-fence abandonment is warning-level instead of error-level, with regression coverage. Renewal failure after heartbeat runway exhaustion stays error-level. Rejected settlements also stay error-level because the database can reject them for deadlines as well as a stale fence.

### COMPANION-RUNTIME-5 — `runtime.image_build_failed`

**Root cause:** Four attempts are the intentional durable retry budget (30/60/120/300-second backoff); `retryBackoffMs: null` means the fourth attempt was exhausted. The cancellation signature came from an older shared mutable staging signal allowing concurrent build/staging work to cancel another call. Current main already creates a call-local Box runtime adapter, which isolates cancellation. Outer worker shutdown cancellation remains non-failing, while per-attempt timeouts are classified separately.

**Change:** Image-build warnings remain in structured JSON diagnostics without generating one Sentry event per exhausted build. Existing adapter and worker tests validate isolated calls, retry exhaustion, timeout, and shutdown cancellation.

### COMPANION-RUNTIME-2 — `runtime.box.provider_call`

**Root cause:** The roughly 8.5-second failures align with the caller-driven broker/abort window, not the 30-second provider request timeout. Current main preserves caller abort reasons and classifies caller cancellation as non-retryable 499, request timeout as retryable 504, and network failure as retryable 503. Retries remain limited to idempotent lifecycle/observation calls; prompt and decision side effects are never replayed.

**Change:** Failed provider-call timing records stay available in JSON logs but no longer become Sentry exception events. Error records remain actionable and rate-limited.

## Verification

- `pnpm --filter @companion/runtime typecheck`
- `pnpm --filter @companion/companion-runtime typecheck`
- `pnpm --filter @companion/runtime build`
- `pnpm --filter @companion/runtime test` (213 tests)
- `pnpm --filter @companion/companion-runtime test` (286 tests)
- `pnpm typecheck`
- `pnpm lint`
- `pnpm test`
- `pnpm build`
- `pnpm lint:anti-slop -- --base origin/main`
- Disposable PostgreSQL 17: `pnpm test:integration`
- Disposable PostgreSQL 17: `bash scripts/ci-runtime-integration.sh` (runtime DB fencing/takeover, full-stack runtime, and Box simulator)
- Deep independent code review: no remaining findings after one P2 was fixed and re-reviewed

`pnpm verify:change` selected database, runtime, and container follow-up gates. The database and runtime gates passed locally. Docker is unavailable in the cloud workspace, so Railway Containers CI is the authoritative container gate.

Fixes COMPANION-RUNTIME-3, Fixes COMPANION-RUNTIME-5, Fixes COMPANION-RUNTIME-2

<!-- conductor-workspace-link -->

---

[Open workspace in Conductor](https://app.conductor.build/workspace/2888200c-7974-468e-88a4-9026d5de0869)


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/The-Vibe-Company/companion/pull/691?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

