### PR TITLE
fix(runtime): serialize recovery with active lane work

### DIFF
--- a/apps/api/test/integration/companionRuntimeExecutor.integration.test.ts
+++ b/apps/api/test/integration/companionRuntimeExecutor.integration.test.ts
@@ -10000,6 +10000,147 @@ describe("Companion runtime executor PostgreSQL surface", () => {
     }
   });
 
+  it("reclaims a running Start before due same-lane recovery without starving other Companions", async () => {
+    if (!sql) throw new Error("runtime executor database is not initialized");
+    const blockedFixture = await createCompanion({
+      boxReady: true,
+      selectedSkillIds: [],
+      selectedMcpAccountIds: [],
+    });
+    let independentFixture: Awaited<ReturnType<typeof createCompanion>> | undefined;
+    const queuedTurnId = randomUUID();
+    const queuedClientMessageId = randomUUID();
+    const startId = randomUUID();
+    const startExecutor = `${executorId}-same-lane-start`;
+    const takeoverExecutor = `${executorId}-same-lane-takeover`;
+    let claims: Claim[] = [];
+    try {
+      await sql`
+        update companion_turn_attempts
+        set status = 'interrupted', settled_at = now(),
+          last_error_code = 'turn_stalled',
+          last_error_message = 'The Companion stopped making progress.',
+          last_error_action = 'retry', updated_at = now()
+        where id = ${blockedFixture.attemptId}::uuid
+      `;
+      await sql`
+        update companion_turns
+        set status = 'interrupted', settled_at = now(), state_changed_at = now(),
+          last_error_code = 'turn_stalled',
+          last_error_message = 'The Companion stopped making progress.',
+          last_error_action = 'retry', updated_at = now()
+        where id = ${blockedFixture.turnId}::uuid
+      `;
+      const [recovery] = await sql<Array<{ id: string }>>`
+        update companion_operations
+        set available_at = now() + interval '1 hour'
+        where companion_id = ${blockedFixture.companionId}::uuid
+          and source_turn_id = ${blockedFixture.turnId}::uuid
+          and kind = 'restart_pi' and trigger = 'recovery'
+        returning id::text as id
+      `;
+      if (!recovery) throw new Error("expected same-lane recovery");
+
+      await sql`
+        insert into companion_transcript_entries(
+          org_id, companion_id, event_id, ordinal, role, content, author_id
+        ) values (
+          ${ids.orgA}::uuid, ${blockedFixture.companionId}::uuid,
+          ${`msg:${queuedClientMessageId}`}, 1, 'user',
+          'Start after exact cleanup.', ${ids.ownerA}
+        )
+      `;
+      await sql`
+        insert into companion_turns(
+          id, org_id, companion_id, client_message_id, message_event_id,
+          queue_sequence, actor_id, client_surface, status
+        ) values (
+          ${queuedTurnId}::uuid, ${ids.orgA}::uuid, ${blockedFixture.companionId}::uuid,
+          ${queuedClientMessageId}::uuid, ${`msg:${queuedClientMessageId}`}, 2,
+          ${ids.ownerA}, 'web', 'queued'
+        )
+      `;
+      await sql`
+        insert into companion_operations(
+          id, org_id, companion_id, request_id, kind, trigger,
+          actor_id, source_turn_id, runtime_generation, available_at
+        ) values (
+          ${startId}::uuid, ${ids.orgA}::uuid, ${blockedFixture.companionId}::uuid,
+          ${randomUUID()}::uuid, 'start', 'turn', ${ids.ownerA}, ${queuedTurnId}::uuid,
+          1, now()
+        )
+      `;
+
+      await sql`
+        update companion_runtime_instances set health_due_at = now() + interval '1 day'
+        where companion_id = ${blockedFixture.companionId}::uuid
+      `;
+      const nonStartClaims = await claimWorkRows(1, startExecutor);
+      expect(nonStartClaims).not.toEqual(expect.arrayContaining([
+        expect.objectContaining({ workKind: "operation", workId: startId }),
+      ]));
+      for (const nonStartClaim of nonStartClaims) await release(nonStartClaim, startExecutor);
+      const [blockedStart] = await sql<Array<{ status: string; startedAt: Date | null }>>`
+        select status::text as status, started_at as "startedAt"
+        from companion_operations where id = ${startId}::uuid
+      `;
+      expect(blockedStart).toEqual({ status: "pending", startedAt: null });
+
+      // Simulate the finite rolling-deploy overlap produced before this interlock existed.
+      await sql`
+        update companion_operations
+        set status = 'running', claim_epoch = 1, attempt_count = 1,
+          started_at = now(), updated_at = now()
+        where id = ${startId}::uuid
+      `;
+
+      independentFixture = await createCompanion({
+        boxReady: false,
+        selectedSkillIds: [],
+        selectedMcpAccountIds: [],
+      });
+
+      await sql`
+        update companion_operations set available_at = now()
+        where id = ${recovery.id}::uuid
+      `;
+
+      claims = await claimWorkRows(2, takeoverExecutor);
+      expect(claims).toHaveLength(2);
+      expect(claims).toEqual(expect.arrayContaining([
+        expect.objectContaining({
+          companionId: blockedFixture.companionId,
+          workKind: "operation",
+          workId: startId,
+        }),
+        expect.objectContaining({
+          companionId: independentFixture.companionId,
+          workKind: "attempt",
+          workId: independentFixture.attemptId,
+        }),
+      ]));
+      const [operationState] = await sql<Array<{
+        recoveryStatus: string;
+        startStatus: string;
+      }>>`
+        select recovery.status::text as "recoveryStatus",
+          start_operation.status::text as "startStatus"
+        from companion_operations recovery
+        join companion_operations start_operation
+          on start_operation.id = ${startId}::uuid
+        where recovery.id = ${recovery.id}::uuid
+      `;
+      expect(operationState).toEqual({
+        recoveryStatus: "pending",
+        startStatus: "running",
+      });
+    } finally {
+      for (const claim of claims) await release(claim, takeoverExecutor);
+      if (independentFixture) await removeCompanion(independentFixture.companionId);
+      await removeCompanion(blockedFixture.companionId);
+    }
+  });
+
   it("holds a cold main Start behind unresolved routine cleanup, then claims it after proof", async () => {
     if (!sql) throw new Error("runtime executor database is not initialized");
     const fixture = await createCompanion({

--- a/docs/companions-runtime.md
+++ b/docs/companions-runtime.md
@@ -126,7 +126,9 @@ isolated routine-origin turns. At most one attempt is active in each lane, so on
 one routine attempt may run together. FIFO ordering applies within each lane. An unresolved
 `interrupted` occurrence owns only its lane until protocol 7's internal Pi cleanup proves terminal;
 then `resolution = auto_abandoned` releases it without replay. A routine recovery, including one in
-backoff, never delays an independently warm main-lane message.
+backoff, never delays an independently warm main-lane message. On the affected lane, cleanup backoff
+still fences a new Start; any already-active work exposed during rollout is reclaimed before the
+pending recovery can run.
 
 ### Attempt
 

--- a/docs/design.md
+++ b/docs/design.md
@@ -168,7 +168,8 @@ exists, while a live Box requires exact invocation termination. Main cleanup com
 systemd `InvocationID`; routine cleanup uses its run-scoped invocation. A newer invocation is never
 stopped. Runtime checkpoints `cleanup_complete`, marks the occurrence `auto_abandoned`, and releases
 the lane without staging or replaying its prompt. Cleanup retries with a maximum five-minute backoff
-and a fresh fixed ten-minute budget per claim cycle.
+and a fresh fixed ten-minute budget per claim cycle. Backoff still fences a new Start on that lane;
+if rolling deployment exposes already-active same-lane work, Runtime reclaims it before cleanup.
 Settings revisions accepted during a turn apply after
 the routine lane is quiescent and before the next main turn. On a warm Box, configuration is published as
 applied only after runtime stages the exact snapshot, restarts Pi, and observes a different idle Pi

--- a/packages/db/drizzle/0158_companion_recovery_lane_interlock.sql
+++ b/packages/db/drizzle/0158_companion_recovery_lane_interlock.sql
@@ -1,0 +1,105 @@
+-- A recovery is exact lane-local cleanup, not higher-priority lifecycle work. Keep a pending
+-- recovery behind any operation or attempt that is already active on its lane, and keep a new
+-- Start behind unresolved cleanup even while that cleanup is waiting for backoff. This also
+-- repairs the rolling overlap by reclaiming the already-running work before cleanup.
+DO $companion_recovery_lane_interlock$
+DECLARE
+  v_signature text :=
+    'public.companion_runtime_claim_work_without_material_guard(text,integer,integer,bigint)';
+  v_definition text := pg_catalog.pg_get_functiondef(pg_catalog.to_regprocedure(v_signature));
+  v_old text;
+  v_new text;
+  v_count integer;
+BEGIN
+  v_old := $r$        AND o.kind IN ('stop', 'restart_pi', 'restart_box')
+        AND o.status IN ('pending', 'running') AND o.available_at <= v_now
+      ORDER BY CASE WHEN o.status = 'running' THEN 0 ELSE 1 END, o.queue_sequence, o.id
+      LIMIT 1
+      FOR UPDATE;$r$;
+  v_new := $r$        AND o.kind IN ('stop', 'restart_pi', 'restart_box')
+        AND o.status IN ('pending', 'running') AND o.available_at <= v_now
+        AND (
+          o.status = 'running'
+          OR o.trigger <> 'recovery'
+          OR (
+            NOT EXISTS (
+              SELECT 1 FROM public.companion_operations active_operation
+              WHERE active_operation.org_id = o.org_id
+                AND active_operation.companion_id = o.companion_id
+                AND active_operation.execution_lane = v_lane
+                AND active_operation.status = 'running'
+            )
+            AND NOT EXISTS (
+              SELECT 1 FROM public.companion_turn_attempts active_attempt
+              WHERE active_attempt.org_id = o.org_id
+                AND active_attempt.companion_id = o.companion_id
+                AND active_attempt.execution_lane = v_lane
+                AND active_attempt.status IN (
+                  'starting', 'dispatching', 'running', 'needs_input'
+                )
+            )
+          )
+        )
+      ORDER BY CASE WHEN o.status = 'running' THEN 0 ELSE 1 END, o.queue_sequence, o.id
+      LIMIT 1
+      FOR UPDATE;$r$;
+  v_count := (char_length(v_definition) - char_length(replace(v_definition, v_old, '')))
+    / char_length(v_old);
+  IF v_definition IS NULL OR v_count <> 1 THEN
+    RAISE EXCEPTION 'recovery active-lane interlock matched %, expected 1', COALESCE(v_count, 0)
+      USING ERRCODE = '55000';
+  END IF;
+  v_definition := replace(v_definition, v_old, v_new);
+
+  v_old := $r$        AND (
+          o.trigger <> 'turn'
+          OR EXISTS (
+            SELECT 1
+            FROM public.companion_turns source_turn
+            WHERE source_turn.org_id = o.org_id
+              AND source_turn.companion_id = o.companion_id
+              AND source_turn.id = o.source_turn_id
+              AND source_turn.status = 'queued'
+          )
+        )
+      ORDER BY CASE WHEN o.status = 'running' THEN 0 ELSE 1 END, o.queue_sequence, o.id$r$;
+  v_new := $r$        AND (
+          o.trigger <> 'turn'
+          OR EXISTS (
+            SELECT 1
+            FROM public.companion_turns source_turn
+            WHERE source_turn.org_id = o.org_id
+              AND source_turn.companion_id = o.companion_id
+              AND source_turn.id = o.source_turn_id
+              AND source_turn.status = 'queued'
+          )
+        )
+        AND (
+          o.status = 'running'
+          OR NOT EXISTS (
+            SELECT 1
+            FROM public.companion_operations recovery_operation
+            JOIN public.companion_turns recovery_source
+              ON recovery_source.org_id = recovery_operation.org_id
+             AND recovery_source.companion_id = recovery_operation.companion_id
+             AND recovery_source.id = recovery_operation.source_turn_id
+            WHERE recovery_operation.org_id = o.org_id
+              AND recovery_operation.companion_id = o.companion_id
+              AND recovery_operation.execution_lane = v_lane
+              AND recovery_operation.kind = 'restart_pi'
+              AND recovery_operation.trigger = 'recovery'
+              AND recovery_operation.status IN ('pending', 'running')
+              AND recovery_source.status = 'interrupted'
+              AND recovery_source.resolution IS NULL
+          )
+        )
+      ORDER BY CASE WHEN o.status = 'running' THEN 0 ELSE 1 END, o.queue_sequence, o.id$r$;
+  v_count := (char_length(v_definition) - char_length(replace(v_definition, v_old, '')))
+    / char_length(v_old);
+  IF v_count <> 1 THEN
+    RAISE EXCEPTION 'Start recovery interlock matched %, expected 1', v_count
+      USING ERRCODE = '55000';
+  END IF;
+  EXECUTE replace(v_definition, v_old, v_new);
+END
+$companion_recovery_lane_interlock$;

--- a/packages/db/drizzle/meta/_journal.json
+++ b/packages/db/drizzle/meta/_journal.json
@@ -1107,6 +1107,13 @@
       "when": 1793297200000,
       "tag": "0157_companion_recovery_cleanup_protocol_7",
       "breakpoints": true
+    },
+    {
+      "idx": 158,
+      "version": "7",
+      "when": 1793300800000,
+      "tag": "0158_companion_recovery_lane_interlock",
+      "breakpoints": true
     }
   ]
 }


### PR DESCRIPTION
## Summary

- prevent protocol-7 recovery from claiming a lane while an operation or turn attempt is already active there
- keep new same-lane Starts behind unresolved recovery, including recovery backoff, while preserving reclaim of an already-running Start after a rolling deploy
- add a real-PostgreSQL regression proving the overlap no longer aborts the claim batch or starves an independent Companion
- align the Runtime v2 design documentation with the lane interlock

## Incident

A due recovery could be selected before an already-running same-lane Start. Promoting that recovery to `running` violated `companion_operations_one_running_uq`, aborting the whole multi-claim transaction and preventing unrelated Companions from receiving work.

The migration changes scheduling predicates only. It contains no Companion-specific IDs and performs no production data rewrite.

## Verification

- [x] regression reproduced the unique-index failure before the fix and passed afterward
- [x] Companion runtime executor PostgreSQL suite: 78/78
- [x] runtime service integration suite: 2/2
- [x] Box/Pi simulator suite: 84/84
- [x] `pnpm verify:change` fast checks: hygiene, lint, typecheck, unit tests, and builds
- [x] independent light review: all five changed files covered, no P0-P3 findings
- [x] latest-commit GitHub CI: 12 successful, 1 skipped, 0 failed, 0 pending

The repository-wide database follow-up gate was not completed locally because the available system database was not a migrated split-role test base. Browser and prebuilt-container follow-up gates were also left to their purpose-built environments.

## Risk and review focus

The main risk is the SQL migration's exact rewrite of the durable claim function. Please focus review on the recovery/Start selector predicates and the intended mixed-version rolling-deploy behavior.

This PR does not deploy or mutate production state and does not change the Runtime v2 protocol.
