### PR TITLE
fix(agents): load production debug credentials from environment

### DIFF
--- a/.agents/skills/debug-companions-prod/SKILL.md
+++ b/.agents/skills/debug-companions-prod/SKILL.md
@@ -50,7 +50,9 @@ From the runbook — these are not negotiable:
 ## Prerequisites
 
 - `psql` on PATH (PostgreSQL 17 client).
-- `~/.companion-prod.env`, mode exactly `0600` (scripts refuse otherwise):
+- Credentials exposed as process variables, as in a Conductor cloud workspace.
+  `~/.companion-prod.env` is an optional local fallback and must be mode exactly
+  `0600` when present:
 
   ```dotenv
   RAILWAY_API_TOKEN=...            # Railway token (bearer or project token)
@@ -66,8 +68,9 @@ From the runbook — these are not negotiable:
   chmod 600 ~/.companion-prod.env
   ```
 
-Values are read only from this file, passed to subprocesses via the
-environment, and never printed or placed in argv.
+Process variables override file values. Only the variables listed above are
+loaded; unrelated process secrets are ignored. Values passed to subprocesses
+stay in the environment and are never printed or placed in argv.
 
 ## First five minutes
 

--- a/.agents/skills/debug-companions-prod/references/railway-api.md
+++ b/.agents/skills/debug-companions-prod/references/railway-api.md
@@ -26,9 +26,9 @@ Railway accepts different headers depending on the token kind. The scripts try
    Project-Access-Token: <RAILWAY_API_TOKEN>
    ```
 
-Both use the same `RAILWAY_API_TOKEN` value from `~/.companion-prod.env`; set
-whichever kind you provisioned. A project token is the least-privilege choice
-for this skill.
+Both use the same `RAILWAY_API_TOKEN` value from the process environment or the
+optional `~/.companion-prod.env` fallback. A project token is the
+least-privilege choice for this skill.
 
 ## UNVERIFIED schema — needs one live probe
 

--- a/.agents/skills/debug-companions-prod/references/redaction.md
+++ b/.agents/skills/debug-companions-prod/references/redaction.md
@@ -50,8 +50,9 @@ Applied in order:
 - `db_query.py decisions` never selects `response_text` (member content).
 - `db_query.py` has no free-SQL mode, so a transcript can never contain an
   ad-hoc `select *` over member data.
-- The credential file `~/.companion-prod.env` is refused unless it is mode
-  `0600`, and its values are never echoed.
+- Process credentials are loaded only from the skill's allowlist. The optional
+  `~/.companion-prod.env` fallback is refused unless it is mode `0600`, and no
+  credential value is ever echoed.
 
 ## Rules for the operator
 

--- a/.agents/skills/debug-companions-prod/scripts/prodlib.py
+++ b/.agents/skills/debug-companions-prod/scripts/prodlib.py
@@ -4,8 +4,9 @@
 Read-only production debugging support. This module owns the three safety
 contracts every script in this skill relies on:
 
-- credentials come only from ``~/.companion-prod.env`` and the file must be
-  mode 0600 (anything else is a hard refusal, exit 2);
+- credentials come from the process environment first, with
+  ``~/.companion-prod.env`` as an optional local fallback whose mode must be
+  0600 when present;
 - ``redact()`` is applied to every output path, so tokens, signed URLs, and
   database credentials cannot leak into a transcript;
 - secrets are passed to subprocesses via the environment, never argv.
@@ -121,52 +122,58 @@ def print_json(data: object) -> None:
     print(redact(json.dumps(data, indent=2, sort_keys=True, default=str)))
 
 
-# --- credential file ------------------------------------------------------
+# --- credentials ----------------------------------------------------------
 
-def load_env(path: str = ENV_FILE) -> dict:
-    """Load KEY=VALUE lines from the operator credential file.
+def load_env(path: str = ENV_FILE, process_env: dict | None = None) -> dict:
+    """Load allowlisted credentials from the environment and optional file.
 
-    Refuses (exit 2) when the file is missing or its mode is not exactly 0600,
-    so a group- or world-readable credential file is never used.
+    Process variables override file values. A present file must still be mode
+    0600, so a group- or world-readable credential file is never used. A
+    missing file is accepted when at least one allowlisted process variable is
+    present; individual scripts then require only the values they consume.
     """
+    source_env = os.environ if process_env is None else process_env
+    process_values = {key: source_env[key] for key in KNOWN_KEYS if key in source_env}
+    env = dict(DEFAULTS)
     try:
         info = os.stat(path)
     except FileNotFoundError:
-        fail(
-            f"{path} is missing. Create it with KEY=VALUE lines "
-            "(RAILWAY_API_TOKEN, RAILWAY_PROJECT_ID, RAILWAY_ENVIRONMENT_ID, "
-            "COMPANION_BOX_API_KEY, PROD_DATABASE_READ_URL, optional "
-            "COMPANION_BOX_API_BASE and DEBUG_PROD_ALLOW_RESTART) and run "
-            f"chmod 600 {path}. See SKILL.md → Prerequisites.",
-        )
-    mode = stat.S_IMODE(info.st_mode)
-    if mode != 0o600:
-        fail(
-            f"{path} has mode {oct(mode)}; it must be exactly 0600. "
-            f"Run: chmod 600 {path}",
-        )
-    env = dict(DEFAULTS)
-    with open(path, encoding="utf-8") as handle:
-        for line_number, raw_line in enumerate(handle, start=1):
-            line = raw_line.strip()
-            if not line or line.startswith("#"):
-                continue
-            if "=" not in line:
-                fail(f"{path}:{line_number} is not a KEY=VALUE line")
-            key, _, value = line.partition("=")
-            key = key.strip()
-            value = value.strip()
-            if len(value) >= 2 and value[0] == value[-1] and value[0] in ('"', "'"):
-                value = value[1:-1]
-            if key:
-                env[key] = value
+        if not process_values:
+            fail(
+                "Production debug credentials are unavailable. Set the required "
+                "allowlisted process variables, or create "
+                f"{path} with KEY=VALUE lines and run chmod 600 {path}. "
+                "See SKILL.md → Prerequisites.",
+            )
+    else:
+        mode = stat.S_IMODE(info.st_mode)
+        if mode != 0o600:
+            fail(
+                f"{path} has mode {oct(mode)}; it must be exactly 0600. "
+                f"Run: chmod 600 {path}",
+            )
+        with open(path, encoding="utf-8") as handle:
+            for line_number, raw_line in enumerate(handle, start=1):
+                line = raw_line.strip()
+                if not line or line.startswith("#"):
+                    continue
+                if "=" not in line:
+                    fail(f"{path}:{line_number} is not a KEY=VALUE line")
+                key, _, value = line.partition("=")
+                key = key.strip()
+                value = value.strip()
+                if len(value) >= 2 and value[0] == value[-1] and value[0] in ('"', "'"):
+                    value = value[1:-1]
+                if key in KNOWN_KEYS:
+                    env[key] = value
+    env.update(process_values)
     return env
 
 
 def require(env: dict, key: str) -> str:
     value = env.get(key, "")
     if not value:
-        fail(f"{key} is not set in {ENV_FILE}")
+        fail(f"{key} is not set in the process environment or {ENV_FILE}")
     return value
 
 

--- a/.agents/skills/debug-companions-prod/scripts/railway_restart.py
+++ b/.agents/skills/debug-companions-prod/scripts/railway_restart.py
@@ -3,7 +3,8 @@
 
 Double-gated: it refuses unless BOTH the explicit
 ``--i-know-this-restarts-prod`` flag is passed AND ``DEBUG_PROD_ALLOW_RESTART=1``
-is set in ``~/.companion-prod.env``. It never targets the ``release`` service.
+is set in the process environment or optional credential file. It never targets
+the ``release`` service.
 
 The ``deploymentRestart`` GraphQL mutation shape is UNVERIFIED — see
 references/railway-api.md.
@@ -71,7 +72,8 @@ def check_restart_allowed(
         )
     if allow_restart_env != "1":
         return False, (
-            "DEBUG_PROD_ALLOW_RESTART is not 1 in ~/.companion-prod.env. This "
+            "DEBUG_PROD_ALLOW_RESTART is not 1 in the process environment or "
+            "~/.companion-prod.env. This "
             "second gate exists so a copy-pasted command cannot restart prod; "
             "set it deliberately, run the restart, then unset it"
         )

--- a/.agents/skills/debug-companions-prod/scripts/railway_status.py
+++ b/.agents/skills/debug-companions-prod/scripts/railway_status.py
@@ -103,7 +103,8 @@ def railway_graphql(env: dict, query: str, variables: dict, http=prodlib.http_js
     if _auth_failed(status, payload):
         raise prodlib.ProdToolError(
             "Railway rejected both the Authorization: Bearer and Project-Access-Token "
-            "auth styles. Check RAILWAY_API_TOKEN in ~/.companion-prod.env and see "
+            "auth styles. Check RAILWAY_API_TOKEN in the process environment or "
+            "~/.companion-prod.env and see "
             "references/railway-api.md.",
         )
     if status != 200 or not isinstance(payload, dict):

--- a/.agents/skills/debug-companions-prod/scripts/test_prodlib.py
+++ b/.agents/skills/debug-companions-prod/scripts/test_prodlib.py
@@ -87,10 +87,22 @@ class LoadEnvTest(unittest.TestCase):
         self.addCleanup(os.unlink, handle.name)
         return handle.name
 
-    def test_missing_file_refuses_with_exit_2(self):
+    def test_missing_file_and_environment_refuses_with_exit_2(self):
         with self.assertRaises(SystemExit) as ctx:
-            prodlib.load_env("/nonexistent/companion-prod.env")
+            prodlib.load_env("/nonexistent/companion-prod.env", process_env={})
         self.assertEqual(ctx.exception.code, 2)
+
+    def test_process_environment_works_without_file(self):
+        env = prodlib.load_env(
+            "/nonexistent/companion-prod.env",
+            process_env={
+                "RAILWAY_API_TOKEN": "cloud-token",
+                "RAILWAY_PROJECT_ID": "cloud-project",
+            },
+        )
+        self.assertEqual(env["RAILWAY_API_TOKEN"], "cloud-token")
+        self.assertEqual(env["RAILWAY_PROJECT_ID"], "cloud-project")
+        self.assertEqual(env["COMPANION_BOX_API_BASE"], "https://ascii.dev/api/box/v1")
 
     def test_group_readable_file_refuses_with_exit_2(self):
         path = self._write_env("RAILWAY_API_TOKEN=x\n", 0o640)
@@ -110,11 +122,31 @@ class LoadEnvTest(unittest.TestCase):
             'COMPANION_BOX_API_KEY="boxkey"\n',
             0o600,
         )
-        env = prodlib.load_env(path)
+        env = prodlib.load_env(path, process_env={})
         self.assertEqual(env["RAILWAY_API_TOKEN"], "tok")
         self.assertEqual(env["RAILWAY_PROJECT_ID"], "proj")
         self.assertEqual(env["COMPANION_BOX_API_KEY"], "boxkey")
         self.assertEqual(env["COMPANION_BOX_API_BASE"], "https://ascii.dev/api/box/v1")
+
+    def test_process_environment_overrides_file_and_file_fills_missing_values(self):
+        path = self._write_env(
+            "RAILWAY_API_TOKEN=file-token\n"
+            "RAILWAY_PROJECT_ID=file-project\n"
+            "DEBUG_PROD_ALLOW_RESTART=1\n",
+            0o600,
+        )
+        env = prodlib.load_env(
+            path,
+            process_env={
+                "RAILWAY_API_TOKEN": "cloud-token",
+                "DEBUG_PROD_ALLOW_RESTART": "",
+                "UNRELATED_SECRET": "must-not-be-copied",
+            },
+        )
+        self.assertEqual(env["RAILWAY_API_TOKEN"], "cloud-token")
+        self.assertEqual(env["RAILWAY_PROJECT_ID"], "file-project")
+        self.assertEqual(env["DEBUG_PROD_ALLOW_RESTART"], "")
+        self.assertNotIn("UNRELATED_SECRET", env)
 
     def test_require_refuses_missing_key(self):
         with self.assertRaises(SystemExit) as ctx:

--- a/.claude/skills/debug-companions-prod/SKILL.md
+++ b/.claude/skills/debug-companions-prod/SKILL.md
@@ -50,7 +50,9 @@ From the runbook — these are not negotiable:
 ## Prerequisites
 
 - `psql` on PATH (PostgreSQL 17 client).
-- `~/.companion-prod.env`, mode exactly `0600` (scripts refuse otherwise):
+- Credentials exposed as process variables, as in a Conductor cloud workspace.
+  `~/.companion-prod.env` is an optional local fallback and must be mode exactly
+  `0600` when present:
 
   ```dotenv
   RAILWAY_API_TOKEN=...            # Railway token (bearer or project token)
