### PR TITLE
fix(runtime): preserve main turn start budget

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -450,11 +450,12 @@ approval. A newer member message ends the wait sooner so Pi can finish safely be
 queued turn runs. Outside `needs_input`, ten minutes without correlated activity always becomes a
 visible terminal outcome; the two-hour absolute ceiling remains authoritative everywhere.
 
-An `interrupted` card explains that delivery became ambiguous, previous external effects may have
-succeeded, the occurrence will not be replayed, and later work continues automatically. It is
-passive for Owner, Editor, and Viewer: no Retry or Cancel action is shown. Stable, expurgated errors
-outside terminal interruptions may offer only their allowed action, such as Restart Pi or Switch
-model. Full Box never appears as an automatic repair in the thread.
+An unresolved legacy `interrupted` card explains that delivery became ambiguous, previous external
+effects may have succeeded, and the occurrence will not be replayed. Protocol-6 interruptions are
+settled `auto_abandoned` immediately and remain durable history without occupying the conversation
+tail; later work continues automatically. Neither state exposes Retry or Cancel. Stable,
+expurgated errors outside terminal interruptions may offer only their allowed action, such as
+Restart Pi or Switch model. Full Box never appears as an automatic repair in the thread.
 
 The transcript keeps day boundaries and one member-private `New` divider, neither inside a turn.
 Loading uses static skeleton lines. A reply keeps Copy as its one ordinary action, always reachable

