### PR TITLE
fix(macos): allow installer signing in CI

### DIFF
--- a/.github/workflows/macos-testflight.yml
+++ b/.github/workflows/macos-testflight.yml
@@ -60,7 +60,7 @@ jobs:
     if: needs.release-scope.outputs.macos == 'true'
     runs-on: macos-26
     environment: macos-testflight
-    timeout-minutes: 45
+    timeout-minutes: 30
     steps:
       - name: Checkout
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
@@ -111,11 +111,12 @@ jobs:
           security set-keychain-settings -lut 21600 "$keychain_path"
           security unlock-keychain -p "$keychain_password" "$keychain_path"
           security import "$distribution_path" -P "$MACOS_DISTRIBUTION_P12_PASSWORD" -t cert -f pkcs12 -k "$keychain_path" -T /usr/bin/codesign -T /usr/bin/security
-          security import "$installer_path" -P "$MACOS_INSTALLER_P12_PASSWORD" -t cert -f pkcs12 -k "$keychain_path" -T /usr/bin/codesign -T /usr/bin/security
+          security import "$installer_path" -P "$MACOS_INSTALLER_P12_PASSWORD" -t cert -f pkcs12 -k "$keychain_path" -T /usr/bin/codesign -T /usr/bin/productbuild -T /usr/bin/productsign -T /usr/bin/security
           security set-key-partition-list -S apple-tool:,apple: -k "$keychain_password" "$keychain_path"
           security list-keychains -d user -s "$keychain_path"
 
       - name: Archive and upload to App Store Connect
+        id: release
         env:
           ASC_KEY_ID: ${{ secrets.ASC_KEY_ID }}
           ASC_ISSUER_ID: ${{ secrets.ASC_ISSUER_ID }}
@@ -142,7 +143,7 @@ jobs:
           fi
 
       - name: Upload release diagnostics
-        if: failure()
+        if: always() && steps.release.outcome != 'success'
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: macos-testflight-diagnostics

--- a/scripts/macos-release.test.mjs
+++ b/scripts/macos-release.test.mjs
@@ -34,7 +34,17 @@ function commitFixture(cwd, path, contents, message) {
   mkdirSync(dirname(absolutePath), { recursive: true });
   writeFileSync(absolutePath, contents);
   git(cwd, ["add", "--", path]);
-  git(cwd, ["-c", "user.name=Fixture", "-c", "user.email=fixture@example.invalid", "commit", "-m", message]);
+  git(cwd, [
+    "-c",
+    "user.name=Fixture",
+    "-c",
+    "user.email=fixture@example.invalid",
+    "-c",
+    "commit.gpgsign=false",
+    "commit",
+    "-m",
+    message,
+  ]);
   return git(cwd, ["rev-parse", "HEAD"]);
 }
 
@@ -171,6 +181,9 @@ test("the macOS TestFlight workflow releases only a CI-approved main commit", ()
   assert.match(workflow, /MACOS_DISTRIBUTION_P12: \$\{\{ secrets\.MACOS_DISTRIBUTION_P12 \}\}/);
   assert.match(workflow, /MACOS_INSTALLER_P12: \$\{\{ secrets\.MACOS_INSTALLER_P12 \}\}/);
   assert.match(workflow, /MACOS_PROVISIONING_PROFILE: \$\{\{ secrets\.MACOS_PROVISIONING_PROFILE \}\}/);
+  assert.match(workflow, /-T \/usr\/bin\/productbuild -T \/usr\/bin\/productsign/);
+  assert.match(workflow, /id: release/);
+  assert.match(workflow, /if: always\(\) && steps\.release\.outcome != 'success'/);
   assert.match(workflow, /bash apps\/macos\/scripts\/release\.sh/);
   assert.doesNotMatch(workflow, /pull_request:/);
 });


### PR DESCRIPTION
## Summary
- trust `productbuild` and `productsign` for the imported Mac Installer private key
- retain release diagnostics when the delivery job is cancelled or times out
- disable inherited commit signing in temporary Git test fixtures

## Validation
- `node --test scripts/macos-devx.test.mjs scripts/macos-release.test.mjs` (10 passed)
- fresh-keychain `productbuild` signing smoke with the backed-up Installer certificate
- `git diff --check`

## Failure evidence
The first post-merge macOS release archived and signed successfully, then `xcodebuild -exportArchive` waited in `productbuild` until the 45-minute job timeout. No new upload appeared in App Store Connect, and the temporary signing assets were cleaned.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/The-Vibe-Company/companion/pull/707?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

The PR updates the macOS TestFlight workflow to authorize installer-signing tools, retain release logs after cancellation or timeout, and fail stalled releases sooner.
- Grants `/usr/bin/productbuild` and `/usr/bin/productsign` access to the imported installer private key.
- Identifies the release step and uploads diagnostics whenever it does not succeed.
- Disables inherited Git commit signing in temporary test fixtures and adds regression assertions for the workflow changes.
</details>


<details><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge, with no concrete blocking or independently actionable non-blocking issue identified.

The installer identity is granted access to the actual macOS packaging tools, cancellation-aware diagnostics remain reachable, and the accompanying test changes correctly protect those workflow settings and isolate fixture commits from inherited signing configuration.
</details>


<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| .github/workflows/macos-testflight.yml | Correctly extends the installer-key ACL, identifies the release step for cancellation-aware diagnostics, and reduces the stalled-job timeout without an established functional regression. |
| scripts/macos-release.test.mjs | Prevents global Git signing configuration from breaking fixture commits and adds workflow regression assertions consistent with existing repository conventions. |

</details>


<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
  A[Import distribution and installer identities] --> B[Grant installer key access to productbuild and productsign]
  B --> C[Archive application]
  C --> D[Export and upload to App Store Connect]
  D -->|Success| E[Remove temporary signing assets]
  D -->|Failure, cancellation, or timeout| E
  E --> F{Release step succeeded?}
  F -->|Yes| G[Finish]
  F -->|No| H[Upload release log artifact]
```
</details>

<sub>Reviews (1): Last reviewed commit: ["fix(macos): allow installer signing in C..."](https://github.com/the-vibe-company/companion/commit/dda229855289ff60d58b25f68ae4168770454c7e) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=59236315)</sub>

<!-- /greptile_comment -->