### PR TITLE
fix(macos): keep TestFlight package readable

### DIFF
--- a/apps/macos/scripts/release.sh
+++ b/apps/macos/scripts/release.sh
@@ -44,8 +44,7 @@ if [[ -n "${ASC_KEY_PATH:-}" ]]; then
 elif [[ -n "${ASC_KEY_P8:-}" ]]; then
   KEY_TEMP_DIR="$(mktemp -d "${TMPDIR:-/tmp}/companion-asc-key.XXXXXX")"
   KEY_PATH="$KEY_TEMP_DIR/AuthKey_${ASC_KEY_ID}.p8"
-  umask 077
-  printf '%s\n' "$ASC_KEY_P8" > "$KEY_PATH"
+  (umask 077 && printf '%s\n' "$ASC_KEY_P8" > "$KEY_PATH")
 else
   echo "ASC_KEY_PATH or ASC_KEY_P8 is required" >&2
   exit 1

--- a/scripts/macos-release.test.mjs
+++ b/scripts/macos-release.test.mjs
@@ -7,6 +7,7 @@ import {
   readFileSync,
   readdirSync,
   rmSync,
+  statSync,
   writeFileSync,
 } from "node:fs";
 import { tmpdir } from "node:os";
@@ -118,6 +119,8 @@ test("the native macOS release archives then uploads with an ephemeral API key",
   assert.ok(calls[1].includes(resolve(ROOT, "apps/macos/Config/ExportOptions.plist")));
   assert.equal(readFileSync(join(outputDir, "archive.log"), "utf8"), "stub archive success\n");
   assert.equal(readFileSync(join(outputDir, "export.log"), "utf8"), "stub -exportArchive success\n");
+  assert.equal(statSync(join(outputDir, "archive.log")).mode & 0o044, 0o044);
+  assert.equal(statSync(join(outputDir, "export.log")).mode & 0o044, 0o044);
   assert.deepEqual(keyDirectories, []);
   assert.doesNotMatch(`${result.stdout}${result.stderr}${calls.flat().join(" ")}`, new RegExp(PRIVATE_KEY_FIXTURE));
 });


### PR DESCRIPTION
## Summary
- scope the restrictive umask to the temporary App Store Connect API key only
- preserve normal read permissions for Xcode archive and installer outputs
- cover the CI-only permission regression with release tests

## Verification
- node --test scripts/macos-release.test.mjs
- bash -n apps/macos/scripts/release.sh
- git diff --check

Fixes App Store Connect upload error 90255 observed in release run 33562912540.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/The-Vibe-Company/companion/pull/709?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR confines the restrictive umask to the temporary App Store Connect API key so subsequent Xcode outputs retain normal read permissions.
- Keeps the ephemeral API key private without affecting archive and export permissions.
- Adds regression assertions covering readability of archive and export logs.
</details>


<details><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge, with the private key still protected and release outputs no longer inheriting its restrictive permissions.

The standalone subshell preserves key-write failure propagation and limits umask 077 to the sensitive file, while the added tests cover the output-permission regression.
</details>


<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| apps/macos/scripts/release.sh | Correctly scopes the restrictive umask to the API-key write while preserving failure propagation under `set -e`. |
| scripts/macos-release.test.mjs | Adds focused permission assertions that would fail under the prior script-wide restrictive umask. |

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(macos): keep TestFlight package read..."](https://github.com/the-vibe-company/companion/commit/0e8e03f45f7567f24bb8dd6a2c364bfa295bfa7c) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=59244626)</sub>

<!-- /greptile_comment -->