### PR TITLE
chore(repo): declare canonical repository

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,6 +4,10 @@
   "private": true,
   "type": "module",
   "description": "Companion \u2014 self-hostable Skills Hub for organizations and coding agents.",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/The-Vibe-Company/companion.git"
+  },
   "license": "MIT",
   "packageManager": "pnpm@9.12.0",
   "engines": {


### PR DESCRIPTION
Adds the canonical repository metadata after the companion-v2 cutover. This watched root change also verifies that all repaired Railway Git triggers receive the next main push automatically.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/The-Vibe-Company/companion/pull/694?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

