### PR TITLE
fix(macos): release TestFlight pipeline changes

### DIFF
--- a/scripts/macos-release.test.mjs
+++ b/scripts/macos-release.test.mjs
@@ -160,6 +160,21 @@ test("TestFlight scope includes macOS changes from the complete approved push", 
   assert.equal(testflightScope(macosSha, releaseSha, { cwd: fixtureRoot }).macos, false);
 });
 
+test("TestFlight scope treats its release plumbing as a macOS change", (t) => {
+  const fixtureRoot = mkdtempSync(join(tmpdir(), "companion-macos-release-plumbing-test-"));
+  t.after(() => rmSync(fixtureRoot, { force: true, recursive: true }));
+  git(fixtureRoot, ["init", "--quiet"]);
+  commitFixture(fixtureRoot, "README.md", "fixture\n", "initial");
+  const beforeSha = git(fixtureRoot, ["rev-parse", "HEAD"]);
+  const releaseSha = commitFixture(
+    fixtureRoot,
+    ".github/workflows/macos-testflight.yml",
+    "name: fixture\n",
+    "macOS release plumbing",
+  );
+  assert.equal(testflightScope(beforeSha, releaseSha, { cwd: fixtureRoot }).macos, true);
+});
+
 test("the macOS TestFlight workflow releases only a CI-approved main commit", () => {
   const workflow = read(".github/workflows/macos-testflight.yml");
   const ciWorkflow = read(".github/workflows/ci.yml");

--- a/scripts/macos-testflight-scope.mjs
+++ b/scripts/macos-testflight-scope.mjs
@@ -18,11 +18,20 @@ function gitChangedFiles(beforeSha, releaseSha, { cwd = process.cwd(), exec = ex
     .filter(Boolean);
 }
 
+function isMacosReleaseChange(path) {
+  return (
+    path.startsWith("apps/macos/") ||
+    path === ".github/workflows/macos-testflight.yml" ||
+    path === "scripts/macos-testflight-scope.mjs" ||
+    path === "scripts/macos-release.test.mjs"
+  );
+}
+
 export function testflightScope(beforeSha, releaseSha, options) {
   assertSha("before SHA", beforeSha, { allowZero: true });
   assertSha("release SHA", releaseSha);
   const changedFiles = gitChangedFiles(beforeSha, releaseSha, options);
-  return { changedFiles, macos: changedFiles.some((path) => path.startsWith("apps/macos/")), releaseSha };
+  return { changedFiles, macos: changedFiles.some(isMacosReleaseChange), releaseSha };
 }
 
 function requiredEnv(name) {


### PR DESCRIPTION
## Summary
- treat macOS TestFlight workflow and release-plumbing changes as native macOS release changes
- add behavior coverage proving pipeline changes trigger the upload lane

## Validation
- `node --test scripts/macos-devx.test.mjs scripts/macos-release.test.mjs` (11 passed)
- `git diff --check`

## Context
PR #707 fixed the Installer key access, but its post-merge delivery correctly skipped because the previous scope classifier only matched `apps/macos/`. This change lets release-pipeline fixes validate themselves end to end.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/The-Vibe-Company/companion/pull/708?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR broadens macOS TestFlight change detection so edits to the workflow, scope classifier, and release test trigger the existing upload lane.
- Adds an explicit classifier for macOS application and release-plumbing paths.
- Adds behavior coverage confirming that a workflow-only change is treated as a macOS release change.
</details>


<details><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge, with no changed-code-triggered defects identified.

The classifier is safely broadened to include the intended release-plumbing files, and the added test exercises the workflow-path behavior without changing production release execution.
</details>


<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| scripts/macos-testflight-scope.mjs | Expands the macOS release scope from application files alone to three release-plumbing files without altering SHA validation or workflow execution. |
| scripts/macos-release.test.mjs | Adds a focused fixture test proving that changes to the TestFlight workflow activate macOS release scope. |

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(macos): release TestFlight pipeline ..."](https://github.com/the-vibe-company/companion/commit/90d854945810b4d1c8bdc26c61c4948bac35133e) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=59240048)</sub>

<!-- /greptile_comment -->