### PR TITLE
docs(agents): configure Companion Linear access

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -192,9 +192,9 @@ its full real-Linux acceptance is slow; run it locally as the final validation a
 
 ### Issue tracker
 
-Issues live in Linear, reached through the GraphQL API with `LINEAR_API_KEY`; the team and project
-are confirmed with the user on first use. GitHub holds only pull requests. See
-`docs/agents/issue-tracker.md`.
+Issues live in Linear, reached through the GraphQL API with `LINEAR_TVC_API_KEY` when available and
+`LINEAR_API_KEY` otherwise; the project is `Companions`, and the team is confirmed with the user on
+first write. GitHub holds only pull requests. See `docs/agents/issue-tracker.md`.
 
 ### Triage labels
 

--- a/docs/agents/issue-tracker.md
+++ b/docs/agents/issue-tracker.md
@@ -7,39 +7,50 @@ Issues and specs for this repo live in **Linear**, not GitHub Issues. Skills suc
 ## Access
 
 - Endpoint: `https://api.linear.app/graphql`
-- Auth: personal API key from the `LINEAR_API_KEY` environment variable, sent raw in the
-  `Authorization` header (no `Bearer` prefix).
-- The key is The Vibe Company's Linear key, held as a Companion secret. If the variable is not
-  already exported, source the Companion projection before calling the API:
+- Auth: prefer the personal API key from `LINEAR_TVC_API_KEY` when it is available, otherwise
+  fall back to `LINEAR_API_KEY`. Send the selected key raw in the `Authorization` header (no
+  `Bearer` prefix). This precedence applies to every Linear read and write for Companion.
+- The fallback key is The Vibe Company's Linear key, held as a Companion secret. If neither
+  variable is already exported, source the Companion projection before calling the API:
   `set -a; . ~/.companion/secrets/<workspace-id>/_manual/linear/.env; set +a`
   (the projection is written by `sync_secrets.py manual linear <secret-id> LINEAR_API_KEY --confirm`
   from the `companion` skill; never print or copy its contents).
-- If `LINEAR_API_KEY` is missing or the request returns `401`, **stop** and tell the user the
-  exact setup requirement. Never draft or "remember" issues instead of filing them.
+- If both `LINEAR_TVC_API_KEY` and `LINEAR_API_KEY` are missing, or the request returns `401`,
+  **stop** and tell the user the exact setup requirement. Never draft or "remember" issues instead
+  of filing them.
 
 Helper used throughout this file (`lq` = "linear query"):
 
 ```bash
-lq() { local vars="${2:-"{}"}"; curl -sS https://api.linear.app/graphql \
-  -H "Content-Type: application/json" -H "Authorization: $LINEAR_API_KEY" \
-  --data "$(jq -cn --arg q "$1" --argjson v "$vars" '{query:$q, variables:$v}')"; }
+lq() {
+  local query="$1" vars="${2:-"{}"}"
+  local linear_key="${LINEAR_TVC_API_KEY:-${LINEAR_API_KEY:-}}"
+  if [[ -z "$linear_key" ]]; then
+    printf '%s\n' 'Linear auth unavailable: set LINEAR_TVC_API_KEY or LINEAR_API_KEY.' >&2
+    return 1
+  fi
+  curl -sS https://api.linear.app/graphql \
+    -H "Content-Type: application/json" -H "Authorization: $linear_key" \
+    --data "$(jq -cn --arg q "$query" --argjson v "$vars" '{query:$q, variables:$v}')"
+}
 ```
 
 ## Scope: team and project
 
-**Confirmed team key:** _not yet confirmed_ · **Confirmed project:** _none_
+**Confirmed team key:** _not yet confirmed_ · **Confirmed project:** `Companions`
 
-The Companion team and project have not been pinned yet. On the **first Linear write in a
-session**, discover the candidates and confirm the target with the user before creating anything:
+The Companion team has not been pinned yet. On the **first Linear write in a session**, discover
+the team candidates and resolve the confirmed `Companions` project, then confirm the target team
+with the user before creating anything:
 
 ```bash
 lq 'query { teams { nodes { id key name } } }' | jq '.data.teams.nodes'
 lq 'query { projects(first: 50) { nodes { id name state teams { nodes { key } } } } }' | jq '.data.projects.nodes'
 ```
 
-Once the user confirms, replace the line above with the real key and project name so later
-sessions skip the discovery step. Reads may proceed without confirmation when the user has named
-the team or issue identifier explicitly.
+Once the user confirms, replace the team placeholder above with the real key so later sessions skip
+team discovery. Keep `Companions` as the project. Reads may proceed without confirmation when the
+user has named the team or issue identifier explicitly.
 
 ## Conventions
 


### PR DESCRIPTION
## Summary
- Prefer `LINEAR_TVC_API_KEY` for all Companion Linear reads and writes, with `LINEAR_API_KEY` as fallback.
- Pin the repository issue-tracker configuration to the `Companions` Linear project while leaving the team confirmation flow intact.

## Verification
- [x] Helper precedence harness with sentinel values — TVC preference, legacy fallback, and missing-key failure passed.
- [x] `git diff --check -- CLAUDE.md docs/agents/issue-tracker.md` — passed.
- [x] Scoped secret-pattern and consistency scan — passed; no inline Linear secret.
- [x] `pnpm verify:change` fast checks — 129 hygiene tests, anti-slop, lint, typecheck, tests, and build passed.
- [ ] Database/runtime/container follow-ups — not applicable to this documentation-only commit; selected because of unrelated local `packages/box-sim/src/cli.ts` worktree state that is not in this PR.

## CI
- Status: pending GitHub checks.

## Review Gate
- `review-code-dev` quick: passed with no findings.
- Required lenses: none; documentation-only agent workflow configuration.

## Risk
- Low. Documentation and agent workflow configuration only; no runtime code or secret values changed.

## Human Review Notes
- Confirm the credential precedence and `Companions` project naming match the intended Linear workspace conventions.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/The-Vibe-Company/companion/pull/704?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

Updates Companion’s Linear workflow documentation to prefer `LINEAR_TVC_API_KEY` while retaining `LINEAR_API_KEY` as a fallback.
- Pins issue creation to the `Companions` Linear project.
- Keeps team discovery and user confirmation on the first write.
- Adds an `lq` helper that enforces credential precedence and fails clearly when neither key exists.
</details>


<details><summary><h3>Confidence Score: 5/5</h3></summary>

The documentation-only change appears safe to merge with no actionable defects identified.

The fallback remains compatible with the existing projected `LINEAR_API_KEY`, and the instructions resolve the pinned project before each session’s first write.
</details>


<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| CLAUDE.md | Aligns top-level agent guidance with the new Linear credential precedence and pinned project workflow. |
| docs/agents/issue-tracker.md | Documents credential selection, missing-key handling, and per-session resolution of the pinned Companions project without introducing a concrete workflow failure. |

</details>

<sub>Reviews (1): Last reviewed commit: ["docs(agents): configure Companion Linear..."](https://github.com/the-vibe-company/companion/commit/9caeff8fda6267177455adb6cbc28c02dea99eda) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=59189956)</sub>

<!-- /greptile_comment -->