@@ -66,8 +68,9 @@ From the runbook — these are not negotiable:
   chmod 600 ~/.companion-prod.env
   ```
 
-Values are read only from this file, passed to subprocesses via the
-environment, and never printed or placed in argv.
+Process variables override file values. Only the variables listed above are
+loaded; unrelated process secrets are ignored. Values passed to subprocesses
+stay in the environment and are never printed or placed in argv.
 
 ## First five minutes
 

--- a/.claude/skills/debug-companions-prod/references/railway-api.md
+++ b/.claude/skills/debug-companions-prod/references/railway-api.md
@@ -26,9 +26,9 @@ Railway accepts different headers depending on the token kind. The scripts try
    Project-Access-Token: <RAILWAY_API_TOKEN>
    ```
 
-Both use the same `RAILWAY_API_TOKEN` value from `~/.companion-prod.env`; set
-whichever kind you provisioned. A project token is the least-privilege choice
-for this skill.
+Both use the same `RAILWAY_API_TOKEN` value from the process environment or the
+optional `~/.companion-prod.env` fallback. A project token is the
+least-privilege choice for this skill.
 
 ## UNVERIFIED schema — needs one live probe
 

--- a/.claude/skills/debug-companions-prod/references/redaction.md
+++ b/.claude/skills/debug-companions-prod/references/redaction.md
@@ -50,8 +50,9 @@ Applied in order:
 - `db_query.py decisions` never selects `response_text` (member content).
 - `db_query.py` has no free-SQL mode, so a transcript can never contain an
   ad-hoc `select *` over member data.