--- a/apps/api/test/integration/companionRuntimeExecutor.integration.test.ts
+++ b/apps/api/test/integration/companionRuntimeExecutor.integration.test.ts
@@ -3219,6 +3219,7 @@ describe("Companion runtime executor PostgreSQL surface", () => {
         { name: "missing", boxId: "bx_2345678a", surface: "web", materialSurface: null, expires: null },
         { name: "near-expiry", boxId: "bx_2345678b", surface: "web", materialSurface: "web", expires: "2 hours 4 minutes" },
         { name: "native-boundary", boxId: "bx_2345678c", surface: "native_mobile", materialSurface: "web", expires: "6 hours" },
+        { name: "native-near-expiry", boxId: "bx_2345678e", surface: "native_mobile", materialSurface: "native_mobile", expires: "2 hours 4 minutes" },
       ] as const) {
         const [created] = await asApi({
           orgId: ids.orgA,
@@ -3238,7 +3239,8 @@ describe("Companion runtime executor PostgreSQL surface", () => {
           set box_id = ${variant.boxId},
               box_state = 'ready', pi_state = 'idle', pi_invocation_id = 'pi-warm-material',
               disk_layout_version = 14, applied_settings_revision = desired_settings_revision,
-              applied_skills_revision = 1, applied_client_surface = 'web',
+              applied_skills_revision = 1,
+              applied_client_surface = ${variant.surface}::public.companion_client_surface,
               last_observed_at = now()
           where companion_id = ${companionId}::uuid
         `;
@@ -3344,6 +3346,82 @@ describe("Companion runtime executor PostgreSQL surface", () => {
         from companion_operations where id = ${claim.workId}::uuid
       `;
       expect(operation).toMatchObject({ kind: "start", sourceTurnId: expect.any(String) });
+      await release(claim);
+    } finally {
+      if (companionId) await removeCompanion(companionId);
+    }
+  });
+
+  it("claims a warm main turn when installed Skills are ahead of its required revision", async () => {
+    if (!sql) throw new Error("runtime executor database is not initialized");
+    let companionId = "";
+    try {
+      const [created] = await asApi({
+        orgId: ids.orgA,
+        actorId: ids.ownerA,
+        action: (tx) => tx<Array<{ companionId: string }>>`
+          select companion_id::text as "companionId"
+          from public.companion_api_create_companion(
+            ${ids.orgA}::uuid, 'Ahead Skills material', null, null, null,
+            '[]'::jsonb, false, '[]'::jsonb
+          )
+        `,
+      });
+      companionId = created?.companionId ?? "";
+      await sql`
+        update companion_runtime_instances instance
+        set box_id = 'bx_2345678f', box_state = 'ready', pi_state = 'idle',
+            pi_invocation_id = 'pi-ahead-skills', disk_layout_version = 14,
+            applied_settings_revision = desired_settings_revision,
+            applied_skills_revision = companion.skills_revision,
+            applied_client_surface = 'web', last_observed_at = now()
+        from companions companion
+        where instance.companion_id = ${companionId}::uuid
+          and companion.org_id = instance.org_id
+          and companion.id = instance.companion_id
+      `;
+      await sql`
+        update companion_runtime_instances
+        set material_client_surface = 'web', material_pi_invocation_id = 'pi-ahead-skills',
+            material_expires_at = now() + interval '6 hours'
+        where companion_id = ${companionId}::uuid
+      `;
+
+      const [enqueued] = await asApi({
+        orgId: ids.orgA,
+        actorId: ids.ownerA,
+        action: (tx: Tx) => tx<Array<{
+          operation: IntegrationJsonObject | null;
+          turn: { id: string };
+        }>>`
+          select operation, turn from public.companion_api_enqueue_turn(
+            ${ids.orgA}::uuid, ${companionId}::uuid, ${randomUUID()}::uuid,
+            'Use the already-installed Skills revision.', 'web', '[]'::jsonb
+          )
+        `,
+      });
+      expect(enqueued?.operation).toBeNull();
+
+      // A deferred Skill publication may advance the installed snapshot while this warm turn is
+      // queued. Refresh the material proof after that activation: ahead-of-required is still warm.
+      await sql`
+        update companion_runtime_instances
+        set applied_skills_revision = applied_skills_revision + 1
+        where companion_id = ${companionId}::uuid
+      `;
+      await sql`
+        update companion_runtime_instances
+        set material_client_surface = 'web', material_pi_invocation_id = pi_invocation_id,
+            material_expires_at = now() + interval '6 hours', last_observed_at = now()
+        where companion_id = ${companionId}::uuid
+      `;
+
+      const claim = await claimWork();
+      expect(claim).toMatchObject({
+        companionId,
+        workKind: "attempt",
+        workId: expect.any(String),
+      });
       await release(claim);
     } finally {
       if (companionId) await removeCompanion(companionId);
@@ -5901,6 +5979,174 @@ describe("Companion runtime executor PostgreSQL surface", () => {
       expect(resumedClaim).toMatchObject({ workKind: "attempt", workId: fixture.attemptId });
       await release(resumedClaim);
     } finally {
+      await removeCompanion(fixture.companionId);
+    }
+  });
+
+  it("preserves the main cold-start budget while an isolated routine owns shared staging", async () => {
+    if (!sql) throw new Error("runtime executor database is not initialized");
+    const fixture = await createCompanion({
+      boxReady: true,
+      selectedSkillIds: [],
+      selectedMcpAccountIds: [],
+    });
+    const routineId = randomUUID();
+    const routineExecutor = `${executorId}-routine-budget`;
+    const mainExecutor = `${executorId}-main-budget`;
+    let routineClaim: Claim | undefined;
+    let mainClaim: Claim | undefined;
+    try {
+      await sql`
+        update companion_runtime_instances
+        set material_pi_invocation_id = pi_invocation_id, material_client_surface = 'web',
+          material_expires_at = now() + interval '6 hours', last_observed_at = now()
+        where companion_id = ${fixture.companionId}::uuid
+      `;
+      const initialMain = await claimWork();
+      await sql`
+        update companion_turn_attempts set status = 'cancelled', settled_at = now()
+        where id = ${fixture.attemptId}::uuid
+      `;
+      await sql`
+        update companion_turns set status = 'cancelled', settled_at = now()
+        where id = ${fixture.turnId}::uuid
+      `;
+      await release(initialMain);
+
+      await asApi({
+        orgId: ids.orgA,
+        actorId: ids.ownerA,
+        action: (tx) => tx`
+          select public.companion_api_create_routine(
+            ${ids.orgA}::uuid, ${fixture.companionId}::uuid, ${routineId}::uuid,
+            'Cold-start budget routine', 'Prepare an isolated report.', '0 9 * * *', 'UTC', true,
+            now() + interval '1 hour'
+          )
+        `,
+      });
+      await sql`
+        update companion_routines set next_fire_at = now() - interval '1 second'
+        where id = ${routineId}::uuid
+      `;
+      const [due] = await asWorker((tx) => tx<Array<{ scheduledFor: Date }>>`
+        select scheduled_for as "scheduledFor"
+        from public.companion_claim_due_routines('budget-worker', 1, 60)
+        where routine_id = ${routineId}::uuid
+      `);
+      if (!due) throw new Error("expected the budget routine to become due");
+      const fired = await asWorker((tx) => tx<Array<{ outcome: string }>>`
+        select outcome from public.companion_fire_routine(
+          'budget-worker', ${ids.orgA}::uuid, ${routineId}::uuid, ${randomUUID()}::uuid,
+          ${due.scheduledFor.toISOString()}::timestamptz, now() + interval '1 hour'
+        )
+      `);
+      expect(fired).toEqual([{ outcome: "fired" }]);
+
+      [routineClaim] = await claimWorkRows(1, routineExecutor);
+      expect(routineClaim).toMatchObject({
+        workKind: "attempt",
+        companionId: fixture.companionId,
+      });
+      if (!routineClaim) throw new Error("expected the isolated routine claim");
+
+      const [routineTurn] = await sql<Array<{ turnId: string }>>`
+        select turn_id::text as "turnId"
+        from companion_turn_attempts where id = ${routineClaim.workId}::uuid
+      `;
+      if (!routineTurn) throw new Error("expected the isolated routine turn");
+      await sql`
+        update companion_turns set status = 'running'
+        where id = ${routineTurn.turnId}::uuid
+      `;
+      await sql`
+        update companion_turn_attempts
+        set status = 'running', checkpoint = 'running', dispatch_state = 'accepted',
+          provider_credential_refs = '[]'::jsonb, mcp_credential_refs = '[]'::jsonb,
+          command_id = ${randomUUID()}::uuid,
+          pi_invocation_id = ${`routine:${routineTurn.turnId}:dispatch-v2:budget`},
+          dispatch_accepted_at = now(), last_activity_at = now()
+        where id = ${routineClaim.workId}::uuid
+      `;
+      await sql`
+        update companion_runtime_instances
+        set material_expires_at = null, material_pi_invocation_id = null,
+          material_client_surface = null, pi_state = 'unknown'
+        where companion_id = ${fixture.companionId}::uuid
+      `;
+
+      const [enqueued] = await asApi({
+        orgId: ids.orgA,
+        actorId: ids.ownerA,
+        action: (tx) => tx<Array<{ turn: { id: string } }>>`
+          select turn from public.companion_api_enqueue_turn(
+            ${ids.orgA}::uuid, ${fixture.companionId}::uuid, ${randomUUID()}::uuid,
+            'Start after the isolated routine finishes preparing.', 'web', '[]'::jsonb
+          )
+        `,
+      });
+      const mainTurnId = stringValue(enqueued?.turn.id);
+      if (mainTurnId === null) throw new Error("expected the queued main turn");
+
+      // Repeated scheduler passes model high-frequency routine preparation. None may consume the
+      // main turn's three-minute budget before shared Start can be claimed.
+      for (let pass = 0; pass < 4; pass += 1) {
+        expect(await claimWorkRows(1, mainExecutor)).toEqual([]);
+      }
+      const [waiting] = await sql<Array<{
+        coldStartDeadlineAt: Date | null;
+        startCount: number;
+        status: string;
+      }>>`
+        select turn_row.cold_start_deadline_at as "coldStartDeadlineAt",
+          turn_row.status::text as status,
+          count(start_operation.id)::integer as "startCount"
+        from companion_turns turn_row
+        left join companion_operations start_operation
+          on start_operation.source_turn_id = turn_row.id
+          and start_operation.kind = 'start'
+          and start_operation.status in ('pending', 'running')
+        where turn_row.id = ${mainTurnId}::uuid
+        group by turn_row.id
+      `;
+      expect(waiting).toEqual({ coldStartDeadlineAt: null, startCount: 0, status: "queued" });
+
+      await sql`
+        update companion_turn_attempts set status = 'cancelled', settled_at = now()
+        where id = ${routineClaim.workId}::uuid
+      `;
+      await sql`
+        update companion_turns set status = 'cancelled', settled_at = now()
+        where id = ${routineTurn.turnId}::uuid
+      `;
+      await release(routineClaim, routineExecutor);
+      routineClaim = undefined;
+
+      [mainClaim] = await claimWorkRows(1, mainExecutor);
+      expect(mainClaim).toMatchObject({ workKind: "operation", companionId: fixture.companionId });
+      const [started] = await sql<Array<{
+        coldStartDeadlineAt: Date | null;
+        remainingSeconds: number;
+        status: string;
+      }>>`
+        select source_turn.cold_start_deadline_at as "coldStartDeadlineAt",
+          extract(epoch from source_turn.cold_start_deadline_at - now())::integer
+            as "remainingSeconds",
+          source_turn.status::text as status
+        from companion_operations operation
+        join companion_turns source_turn on source_turn.id = operation.source_turn_id
+        where operation.id = ${mainClaim!.workId}::uuid
+      `;
+      expect(started?.coldStartDeadlineAt).not.toBeNull();
+      expect(started?.remainingSeconds).toBeGreaterThanOrEqual(175);
+      expect(started?.status).toBe("queued");
+      expect(await authorizeClaim(mainClaim!, mainExecutor)).toEqual({
+        authorized: true,
+        denialCode: null,
+      });
+    } finally {
+      if (mainClaim) await release(mainClaim, mainExecutor);
+      if (routineClaim) await release(routineClaim, routineExecutor);
+      await sql`delete from companion_routines where companion_id = ${fixture.companionId}::uuid`;
       await removeCompanion(fixture.companionId);
     }
   });

--- a/apps/api/test/integration/companionSelfHealMigration.integration.test.ts
+++ b/apps/api/test/integration/companionSelfHealMigration.integration.test.ts
@@ -1,8 +1,7 @@
 /**
  * Product promise:
- * Protocol 6 makes every interrupted occurrence terminal history. The migration releases old
- * queue locks, retires durable recovery operations, and prevents protocol-5 executors from
- * claiming work under the new rules.
+ * Protocol 6 makes every interrupted occurrence terminal history. The follow-up projection fix
+ * keeps that evidence durable without presenting it as an actionable thread-tail state.
  *
  * Why integrated:
  * This is a deployment-time backfill across transition triggers, partial indexes, lane claims,
@@ -83,7 +82,7 @@ async function asRole<T>(
   return result.value;
 }
 
-describe("0155 terminal interruption protocol-6 upgrade", () => {
+describe("0155 terminal interruption protocol-6 upgrade with 0156 projection repair", () => {
   beforeAll(async () => {
     await adminSql.unsafe(`
       create role ${apiRole} login nosuperuser nobypassrls noinherit;
@@ -187,6 +186,7 @@ describe("0155 terminal interruption protocol-6 upgrade", () => {
     if (!queuedChatTurnId || !queuedRoutineTurnId) throw new Error("queued turn fixture failed");
 
     await applyMigrationFile("0155_companion_interruption_terminal_protocol_6.sql");
+    await applyMigrationFile("0156_companion_main_start_budget_and_interruption_projection.sql");
     await applySplitGrants();
     await upgradeSql`
       select * from public.companion_runtime_enable(
@@ -248,7 +248,7 @@ describe("0155 terminal interruption protocol-6 upgrade", () => {
     });
   });
 
-  it("keeps terminal interruption history in thread window and delta projections", async () => {
+  it("keeps terminal interruption evidence out of actionable thread projections", async () => {
     const [window] = await asRole(apiRole, (tx) => tx<Array<{
       interruptedTurn: { id: string; status: string; resolution: string } | null;
     }>>`
@@ -266,16 +266,8 @@ describe("0155 terminal interruption protocol-6 upgrade", () => {
       )
     `);
 
-    expect(window?.interruptedTurn).toMatchObject({
-      id: interruptedTurnId,
-      status: "interrupted",
-      resolution: "auto_abandoned",
-    });
-    expect(delta?.interruptedTurn).toMatchObject({
-      id: interruptedTurnId,
-      status: "interrupted",
-      resolution: "auto_abandoned",
-    });
+    expect(window?.interruptedTurn).toBeNull();
+    expect(delta?.interruptedTurn).toBeNull();
   });
 
   it("refuses protocol 5 and lets protocol 6 claim the next FIFO turn", async () => {

--- a/apps/ios/Companion/Screens/ChatView.swift
+++ b/apps/ios/Companion/Screens/ChatView.swift
@@ -372,7 +372,7 @@ struct ChatView: View {
                                         }
                                     }
 
-                                    if let interruptedTurn = thread?.interruptedTurn {
+                                    if let interruptedTurn = thread?.visibleInterruptedTurn {
                                         CompanionInterruptedTurnNotice(
                                             turn: interruptedTurn,
                                             queuedCount: thread?.queuedCount ?? 0
@@ -1670,7 +1670,7 @@ struct ChatView: View {
         if let pending = pendingMessages.last {
             return "pending-\(pending.id)"
         }
-        if let interruptedTurn = thread?.interruptedTurn {
+        if let interruptedTurn = thread?.visibleInterruptedTurn {
             return "interrupted-\(interruptedTurn.id)"
         }
         return entries.last?.id ?? "bottom"

--- a/apps/ios/Companion/Screens/CompanionInterruptedTurnDemoView.swift
+++ b/apps/ios/Companion/Screens/CompanionInterruptedTurnDemoView.swift
@@ -27,9 +27,10 @@ private enum CompanionInterruptedTurnDemoFixtures {
       "companion_id":"5b7d655e-36bb-4fbe-9acd-e56103759911",
       "client_message_id":"bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb",
       "status":"interrupted","queue_sequence":20,"latest_attempt":null,"replying":false,
-      "error":{"code":"cold_start_deadline_exceeded","message":"The Companion did not start before its deadline.","action":"retry"},
+      "error":{"code":"cold_start_deadline_exceeded","message":"The Companion did not start before its deadline.","action":"none"},
       "state_changed_at":"2026-08-26T05:59:33.505Z","settled_at":"2026-08-26T05:59:33.505Z",
-      "created_at":"2026-08-26T05:55:12.466Z","updated_at":"2026-08-26T05:59:33.505Z"
+      "created_at":"2026-08-26T05:55:12.466Z","updated_at":"2026-08-26T05:59:33.505Z",
+      "resolution":"auto_abandoned"
     }
     """#)
 

--- a/apps/ios/CompanionKit/Sources/CompanionKit/CompanionThreadCoordination.swift
+++ b/apps/ios/CompanionKit/Sources/CompanionKit/CompanionThreadCoordination.swift
@@ -178,7 +178,7 @@ public struct CompanionScrollTailSnapshot: Equatable, Sendable {
                 $0.ordinal == $1.ordinal ? $0.eventID < $1.eventID : $0.ordinal < $1.ordinal
             }
             .last
-        self.init(lastEntry: lastEntry, interruptedTurn: thread.interruptedTurn)
+        self.init(lastEntry: lastEntry, interruptedTurn: thread.visibleInterruptedTurn)
     }
 }
 

--- a/apps/ios/CompanionKit/Sources/CompanionKit/Models.swift
+++ b/apps/ios/CompanionKit/Sources/CompanionKit/Models.swift
@@ -2734,6 +2734,15 @@ public struct CompanionThread: Codable, Equatable, Sendable {
     public let queuedCount: Int
     public let interruptedTurn: CompanionTurn?
 
+    /// Only unresolved legacy interruptions can still represent an actionable tail state.
+    /// Protocol-6 interruptions are auto-abandoned and remain durable server history without
+    /// occupying the conversation tail, including when an older cached projection contains one.
+    public var visibleInterruptedTurn: CompanionTurn? {
+        guard interruptedTurn?.status == .interrupted,
+              interruptedTurn?.resolution == nil else { return nil }
+        return interruptedTurn
+    }
+
     enum CodingKeys: String, CodingKey {
         case companionID = "companion_id"
         case viewerID = "viewer_id"

--- a/apps/ios/CompanionKit/Tests/CompanionKitTests/CompanionKitTests.swift
+++ b/apps/ios/CompanionKit/Tests/CompanionKitTests/CompanionKitTests.swift
@@ -1818,7 +1818,7 @@ func submitsEveryCompanionDecisionActionThroughTheSharedRoute() async throws {
 }
 
 @Test
-func decodesInterruptedTurnAndItsSafeRecoveryAction() throws {
+func decodesOnlyUnresolvedLegacyInterruptionAsVisible() throws {
     let data = Data(#"""
     {
       "companion_id":"5b7d655e-36bb-4fbe-9acd-e56103759911",
@@ -1849,6 +1849,41 @@ func decodesInterruptedTurnAndItsSafeRecoveryAction() throws {
     #expect(thread.interruptedTurn?.status == .interrupted)
     #expect(thread.interruptedTurn?.error?.action == "retry")
     #expect(thread.interruptedTurn?.latestAttempt == nil)
+    #expect(thread.visibleInterruptedTurn?.id == thread.interruptedTurn?.id)
+}
+
+@Test
+func hidesAutoAbandonedInterruptionFromConversationTail() throws {
+    let data = Data(#"""
+    {
+      "companion_id":"5b7d655e-36bb-4fbe-9acd-e56103759911",
+      "viewer_id":"owner-1",
+      "read_only":false,
+      "can_send":true,
+      "entries":[],
+      "queued_count":0,
+      "interrupted_turn":{
+        "id":"aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa",
+        "companion_id":"5b7d655e-36bb-4fbe-9acd-e56103759911",
+        "client_message_id":"bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb",
+        "status":"interrupted",
+        "queue_sequence":20,
+        "latest_attempt":null,
+        "replying":false,
+        "error":{"code":"cold_start_deadline_exceeded","message":"The Companion did not start before its deadline.","action":"none"},
+        "state_changed_at":"2026-08-26T05:59:33.505Z",
+        "settled_at":"2026-08-26T05:59:33.505Z",
+        "created_at":"2026-08-26T05:55:12.466Z",
+        "updated_at":"2026-08-26T05:59:33.505Z",
+        "resolution":"auto_abandoned"
+      }
+    }
+    """#.utf8)
+
+    let thread = try JSONDecoder().decode(CompanionThread.self, from: data)
+    #expect(thread.interruptedTurn?.resolution == "auto_abandoned")
+    #expect(thread.visibleInterruptedTurn == nil)
+    #expect(CompanionScrollTailSnapshot(thread: thread).interruptedTurn == nil)
 }
 
 @Test

--- a/apps/ios/CompanionKit/Tests/CompanionKitTests/CompanionLocalCacheTests.swift
+++ b/apps/ios/CompanionKit/Tests/CompanionKitTests/CompanionLocalCacheTests.swift
@@ -624,6 +624,51 @@ func threadDeltaKeepsFullLiveHistoryAndResetsExceptionalHistory() throws {
 }
 
 @Test
+func threadDeltaClearsCachedInterruptedTailAfterServerSettlement() throws {
+    let interrupted: CompanionThread = try decodeFixture(#"""
+    {
+      "companion_id":"22222222-2222-4222-8222-222222222222","viewer_id":"user-1",
+      "read_only":false,"can_send":true,"transcription_available":true,
+      "entries":[],"active_turn":null,"queued_count":0,
+      "interrupted_turn":{
+        "id":"33333333-3333-4333-8333-333333333333",
+        "companion_id":"22222222-2222-4222-8222-222222222222",
+        "client_message_id":"44444444-4444-4444-8444-444444444444",
+        "status":"interrupted","queue_sequence":2,"latest_attempt":null,"replying":false,
+        "error":{"code":"cold_start_deadline_exceeded","message":"Did not start.","action":"retry"},
+        "state_changed_at":"2026-08-29T00:00:00Z","settled_at":"2026-08-29T00:00:00Z",
+        "created_at":"2026-08-29T00:00:00Z","updated_at":"2026-08-29T00:00:00Z"
+      }
+    }
+    """#)
+    #expect(interrupted.visibleInterruptedTurn != nil)
+
+    let delta = CompanionThreadDelta(
+        cursor: "settled-cursor",
+        resetEntries: false,
+        changedEntries: [],
+        deletedEventIDs: [],
+        thread: CompanionThreadMetadata(
+            companionID: interrupted.companionID,
+            viewerID: interrupted.viewerID,
+            readOnly: interrupted.readOnly,
+            canSend: interrupted.canSend,
+            transcriptionAvailable: interrupted.transcriptionAvailable,
+            activeTurn: nil,
+            queuedCount: 0,
+            interruptedTurn: nil
+        )
+    )
+    let merged = delta.applying(to: CompanionThreadSnapshot(
+        cursor: "cached-cursor",
+        thread: interrupted
+    ))
+
+    #expect(merged.thread.interruptedTurn == nil)
+    #expect(merged.thread.visibleInterruptedTurn == nil)
+}
+
+@Test
 func threadWindowsAndDeltasPreserveRoutineNotifyGroupingEvidence() throws {
     let routineID = "33333333-3333-4333-8333-333333333333"
     let firstRunID = "44444444-4444-4444-8444-444444444444"

--- a/apps/ios/README.md
+++ b/apps/ios/README.md
@@ -86,8 +86,9 @@ unavailable plugin selections, and never receives mutation or restart controls. 
 native thread renders every durable decision request. Owner and Editor can answer `ask_user`,
 approve or deny asynchronous Companion control changes for models, OAuth, routines, triggers, and
 peer grants, and handle historical shell/file and legacy proposal
-requests without leaving iOS. An interrupted turn is equally explicit: it is terminal immediately
-and is not replayed; later work continues in order while Viewer remains read-only. The
+requests without leaving iOS. An interrupted turn is terminal immediately and is not replayed;
+after settlement it remains durable history without a persistent conversation-tail card, and later
+work continues in order while Viewer remains read-only. The
 roster also manages model providers and MCP plugins. Provider
 connections support encrypted API keys plus the shared Claude authorization-code and Codex device
 flows. The live server catalog includes Claude, Codex, Kimi, Moonshot, z.ai, OpenAI API, and Google
@@ -261,8 +262,9 @@ decision controls. Set `COMPANION_DECISION_DEMO_FAIL_ONCE=<request-id>` to exerc
 submission followed by an enabled retry.
 Add `-markdown-table-dark-demo` alongside `-markdown-table-demo` to exercise the table gallery with
 the adaptive Companion color tokens in dark appearance.
-The interruption demo shows the passive terminal state shared by every workspace role;
-interrupted occurrences are not replayed and later work continues automatically.
+The interruption demo previews the passive terminal-state component shared by every workspace role;
+settled protocol-6 occurrences are not projected at the conversation tail, are not replayed, and
+later work continues automatically.
 Set `COMPANION_TRANSCRIPT_DEMO_SHORT=1` with `-companion-transcript-window-demo` to exercise the
 same mixed chat surface in a short thread; the default fixture keeps the 120-entry load-more path.
 Set `COMPANION_TRANSCRIPT_DEMO_STAGED_POLL=1` with `-companion-transcript-window-demo` to stage a

--- a/docs/companions-runtime.md
+++ b/docs/companions-runtime.md
@@ -730,12 +730,19 @@ ordinary main turns never inspect or terminate the run-scoped routine broker.
 
 Shared Box lifecycle and staging stays on the main lane and waits for the routine lane to be
 quiescent. An active routine prevents Pi recycle, settings apply, health repair, or other shared
-lifecycle work from racing its run root. An interrupted routine is terminal, owns no lane, and does
-not block main chat. Explicit Full Box restart and permanent delete may preempt and settle an active
+lifecycle work from racing its run root. A queued main turn does not acquire its cold-start deadline
+or derived Start operation during that wait; its full three-minute budget begins once routine
+quiescence makes shared lifecycle work schedulable. An interrupted routine is terminal, owns no
+lane, and does not block main chat. Explicit Full Box restart and permanent delete may preempt and settle an active
 routine occurrence, then terminate only its exact run-scoped invocation before contacting the
 provider. Routine takeover, active cancellation, and settlement never stop the main Pi. The routine context
 substrate is a pinned read-only view of the main conversation; routine-local memory remains private
 to the run, so concurrency introduces no second writer to parent memory.
+
+Terminal `auto_abandoned` interruptions remain durable occurrence evidence and notification input,
+but first-party thread and runtime projections return no `interrupted_turn` tail state for them.
+Only an unresolved legacy interruption can occupy that compatibility field; no protocol-6 Retry or
+Cancel boundary exists.
 
 The isolated invocation is pinned separately from the main Pi identity at dispatch write intent.
 Runtime validates that pinned value for broker reads, durable projection, terminal acknowledgement,

--- a/docs/design.md
+++ b/docs/design.md
@@ -188,6 +188,12 @@ sooner, remains an ordinary queued turn, and never supplies an implicit answer. 
 no cold-start deadline until it reaches the head; runtime then decides whether restaging is needed
 and starts the three-minute cold-start window from that decision.
 
+That decision is gated by shared lifecycle availability. While an isolated routine owns its lane,
+material preparation may be revisited but must not stamp a main turn's cold-start deadline or create
+its Start derivative. The three-minute budget begins only after the routine lane is quiescent and
+main Start can enter scheduling; an acknowledged prompt is thereafter governed only by attempt
+deadlines.
+
 The stateless loopback `companion-control` MCP is staged on every ordinary main attempt. Direct
 configuration mutations persist desired state and report `apply_pending`; sensitive mutations
 persist an asynchronous control request and return immediately. Approval applies once in the API

--- a/packages/contracts/src/companionBudgets.ts
+++ b/packages/contracts/src/companionBudgets.ts
@@ -180,6 +180,8 @@ export const COMPANION_SQL_BUDGET_CONTRACT: Readonly<Record<string, readonly str
     "2 hours 5 minutes",
     "3 minutes",
   ],
+  // Enqueue-time observation grace + materialMinTtlMs, rechecked before a warm attempt claim.
+  companion_runtime_main_turn_material_ready: ["2 minutes", "2 hours 5 minutes"],
   // Enqueue-time material grace + materialMinTtlMs.
   companion_api_enqueue_turn: ["2 minutes", "2 hours 5 minutes"],
   // materialMinTtlMs + snapshot retention.

--- a/packages/contracts/src/companions.ts
+++ b/packages/contracts/src/companions.ts
@@ -2018,7 +2018,7 @@ export const companionThreadSchema = z.object({
   active_turn: companionActiveTurnSchema.nullable(),
   /** Exact number of later turns still ordered in PostgreSQL. */
   queued_count: z.number().int().nonnegative(),
-  /** The queue-blocking ambiguous turn that requires explicit Retry or Cancel, if any. */
+  /** An unresolved legacy interruption, if any; terminal auto-abandoned turns are not projected. */
   interrupted_turn: companionInterruptedTurnSchema.nullable(),
   last_message_at: z.string().datetime().nullable(),
   /**

--- a/packages/core/src/companionRuntimeApi.ts
+++ b/packages/core/src/companionRuntimeApi.ts
@@ -710,7 +710,10 @@ async function readCompanionThreadProjection(input: {
     entries,
     active_turn: activeTurn?.status === "interrupted" ? null : activeTurn,
     queued_count: queuedCount,
-    interrupted_turn: interruptedTurn?.status === "interrupted" ? interruptedTurn : null,
+    interrupted_turn:
+      interruptedTurn?.status === "interrupted" && interruptedTurn.resolution === null
+        ? interruptedTurn
+        : null,
     last_message_at: iso(row.last_message_at),
     last_read_ordinal: row.previous_last_read_ordinal === null
       ? null
@@ -797,7 +800,10 @@ function companionThreadMetadata(input: {
     can_send: input.row.access_role !== "viewer",
     active_turn: activeTurn?.status === "interrupted" ? null : activeTurn,
     queued_count: integer(input.row.queued_count),
-    interrupted_turn: interruptedTurn?.status === "interrupted" ? interruptedTurn : null,
+    interrupted_turn:
+      interruptedTurn?.status === "interrupted" && interruptedTurn.resolution === null
+        ? interruptedTurn
+        : null,
     last_message_at: iso(input.row.last_message_at),
     last_read_ordinal: input.row.previous_last_read_ordinal === null
       ? null

--- a/packages/db/drizzle/0156_companion_main_start_budget_and_interruption_projection.sql
+++ b/packages/db/drizzle/0156_companion_main_start_budget_and_interruption_projection.sql
@@ -1,0 +1,243 @@
+-- A main turn may be queued while an isolated routine owns the routine lane. Shared Box lifecycle
+-- and material staging intentionally wait for that routine, so do not start the main turn's
+-- three-minute cold-start budget until the shared start operation can actually enter scheduling.
+-- Locking the routine lease closes the check/insert race: after the Start row commits, routine
+-- claims already yield to pending main operations.
+DO $companion_main_start_budget$
+DECLARE
+  v_signature text := 'public.companion_runtime_prepare_queued_turn_material(bigint)';
+  v_definition text := pg_catalog.pg_get_functiondef(pg_catalog.to_regprocedure(v_signature));
+  v_old text := $r$  IF NOT FOUND THEN RETURN false; END IF;
+
+  SELECT queued_turn.id, queued_turn.actor_id$r$;
+  v_new text := $r$  IF NOT FOUND THEN RETURN false; END IF;
+
+  PERFORM 1
+  FROM public.companion_runtime_leases routine_lease
+  WHERE routine_lease.org_id = v_org_id
+    AND routine_lease.companion_id = v_companion_id
+    AND routine_lease.lane = 'routine'
+  FOR UPDATE SKIP LOCKED;
+  IF NOT FOUND
+     OR NOT public.companion_runtime_routine_lane_quiescent(v_org_id, v_companion_id) THEN
+    RETURN false;
+  END IF;
+
+  SELECT queued_turn.id, queued_turn.actor_id$r$;
+  v_count integer;
+BEGIN
+  v_count := (char_length(v_definition) - char_length(replace(v_definition, v_old, '')))
+    / char_length(v_old);
+  IF v_definition IS NULL OR v_count <> 1 THEN
+    RAISE EXCEPTION 'main start budget guard matched %, expected 1', COALESCE(v_count, 0)
+      USING ERRCODE = '55000';
+  END IF;
+  EXECUTE replace(v_definition, v_old, v_new);
+END
+$companion_main_start_budget$;
+--> statement-breakpoint
+
+-- Unified first-party material contains expiring control and plugin capabilities on every client
+-- surface. Make native enqueue and deferred preparation use the same two-hour reserve as the claim
+-- guard; otherwise an expired native snapshot can be considered warm by one boundary and rejected
+-- by the next with no Start work left to claim.
+DO $companion_native_material_expiry$
+DECLARE
+  v_enqueue_signature text :=
+    'public.companion_api_enqueue_turn(uuid,uuid,uuid,text,public.companion_client_surface,'
+    || 'jsonb,uuid,text,uuid,text)';
+  v_enqueue_definition text :=
+    pg_catalog.pg_get_functiondef(pg_catalog.to_regprocedure(v_enqueue_signature));
+  v_enqueue_old text := $r$    AND (
+      p_client_surface = 'native_mobile'
+        AND v_instance.material_client_surface = 'native_mobile'
+      OR p_client_surface IN ('web', 'mobile_web')
+        AND v_instance.material_client_surface IN ('web', 'mobile_web')
+        AND v_instance.material_expires_at > v_now + interval '2 hours 5 minutes'
+    )$r$;
+  v_enqueue_new text := $r$    AND (
+      p_client_surface = 'native_mobile'
+        AND v_instance.material_client_surface = 'native_mobile'
+      OR p_client_surface IN ('web', 'mobile_web')
+        AND v_instance.material_client_surface IN ('web', 'mobile_web')
+    )
+    AND v_instance.material_expires_at > v_now + interval '2 hours 5 minutes'$r$;
+  v_prepare_signature text := 'public.companion_runtime_prepare_queued_turn_material(bigint)';
+  v_prepare_definition text :=
+    pg_catalog.pg_get_functiondef(pg_catalog.to_regprocedure(v_prepare_signature));
+  v_prepare_old text[] := ARRAY[
+$r$          AND (
+            queued_turn.client_surface = 'native_mobile'
+              AND instance.material_client_surface = 'native_mobile'
+            OR queued_turn.client_surface IN ('web', 'mobile_web')
+              AND instance.material_client_surface IN ('web', 'mobile_web')
+              AND instance.material_expires_at > v_now + interval '2 hours 5 minutes'
+          )$r$,
+$r$      AND (
+        queued_turn.client_surface = 'native_mobile'
+          AND instance.material_client_surface = 'native_mobile'
+        OR queued_turn.client_surface IN ('web', 'mobile_web')
+          AND instance.material_client_surface IN ('web', 'mobile_web')
+          AND instance.material_expires_at > v_now + interval '2 hours 5 minutes'
+      )$r$
+  ];
+  v_prepare_new text[] := ARRAY[
+$r$          AND (
+            queued_turn.client_surface = 'native_mobile'
+              AND instance.material_client_surface = 'native_mobile'
+            OR queued_turn.client_surface IN ('web', 'mobile_web')
+              AND instance.material_client_surface IN ('web', 'mobile_web')
+          )
+          AND instance.material_expires_at > v_now + interval '2 hours 5 minutes'$r$,
+$r$      AND (
+        queued_turn.client_surface = 'native_mobile'
+          AND instance.material_client_surface = 'native_mobile'
+        OR queued_turn.client_surface IN ('web', 'mobile_web')
+          AND instance.material_client_surface IN ('web', 'mobile_web')
+      )
+      AND instance.material_expires_at > v_now + interval '2 hours 5 minutes'$r$
+  ];
+  v_count integer;
+  v_index integer;
+BEGIN
+  v_count := (char_length(v_enqueue_definition)
+    - char_length(replace(v_enqueue_definition, v_enqueue_old, '')))
+    / char_length(v_enqueue_old);
+  IF v_enqueue_definition IS NULL OR v_count <> 1 THEN
+    RAISE EXCEPTION 'native enqueue expiry guard matched %, expected 1', COALESCE(v_count, 0)
+      USING ERRCODE = '55000';
+  END IF;
+  EXECUTE replace(v_enqueue_definition, v_enqueue_old, v_enqueue_new);
+
+  IF v_prepare_definition IS NULL THEN
+    RAISE EXCEPTION 'queued material preparation is missing' USING ERRCODE = '55000';
+  END IF;
+  FOR v_index IN 1..cardinality(v_prepare_old) LOOP
+    v_count := (char_length(v_prepare_definition)
+      - char_length(replace(v_prepare_definition, v_prepare_old[v_index], '')))
+      / char_length(v_prepare_old[v_index]);
+    IF v_count <> 1 THEN
+      RAISE EXCEPTION 'native preparation expiry guard % matched %, expected 1', v_index, v_count
+        USING ERRCODE = '55000';
+    END IF;
+    v_prepare_definition := replace(
+      v_prepare_definition, v_prepare_old[v_index], v_prepare_new[v_index]
+    );
+  END LOOP;
+  EXECUTE v_prepare_definition;
+END
+$companion_native_material_expiry$;
+--> statement-breakpoint
+
+-- The material wrapper and the lane-aware claimer are separate functions. If preparation defers
+-- for an active routine, the claimer must not fall through and manufacture a main attempt against
+-- stale material. Warm main turns still run concurrently with routines; only turns lacking the
+-- exact current staged snapshot wait for shared lifecycle work.
+CREATE FUNCTION public.companion_runtime_main_turn_material_ready(
+  p_org_id uuid,
+  p_companion_id uuid,
+  p_turn_id uuid
+)
+RETURNS boolean
+LANGUAGE sql
+STABLE
+SECURITY DEFINER
+SET search_path = pg_catalog, public
+SET row_security = on
+AS $$
+  SELECT COALESCE((
+    SELECT instance.box_state IN ('ready', 'idle', 'running')
+      AND instance.pi_state = 'idle'
+      AND instance.last_observed_at >= statement_timestamp() - interval '2 minutes'
+      AND instance.material_pi_invocation_id = instance.pi_invocation_id
+      AND (
+        queued_turn.client_surface = 'native_mobile'
+          AND instance.material_client_surface = 'native_mobile'
+        OR queued_turn.client_surface IN ('web', 'mobile_web')
+          AND instance.material_client_surface IN ('web', 'mobile_web')
+      )
+      AND instance.material_expires_at > statement_timestamp() + interval '2 hours 5 minutes'
+      AND instance.desired_settings_revision = instance.applied_settings_revision
+      AND instance.applied_skills_revision >= companion.skills_revision
+    FROM public.companion_turns queued_turn
+    JOIN public.companion_runtime_instances instance
+      ON instance.org_id = queued_turn.org_id
+     AND instance.companion_id = queued_turn.companion_id
+    JOIN public.companions companion
+      ON companion.org_id = queued_turn.org_id
+     AND companion.id = queued_turn.companion_id
+    WHERE queued_turn.org_id = p_org_id
+      AND queued_turn.companion_id = p_companion_id
+      AND queued_turn.id = p_turn_id
+      AND queued_turn.routine_snapshot_id IS NULL
+      AND queued_turn.status = 'queued'
+  ), false)
+$$;
+--> statement-breakpoint
+
+REVOKE ALL ON FUNCTION public.companion_runtime_main_turn_material_ready(uuid, uuid, uuid)
+  FROM PUBLIC;
+--> statement-breakpoint
+
+DO $companion_main_attempt_material_guard$
+DECLARE
+  v_signature text :=
+    'public.companion_runtime_claim_work_without_material_guard(text,integer,integer,bigint)';
+  v_definition text := pg_catalog.pg_get_functiondef(pg_catalog.to_regprocedure(v_signature));
+  v_old text := $r$        AND public.companion_runtime_turn_lane(t.org_id, t.companion_id, t.id) = v_lane
+        AND (
+          v_lane = 'main'
+          OR NOT EXISTS ($r$;
+  v_new text := $r$        AND public.companion_runtime_turn_lane(t.org_id, t.companion_id, t.id) = v_lane
+        AND (
+          v_lane = 'routine'
+          OR public.companion_runtime_main_turn_material_ready(t.org_id, t.companion_id, t.id)
+        )
+        AND (
+          v_lane = 'main'
+          OR NOT EXISTS ($r$;
+  v_count integer;
+BEGIN
+  v_count := (char_length(v_definition) - char_length(replace(v_definition, v_old, '')))
+    / char_length(v_old);
+  IF v_definition IS NULL OR v_count <> 1 THEN
+    RAISE EXCEPTION 'main attempt material guard matched %, expected 1', COALESCE(v_count, 0)
+      USING ERRCODE = '55000';
+  END IF;
+  EXECUTE replace(v_definition, v_old, v_new);
+END
+$companion_main_attempt_material_guard$;
+--> statement-breakpoint
+
+-- Protocol 6 interruptions are terminal auto-abandoned evidence, not actionable lane state. Keep
+-- the durable turn and notification, but stop projecting a settled interruption as a permanent
+-- thread-tail card. The unresolved filter also preserves compatibility with an older in-flight
+-- protocol during a rolling deployment.
+DO $companion_hide_settled_interruptions$
+DECLARE
+  v_signature text;
+  v_definition text;
+  v_order text := 'ORDER BY interrupted.queue_sequence DESC, interrupted.id DESC LIMIT 1';
+  v_filtered_order text := $r$AND interrupted.resolution IS NULL
+      ORDER BY interrupted.queue_sequence DESC, interrupted.id DESC LIMIT 1$r$;
+  v_count integer;
+BEGIN
+  FOREACH v_signature IN ARRAY ARRAY[
+    'public.companion_api_read_runtime(uuid,uuid)',
+    'public.companion_api_list_runtime(uuid)',
+    'public.companion_api_read_thread(uuid,uuid)',
+    'public.companion_api_sync_thread(uuid,uuid)',
+    'public.companion_api_thread_metadata(uuid,uuid,boolean)'
+  ] LOOP
+    v_definition := pg_catalog.pg_get_functiondef(pg_catalog.to_regprocedure(v_signature));
+    v_count := (char_length(v_definition) - char_length(replace(v_definition, v_order, '')))
+      / char_length(v_order);
+    IF v_definition IS NULL OR v_count <> 1 THEN
+      RAISE EXCEPTION 'settled interruption filter % matched %, expected 1',
+        v_signature, COALESCE(v_count, 0) USING ERRCODE = '55000';
+    END IF;
+    EXECUTE replace(v_definition, v_order, v_filtered_order);
+  END LOOP;
+END
+$companion_hide_settled_interruptions$;
+--> statement-breakpoint

--- a/packages/db/drizzle/meta/_journal.json
+++ b/packages/db/drizzle/meta/_journal.json
@@ -1093,6 +1093,13 @@
       "when": 1793207200000,
       "tag": "0155_companion_interruption_terminal_protocol_6",
       "breakpoints": true
+    },
+    {
+      "idx": 156,
+      "version": "7",
+      "when": 1793293600000,
+      "tag": "0156_companion_main_start_budget_and_interruption_projection",
+      "breakpoints": true
     }
   ]
 }


### PR DESCRIPTION
## Summary

- start a main turn's three-minute cold-start budget only when shared Box lifecycle work can actually be scheduled after an isolated routine
- prevent the lane-aware claimer from dispatching a main attempt against stale or expiring staged material
- stop projecting settled `auto_abandoned` interruptions as a permanent first-party thread tail, with an iOS cache/rendering defense
- add concurrent routine/main, material-load, projection, scroll-tail, and local-cache regressions

## Root cause

Parallel routine scheduling made material preparation lane-local, so scheduler passes could stamp a main turn's deadline and create Start work while an active routine still blocked that Start at the shared lifecycle gate. Frequent routine passes consumed the main turn's three-minute budget before provider contact. The lane-aware claimer could also fall through to attempt creation when preparation deferred.

Protocol 6 settled interruptions immediately as `auto_abandoned`, but its migration also removed the unresolved-only filter from all first-party read functions. Core and the local-first iOS client therefore kept projecting and caching terminal history as the current interruption card. Current iOS source has no Retry/Cancel controls; those controls identify an older installed binary, while the persistent card itself was caused by the projection contract.

## Verification

- `pnpm ci:quality` — 40/40 tasks
- focused PostgreSQL runtime/projection suite — 70/70 tests
- canonical runtime integration — 125 API database-contract tests, real-process runtime takeover/purge, 83 Box/Pi simulator tests
- `pnpm verify:change` fast checks and build — passed; environment-dependent follow-up gates left to PR CI
- independent `review-code-dev` gate — no remaining P0-P3 findings

## Local environment limits

- Box Lab real-VM smoke is unavailable in this cloud VM (no Docker; threaded host cgroup). This patch does not change Pi installation/layout, bundle pins, lifecycle adapters, or Box Lab.
- Swift/Xcode/XcodeBuildMCP are unavailable on Linux; existing Apple Quality CI is the authoritative CompanionKit test and generic simulator-build gate.

<!-- conductor-workspace-link -->

---

[Open workspace in Conductor](https://app.conductor.build/workspace/66871e2c-ac89-48f5-a237-89d83eafdecf)


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/The-Vibe-Company/companion/pull/701?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

