### PR TITLE
fix(runtime): clarify database role startup refusal

### DIFF
--- a/apps/runtime/src/database.test.ts
+++ b/apps/runtime/src/database.test.ts
@@ -4,7 +4,6 @@ import { describe, expect, it, vi } from "vitest";
 import type { RuntimeServiceConfig } from "./config";
 import {
   RUNTIME_DB_STATEMENT_TIMEOUT_MS,
-  RuntimeDatabaseRoleError,
   runtimeDatabasePoolOptions,
   verifyRuntimeDatabaseRole,
 } from "./database";
@@ -77,33 +76,37 @@ describe("runtime database role verification", () => {
   });
 
   it.each([
-    ["a different login", { currentRole: "companion_api" }],
-    ["a superuser", { isSuperuser: true }],
-    ["a BYPASSRLS role", { bypassesRls: true }],
-    ["an inheriting role", { inheritsPrivileges: true }],
-    ["a role membership", { hasMemberships: true }],
-    ["database CREATE", { hasDatabaseCreatePrivilege: true }],
-    ["public schema CREATE", { hasPublicSchemaCreatePrivilege: true }],
-    ["database or schema ownership", { ownsDatabaseOrSchema: true }],
-    ["relation ownership", { ownsRelations: true }],
-    ["function or type ownership", { ownsFunctionsOrTypes: true }],
-    ["a partial protected schema", { protectedRelationCount: 9 }],
-    ["direct public relation access", { hasPublicRelationPrivileges: true }],
-    ["a missing required function grant", { requiredFunctionsReady: false }],
-    ["required function ownership", { ownsRequiredFunctions: true }],
-    ["an extra definer grant", { hasUnexpectedDefinerGrant: true }],
-  ])("rejects %s", async (_label, override) => {
+    ["a different login", { currentRole: "companion_api" }, "login_mismatch"],
+    ["a superuser", { isSuperuser: true }, "unsafe_role_attributes"],
+    ["a BYPASSRLS role", { bypassesRls: true }, "unsafe_role_attributes"],
+    ["an inheriting role", { inheritsPrivileges: true }, "unsafe_role_attributes"],
+    ["a role membership", { hasMemberships: true }, "role_membership"],
+    ["database CREATE", { hasDatabaseCreatePrivilege: true }, "create_privilege"],
+    ["public schema CREATE", { hasPublicSchemaCreatePrivilege: true }, "create_privilege"],
+    ["database or schema ownership", { ownsDatabaseOrSchema: true }, "object_ownership"],
+    ["relation ownership", { ownsRelations: true }, "object_ownership"],
+    ["function or type ownership", { ownsFunctionsOrTypes: true }, "object_ownership"],
+    ["a partial protected schema", { protectedRelationCount: 9 }, "release_schema_incomplete"],
+    ["a missing required function grant", { requiredFunctionsReady: false }, "release_schema_incomplete"],
+    ["direct public relation access", { hasPublicRelationPrivileges: true }, "relation_privilege"],
+    ["required function ownership", { ownsRequiredFunctions: true }, "required_function_ownership"],
+    ["an extra definer grant", { hasUnexpectedDefinerGrant: true }, "unexpected_function_grant"],
+  ])("rejects %s with a safe reason", async (_label, override, failure) => {
     // SAFETY: The test double implements the single `unsafe` method consumed by the verifier.
     await expect(verifyRuntimeDatabaseRole({
       unsafe: vi.fn(async () => [{ ...validProfile, ...override }]),
-    } as never, "companion_runtime_v2")).rejects.toBeInstanceOf(RuntimeDatabaseRoleError);
+    } as never, "companion_runtime_v2")).rejects.toMatchObject({
+      name: "RuntimeDatabaseRoleError",
+      failure,
+      stableCode: `runtime_database_role_${failure}`,
+    });
   });
 
   it("fails closed for a missing profile", async () => {
     // SAFETY: The test double implements the single `unsafe` method consumed by the verifier.
     await expect(verifyRuntimeDatabaseRole({
       unsafe: vi.fn(async () => []),
-    } as never, "companion_runtime_v2")).rejects.toBeInstanceOf(RuntimeDatabaseRoleError);
+    } as never, "companion_runtime_v2")).rejects.toMatchObject({ failure: "profile_unavailable" });
   });
 
   it("fails closed for a partial profile", async () => {
@@ -111,7 +114,9 @@ describe("runtime database role verification", () => {
     // SAFETY: The test double implements the single `unsafe` method consumed by the verifier.
     await expect(verifyRuntimeDatabaseRole({
       unsafe: vi.fn(async () => [partial]),
-    } as never, "companion_runtime_v2")).rejects.toBeInstanceOf(RuntimeDatabaseRoleError);
+    } as never, "companion_runtime_v2")).rejects.toMatchObject({
+      failure: "role_membership",
+    });
   });
 
   it("does not include connection or role values in a mismatch error", async () => {

--- a/apps/runtime/src/index.ts
+++ b/apps/runtime/src/index.ts
@@ -1,12 +1,19 @@
+/* oxlint-disable anti-slop/no-unknown-parameters -- This is the process-level rejected-promise boundary; startup reporting normalizes the value before any sink receives it. */
 import "./sentry";
 import { captureRuntimeException, Sentry } from "./sentry";
 import { runRuntimeUntilSignal } from "./process";
 import { buildProductionRuntimeService } from "./production";
-import { logRuntimeStartupFailure } from "./startupLog";
+import { handleRuntimeStartupFailure, logRuntimeStartupFailure } from "./startupLog";
 
-void runRuntimeUntilSignal({ build: buildProductionRuntimeService }).catch(async (error: unknown) => {
-  captureRuntimeException(error);
-  logRuntimeStartupFailure(error);
-  await Sentry.flush(2000);
-  process.exitCode = 1;
-});
+void runRuntimeUntilSignal({ build: buildProductionRuntimeService }).catch((error: unknown) =>
+  handleRuntimeStartupFailure(error, {
+    capture: captureRuntimeException,
+    flush: async () => {
+      await Sentry.flush(2000);
+    },
+    log: logRuntimeStartupFailure,
+    setExitCode: (code) => {
+      process.exitCode = code;
+    },
+  }),
+);

--- a/apps/runtime/src/production.test.ts
+++ b/apps/runtime/src/production.test.ts
@@ -12,6 +12,7 @@ import type {
 } from "@companion/companion-runtime";
 
 import type { RuntimeDatabase } from "./database";
+import { RuntimeDatabaseRoleError } from "./database";
 import {
   buildProductionRuntimeService,
   type RuntimeArchiveStorage,
@@ -51,6 +52,24 @@ function database(): RuntimeDatabase {
 }
 
 describe("production runtime composition", () => {
+  it("closes the pool and constructs no service when database role verification refuses startup", async () => {
+    const db = database();
+    const failure = new RuntimeDatabaseRoleError("login_mismatch");
+    vi.mocked(db.verifyRole).mockRejectedValue(failure);
+    const createStore = vi.fn(() => ({} as RuntimeStore));
+
+    await expect(buildProductionRuntimeService({
+      env: {
+        DATABASE_COMPANION_RUNTIME_URL: databaseUrl,
+        COMPANION_COMPANIONS_ENABLED: "false",
+      },
+      factories: { createDatabase: () => db, createStore },
+    })).rejects.toBe(failure);
+
+    expect(createStore).not.toHaveBeenCalled();
+    expect(db.close).toHaveBeenCalledOnce();
+  });
+
   it("verifies the runtime role but constructs no external client on the kill-switch path", async () => {
     const db = database();
     const store = {} as RuntimeStore;

--- a/apps/runtime/src/startupLog.test.ts
+++ b/apps/runtime/src/startupLog.test.ts
@@ -1,6 +1,12 @@
 import { describe, expect, it } from "vitest";
 
-import { logRuntimeStartupFailure } from "./startupLog";
+import { RuntimeDatabaseRoleError } from "./database";
+import {
+  handleRuntimeStartupFailure,
+  logRuntimeStartupFailure,
+  shouldCaptureRuntimeStartupFailure,
+  type RuntimeStartupFailureEffects,
+} from "./startupLog";
 
 describe("runtime startup failure logs", () => {
   it("prints the thrown cause instead of a generic startup line", () => {
@@ -10,6 +16,7 @@ describe("runtime startup failure logs", () => {
       (line) => lines.push(line),
     );
     expect(lines).toHaveLength(1);
+    // SAFETY: logRuntimeStartupFailure always serializes one JSON object through the process logger.
     const parsed = JSON.parse(lines[0] ?? "{}") as {
       event?: string;
       thrown?: { message?: string };
@@ -17,5 +24,57 @@ describe("runtime startup failure logs", () => {
     expect(parsed.event).toBe("runtime.startup.failed");
     expect(parsed.thrown?.message).toContain("COMPANION_BOX_API_KEY");
     expect(lines[0]).not.toBe("runtime failed to start");
+  });
+
+  it("keeps a role-readiness refusal in the fatal startup log instead of handled Sentry reporting", () => {
+    const lines: string[] = [];
+    const error = new RuntimeDatabaseRoleError("release_schema_incomplete");
+
+    logRuntimeStartupFailure(error, (line) => lines.push(line));
+
+    expect(shouldCaptureRuntimeStartupFailure(error)).toBe(false);
+    expect(shouldCaptureRuntimeStartupFailure(new Error("unexpected startup failure"))).toBe(true);
+    expect(lines).toHaveLength(1);
+    // SAFETY: logRuntimeStartupFailure always serializes one JSON object through the process logger.
+    const parsed = JSON.parse(lines[0] ?? "{}") as {
+      thrown?: { message?: string; stableCode?: string };
+    };
+    expect(parsed.thrown?.message).toContain("apply its migrations and runtime grants");
+    expect(parsed.thrown?.stableCode).toBe("runtime_database_role_release_schema_incomplete");
+  });
+
+  it.each([
+    {
+      name: "role-readiness refusal",
+      error: new RuntimeDatabaseRoleError("release_schema_incomplete"),
+      expectedEvents: ["log", "exit:1"],
+    },
+    {
+      name: "unexpected startup failure",
+      error: new Error("unexpected startup failure"),
+      expectedEvents: ["log", "exit:1", "capture", "flush"],
+    },
+  ])("applies the process-boundary reporting policy for a $name", async ({ error, expectedEvents }) => {
+    const events: string[] = [];
+    const effects: RuntimeStartupFailureEffects = {
+      capture: (captured) => {
+        expect(captured).toBe(error);
+        events.push("capture");
+      },
+      flush: async () => {
+        events.push("flush");
+      },
+      log: (logged) => {
+        expect(logged).toBe(error);
+        events.push("log");
+      },
+      setExitCode: (code) => {
+        events.push(`exit:${code}`);
+      },
+    };
+
+    await handleRuntimeStartupFailure(error, effects);
+
+    expect(events).toEqual(expectedEvents);
   });
 });

--- a/apps/runtime/src/startupLog.ts
+++ b/apps/runtime/src/startupLog.ts
@@ -1,4 +1,12 @@
+/* oxlint-disable anti-slop/no-unknown-parameters -- This is the process-level rejected-promise boundary; describeThrownError performs the repository's bounded normalization before logging. */
 import { createJsonRuntimeProcessLog, describeThrownError } from "@companion/companion-runtime";
+
+import { RuntimeDatabaseRoleError } from "./database";
+
+/** A role refusal is already an intentional fatal readiness signal in the platform logs. */
+export function shouldCaptureRuntimeStartupFailure(error: unknown): boolean {
+  return !(error instanceof RuntimeDatabaseRoleError);
+}
 
 /** Startup failures used to print only "runtime failed to start" and drop the cause. */
 export function logRuntimeStartupFailure(
@@ -12,4 +20,24 @@ export function logRuntimeStartupFailure(
     event: "runtime.startup.failed",
     thrown: describeThrownError(error),
   });
+}
+
+export interface RuntimeStartupFailureEffects {
+  capture(error: unknown): void;
+  flush(): Promise<void>;
+  log(error: unknown): void;
+  setExitCode(code: number): void;
+}
+
+/** Apply the complete process-boundary policy for a rejected runtime startup. */
+export async function handleRuntimeStartupFailure(
+  error: unknown,
+  effects: RuntimeStartupFailureEffects,
+): Promise<void> {
+  effects.log(error);
+  effects.setExitCode(1);
+  if (!shouldCaptureRuntimeStartupFailure(error)) return;
+
+  effects.capture(error);
+  await effects.flush();
 }

--- a/packages/db/src/runtimeRole.ts
+++ b/packages/db/src/runtimeRole.ts
@@ -1,9 +1,43 @@
 import type { Sql } from "postgres";
 
+export type RuntimeDatabaseRoleFailure =
+  | "profile_unavailable"
+  | "login_mismatch"
+  | "unsafe_role_attributes"
+  | "role_membership"
+  | "create_privilege"
+  | "object_ownership"
+  | "release_schema_incomplete"
+  | "relation_privilege"
+  | "required_function_ownership"
+  | "unexpected_function_grant";
+
+const RUNTIME_DATABASE_ROLE_MESSAGES = {
+  profile_unavailable: "Runtime database role verification returned no complete profile",
+  login_mismatch:
+    "Runtime database connection authenticated as a different role than DATABASE_COMPANION_RUNTIME_URL",
+  unsafe_role_attributes:
+    "Runtime database role must be LOGIN NOSUPERUSER NOBYPASSRLS NOINHERIT",
+  role_membership: "Runtime database role must not have any role memberships",
+  create_privilege: "Runtime database role must not have database or public schema CREATE",
+  object_ownership: "Runtime database role must not own database objects",
+  release_schema_incomplete:
+    "Runtime database is not ready for this release; apply its migrations and runtime grants before starting apps/runtime",
+  relation_privilege: "Runtime database role must not have direct public relation privileges",
+  required_function_ownership: "Runtime database role must not own runtime functions",
+  unexpected_function_grant:
+    "Runtime database role has an unexpected SECURITY DEFINER grant; reapply the runtime grants",
+} satisfies Record<RuntimeDatabaseRoleFailure, string>;
+
 export class RuntimeDatabaseRoleError extends Error {
-  constructor() {
-    super("Runtime database connection does not use the configured dedicated role");
+  readonly failure: RuntimeDatabaseRoleFailure;
+  readonly stableCode: string;
+
+  constructor(failure: RuntimeDatabaseRoleFailure) {
+    super(RUNTIME_DATABASE_ROLE_MESSAGES[failure]);
     this.name = "RuntimeDatabaseRoleError";
+    this.failure = failure;
+    this.stableCode = `runtime_database_role_${failure}`;
   }
 }
 
@@ -182,25 +216,40 @@ export async function verifyRuntimeDatabaseRole(
 ): Promise<void> {
   const rows = await sql.unsafe<RuntimeRoleProfile[]>(RUNTIME_ROLE_PROFILE_SQL);
   const profile = rows[0];
+  if (rows.length !== 1 || !profile) {
+    throw new RuntimeDatabaseRoleError("profile_unavailable");
+  }
+  if (profile.currentRole !== expectedRole) {
+    throw new RuntimeDatabaseRoleError("login_mismatch");
+  }
   if (
-    rows.length !== 1
-    || profile?.currentRole !== expectedRole
-    || profile.canLogin !== true
+    profile.canLogin !== true
     || profile.isSuperuser !== false
     || profile.bypassesRls !== false
     || profile.inheritsPrivileges !== false
-    || profile.hasMemberships !== false
-    || profile.hasDatabaseCreatePrivilege !== false
+  ) throw new RuntimeDatabaseRoleError("unsafe_role_attributes");
+  if (profile.hasMemberships !== false) {
+    throw new RuntimeDatabaseRoleError("role_membership");
+  }
+  if (
+    profile.hasDatabaseCreatePrivilege !== false
     || profile.hasPublicSchemaCreatePrivilege !== false
-    || profile.ownsDatabaseOrSchema !== false
+  ) throw new RuntimeDatabaseRoleError("create_privilege");
+  if (
+    profile.ownsDatabaseOrSchema !== false
     || profile.ownsRelations !== false
     || profile.ownsFunctionsOrTypes !== false
-    || profile.protectedRelationCount !== 14
-    || profile.hasPublicRelationPrivileges !== false
-    || profile.requiredFunctionsReady !== true
-    || profile.ownsRequiredFunctions !== false
-    || profile.hasUnexpectedDefinerGrant !== false
-  ) {
-    throw new RuntimeDatabaseRoleError();
+  ) throw new RuntimeDatabaseRoleError("object_ownership");
+  if (profile.protectedRelationCount !== 14 || profile.requiredFunctionsReady !== true) {
+    throw new RuntimeDatabaseRoleError("release_schema_incomplete");
+  }
+  if (profile.hasPublicRelationPrivileges !== false) {
+    throw new RuntimeDatabaseRoleError("relation_privilege");
+  }
+  if (profile.ownsRequiredFunctions !== false) {
+    throw new RuntimeDatabaseRoleError("required_function_ownership");
+  }
+  if (profile.hasUnexpectedDefinerGrant !== false) {
+    throw new RuntimeDatabaseRoleError("unexpected_function_grant");
   }
 }


### PR DESCRIPTION
## Summary
- Replace the runtime database-role verifier's catch-all error with safe, stable failure categories so boot logs identify whether authentication, privileges, grants, or release schema readiness failed.
- Keep runtime startup fail-closed before service construction, but treat an expected `RuntimeDatabaseRoleError` as a fatal readiness refusal in process logs instead of manually reporting it as a handled Sentry exception.
- Cover database-role classification, database teardown, production composition short-circuiting, and both branches of the process-level Sentry policy.

## Root cause
`apps/runtime` already created one postgres.js pool exclusively from `DATABASE_COMPANION_RUNTIME_URL` and verified that pool before constructing the runtime service; no migration, health-check, fallback, or admin pool bypass exists in the startup path. The generic verifier error collapsed every login/privilege/schema mismatch into the same message, and the top-level rejection handler then manually captured that intentional fatal startup refusal in Sentry. This produced COMPANION-RUNTIME-9 as a handled `runtime.process` event even though startup was refusing to continue.

## Verification
- [x] `pnpm --filter @companion/runtime test` - 21 files, 216 tests passed
- [x] `pnpm --filter @companion/runtime typecheck` - passed
- [x] `pnpm --filter @companion/runtime build` - passed
- [x] `bash scripts/ci-runtime-integration.sh` with disposable PostgreSQL 17 - API runtime suites, runtime purge/full-stack integration, and Box simulator passed
- [x] `pnpm test:integration` with CI-equivalent split-role environment - 33 main files/256 tests, Skill Database 20 tests, RLS/Skill Database 25 tests passed
- [x] `pnpm typecheck && pnpm lint && pnpm test && pnpm build && git diff --check` - passed before the bounded review fix; affected runtime test/typecheck/build/lint were rerun afterward
- [x] `pnpm lint:anti-slop -- --base origin/main` - passed
- [ ] `APP_URL=http://127.0.0.1:3000 pnpm browser:smoke` - fixture upload blocked because this cloud workspace intentionally has no MinIO; no frontend files changed
- [ ] container smoke - local Docker daemon unavailable; covered by PR CI

## CI
- Latest commit: `893a90ffaf6e1e394468b9544ce80d667bcf915f`
- Status: all visible non-skipped checks green
- Checks: Scope, Hygiene, Quality Node 22, Application Build, Database Integration, Railway Containers, Browser Critical Flows, CI Gate, Vercel, and Vercel Preview Comments passed; cubic completed neutral and Apple Quality was skipped by scope

## Review Gate
- `review-code-dev`: passed after fixing one P2 boundary-test gap; no P0-P3 findings remain
- Required lenses: database privilege boundary, startup lifecycle, Sentry reporting, adversarial bypass check

## Risk
- No database schema or grant changes; the existing fail-closed verifier remains in place.
- Operational behavior changes only for dedicated-role readiness failures: they remain fatal and actionable in runtime logs, but are no longer manually captured as handled Sentry exceptions.

## Human Review Notes
- Historical Sentry data did not include the specific failed verifier predicate. The new stable code makes any future refusal distinguish authentication, unsafe role attributes, missing release schema/grants, or excess privileges without logging credentials.