-- The credential file `~/.companion-prod.env` is refused unless it is mode
-  `0600`, and its values are never echoed.
+- Process credentials are loaded only from the skill's allowlist. The optional
+  `~/.companion-prod.env` fallback is refused unless it is mode `0600`, and no
+  credential value is ever echoed.
 
 ## Rules for the operator
 

--- a/.claude/skills/debug-companions-prod/scripts/prodlib.py
+++ b/.claude/skills/debug-companions-prod/scripts/prodlib.py
@@ -4,8 +4,9 @@
 Read-only production debugging support. This module owns the three safety
 contracts every script in this skill relies on:
 
-- credentials come only from ``~/.companion-prod.env`` and the file must be
-  mode 0600 (anything else is a hard refusal, exit 2);
+- credentials come from the process environment first, with
+  ``~/.companion-prod.env`` as an optional local fallback whose mode must be
+  0600 when present;
 - ``redact()`` is applied to every output path, so tokens, signed URLs, and
   database credentials cannot leak into a transcript;
 - secrets are passed to subprocesses via the environment, never argv.
@@ -121,52 +122,58 @@ def print_json(data: object) -> None:
     print(redact(json.dumps(data, indent=2, sort_keys=True, default=str)))
 
 
-# --- credential file ------------------------------------------------------
+# --- credentials ----------------------------------------------------------
 
-def load_env(path: str = ENV_FILE) -> dict:
-    """Load KEY=VALUE lines from the operator credential file.
+def load_env(path: str = ENV_FILE, process_env: dict | None = None) -> dict:
+    """Load allowlisted credentials from the environment and optional file.
 
-    Refuses (exit 2) when the file is missing or its mode is not exactly 0600,
-    so a group- or world-readable credential file is never used.
+    Process variables override file values. A present file must still be mode
+    0600, so a group- or world-readable credential file is never used. A
+    missing file is accepted when at least one allowlisted process variable is
+    present; individual scripts then require only the values they consume.
     """
+    source_env = os.environ if process_env is None else process_env
+    process_values = {key: source_env[key] for key in KNOWN_KEYS if key in source_env}
+    env = dict(DEFAULTS)
     try:
         info = os.stat(path)
     except FileNotFoundError:
-        fail(
-            f"{path} is missing. Create it with KEY=VALUE lines "
-            "(RAILWAY_API_TOKEN, RAILWAY_PROJECT_ID, RAILWAY_ENVIRONMENT_ID, "
-            "COMPANION_BOX_API_KEY, PROD_DATABASE_READ_URL, optional "
-            "COMPANION_BOX_API_BASE and DEBUG_PROD_ALLOW_RESTART) and run "
-            f"chmod 600 {path}. See SKILL.md → Prerequisites.",
-        )
-    mode = stat.S_IMODE(info.st_mode)
-    if mode != 0o600:
-        fail(
-            f"{path} has mode {oct(mode)}; it must be exactly 0600. "
-            f"Run: chmod 600 {path}",
-        )
-    env = dict(DEFAULTS)
-    with open(path, encoding="utf-8") as handle:
-        for line_number, raw_line in enumerate(handle, start=1):
-            line = raw_line.strip()
-            if not line or line.startswith("#"):
-                continue
-            if "=" not in line:
-                fail(f"{path}:{line_number} is not a KEY=VALUE line")
-            key, _, value = line.partition("=")
-            key = key.strip()
-            value = value.strip()
-            if len(value) >= 2 and value[0] == value[-1] and value[0] in ('"', "'"):
-                value = value[1:-1]
-            if key:
-                env[key] = value
+        if not process_values:
+            fail(
+                "Production debug credentials are unavailable. Set the required "
+                "allowlisted process variables, or create "
+                f"{path} with KEY=VALUE lines and run chmod 600 {path}. "
+                "See SKILL.md → Prerequisites.",
+            )
+    else:
+        mode = stat.S_IMODE(info.st_mode)
+        if mode != 0o600:
+            fail(
+                f"{path} has mode {oct(mode)}; it must be exactly 0600. "
+                f"Run: chmod 600 {path}",
+            )
+        with open(path, encoding="utf-8") as handle:
+            for line_number, raw_line in enumerate(handle, start=1):
+                line = raw_line.strip()
+                if not line or line.startswith("#"):
+                    continue
+                if "=" not in line:
+                    fail(f"{path}:{line_number} is not a KEY=VALUE line")
+                key, _, value = line.partition("=")
+                key = key.strip()
+                value = value.strip()
+                if len(value) >= 2 and value[0] == value[-1] and value[0] in ('"', "'"):
+                    value = value[1:-1]
+                if key in KNOWN_KEYS:
+                    env[key] = value
+    env.update(process_values)
     return env
 
 
 def require(env: dict, key: str) -> str:
     value = env.get(key, "")
     if not value:
-        fail(f"{key} is not set in {ENV_FILE}")
+        fail(f"{key} is not set in the process environment or {ENV_FILE}")
     return value
 
 

--- a/.claude/skills/debug-companions-prod/scripts/railway_restart.py
+++ b/.claude/skills/debug-companions-prod/scripts/railway_restart.py
@@ -3,7 +3,8 @@
 
 Double-gated: it refuses unless BOTH the explicit
 ``--i-know-this-restarts-prod`` flag is passed AND ``DEBUG_PROD_ALLOW_RESTART=1``
-is set in ``~/.companion-prod.env``. It never targets the ``release`` service.
+is set in the process environment or optional credential file. It never targets
+the ``release`` service.
 
 The ``deploymentRestart`` GraphQL mutation shape is UNVERIFIED — see
 references/railway-api.md.
@@ -71,7 +72,8 @@ def check_restart_allowed(
         )
     if allow_restart_env != "1":
         return False, (
-            "DEBUG_PROD_ALLOW_RESTART is not 1 in ~/.companion-prod.env. This "
+            "DEBUG_PROD_ALLOW_RESTART is not 1 in the process environment or "
+            "~/.companion-prod.env. This "
             "second gate exists so a copy-pasted command cannot restart prod; "
             "set it deliberately, run the restart, then unset it"
         )

--- a/.claude/skills/debug-companions-prod/scripts/railway_status.py
+++ b/.claude/skills/debug-companions-prod/scripts/railway_status.py
@@ -103,7 +103,8 @@ def railway_graphql(env: dict, query: str, variables: dict, http=prodlib.http_js
     if _auth_failed(status, payload):
         raise prodlib.ProdToolError(
             "Railway rejected both the Authorization: Bearer and Project-Access-Token "
-            "auth styles. Check RAILWAY_API_TOKEN in ~/.companion-prod.env and see "
+            "auth styles. Check RAILWAY_API_TOKEN in the process environment or "
+            "~/.companion-prod.env and see "
             "references/railway-api.md.",
         )
     if status != 200 or not isinstance(payload, dict):

--- a/.claude/skills/debug-companions-prod/scripts/test_prodlib.py
+++ b/.claude/skills/debug-companions-prod/scripts/test_prodlib.py
@@ -87,10 +87,22 @@ class LoadEnvTest(unittest.TestCase):
         self.addCleanup(os.unlink, handle.name)
         return handle.name
 
-    def test_missing_file_refuses_with_exit_2(self):
+    def test_missing_file_and_environment_refuses_with_exit_2(self):
         with self.assertRaises(SystemExit) as ctx:
-            prodlib.load_env("/nonexistent/companion-prod.env")
+            prodlib.load_env("/nonexistent/companion-prod.env", process_env={})
         self.assertEqual(ctx.exception.code, 2)
+
+    def test_process_environment_works_without_file(self):
+        env = prodlib.load_env(
+            "/nonexistent/companion-prod.env",
+            process_env={
+                "RAILWAY_API_TOKEN": "cloud-token",
+                "RAILWAY_PROJECT_ID": "cloud-project",
+            },
+        )
+        self.assertEqual(env["RAILWAY_API_TOKEN"], "cloud-token")
+        self.assertEqual(env["RAILWAY_PROJECT_ID"], "cloud-project")
+        self.assertEqual(env["COMPANION_BOX_API_BASE"], "https://ascii.dev/api/box/v1")
 
     def test_group_readable_file_refuses_with_exit_2(self):
         path = self._write_env("RAILWAY_API_TOKEN=x\n", 0o640)
@@ -110,11 +122,31 @@ class LoadEnvTest(unittest.TestCase):
             'COMPANION_BOX_API_KEY="boxkey"\n',
             0o600,
         )
-        env = prodlib.load_env(path)
+        env = prodlib.load_env(path, process_env={})
         self.assertEqual(env["RAILWAY_API_TOKEN"], "tok")
         self.assertEqual(env["RAILWAY_PROJECT_ID"], "proj")
         self.assertEqual(env["COMPANION_BOX_API_KEY"], "boxkey")
         self.assertEqual(env["COMPANION_BOX_API_BASE"], "https://ascii.dev/api/box/v1")
+
+    def test_process_environment_overrides_file_and_file_fills_missing_values(self):
+        path = self._write_env(
+            "RAILWAY_API_TOKEN=file-token\n"
+            "RAILWAY_PROJECT_ID=file-project\n"
+            "DEBUG_PROD_ALLOW_RESTART=1\n",
+            0o600,
+        )
+        env = prodlib.load_env(
+            path,
+            process_env={
+                "RAILWAY_API_TOKEN": "cloud-token",
+                "DEBUG_PROD_ALLOW_RESTART": "",
+                "UNRELATED_SECRET": "must-not-be-copied",
+            },
+        )
+        self.assertEqual(env["RAILWAY_API_TOKEN"], "cloud-token")
+        self.assertEqual(env["RAILWAY_PROJECT_ID"], "file-project")
+        self.assertEqual(env["DEBUG_PROD_ALLOW_RESTART"], "")
+        self.assertNotIn("UNRELATED_SECRET", env)
 
     def test_require_refuses_missing_key(self):
         with self.assertRaises(SystemExit) as ctx:


### PR DESCRIPTION
## Summary
- allow the production-debugging skill to use allowlisted credentials injected into ephemeral Conductor cloud environments
- keep `~/.companion-prod.env` as an optional `0600` fallback, with process values taking precedence
- cover process-only loading, precedence, empty overrides, unrelated-secret exclusion, and file behavior in both skill copies

## Verification
- [x] production-debugging Python suites in `.agents` and `.claude` — 136 tests passed
- [x] `pnpm verify:change` — hygiene, lint, typecheck, and tests passed across 20 packages; no follow-up gates required
- [x] `git diff --check` and secret-pattern scan — clean

## CI
- Latest commit: `0d7a8ccfa31858fd9b6d985f426d98a5771e3c6e`
- Status: all visible non-skipped checks passed
- Checks: Scope, Hygiene, Quality Node 22, CI Gate, Greptile Review, Vercel, and Vercel Preview Comments passed; unrelated lanes were skipped by scope

## Review Gate
- `review-code-dev`: passed with no findings
- Coverage: 14/14 changed files
- Required lenses: credential handling/allowlist and `.agents`/`.claude` parity

## Risk
- The skill now trusts only its allowlisted process variables before the optional fallback file.
- A present fallback file still fails closed unless its mode is exactly `0600`.

## Human Review Notes
- Please focus on credential precedence and the intentional behavior where an explicitly empty process variable overrides a fallback-file value.
