### PR TITLE
refactor(runtime): introduce the Runtime v3 progression seam

### DIFF
--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -14,3 +14,12 @@ paths = [
   '''\.claude/skills/debug-companions-prod/scripts/test_prodlib\.py''',
   '''\.agents/skills/debug-companions-prod/scripts/test_prodlib\.py''',
 ]
+
+# Runtime v3 lease-fencing tests need stable UUID-shaped tokens so assertions can distinguish
+# independent claims. These three exact literals are synthetic fixtures, not credentials. Keep the
+# exemption value-specific because the history scan evaluates the commits that introduced them.
+regexes = [
+  '''3c706ec6-5caf-41fc-a009-614730726ebe''',
+  '''a60fa0eb-e514-4453-94ef-d6668220fb85''',
+  '''2aa20f71-0f55-4f57-82a8-561256f42da3''',
+]

--- a/apps/api/src/runtimeRoleGrants.test.ts
+++ b/apps/api/src/runtimeRoleGrants.test.ts
@@ -226,9 +226,11 @@ describe("Skills Hub runtime-role grants", () => {
     // bookkeeping to the API role; the JSON projection stays internal.
     const sentinel = sql.indexOf("'public.companion_api_list_triggers(uuid,uuid)'");
     expect(sentinel).toBeGreaterThan(-1);
+    const runtimeV3Sentinel = sql.indexOf("-- 0159 is the dormant Runtime v3 expand seam", sentinel);
+    expect(runtimeV3Sentinel).toBeGreaterThan(sentinel);
     const triggerBlock = sql.slice(
       sentinel,
-      sql.indexOf("-- A migration owner can carry arbitrary", sentinel),
+      runtimeV3Sentinel,
     );
     for (const signature of [
       "companion_api_list_triggers(uuid,uuid)",

--- a/apps/runtime/src/database.test.ts
+++ b/apps/runtime/src/database.test.ts
@@ -20,7 +20,7 @@ const validProfile = {
   ownsDatabaseOrSchema: false,
   ownsRelations: false,
   ownsFunctionsOrTypes: false,
-  protectedRelationCount: 15,
+  protectedRelationCount: 18,
   hasPublicRelationPrivileges: false,
   requiredFunctionsReady: true,
   ownsRequiredFunctions: false,
@@ -73,6 +73,9 @@ describe("runtime database role verification", () => {
     expect(query).toContain("companion_runtime_renew_and_authorize");
     expect(query).toContain("companion_runtime_get_routine_material");
     expect(query).toContain("companion_routine_context_substrates");
+    expect(query).toContain("companion_v3_runtime_claim");
+    expect(query).toContain("companion_v3_runtime_complete");
+    expect(query).toContain("companion_v3_lane_leases");
   });
 
   it.each([

--- a/apps/runtime/src/runtimeV3ProgressionStore.ts
+++ b/apps/runtime/src/runtimeV3ProgressionStore.ts
@@ -1,6 +1,6 @@
 import type {
-  RuntimeV3ProgressionOutcome,
-  RuntimeV3ProgressionPersistence,
+  RuntimeV3ConvergencePersistence,
+  RuntimeV3DurableOutcome,
   RuntimeV3Turn,
 } from "@companion/companion-runtime/v3/internal";
 import type { Sql } from "postgres";
@@ -20,6 +20,7 @@ interface TerminalCompletion {
   outcome: "release" | "succeeded" | "failed" | "interrupted";
   code: string | null;
   message: string | null;
+  action: string | null;
 }
 
 function turnFromRow(row: {
@@ -36,70 +37,37 @@ function turnFromRow(row: {
   };
 }
 
-function terminalInput(outcome: RuntimeV3ProgressionOutcome): TerminalCompletion {
+function terminalInput(outcome: RuntimeV3DurableOutcome): TerminalCompletion {
   if (outcome.kind === "failed" || outcome.kind === "interrupted") {
-    return { outcome: outcome.kind, code: outcome.code, message: outcome.message };
+    return {
+      outcome: outcome.kind,
+      code: outcome.error.code,
+      message: outcome.error.message,
+      action: outcome.error.action,
+    };
   }
-  return { outcome: outcome.kind, code: null, message: null };
+  return { outcome: outcome.kind, code: null, message: null, action: null };
 }
 
-/** PostgreSQL adapter kept outside the v3 module's caller-facing interface and composition root. */
-export function createRuntimeV3PostgresPersistence(sql: Sql): RuntimeV3ProgressionPersistence {
+/** Runtime-role PostgreSQL adapter kept outside the caller-facing interface and composition root. */
+export function createRuntimeV3PostgresConvergence(sql: Sql): RuntimeV3ConvergencePersistence {
   return {
-    async admitTurn(input) {
-      if (input.lane !== "main") {
-        throw new Error("background admission belongs to the worker persistence adapter");
-      }
-      const rows = await sql<Array<{
-        turnId: string;
-        commandId: string;
-        lane: "main";
-        state: RuntimeV3Turn["state"];
-      }>>`
-        select turn_id as "turnId", command_id as "commandId", lane::text, state::text
-        from public.companion_v3_api_admit_turn(
-          ${input.orgId}::uuid,
-          ${input.companionId}::uuid,
-          ${input.clientMessageId}::uuid,
-          ${input.messageEventId}
-        )
+    async claimLane({ executorId, lane }) {
+      const rows = await sql<ClaimRow[]>`
+        select org_id as "orgId", companion_id as "companionId", turn_id as "turnId",
+          command_id as "commandId", lane::text, state::text,
+          claim_token as "claimToken", claim_epoch::text as "claimEpoch"
+        from public.companion_v3_runtime_claim(${executorId}, ${lane}, 30, 3)
       `;
       const row = rows[0];
-      if (!row) throw new Error("Runtime v3 admission returned no Turn");
-      return turnFromRow(row);
-    },
-    async recordDesiredLifecycle(input) {
-      const rows = await sql<Array<{ intent: typeof input.intent; revision: string }>>`
-        select intent::text, revision::text
-        from public.companion_v3_api_desire_lifecycle(
-          ${input.orgId}::uuid,
-          ${input.companionId}::uuid,
-          ${input.intent}
-        )
-      `;
-      const row = rows[0];
-      if (!row) throw new Error("Runtime v3 lifecycle change returned no revision");
-      return { intent: row.intent, revision: BigInt(row.revision) };
-    },
-    async claimAvailable({ executorId }) {
-      const claims = await Promise.all((["main", "background"] as const).map(async (lane) => {
-        const rows = await sql<ClaimRow[]>`
-          select org_id as "orgId", companion_id as "companionId", turn_id as "turnId",
-            command_id as "commandId", lane::text, state::text,
-            claim_token as "claimToken", claim_epoch::text as "claimEpoch"
-          from public.companion_v3_runtime_claim(${executorId}, ${lane}, 30, 3)
-        `;
-        const row = rows[0];
-        return row
-          ? {
-            turn: turnFromRow(row),
-            fence: { token: row.claimToken, epoch: BigInt(row.claimEpoch) },
-            orgId: row.orgId,
-            companionId: row.companionId,
-          }
-          : null;
-      }));
-      return claims.filter((claim) => claim !== null);
+      return row
+        ? {
+          turn: turnFromRow(row),
+          fence: { token: row.claimToken, epoch: BigInt(row.claimEpoch) },
+          orgId: row.orgId,
+          companionId: row.companionId,
+        }
+        : null;
     },
     async completeProgression(claim, outcome) {
       const terminal = terminalInput(outcome);
@@ -114,6 +82,7 @@ export function createRuntimeV3PostgresPersistence(sql: Sql): RuntimeV3Progressi
           ${terminal.outcome},
           ${terminal.code},
           ${terminal.message},
+          ${terminal.action}::public.companion_runtime_error_action,
           3
         ) as completed
       `;

--- a/apps/runtime/src/runtimeV3ProgressionStore.ts
+++ b/apps/runtime/src/runtimeV3ProgressionStore.ts
@@ -14,6 +14,7 @@ interface ClaimRow {
   state: RuntimeV3Turn["state"];
   claimToken: string;
   claimEpoch: string;
+  gateEpoch: string;
 }
 
 interface TerminalCompletion {
@@ -56,14 +57,19 @@ export function createRuntimeV3PostgresConvergence(sql: Sql): RuntimeV3Convergen
       const rows = await sql<ClaimRow[]>`
         select org_id as "orgId", companion_id as "companionId", turn_id as "turnId",
           command_id as "commandId", lane::text, state::text,
-          claim_token as "claimToken", claim_epoch::text as "claimEpoch"
+          claim_token as "claimToken", claim_epoch::text as "claimEpoch",
+          gate_epoch::text as "gateEpoch"
         from public.companion_v3_runtime_claim(${executorId}, ${lane}, 30, 3)
       `;
       const row = rows[0];
       return row
         ? {
           turn: turnFromRow(row),
-          fence: { token: row.claimToken, epoch: BigInt(row.claimEpoch) },
+          fence: {
+            token: row.claimToken,
+            epoch: BigInt(row.claimEpoch),
+            gateEpoch: BigInt(row.gateEpoch),
+          },
           orgId: row.orgId,
           companionId: row.companionId,
         }
@@ -79,6 +85,7 @@ export function createRuntimeV3PostgresConvergence(sql: Sql): RuntimeV3Convergen
           ${claim.turn.id}::uuid,
           ${claim.fence.token}::uuid,
           ${claim.fence.epoch.toString()}::bigint,
+          ${claim.fence.gateEpoch.toString()}::bigint,
           ${terminal.outcome},
           ${terminal.code},
           ${terminal.message},

--- a/apps/runtime/src/runtimeV3ProgressionStore.ts
+++ b/apps/runtime/src/runtimeV3ProgressionStore.ts
@@ -1,0 +1,123 @@
+import type {
+  RuntimeV3ProgressionOutcome,
+  RuntimeV3ProgressionPersistence,
+  RuntimeV3Turn,
+} from "@companion/companion-runtime/v3/internal";
+import type { Sql } from "postgres";
+
+interface ClaimRow {
+  orgId: string;
+  companionId: string;
+  turnId: string;
+  commandId: string;
+  lane: "main" | "background";
+  state: RuntimeV3Turn["state"];
+  claimToken: string;
+  claimEpoch: string;
+}
+
+interface TerminalCompletion {
+  outcome: "release" | "succeeded" | "failed" | "interrupted";
+  code: string | null;
+  message: string | null;
+}
+
+function turnFromRow(row: {
+  turnId: string;
+  commandId: string;
+  lane: "main" | "background";
+  state: RuntimeV3Turn["state"];
+}): RuntimeV3Turn {
+  return {
+    id: row.turnId,
+    commandId: row.commandId,
+    lane: row.lane,
+    state: row.state,
+  };
+}
+
+function terminalInput(outcome: RuntimeV3ProgressionOutcome): TerminalCompletion {
+  if (outcome.kind === "failed" || outcome.kind === "interrupted") {
+    return { outcome: outcome.kind, code: outcome.code, message: outcome.message };
+  }
+  return { outcome: outcome.kind, code: null, message: null };
+}
+
+/** PostgreSQL adapter kept outside the v3 module's caller-facing interface and composition root. */
+export function createRuntimeV3PostgresPersistence(sql: Sql): RuntimeV3ProgressionPersistence {
+  return {
+    async admitTurn(input) {
+      if (input.lane !== "main") {
+        throw new Error("background admission belongs to the worker persistence adapter");
+      }
+      const rows = await sql<Array<{
+        turnId: string;
+        commandId: string;
+        lane: "main";
+        state: RuntimeV3Turn["state"];
+      }>>`
+        select turn_id as "turnId", command_id as "commandId", lane::text, state::text
+        from public.companion_v3_api_admit_turn(
+          ${input.orgId}::uuid,
+          ${input.companionId}::uuid,
+          ${input.clientMessageId}::uuid,
+          ${input.messageEventId}
+        )
+      `;
+      const row = rows[0];
+      if (!row) throw new Error("Runtime v3 admission returned no Turn");
+      return turnFromRow(row);
+    },
+    async recordDesiredLifecycle(input) {
+      const rows = await sql<Array<{ intent: typeof input.intent; revision: string }>>`
+        select intent::text, revision::text
+        from public.companion_v3_api_desire_lifecycle(
+          ${input.orgId}::uuid,
+          ${input.companionId}::uuid,
+          ${input.intent}
+        )
+      `;
+      const row = rows[0];
+      if (!row) throw new Error("Runtime v3 lifecycle change returned no revision");
+      return { intent: row.intent, revision: BigInt(row.revision) };
+    },
+    async claimAvailable({ executorId }) {
+      const claims = await Promise.all((["main", "background"] as const).map(async (lane) => {
+        const rows = await sql<ClaimRow[]>`
+          select org_id as "orgId", companion_id as "companionId", turn_id as "turnId",
+            command_id as "commandId", lane::text, state::text,
+            claim_token as "claimToken", claim_epoch::text as "claimEpoch"
+          from public.companion_v3_runtime_claim(${executorId}, ${lane}, 30, 3)
+        `;
+        const row = rows[0];
+        return row
+          ? {
+            turn: turnFromRow(row),
+            fence: { token: row.claimToken, epoch: BigInt(row.claimEpoch) },
+            orgId: row.orgId,
+            companionId: row.companionId,
+          }
+          : null;
+      }));
+      return claims.filter((claim) => claim !== null);
+    },
+    async completeProgression(claim, outcome) {
+      const terminal = terminalInput(outcome);
+      const rows = await sql<Array<{ completed: boolean }>>`
+        select public.companion_v3_runtime_complete(
+          ${claim.orgId}::uuid,
+          ${claim.companionId}::uuid,
+          ${claim.turn.lane},
+          ${claim.turn.id}::uuid,
+          ${claim.fence.token}::uuid,
+          ${claim.fence.epoch.toString()}::bigint,
+          ${terminal.outcome},
+          ${terminal.code},
+          ${terminal.message},
+          3
+        ) as completed
+      `;
+      return rows[0]?.completed === true;
+    },
+  };
+}

--- a/apps/runtime/test/integration/runtimeV3Progression.integration.test.ts
+++ b/apps/runtime/test/integration/runtimeV3Progression.integration.test.ts
@@ -163,9 +163,10 @@ describe("dormant Runtime v3 progression facts", () => {
       turnId: string;
       token: string;
       epoch: string;
+      gate: string;
     }>>`
       select command_id as "commandId", lane::text, turn_id as "turnId",
-        claim_token as token, claim_epoch::text as epoch
+        claim_token as token, claim_epoch::text as epoch, gate_epoch::text as gate
       from public.companion_v3_runtime_claim(
         'runtime-a', 'main', 30, 3
       )`;
@@ -189,6 +190,7 @@ describe("dormant Runtime v3 progression facts", () => {
     await runtimeSql`select public.companion_v3_runtime_complete(
       ${ids.org}::uuid, ${ids.companion}::uuid, 'main', ${mainClaim[0]!.turnId}::uuid,
       ${mainClaim[0]!.token}::uuid, ${mainClaim[0]!.epoch}::bigint,
+      ${mainClaim[0]!.gate}::bigint,
       'succeeded', null, null, null, 3
     )`;
     const nextMain = await runtimeSql<Array<{ commandId: string }>>`
@@ -216,12 +218,14 @@ describe("dormant Runtime v3 progression facts", () => {
 
   it("increments lane fences monotonically and rejects stale completion", async () => {
     await admitMain(randomUUID());
-    const first = await runtimeSql<Array<{ token: string; epoch: string; turnId: string }>>`
-      select claim_token as token, claim_epoch::text as epoch, turn_id as "turnId"
+    const first = await runtimeSql<Array<{ token: string; epoch: string; gate: string; turnId: string }>>`
+      select claim_token as token, claim_epoch::text as epoch, gate_epoch::text as gate,
+        turn_id as "turnId"
       from public.companion_v3_runtime_claim('runtime-c', 'main', 1, 3)`;
     await ownerSql`select pg_sleep(1.1)`;
-    const second = await runtimeSql<Array<{ token: string; epoch: string; turnId: string }>>`
-      select claim_token as token, claim_epoch::text as epoch, turn_id as "turnId"
+    const second = await runtimeSql<Array<{ token: string; epoch: string; gate: string; turnId: string }>>`
+      select claim_token as token, claim_epoch::text as epoch, gate_epoch::text as gate,
+        turn_id as "turnId"
       from public.companion_v3_runtime_claim('runtime-d', 'main', 30, 3)`;
 
     expect(BigInt(second[0]!.epoch)).toBeGreaterThan(BigInt(first[0]!.epoch));
@@ -229,6 +233,7 @@ describe("dormant Runtime v3 progression facts", () => {
       select public.companion_v3_runtime_complete(
         ${ids.org}::uuid, ${ids.companion}::uuid, 'main', ${first[0]!.turnId}::uuid,
         ${first[0]!.token}::uuid, ${first[0]!.epoch}::bigint,
+        ${first[0]!.gate}::bigint,
         'release', null, null, null, 3
       ) as completed`;
     expect(stale[0]!.completed).toBe(false);
@@ -236,13 +241,15 @@ describe("dormant Runtime v3 progression facts", () => {
 
   it("rejects a null completion outcome without releasing the lane lease", async () => {
     await admitMain(randomUUID());
-    const claim = await runtimeSql<Array<{ token: string; epoch: string; turnId: string }>>`
-      select claim_token as token, claim_epoch::text as epoch, turn_id as "turnId"
+    const claim = await runtimeSql<Array<{ token: string; epoch: string; gate: string; turnId: string }>>`
+      select claim_token as token, claim_epoch::text as epoch, gate_epoch::text as gate,
+        turn_id as "turnId"
       from public.companion_v3_runtime_claim('runtime-null-outcome', 'main', 30, 3)`;
 
     await expect(runtimeSql`select public.companion_v3_runtime_complete(
       ${ids.org}::uuid, ${ids.companion}::uuid, 'main', ${claim[0]!.turnId}::uuid,
       ${claim[0]!.token}::uuid, ${claim[0]!.epoch}::bigint,
+      ${claim[0]!.gate}::bigint,
       ${null}::text, null, null, null, 3
     )`).rejects.toThrow(/invalid Runtime v3 completion/);
 
@@ -254,6 +261,92 @@ describe("dormant Runtime v3 progression facts", () => {
           and lease.lane = turn_row.lane and lease.turn_id = turn_row.id
       where turn_row.id = ${claim[0]!.turnId}::uuid`;
     expect(facts).toEqual([{ state: "queued", token: claim[0]!.token }]);
+  });
+
+  it("rejects a null lease duration without materializing a lane claim", async () => {
+    await admitMain(randomUUID());
+
+    await expect(runtimeSql`select * from public.companion_v3_runtime_claim(
+      'runtime-null-lease', 'main', ${null}::integer, 3
+    )`).rejects.toThrow(/invalid Runtime v3 claim/);
+
+    const facts = await ownerSql<Array<{
+      state: string;
+      token: string | null;
+      gate: string | null;
+      expiresAt: Date | null;
+    }>>`
+      select turn_row.state::text, lease.claim_token::text as token,
+        lease.gate_epoch::text as gate, lease.expires_at as "expiresAt"
+      from public.companion_v3_turns turn_row
+      join public.companion_v3_lane_leases lease
+        on lease.org_id = turn_row.org_id and lease.companion_id = turn_row.companion_id
+          and lease.lane = turn_row.lane
+      where turn_row.org_id = ${ids.org}::uuid
+        and turn_row.companion_id = ${ids.companion}::uuid`;
+    expect(facts).toEqual([{ state: "queued", token: null, gate: null, expiresAt: null }]);
+  });
+
+  it("invalidates held lane claims when the shared runtime gate advances", async () => {
+    await admitMain(randomUUID());
+    const claim = await runtimeSql<Array<{
+      token: string;
+      epoch: string;
+      gate: string;
+      turnId: string;
+    }>>`
+      select claim_token as token, claim_epoch::text as epoch, gate_epoch::text as gate,
+        turn_id as "turnId"
+      from public.companion_v3_runtime_claim('runtime-gate-fence', 'main', 30, 3)`;
+    let disabledGate: string | undefined;
+    try {
+      const disabled = await runtimeSql<Array<{ enabled: boolean; gate: string }>>`
+        select enabled, gate_epoch::text as gate
+        from public.companion_runtime_disable(
+          ${claim[0]!.gate}::bigint, 'runtime-v3-gate-test'
+        )`;
+      disabledGate = disabled[0]!.gate;
+      expect(disabled).toEqual([{
+        enabled: false,
+        gate: expect.stringMatching(/^\d+$/),
+      }]);
+      expect(BigInt(disabledGate)).toBeGreaterThan(BigInt(claim[0]!.gate));
+
+      const completion = await runtimeSql<Array<{ completed: boolean }>>`
+        select public.companion_v3_runtime_complete(
+          ${ids.org}::uuid, ${ids.companion}::uuid, 'main', ${claim[0]!.turnId}::uuid,
+          ${claim[0]!.token}::uuid, ${claim[0]!.epoch}::bigint,
+          ${claim[0]!.gate}::bigint, 'succeeded', null, null, null, 3
+        ) as completed`;
+      expect(completion).toEqual([{ completed: false }]);
+
+      const facts = await ownerSql<Array<{
+        state: string;
+        token: string | null;
+        gate: string | null;
+        epoch: string;
+      }>>`
+        select turn_row.state::text, lease.claim_token::text as token,
+          lease.gate_epoch::text as gate, lease.claim_epoch::text as epoch
+        from public.companion_v3_turns turn_row
+        join public.companion_v3_lane_leases lease
+          on lease.org_id = turn_row.org_id and lease.companion_id = turn_row.companion_id
+            and lease.lane = turn_row.lane
+        where turn_row.id = ${claim[0]!.turnId}::uuid`;
+      expect(facts).toEqual([{
+        state: "queued",
+        token: null,
+        gate: null,
+        epoch: expect.stringMatching(/^\d+$/),
+      }]);
+      expect(BigInt(facts[0]!.epoch)).toBeGreaterThan(BigInt(claim[0]!.epoch));
+    } finally {
+      if (disabledGate) {
+        await ownerSql`select * from public.companion_runtime_enable(
+          ${disabledGate}::bigint, 'runtime-v3-gate-test'
+        )`;
+      }
+    }
   });
 
   it("drives PostgreSQL claims through the closed progression interface", async () => {

--- a/apps/runtime/test/integration/runtimeV3Progression.integration.test.ts
+++ b/apps/runtime/test/integration/runtimeV3Progression.integration.test.ts
@@ -5,16 +5,17 @@
  *
  * Why integrated: FORCE RLS, split grants, SKIP LOCKED, and monotonic takeover epochs only exist in
  * a real migrated PostgreSQL database. An in-memory adapter cannot prove them.
+ * Sensitivity: removing org scoping, fencing, split grants, or either independent lane loop makes
+ * a named assertion fail; replacing PostgreSQL with an in-memory fake invalidates the suite.
  */
 import { randomUUID } from "node:crypto";
 import {
-  createRuntimeV3Progression,
-  type RuntimeV3ProgressionPersistence,
+  createRuntimeV3Convergence,
 } from "@companion/companion-runtime/v3/internal";
 import postgres from "postgres";
 import { afterAll, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 
-import { createRuntimeV3PostgresPersistence } from "../../src/runtimeV3ProgressionStore";
+import { createRuntimeV3PostgresConvergence } from "../../src/runtimeV3ProgressionStore";
 
 const ownerUrl = process.env.DATABASE_MIGRATION_URL ?? process.env.DATABASE_URL;
 const apiUrl = process.env.DATABASE_API_URL;
@@ -31,6 +32,11 @@ const runtimeSql = postgres(runtimeUrl, { max: 3 });
 let apiRole = "";
 let workerRole = "";
 let runtimeRole = "";
+let originalRuntimeGate: {
+  enabled: boolean;
+  enabledAt: Date | null;
+  disabledAt: Date | null;
+} | undefined;
 const suffix = randomUUID().replaceAll("-", "").slice(0, 16);
 const ids = {
   org: randomUUID(),
@@ -75,6 +81,17 @@ describe("dormant Runtime v3 progression facts", () => {
     apiRole = apiRows[0]!.currentUser;
     workerRole = workerRows[0]!.currentUser;
     runtimeRole = runtimeRows[0]!.currentUser;
+    const gateRows = await ownerSql<Array<{
+      enabled: boolean;
+      enabledAt: Date | null;
+      disabledAt: Date | null;
+    }>>`
+      select enabled, enabled_at as "enabledAt", disabled_at as "disabledAt"
+      from public.companion_runtime_control where id = 'runtime-v2' for update`;
+    originalRuntimeGate = gateRows[0];
+    await ownerSql`update public.companion_runtime_control
+      set enabled = true, enabled_at = coalesce(enabled_at, clock_timestamp()), disabled_at = null
+      where id = 'runtime-v2'`;
     await ownerSql.unsafe(`
       insert into public."user" (id, name, email, email_verified)
       values ('${ids.owner}', 'Owner', '${ids.owner}@example.test', true);
@@ -102,6 +119,13 @@ describe("dormant Runtime v3 progression facts", () => {
   });
 
   afterAll(async () => {
+    if (originalRuntimeGate) {
+      await ownerSql`update public.companion_runtime_control
+        set enabled = ${originalRuntimeGate.enabled},
+          enabled_at = ${originalRuntimeGate.enabledAt},
+          disabled_at = ${originalRuntimeGate.disabledAt}
+        where id = 'runtime-v2'`;
+    }
     await ownerSql`delete from public.companions where id = ${ids.companion}::uuid`;
     await ownerSql`delete from public.organizations where id = ${ids.org}::uuid`;
     await ownerSql`delete from public."user" where id = ${ids.owner}`;
@@ -153,15 +177,41 @@ describe("dormant Runtime v3 progression facts", () => {
     expect(mainClaim).toEqual([expect.objectContaining({ commandId: mainOne, lane: "main" })]);
     expect(backgroundClaim).toEqual([{ commandId: background, lane: "background" }]);
     expect(replay).toEqual([{ replayed: true }]);
+    let lifecycle: Array<{ intent: string; revision: string }> = [];
+    await asApi(async (sql) => {
+      lifecycle = await sql<Array<{ intent: string; revision: string }>>`
+        select intent::text, revision::text
+        from public.companion_v3_api_desire_lifecycle(
+          ${ids.org}::uuid, ${ids.companion}::uuid, 'archive'
+        )`;
+    });
+    expect(lifecycle).toEqual([{ intent: "archive", revision: "2" }]);
     await runtimeSql`select public.companion_v3_runtime_complete(
       ${ids.org}::uuid, ${ids.companion}::uuid, 'main', ${mainClaim[0]!.turnId}::uuid,
       ${mainClaim[0]!.token}::uuid, ${mainClaim[0]!.epoch}::bigint,
-      'succeeded', null, null, 3
+      'succeeded', null, null, null, 3
     )`;
     const nextMain = await runtimeSql<Array<{ commandId: string }>>`
       select command_id as "commandId"
       from public.companion_v3_runtime_claim('runtime-a', 'main', 30, 3)`;
     expect(nextMain).toEqual([{ commandId: mainTwo }]);
+  });
+
+  it("resolves concurrent retries of one client message to one Turn", async () => {
+    const command = randomUUID();
+    const admissions: Array<Array<{ turnId: string; replayed: boolean }>> = [[], []];
+    await Promise.all(admissions.map(async (_rows, index) => {
+      await asApi(async (sql) => {
+        admissions[index] = await sql<Array<{ turnId: string; replayed: boolean }>>`
+          select turn_id as "turnId", replayed
+          from public.companion_v3_api_admit_turn(
+            ${ids.org}::uuid, ${ids.companion}::uuid, ${command}::uuid, ${`msg:${command}`}
+          )`;
+      });
+    }));
+
+    expect(new Set(admissions.flat().map((admission) => admission.turnId)).size).toBe(1);
+    expect(admissions.flat().map((admission) => admission.replayed).sort()).toEqual([false, true]);
   });
 
   it("increments lane fences monotonically and rejects stale completion", async () => {
@@ -178,16 +228,16 @@ describe("dormant Runtime v3 progression facts", () => {
     const stale = await runtimeSql<Array<{ completed: boolean }>>`
       select public.companion_v3_runtime_complete(
         ${ids.org}::uuid, ${ids.companion}::uuid, 'main', ${first[0]!.turnId}::uuid,
-        ${first[0]!.token}::uuid, ${first[0]!.epoch}::bigint, 'release', null, null, 3
+        ${first[0]!.token}::uuid, ${first[0]!.epoch}::bigint,
+        'release', null, null, null, 3
       ) as completed`;
     expect(stale[0]!.completed).toBe(false);
   });
 
   it("drives PostgreSQL claims through the closed progression interface", async () => {
     await admitMain(randomUUID());
-    const persistence: RuntimeV3ProgressionPersistence = createRuntimeV3PostgresPersistence(runtimeSql);
-    const progression = createRuntimeV3Progression({
-      persistence,
+    const progression = createRuntimeV3Convergence({
+      persistence: createRuntimeV3PostgresConvergence(runtimeSql),
       advance: async () => ({ kind: "succeeded" }),
     });
 
@@ -197,18 +247,24 @@ describe("dormant Runtime v3 progression facts", () => {
 
   it("progresses an available background lane without waiting for main", async () => {
     const main = randomUUID();
-    const background = randomUUID();
+    const backgroundOne = randomUUID();
+    const backgroundTwo = randomUUID();
     await admitMain(main);
     await workerSql`select * from public.companion_v3_worker_admit_turn(
-      ${ids.org}::uuid, ${ids.companion}::uuid, ${background}::uuid,
-      ${`msg:${background}`}, ${ids.owner}
+      ${ids.org}::uuid, ${ids.companion}::uuid, ${backgroundOne}::uuid,
+      ${`msg:${backgroundOne}`}, ${ids.owner}
+    )`;
+    await workerSql`select * from public.companion_v3_worker_admit_turn(
+      ${ids.org}::uuid, ${ids.companion}::uuid, ${backgroundTwo}::uuid,
+      ${`msg:${backgroundTwo}`}, ${ids.owner}
     )`;
     let releaseMain!: () => void;
     const mainWait = new Promise<void>((resolve) => {
       releaseMain = resolve;
     });
-    const progression = createRuntimeV3Progression({
-      persistence: createRuntimeV3PostgresPersistence(runtimeSql),
+    const convergencePersistence = createRuntimeV3PostgresConvergence(runtimeSql);
+    const progression = createRuntimeV3Convergence({
+      persistence: convergencePersistence,
       advance: async (claim) => {
         if (claim.turn.lane === "main") await mainWait;
         return { kind: "succeeded" };
@@ -219,11 +275,13 @@ describe("dormant Runtime v3 progression facts", () => {
     await vi.waitFor(async () => {
       const rows = await ownerSql<Array<{ state: string }>>`
         select state::text from public.companion_v3_turns
-        where companion_id = ${ids.companion}::uuid and command_id = ${background}::uuid`;
-      expect(rows).toEqual([{ state: "succeeded" }]);
+        where org_id = ${ids.org}::uuid and companion_id = ${ids.companion}::uuid
+          and command_id in (${backgroundOne}::uuid, ${backgroundTwo}::uuid)
+        order by queue_sequence`;
+      expect(rows).toEqual([{ state: "succeeded" }, { state: "succeeded" }]);
     });
     releaseMain();
-    await expect(convergence).resolves.toEqual({ progressed: 2, exhausted: false });
+    await expect(convergence).resolves.toEqual({ progressed: 3, exhausted: false });
   });
 
   it("forces RLS and keeps v3 facts behind split role grants", async () => {

--- a/apps/runtime/test/integration/runtimeV3Progression.integration.test.ts
+++ b/apps/runtime/test/integration/runtimeV3Progression.integration.test.ts
@@ -1,0 +1,346 @@
+/**
+ * Product promise: Runtime v3 keeps FIFO, lane independence, and executor fencing as PostgreSQL
+ * facts while callers use the closed TypeScript progression interface. The v2 executor and direct
+ * process-role table access cannot claim or mutate these dormant rows.
+ *
+ * Why integrated: FORCE RLS, split grants, SKIP LOCKED, and monotonic takeover epochs only exist in
+ * a real migrated PostgreSQL database. An in-memory adapter cannot prove them.
+ */
+import { randomUUID } from "node:crypto";
+import {
+  createRuntimeV3Progression,
+  type RuntimeV3ProgressionPersistence,
+} from "@companion/companion-runtime/v3/internal";
+import postgres from "postgres";
+import { afterAll, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { createRuntimeV3PostgresPersistence } from "../../src/runtimeV3ProgressionStore";
+
+const ownerUrl = process.env.DATABASE_MIGRATION_URL ?? process.env.DATABASE_URL;
+const apiUrl = process.env.DATABASE_API_URL;
+const workerUrl = process.env.DATABASE_WORKER_URL;
+const runtimeUrl = process.env.DATABASE_COMPANION_RUNTIME_URL;
+if (!ownerUrl?.trim() || !apiUrl?.trim() || !workerUrl?.trim() || !runtimeUrl?.trim()) {
+  throw new Error("Runtime v3 integration test requires migration, API, worker, and runtime database URLs");
+}
+
+const ownerSql = postgres(ownerUrl, { max: 2 });
+const apiSql = postgres(apiUrl, { max: 2 });
+const workerSql = postgres(workerUrl, { max: 2 });
+const runtimeSql = postgres(runtimeUrl, { max: 3 });
+let apiRole = "";
+let workerRole = "";
+let runtimeRole = "";
+const suffix = randomUUID().replaceAll("-", "").slice(0, 16);
+const ids = {
+  org: randomUUID(),
+  owner: `runtime-v3-owner-${suffix}`,
+  editor: `runtime-v3-editor-${suffix}`,
+  outsider: `runtime-v3-outsider-${suffix}`,
+  companion: randomUUID(),
+};
+
+async function asApiActor(
+  orgId: string,
+  userId: string,
+  query: (sql: postgres.TransactionSql) => Promise<void>,
+): Promise<void> {
+  await apiSql.begin(async (sql) => {
+    await sql`select set_config('app.org_id', ${orgId}, true)`;
+    await sql`select set_config('app.user_id', ${userId}, true)`;
+    await query(sql);
+  });
+}
+
+async function asApi(query: (sql: postgres.TransactionSql) => Promise<void>): Promise<void> {
+  await asApiActor(ids.org, ids.owner, query);
+}
+
+async function admitMain(commandId: string): Promise<void> {
+  await asApi(async (sql) => {
+    await sql`select * from public.companion_v3_api_admit_turn(
+      ${ids.org}::uuid, ${ids.companion}::uuid, ${commandId}::uuid,
+      ${`msg:${commandId}`}
+    )`;
+  });
+}
+
+describe("dormant Runtime v3 progression facts", () => {
+  beforeAll(async () => {
+    const [apiRows, workerRows, runtimeRows] = await Promise.all([
+      apiSql<Array<{ currentUser: string }>>`select current_user as "currentUser"`,
+      workerSql<Array<{ currentUser: string }>>`select current_user as "currentUser"`,
+      runtimeSql<Array<{ currentUser: string }>>`select current_user as "currentUser"`,
+    ]);
+    apiRole = apiRows[0]!.currentUser;
+    workerRole = workerRows[0]!.currentUser;
+    runtimeRole = runtimeRows[0]!.currentUser;
+    await ownerSql.unsafe(`
+      insert into public."user" (id, name, email, email_verified)
+      values ('${ids.owner}', 'Owner', '${ids.owner}@example.test', true);
+      insert into public."user" (id, name, email, email_verified)
+      values ('${ids.editor}', 'Editor', '${ids.editor}@example.test', true);
+      insert into public."user" (id, name, email, email_verified)
+      values ('${ids.outsider}', 'Outsider', '${ids.outsider}@example.test', true);
+      insert into public.organizations (id, name, slug)
+      values ('${ids.org}', 'Runtime v3', 'runtime-v3-${suffix}');
+      insert into public.memberships (org_id, user_id, org_role)
+      values ('${ids.org}', '${ids.owner}', 'owner');
+      insert into public.memberships (org_id, user_id, org_role)
+      values ('${ids.org}', '${ids.editor}', 'developer');
+      insert into public.companions (id, org_id, owner_id, name)
+      values ('${ids.companion}', '${ids.org}', '${ids.owner}', 'Runtime v3 test');
+      insert into public.companion_workspace_access(
+        org_id, companion_id, owner_id, role, granted_by
+      ) values ('${ids.org}', '${ids.companion}', '${ids.owner}', 'editor', '${ids.owner}');
+    `);
+  });
+
+  beforeEach(async () => {
+    await ownerSql`delete from public.companion_v3_instances
+      where org_id = ${ids.org}::uuid and companion_id = ${ids.companion}::uuid`;
+  });
+
+  afterAll(async () => {
+    await ownerSql`delete from public.companions where id = ${ids.companion}::uuid`;
+    await ownerSql`delete from public.organizations where id = ${ids.org}::uuid`;
+    await ownerSql`delete from public."user" where id = ${ids.owner}`;
+    await ownerSql`delete from public."user" where id = ${ids.editor}`;
+    await ownerSql`delete from public."user" where id = ${ids.outsider}`;
+    await Promise.all([
+      apiSql.end({ timeout: 1 }),
+      workerSql.end({ timeout: 1 }),
+      runtimeSql.end({ timeout: 1 }),
+      ownerSql.end({ timeout: 1 }),
+    ]);
+  });
+
+  it("admits main and background Turns FIFO through separate process capabilities", async () => {
+    const mainOne = randomUUID();
+    const mainTwo = randomUUID();
+    const background = randomUUID();
+    await admitMain(mainOne);
+    await admitMain(mainTwo);
+    let replay: Array<{ replayed: boolean }> = [];
+    await asApi(async (sql) => {
+      replay = await sql<Array<{ replayed: boolean }>>`
+        select replayed from public.companion_v3_api_admit_turn(
+          ${ids.org}::uuid, ${ids.companion}::uuid, ${mainOne}::uuid, ${`msg:${mainOne}`}
+        )`;
+    });
+    await workerSql`select * from public.companion_v3_worker_admit_turn(
+      ${ids.org}::uuid, ${ids.companion}::uuid, ${background}::uuid,
+      ${`msg:${background}`}, ${ids.owner}
+    )`;
+
+    const mainClaim = await runtimeSql<Array<{
+      commandId: string;
+      lane: string;
+      turnId: string;
+      token: string;
+      epoch: string;
+    }>>`
+      select command_id as "commandId", lane::text, turn_id as "turnId",
+        claim_token as token, claim_epoch::text as epoch
+      from public.companion_v3_runtime_claim(
+        'runtime-a', 'main', 30, 3
+      )`;
+    const backgroundClaim = await runtimeSql<Array<{ commandId: string; lane: string }>>`
+      select command_id as "commandId", lane::text from public.companion_v3_runtime_claim(
+        'runtime-b', 'background', 30, 3
+      )`;
+
+    expect(mainClaim).toEqual([expect.objectContaining({ commandId: mainOne, lane: "main" })]);
+    expect(backgroundClaim).toEqual([{ commandId: background, lane: "background" }]);
+    expect(replay).toEqual([{ replayed: true }]);
+    await runtimeSql`select public.companion_v3_runtime_complete(
+      ${ids.org}::uuid, ${ids.companion}::uuid, 'main', ${mainClaim[0]!.turnId}::uuid,
+      ${mainClaim[0]!.token}::uuid, ${mainClaim[0]!.epoch}::bigint,
+      'succeeded', null, null, 3
+    )`;
+    const nextMain = await runtimeSql<Array<{ commandId: string }>>`
+      select command_id as "commandId"
+      from public.companion_v3_runtime_claim('runtime-a', 'main', 30, 3)`;
+    expect(nextMain).toEqual([{ commandId: mainTwo }]);
+  });
+
+  it("increments lane fences monotonically and rejects stale completion", async () => {
+    await admitMain(randomUUID());
+    const first = await runtimeSql<Array<{ token: string; epoch: string; turnId: string }>>`
+      select claim_token as token, claim_epoch::text as epoch, turn_id as "turnId"
+      from public.companion_v3_runtime_claim('runtime-c', 'main', 1, 3)`;
+    await ownerSql`select pg_sleep(1.1)`;
+    const second = await runtimeSql<Array<{ token: string; epoch: string; turnId: string }>>`
+      select claim_token as token, claim_epoch::text as epoch, turn_id as "turnId"
+      from public.companion_v3_runtime_claim('runtime-d', 'main', 30, 3)`;
+
+    expect(BigInt(second[0]!.epoch)).toBeGreaterThan(BigInt(first[0]!.epoch));
+    const stale = await runtimeSql<Array<{ completed: boolean }>>`
+      select public.companion_v3_runtime_complete(
+        ${ids.org}::uuid, ${ids.companion}::uuid, 'main', ${first[0]!.turnId}::uuid,
+        ${first[0]!.token}::uuid, ${first[0]!.epoch}::bigint, 'release', null, null, 3
+      ) as completed`;
+    expect(stale[0]!.completed).toBe(false);
+  });
+
+  it("drives PostgreSQL claims through the closed progression interface", async () => {
+    await admitMain(randomUUID());
+    const persistence: RuntimeV3ProgressionPersistence = createRuntimeV3PostgresPersistence(runtimeSql);
+    const progression = createRuntimeV3Progression({
+      persistence,
+      advance: async () => ({ kind: "succeeded" }),
+    });
+
+    await expect(progression.converge({ executorId: "runtime-progression" }))
+      .resolves.toEqual({ progressed: 1, exhausted: false });
+  });
+
+  it("progresses an available background lane without waiting for main", async () => {
+    const main = randomUUID();
+    const background = randomUUID();
+    await admitMain(main);
+    await workerSql`select * from public.companion_v3_worker_admit_turn(
+      ${ids.org}::uuid, ${ids.companion}::uuid, ${background}::uuid,
+      ${`msg:${background}`}, ${ids.owner}
+    )`;
+    let releaseMain!: () => void;
+    const mainWait = new Promise<void>((resolve) => {
+      releaseMain = resolve;
+    });
+    const progression = createRuntimeV3Progression({
+      persistence: createRuntimeV3PostgresPersistence(runtimeSql),
+      advance: async (claim) => {
+        if (claim.turn.lane === "main") await mainWait;
+        return { kind: "succeeded" };
+      },
+    });
+
+    const convergence = progression.converge({ executorId: "runtime-independent-lanes" });
+    await vi.waitFor(async () => {
+      const rows = await ownerSql<Array<{ state: string }>>`
+        select state::text from public.companion_v3_turns
+        where companion_id = ${ids.companion}::uuid and command_id = ${background}::uuid`;
+      expect(rows).toEqual([{ state: "succeeded" }]);
+    });
+    releaseMain();
+    await expect(convergence).resolves.toEqual({ progressed: 2, exhausted: false });
+  });
+
+  it("forces RLS and keeps v3 facts behind split role grants", async () => {
+    const tables = await ownerSql<Array<{ name: string; rls: boolean; forced: boolean }>>`
+      select relname as name, relrowsecurity as rls, relforcerowsecurity as forced
+      from pg_catalog.pg_class
+      where relname in ('companion_v3_instances', 'companion_v3_turns', 'companion_v3_lane_leases')
+      order by relname`;
+    expect(tables).toEqual([
+      { name: "companion_v3_instances", rls: true, forced: true },
+      { name: "companion_v3_lane_leases", rls: true, forced: true },
+      { name: "companion_v3_turns", rls: true, forced: true },
+    ]);
+    const absentAttemptArtifacts = await ownerSql<Array<{
+      attempts: string | null;
+      operations: string | null;
+    }>>`
+      select to_regclass('public.companion_v3_turn_attempts')::text as attempts,
+        to_regclass('public.companion_v3_operations')::text as operations`;
+    expect(absentAttemptArtifacts).toEqual([{ attempts: null, operations: null }]);
+    const grants = await ownerSql<Array<{
+      apiAdmit: boolean;
+      apiClaim: boolean;
+      workerAdmit: boolean;
+      workerClaim: boolean;
+      runtimeAdmit: boolean;
+      runtimeClaim: boolean;
+    }>>`
+      select
+        has_function_privilege(${apiRole},
+          'public.companion_v3_api_admit_turn(uuid,uuid,uuid,text)', 'EXECUTE') as "apiAdmit",
+        has_function_privilege(${apiRole},
+          'public.companion_v3_runtime_claim(text,public.companion_v3_lane,integer,integer)', 'EXECUTE') as "apiClaim",
+        has_function_privilege(${workerRole},
+          'public.companion_v3_worker_admit_turn(uuid,uuid,uuid,text,text)', 'EXECUTE') as "workerAdmit",
+        has_function_privilege(${workerRole},
+          'public.companion_v3_runtime_claim(text,public.companion_v3_lane,integer,integer)', 'EXECUTE') as "workerClaim",
+        has_function_privilege(${runtimeRole},
+          'public.companion_v3_api_admit_turn(uuid,uuid,uuid,text)', 'EXECUTE') as "runtimeAdmit",
+        has_function_privilege(${runtimeRole},
+          'public.companion_v3_runtime_claim(text,public.companion_v3_lane,integer,integer)', 'EXECUTE') as "runtimeClaim"`;
+    expect(grants).toEqual([{
+      apiAdmit: true,
+      apiClaim: false,
+      workerAdmit: true,
+      workerClaim: false,
+      runtimeAdmit: false,
+      runtimeClaim: true,
+    }]);
+    await expect(apiSql`select * from public.companion_v3_turns`).rejects.toMatchObject({ code: "42501" });
+    await expect(workerSql`select * from public.companion_v3_turns`).rejects.toMatchObject({ code: "42501" });
+    await expect(runtimeSql`select * from public.companion_v3_turns`).rejects.toMatchObject({ code: "42501" });
+    await expect(runtimeSql`select * from public.companion_v3_runtime_claim('old', 'main', 30, 2)`)
+      .rejects.toMatchObject({ code: "42501" });
+  });
+
+  it("keeps dormant work non-activatable while the existing runtime gate is disabled", async () => {
+    await admitMain(randomUUID());
+    await ownerSql.begin(async (sql) => {
+      const rows = await sql<Array<{
+        enabled: boolean;
+        enabledAt: Date | null;
+        disabledAt: Date | null;
+      }>>`
+        select enabled, enabled_at as "enabledAt", disabled_at as "disabledAt"
+        from public.companion_runtime_control where id = 'runtime-v2' for update`;
+      await sql`update public.companion_runtime_control
+        set enabled = false, enabled_at = null, disabled_at = clock_timestamp()
+        where id = 'runtime-v2'`;
+      const claims = await sql<Array<{ turnId: string }>>`
+        select turn_id as "turnId"
+        from public.companion_v3_runtime_claim('runtime-disabled', 'main', 30, 3)`;
+      expect(claims).toEqual([]);
+      await sql`update public.companion_runtime_control
+        set enabled = ${rows[0]!.enabled}, enabled_at = ${rows[0]!.enabledAt},
+          disabled_at = ${rows[0]!.disabledAt}
+        where id = 'runtime-v2'`;
+    });
+  });
+
+  it("fails closed for cross-tenant, non-member, and revoked-owner admission", async () => {
+    const crossTenant = randomUUID();
+    const crossTenantCommand = randomUUID();
+    await expect(asApiActor(crossTenant, ids.owner, async (sql) => {
+      await sql`select * from public.companion_v3_api_admit_turn(
+        ${ids.org}::uuid, ${ids.companion}::uuid, ${crossTenantCommand}::uuid,
+        ${`msg:${crossTenantCommand}`}
+      )`;
+    })).rejects.toMatchObject({ code: "42501" });
+    await expect(asApiActor(ids.org, ids.outsider, async (sql) => {
+      const command = randomUUID();
+      await sql`select * from public.companion_v3_api_admit_turn(
+        ${ids.org}::uuid, ${ids.companion}::uuid, ${command}::uuid, ${`msg:${command}`}
+      )`;
+    })).rejects.toMatchObject({ code: "42501" });
+
+    const initialEditorCommand = randomUUID();
+    await asApiActor(ids.org, ids.editor, async (sql) => {
+      await sql`select * from public.companion_v3_api_admit_turn(
+        ${ids.org}::uuid, ${ids.companion}::uuid, ${initialEditorCommand}::uuid,
+        ${`msg:${initialEditorCommand}`}
+      )`;
+    });
+    await ownerSql`delete from public.companion_workspace_access
+      where org_id = ${ids.org}::uuid and companion_id = ${ids.companion}::uuid`;
+    try {
+      const command = randomUUID();
+      await expect(asApiActor(ids.org, ids.editor, async (sql) => {
+        await sql`select * from public.companion_v3_api_admit_turn(
+          ${ids.org}::uuid, ${ids.companion}::uuid, ${command}::uuid, ${`msg:${command}`}
+        )`;
+      })).rejects.toMatchObject({ code: "P0002" });
+    } finally {
+      await ownerSql`insert into public.companion_workspace_access(
+        org_id, companion_id, owner_id, role, granted_by
+      ) values (${ids.org}::uuid, ${ids.companion}::uuid, ${ids.owner}, 'editor', ${ids.owner})
+      on conflict (companion_id) do update set role = excluded.role`;
+    }
+  });
+});

--- a/apps/runtime/test/integration/runtimeV3Progression.integration.test.ts
+++ b/apps/runtime/test/integration/runtimeV3Progression.integration.test.ts
@@ -234,6 +234,28 @@ describe("dormant Runtime v3 progression facts", () => {
     expect(stale[0]!.completed).toBe(false);
   });
 
+  it("rejects a null completion outcome without releasing the lane lease", async () => {
+    await admitMain(randomUUID());
+    const claim = await runtimeSql<Array<{ token: string; epoch: string; turnId: string }>>`
+      select claim_token as token, claim_epoch::text as epoch, turn_id as "turnId"
+      from public.companion_v3_runtime_claim('runtime-null-outcome', 'main', 30, 3)`;
+
+    await expect(runtimeSql`select public.companion_v3_runtime_complete(
+      ${ids.org}::uuid, ${ids.companion}::uuid, 'main', ${claim[0]!.turnId}::uuid,
+      ${claim[0]!.token}::uuid, ${claim[0]!.epoch}::bigint,
+      ${null}::text, null, null, null, 3
+    )`).rejects.toThrow(/invalid Runtime v3 completion/);
+
+    const facts = await ownerSql<Array<{ state: string; token: string | null }>>`
+      select turn_row.state::text, lease.claim_token::text as token
+      from public.companion_v3_turns turn_row
+      join public.companion_v3_lane_leases lease
+        on lease.org_id = turn_row.org_id and lease.companion_id = turn_row.companion_id
+          and lease.lane = turn_row.lane and lease.turn_id = turn_row.id
+      where turn_row.id = ${claim[0]!.turnId}::uuid`;
+    expect(facts).toEqual([{ state: "queued", token: claim[0]!.token }]);
+  });
+
   it("drives PostgreSQL claims through the closed progression interface", async () => {
     await admitMain(randomUUID());
     const progression = createRuntimeV3Convergence({

--- a/docs/companions-runtime.md
+++ b/docs/companions-runtime.md
@@ -1,5 +1,12 @@
 # Companions Runtime v2
 
+> Runtime v3 expand note (THE-510): migration 0159 and the TypeScript progression module add a
+> dormant, separately named v3 persistence/interface seam beside the live system described here.
+> It is not wired into the API, worker, or runtime composition roots and cannot change this v2
+> contract. V3 has one Turn carrying command/admission/activity/outcome facts, independent
+> `main`/`background` leases, no attempt table, and no derived Start operation. Its protocol-3
+> functions remain behind forced RLS, split role grants, and the existing runtime kill switch.
+
 This document is the normative, as-built Runtime v2 Box/Pi contract. Companion remains a Skills Hub
 at its core; the optional Companions surface adds one bounded hosted shape. The guarded cutover
 removed the legacy orchestration surface:

--- a/docs/design.md
+++ b/docs/design.md
@@ -208,6 +208,22 @@ persist an asynchronous control request and return immediately. Approval applies
 and may enqueue an ordinary FIFO continuation. Routine and trigger turns never receive this MCP.
 Directed peer grants allow bounded text delegations without introducing a Group or Room aggregate.
 
+### Dormant Runtime v3 progression seam
+
+Migration 0159 is the expand half of the Runtime v3 wide refactor. It adds separate
+`companion_v3_instances`, `companion_v3_turns`, and retained per-lane lease facts beside Runtime v2.
+A v3 Turn owns its command identity, lane, Pi-admission facts, activity cursor, and outcome; there
+is deliberately no v3 attempt table or derived Start operation. PostgreSQL owns idempotent
+admission, independent `main`/`background` FIFO, and monotonic fence epochs. TypeScript exposes one
+deep progression interface—admit, record desired lifecycle, and converge—and keeps claim and
+completion choreography in its internal adapter.
+
+This seam is dormant. No API, worker, or runtime production composition root calls it, the v2
+executor uses its unchanged protocol-7 functions, and protocol-3 claims still fail closed when the
+existing Companions runtime gate is disabled. The separate function names and required protocol
+argument prevent an old executor from claiming or mutating v3 rows. Later stack layers replace
+behavior behind this interface; they do not activate a second live runtime beside v2.
+
 ## Dedicated runtime execution
 
 `apps/runtime` sweeps every two seconds, claims with a 30-second lease, renews every ten seconds,

--- a/docs/design.md
+++ b/docs/design.md
@@ -220,9 +220,11 @@ completion choreography in its internal adapter.
 
 This seam is dormant. No API, worker, or runtime production composition root calls it, the v2
 executor uses its unchanged protocol-7 functions, and protocol-3 claims still fail closed when the
-existing Companions runtime gate is disabled. The separate function names and required protocol
-argument prevent an old executor from claiming or mutating v3 rows. Later stack layers replace
-behavior behind this interface; they do not activate a second live runtime beside v2.
+existing Companions runtime gate is disabled. V3 lane leases carry that gate's epoch; a gate change
+atomically invalidates their tokens, and both claim and completion lock and verify the shared fence.
+The separate function names and required protocol argument prevent an old executor from claiming
+or mutating v3 rows. Later stack layers replace behavior behind this interface; they do not activate
+a second live runtime beside v2.
 
 ## Dedicated runtime execution
 

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -58,10 +58,11 @@ supporting disposable real-PostgreSQL seam. The interface test must show that ca
 record desired lifecycle, and converge; main and background claims are obtained and advanced
 independently so a blocked main claim cannot serialize or starve background work. PostgreSQL tests
 prove idempotent command admission, per-lane FIFO, monotonic takeover epochs, stale-fence rejection,
-forced RLS, distinct API/worker/runtime function grants, protocol isolation from v2 executors, and
-the absence of a v3 attempt or derived Start-operation table. Until the warm-turn tracer bullet is
-implemented, the existing Runtime v2 topology suite remains the end-to-end behavior regression
-gate; tests must not activate v3 through a production composition root.
+shared kill-switch epoch invalidation, invalid-boundary rejection before lease mutation, forced RLS,
+distinct API/worker/runtime function grants, protocol isolation from v2 executors, and the absence
+of a v3 attempt or derived Start-operation table. Until the warm-turn tracer bullet is implemented,
+the existing Runtime v2 topology suite remains the end-to-end behavior regression gate; tests must
+not activate v3 through a production composition root.
 
 Skill synchronization coverage distinguishes publication-only available revisions from required
 selection revisions. PostgreSQL tests prove wake and desktop accept `applied >= required` while a

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -53,6 +53,16 @@ slow, local-only final validation and is intentionally not part of CI.
 
 ## Runtime test layers
 
+The dormant Runtime v3 expand seam is proved at its public TypeScript progression interface and a
+supporting disposable real-PostgreSQL seam. The interface test must show that callers only admit,
+record desired lifecycle, and converge; main and background claims are obtained and advanced
+independently so a blocked main claim cannot serialize or starve background work. PostgreSQL tests
+prove idempotent command admission, per-lane FIFO, monotonic takeover epochs, stale-fence rejection,
+forced RLS, distinct API/worker/runtime function grants, protocol isolation from v2 executors, and
+the absence of a v3 attempt or derived Start-operation table. Until the warm-turn tracer bullet is
+implemented, the existing Runtime v2 topology suite remains the end-to-end behavior regression
+gate; tests must not activate v3 through a production composition root.
+
 Skill synchronization coverage distinguishes publication-only available revisions from required
 selection revisions. PostgreSQL tests prove wake and desktop accept `applied >= required` while a
 publication is pending. Simulator and fault-injection tests cover `stop Pi -> update Skills ->

--- a/packages/companion-runtime/package.json
+++ b/packages/companion-runtime/package.json
@@ -4,7 +4,8 @@
   "private": true,
   "type": "module",
   "exports": {
-    ".": "./src/index.ts"
+    ".": "./src/index.ts",
+    "./v3/internal": "./src/v3/progression.ts"
   },
   "scripts": {
     "typecheck": "tsc --noEmit",

--- a/packages/companion-runtime/src/index.ts
+++ b/packages/companion-runtime/src/index.ts
@@ -115,3 +115,17 @@ export * from "./scheduler";
 export * from "./settings";
 export * from "./store";
 export * from "./types";
+export {
+  RUNTIME_V3_LANES,
+  RUNTIME_V3_LIFECYCLE_INTENTS,
+} from "./v3/progression";
+export type {
+  RuntimeV3Admission,
+  RuntimeV3DesiredLifecycleChange,
+  RuntimeV3Lane,
+  RuntimeV3LifecycleIntent,
+  RuntimeV3LifecycleRevision,
+  RuntimeV3Progression,
+  RuntimeV3Turn,
+  RuntimeV3TurnState,
+} from "./v3/progression";

--- a/packages/companion-runtime/src/v3/progression.test.ts
+++ b/packages/companion-runtime/src/v3/progression.test.ts
@@ -1,7 +1,15 @@
+/**
+ * Product promise: callers admit intent and request convergence without owning lease choreography.
+ * Regression guarded: a blocked main Turn must never stop later background Turns from progressing.
+ * Why unit-level: deterministic deferred promises expose scheduling at the public module boundary.
+ * Sensitivity: serializing the lane loops or returning arbitrary failure text makes these fail.
+ */
 import { describe, expect, it, vi } from "vitest";
 
 import {
   createRuntimeV3Progression,
+  type RuntimeV3Claim,
+  type RuntimeV3ConvergencePersistence,
   type RuntimeV3ProgressionPersistence,
 } from "./progression";
 
@@ -21,18 +29,31 @@ const mainClaim = {
   },
 };
 
+interface ClaimQueues {
+  main: Array<RuntimeV3Claim | null>;
+  background: Array<RuntimeV3Claim | null>;
+}
+
+function claimFrom(queues: ClaimQueues): RuntimeV3ConvergencePersistence["claimLane"] {
+  return async ({ lane }) => queues[lane].shift() ?? null;
+}
+
 function persistence(
-  overrides: Partial<RuntimeV3ProgressionPersistence> = {},
+  overrides: Partial<RuntimeV3ProgressionPersistence["convergence"]> = {},
 ): RuntimeV3ProgressionPersistence {
   return {
-    admitTurn: vi.fn().mockResolvedValue(acceptedTurn),
-    recordDesiredLifecycle: vi.fn().mockResolvedValue({
-      intent: "archive",
-      revision: 2n,
-    }),
-    claimAvailable: vi.fn().mockResolvedValue([]),
-    completeProgression: vi.fn().mockResolvedValue(true),
-    ...overrides,
+    admission: { admitTurn: vi.fn().mockResolvedValue(acceptedTurn) },
+    lifecycle: {
+      recordDesiredLifecycle: vi.fn().mockResolvedValue({
+        intent: "archive",
+        revision: 2n,
+      }),
+    },
+    convergence: {
+      claimLane: vi.fn().mockResolvedValue(null),
+      completeProgression: vi.fn().mockResolvedValue(true),
+      ...overrides,
+    },
   };
 }
 
@@ -73,17 +94,22 @@ describe("Runtime v3 progression interface", () => {
 
   it("owns autonomous claim and settlement while advancing queued facts", async () => {
     const advance = vi.fn().mockResolvedValue({ kind: "release" as const });
+    const claims: ClaimQueues = {
+      main: [mainClaim, null],
+      background: [null],
+    };
     const store = persistence({
-      claimAvailable: vi.fn()
-        .mockResolvedValueOnce([mainClaim])
-        .mockResolvedValueOnce([]),
+      claimLane: vi.fn(claimFrom(claims)),
     });
     const progression = createRuntimeV3Progression({ persistence: store, advance });
 
     await expect(progression.converge({ executorId: "runtime-1" }))
       .resolves.toEqual({ progressed: 1, exhausted: false });
     expect(advance).toHaveBeenCalledWith(mainClaim);
-    expect(store.completeProgression).toHaveBeenCalledWith(mainClaim, { kind: "release" });
+    expect(store.convergence.completeProgression).toHaveBeenCalledWith(
+      mainClaim,
+      { kind: "release" },
+    );
   });
 
   it("advances main and background claims independently", async () => {
@@ -91,19 +117,26 @@ describe("Runtime v3 progression interface", () => {
     const mainWait = new Promise<void>((resolve) => {
       releaseMain = resolve;
     });
-    const background = {
+    const backgroundOne = {
       orgId: mainClaim.orgId,
       companionId: mainClaim.companionId,
       turn: { ...acceptedTurn, id: "17307732-d811-4eb8-af79-0ae7e7942390", lane: "background" as const },
       fence: { token: "a60fa0eb-e514-4453-94ef-d6668220fb85", epoch: 7n },
     };
+    const backgroundTwo = {
+      ...backgroundOne,
+      turn: { ...backgroundOne.turn, id: "41158351-61ee-4c41-8f5c-888d91df91e1" },
+      fence: { token: "2aa20f71-0f55-4f57-82a8-561256f42da3", epoch: 8n },
+    };
     const completed: string[] = [];
+    const claims: ClaimQueues = {
+      main: [mainClaim, null],
+      background: [backgroundOne, backgroundTwo, null],
+    };
     const store = persistence({
-      claimAvailable: vi.fn()
-        .mockResolvedValueOnce([mainClaim, background])
-        .mockResolvedValueOnce([]),
+      claimLane: vi.fn(claimFrom(claims)),
       completeProgression: vi.fn(async (claimed) => {
-        completed.push(claimed.turn.lane);
+        completed.push(claimed.turn.id);
         return true;
       }),
     });
@@ -116,8 +149,38 @@ describe("Runtime v3 progression interface", () => {
     });
 
     const convergence = progression.converge({ executorId: "runtime-1" });
-    await vi.waitFor(() => expect(completed).toEqual(["background"]));
+    await vi.waitFor(() => expect(completed).toEqual([
+      backgroundOne.turn.id,
+      backgroundTwo.turn.id,
+    ]));
     releaseMain();
-    await expect(convergence).resolves.toEqual({ progressed: 2, exhausted: false });
+    await expect(convergence).resolves.toEqual({ progressed: 3, exhausted: false });
+  });
+
+  it("expurgates terminal failures before they reach persistence", async () => {
+    const claims: ClaimQueues = {
+      main: [mainClaim, null],
+      background: [null],
+    };
+    const store = persistence({
+      claimLane: vi.fn(claimFrom(claims)),
+    });
+    const progression = createRuntimeV3Progression({
+      persistence: store,
+      advance: async () => ({
+        kind: "failed",
+        code: "NOT STABLE",
+        message: "provider rejected https://user:secret@example.test/path?token=secret",
+        action: "retry",
+      }),
+    });
+
+    await progression.converge({ executorId: "runtime-safe-errors" });
+    const completion = vi.mocked(store.convergence.completeProgression).mock.calls[0]?.[1];
+    expect(completion).toMatchObject({
+      kind: "failed",
+      error: { code: "runtime_failure", action: "retry" },
+    });
+    expect(JSON.stringify(completion)).not.toContain("secret");
   });
 });

--- a/packages/companion-runtime/src/v3/progression.test.ts
+++ b/packages/companion-runtime/src/v3/progression.test.ts
@@ -1,0 +1,123 @@
+import { describe, expect, it, vi } from "vitest";
+
+import {
+  createRuntimeV3Progression,
+  type RuntimeV3ProgressionPersistence,
+} from "./progression";
+
+const acceptedTurn = {
+  id: "2f883a91-92dd-4fec-b674-b7d250f81f61",
+  commandId: "c86217bd-d342-475a-a739-a35d0a829bef",
+  lane: "main" as const,
+  state: "queued" as const,
+};
+const mainClaim = {
+  orgId: "2d6ca5e0-1696-4692-baa8-cf722771d01e",
+  companionId: "52cafaca-b95f-4b4d-bd71-d083a7a07939",
+  turn: acceptedTurn,
+  fence: {
+    token: "3c706ec6-5caf-41fc-a009-614730726ebe",
+    epoch: 4n,
+  },
+};
+
+function persistence(
+  overrides: Partial<RuntimeV3ProgressionPersistence> = {},
+): RuntimeV3ProgressionPersistence {
+  return {
+    admitTurn: vi.fn().mockResolvedValue(acceptedTurn),
+    recordDesiredLifecycle: vi.fn().mockResolvedValue({
+      intent: "archive",
+      revision: 2n,
+    }),
+    claimAvailable: vi.fn().mockResolvedValue([]),
+    completeProgression: vi.fn().mockResolvedValue(true),
+    ...overrides,
+  };
+}
+
+describe("Runtime v3 progression interface", () => {
+  it("admits work without exposing persistence choreography", async () => {
+    const store = persistence();
+    const progression = createRuntimeV3Progression({
+      persistence: store,
+      advance: async () => ({ kind: "release" }),
+    });
+
+    await expect(progression.admit({
+      orgId: "2d6ca5e0-1696-4692-baa8-cf722771d01e",
+      companionId: "52cafaca-b95f-4b4d-bd71-d083a7a07939",
+      actorId: "member-1",
+      clientMessageId: "c86217bd-d342-475a-a739-a35d0a829bef",
+      messageEventId: "msg:c86217bd-d342-475a-a739-a35d0a829bef",
+      lane: "main",
+    })).resolves.toEqual(acceptedTurn);
+
+    expect(Object.keys(progression).sort()).toEqual(["admit", "converge", "desire"]);
+  });
+
+  it("accepts only the bounded desired lifecycle intents", async () => {
+    const store = persistence();
+    const progression = createRuntimeV3Progression({
+      persistence: store,
+      advance: async () => ({ kind: "release" }),
+    });
+
+    await expect(progression.desire({
+      orgId: "2d6ca5e0-1696-4692-baa8-cf722771d01e",
+      companionId: "52cafaca-b95f-4b4d-bd71-d083a7a07939",
+      actorId: "member-1",
+      intent: "archive",
+    })).resolves.toEqual({ intent: "archive", revision: 2n });
+  });
+
+  it("owns autonomous claim and settlement while advancing queued facts", async () => {
+    const advance = vi.fn().mockResolvedValue({ kind: "release" as const });
+    const store = persistence({
+      claimAvailable: vi.fn()
+        .mockResolvedValueOnce([mainClaim])
+        .mockResolvedValueOnce([]),
+    });
+    const progression = createRuntimeV3Progression({ persistence: store, advance });
+
+    await expect(progression.converge({ executorId: "runtime-1" }))
+      .resolves.toEqual({ progressed: 1, exhausted: false });
+    expect(advance).toHaveBeenCalledWith(mainClaim);
+    expect(store.completeProgression).toHaveBeenCalledWith(mainClaim, { kind: "release" });
+  });
+
+  it("advances main and background claims independently", async () => {
+    let releaseMain!: () => void;
+    const mainWait = new Promise<void>((resolve) => {
+      releaseMain = resolve;
+    });
+    const background = {
+      orgId: mainClaim.orgId,
+      companionId: mainClaim.companionId,
+      turn: { ...acceptedTurn, id: "17307732-d811-4eb8-af79-0ae7e7942390", lane: "background" as const },
+      fence: { token: "a60fa0eb-e514-4453-94ef-d6668220fb85", epoch: 7n },
+    };
+    const completed: string[] = [];
+    const store = persistence({
+      claimAvailable: vi.fn()
+        .mockResolvedValueOnce([mainClaim, background])
+        .mockResolvedValueOnce([]),
+      completeProgression: vi.fn(async (claimed) => {
+        completed.push(claimed.turn.lane);
+        return true;
+      }),
+    });
+    const progression = createRuntimeV3Progression({
+      persistence: store,
+      advance: async (claimed) => {
+        if (claimed.turn.lane === "main") await mainWait;
+        return { kind: "succeeded" };
+      },
+    });
+
+    const convergence = progression.converge({ executorId: "runtime-1" });
+    await vi.waitFor(() => expect(completed).toEqual(["background"]));
+    releaseMain();
+    await expect(convergence).resolves.toEqual({ progressed: 2, exhausted: false });
+  });
+});

--- a/packages/companion-runtime/src/v3/progression.test.ts
+++ b/packages/companion-runtime/src/v3/progression.test.ts
@@ -26,6 +26,7 @@ const mainClaim = {
   fence: {
     token: "3c706ec6-5caf-41fc-a009-614730726ebe",
     epoch: 4n,
+    gateEpoch: 9n,
   },
 };
 
@@ -121,12 +122,12 @@ describe("Runtime v3 progression interface", () => {
       orgId: mainClaim.orgId,
       companionId: mainClaim.companionId,
       turn: { ...acceptedTurn, id: "17307732-d811-4eb8-af79-0ae7e7942390", lane: "background" as const },
-      fence: { token: "a60fa0eb-e514-4453-94ef-d6668220fb85", epoch: 7n },
+      fence: { token: "a60fa0eb-e514-4453-94ef-d6668220fb85", epoch: 7n, gateEpoch: 9n },
     };
     const backgroundTwo = {
       ...backgroundOne,
       turn: { ...backgroundOne.turn, id: "41158351-61ee-4c41-8f5c-888d91df91e1" },
-      fence: { token: "2aa20f71-0f55-4f57-82a8-561256f42da3", epoch: 8n },
+      fence: { token: "2aa20f71-0f55-4f57-82a8-561256f42da3", epoch: 8n, gateEpoch: 9n },
     };
     const completed: string[] = [];
     const claims: ClaimQueues = {

--- a/packages/companion-runtime/src/v3/progression.ts
+++ b/packages/companion-runtime/src/v3/progression.ts
@@ -1,0 +1,128 @@
+export const RUNTIME_V3_LANES = ["main", "background"] as const;
+export type RuntimeV3Lane = (typeof RUNTIME_V3_LANES)[number];
+
+export const RUNTIME_V3_LIFECYCLE_INTENTS = [
+  "prepare",
+  "archive",
+  "recycle_pi",
+  "delete",
+] as const;
+export type RuntimeV3LifecycleIntent = (typeof RUNTIME_V3_LIFECYCLE_INTENTS)[number];
+
+export type RuntimeV3TurnState =
+  | "queued"
+  | "admitted"
+  | "running"
+  | "needs_input"
+  | "succeeded"
+  | "failed"
+  | "interrupted"
+  | "cancelled";
+
+export interface RuntimeV3Turn {
+  id: string;
+  commandId: string;
+  lane: RuntimeV3Lane;
+  state: RuntimeV3TurnState;
+}
+
+export interface RuntimeV3Admission {
+  orgId: string;
+  companionId: string;
+  actorId: string;
+  clientMessageId: string;
+  messageEventId: string;
+  lane: RuntimeV3Lane;
+}
+
+export interface RuntimeV3DesiredLifecycleChange {
+  orgId: string;
+  companionId: string;
+  actorId: string;
+  intent: RuntimeV3LifecycleIntent;
+}
+
+export interface RuntimeV3LifecycleRevision {
+  intent: RuntimeV3LifecycleIntent;
+  revision: bigint;
+}
+
+export interface RuntimeV3Fence {
+  token: string;
+  epoch: bigint;
+}
+
+export interface RuntimeV3Claim {
+  orgId: string;
+  companionId: string;
+  turn: RuntimeV3Turn;
+  fence: RuntimeV3Fence;
+}
+
+export type RuntimeV3ProgressionOutcome =
+  | { kind: "release" }
+  | { kind: "succeeded" }
+  | { kind: "failed"; code: string; message: string }
+  | { kind: "interrupted"; code: string; message: string };
+
+/**
+ * Internal persistence seam for the progression implementation. HTTP, workers, and lifecycle
+ * callers receive RuntimeV3Progression instead, so none of them coordinate claims or fences.
+ */
+export interface RuntimeV3ProgressionPersistence {
+  admitTurn(input: RuntimeV3Admission): Promise<RuntimeV3Turn>;
+  recordDesiredLifecycle(
+    input: RuntimeV3DesiredLifecycleChange,
+  ): Promise<RuntimeV3LifecycleRevision>;
+  claimAvailable(input: { executorId: string }): Promise<RuntimeV3Claim[]>;
+  completeProgression(
+    claim: RuntimeV3Claim,
+    outcome: RuntimeV3ProgressionOutcome,
+  ): Promise<boolean>;
+}
+
+export interface RuntimeV3Progression {
+  admit(input: RuntimeV3Admission): Promise<RuntimeV3Turn>;
+  desire(input: RuntimeV3DesiredLifecycleChange): Promise<RuntimeV3LifecycleRevision>;
+  converge(input: { executorId: string }): Promise<{
+    progressed: number;
+    exhausted: boolean;
+  }>;
+}
+
+export interface RuntimeV3ProgressionOptions {
+  persistence: RuntimeV3ProgressionPersistence;
+  advance: (claim: RuntimeV3Claim) => Promise<RuntimeV3ProgressionOutcome>;
+}
+
+const CONVERGENCE_LIMIT = 32;
+
+/**
+ * The dormant v3 deep module. It is intentionally absent from every production composition root;
+ * later tracer bullets can move behavior behind this interface without teaching callers lease
+ * choreography. Its internal composition requires an explicit advance adapter so claimed work
+ * can never be silently released by a partial composition.
+ */
+export function createRuntimeV3Progression(
+  options: RuntimeV3ProgressionOptions,
+): RuntimeV3Progression {
+  return {
+    admit: async (input) => await options.persistence.admitTurn(input),
+    desire: async (input) => await options.persistence.recordDesiredLifecycle(input),
+    converge: async ({ executorId }) => {
+      let progressed = 0;
+      while (progressed < CONVERGENCE_LIMIT) {
+        const claims = await options.persistence.claimAvailable({ executorId });
+        if (claims.length === 0) return { progressed, exhausted: false };
+        const completions = await Promise.all(claims.map(async (claim) => {
+          const outcome = await options.advance(claim);
+          return await options.persistence.completeProgression(claim, outcome);
+        }));
+        const completed = completions.filter(Boolean).length;
+        progressed += completed;
+        if (completed === 0) return { progressed, exhausted: false };
+      }
+      return { progressed, exhausted: true };
+    },
+  };
+}

--- a/packages/companion-runtime/src/v3/progression.ts
+++ b/packages/companion-runtime/src/v3/progression.ts
@@ -53,6 +53,7 @@ export interface RuntimeV3LifecycleRevision {
 export interface RuntimeV3Fence {
   token: string;
   epoch: bigint;
+  gateEpoch: bigint;
 }
 
 export interface RuntimeV3Claim {

--- a/packages/companion-runtime/src/v3/progression.ts
+++ b/packages/companion-runtime/src/v3/progression.ts
@@ -1,3 +1,6 @@
+import { safeRuntimeError } from "../errors";
+import type { ErrorAction, SafeRuntimeError } from "../types";
+
 export const RUNTIME_V3_LANES = ["main", "background"] as const;
 export type RuntimeV3Lane = (typeof RUNTIME_V3_LANES)[number];
 
@@ -62,23 +65,43 @@ export interface RuntimeV3Claim {
 export type RuntimeV3ProgressionOutcome =
   | { kind: "release" }
   | { kind: "succeeded" }
-  | { kind: "failed"; code: string; message: string }
-  | { kind: "interrupted"; code: string; message: string };
+  | { kind: "failed"; code: string; message: unknown; action: RuntimeV3ErrorAction }
+  | { kind: "interrupted"; code: string; message: unknown; action: RuntimeV3ErrorAction };
+
+export type RuntimeV3ErrorAction = Exclude<ErrorAction, "restart_box">;
+
+export type RuntimeV3DurableOutcome =
+  | { kind: "release" }
+  | { kind: "succeeded" }
+  | { kind: "failed"; error: SafeRuntimeError }
+  | { kind: "interrupted"; error: SafeRuntimeError };
+
+export interface RuntimeV3AdmissionPersistence {
+  admitTurn(input: RuntimeV3Admission): Promise<RuntimeV3Turn>;
+}
+
+export interface RuntimeV3LifecyclePersistence {
+  recordDesiredLifecycle(
+    input: RuntimeV3DesiredLifecycleChange,
+  ): Promise<RuntimeV3LifecycleRevision>;
+}
+
+export interface RuntimeV3ConvergencePersistence {
+  claimLane(input: { executorId: string; lane: RuntimeV3Lane }): Promise<RuntimeV3Claim | null>;
+  completeProgression(
+    claim: RuntimeV3Claim,
+    outcome: RuntimeV3DurableOutcome,
+  ): Promise<boolean>;
+}
 
 /**
  * Internal persistence seam for the progression implementation. HTTP, workers, and lifecycle
  * callers receive RuntimeV3Progression instead, so none of them coordinate claims or fences.
  */
 export interface RuntimeV3ProgressionPersistence {
-  admitTurn(input: RuntimeV3Admission): Promise<RuntimeV3Turn>;
-  recordDesiredLifecycle(
-    input: RuntimeV3DesiredLifecycleChange,
-  ): Promise<RuntimeV3LifecycleRevision>;
-  claimAvailable(input: { executorId: string }): Promise<RuntimeV3Claim[]>;
-  completeProgression(
-    claim: RuntimeV3Claim,
-    outcome: RuntimeV3ProgressionOutcome,
-  ): Promise<boolean>;
+  admission: RuntimeV3AdmissionPersistence;
+  lifecycle: RuntimeV3LifecyclePersistence;
+  convergence: RuntimeV3ConvergencePersistence;
 }
 
 export interface RuntimeV3Progression {
@@ -90,12 +113,31 @@ export interface RuntimeV3Progression {
   }>;
 }
 
+export type RuntimeV3Convergence = Pick<RuntimeV3Progression, "converge">;
+
 export interface RuntimeV3ProgressionOptions {
   persistence: RuntimeV3ProgressionPersistence;
   advance: (claim: RuntimeV3Claim) => Promise<RuntimeV3ProgressionOutcome>;
 }
 
-const CONVERGENCE_LIMIT = 32;
+export interface RuntimeV3ConvergenceOptions {
+  persistence: RuntimeV3ConvergencePersistence;
+  advance: (claim: RuntimeV3Claim) => Promise<RuntimeV3ProgressionOutcome>;
+}
+
+const LANE_CONVERGENCE_LIMIT = 16;
+
+function durableOutcome(outcome: RuntimeV3ProgressionOutcome): RuntimeV3DurableOutcome {
+  if (outcome.kind !== "failed" && outcome.kind !== "interrupted") return outcome;
+  return {
+    kind: outcome.kind,
+    error: safeRuntimeError({
+      code: outcome.code,
+      message: outcome.message,
+      action: outcome.action,
+    }),
+  };
+}
 
 /**
  * The dormant v3 deep module. It is intentionally absent from every production composition root;
@@ -106,23 +148,39 @@ const CONVERGENCE_LIMIT = 32;
 export function createRuntimeV3Progression(
   options: RuntimeV3ProgressionOptions,
 ): RuntimeV3Progression {
+  const convergence = createRuntimeV3Convergence({
+    persistence: options.persistence.convergence,
+    advance: options.advance,
+  });
   return {
-    admit: async (input) => await options.persistence.admitTurn(input),
-    desire: async (input) => await options.persistence.recordDesiredLifecycle(input),
+    admit: async (input) => await options.persistence.admission.admitTurn(input),
+    desire: async (input) => await options.persistence.lifecycle.recordDesiredLifecycle(input),
+    converge: convergence.converge,
+  };
+}
+
+/** Runtime-process view: lane choice and parallel scheduling stay inside the deep module. */
+export function createRuntimeV3Convergence(
+  options: RuntimeV3ConvergenceOptions,
+): RuntimeV3Convergence {
+  return {
     converge: async ({ executorId }) => {
-      let progressed = 0;
-      while (progressed < CONVERGENCE_LIMIT) {
-        const claims = await options.persistence.claimAvailable({ executorId });
-        if (claims.length === 0) return { progressed, exhausted: false };
-        const completions = await Promise.all(claims.map(async (claim) => {
-          const outcome = await options.advance(claim);
-          return await options.persistence.completeProgression(claim, outcome);
-        }));
-        const completed = completions.filter(Boolean).length;
-        progressed += completed;
-        if (completed === 0) return { progressed, exhausted: false };
-      }
-      return { progressed, exhausted: true };
+      const lanes = await Promise.all(RUNTIME_V3_LANES.map(async (lane) => {
+        let progressed = 0;
+        while (progressed < LANE_CONVERGENCE_LIMIT) {
+          const claim = await options.persistence.claimLane({ executorId, lane });
+          if (!claim) return { progressed, exhausted: false };
+          const outcome = durableOutcome(await options.advance(claim));
+          const completed = await options.persistence.completeProgression(claim, outcome);
+          if (!completed) return { progressed, exhausted: false };
+          progressed += 1;
+        }
+        return { progressed, exhausted: true };
+      }));
+      return {
+        progressed: lanes.reduce((count, lane) => count + lane.progressed, 0),
+        exhausted: lanes.some((lane) => lane.exhausted),
+      };
     },
   };
 }

--- a/packages/db/drizzle/0159_companion_runtime_v3_progression.sql
+++ b/packages/db/drizzle/0159_companion_runtime_v3_progression.sql
@@ -1,0 +1,564 @@
+-- Runtime v3 expand step. These facts and capabilities are deliberately not wired into any
+-- production composition root: Runtime v2 remains the live path until the later cutover stack.
+-- PostgreSQL owns admission identity, per-lane FIFO, and monotonic fences; TypeScript owns what a
+-- claimed fact progresses to. There is no v3 attempt table and no derived Start operation.
+CREATE TYPE public.companion_v3_lane AS ENUM ('main', 'background');
+--> statement-breakpoint
+CREATE TYPE public.companion_v3_turn_state AS ENUM (
+  'queued', 'admitted', 'running', 'needs_input',
+  'succeeded', 'failed', 'interrupted', 'cancelled'
+);
+--> statement-breakpoint
+CREATE TYPE public.companion_v3_admission_state AS ENUM ('pending', 'accepted', 'ambiguous');
+--> statement-breakpoint
+CREATE TYPE public.companion_v3_turn_outcome AS ENUM (
+  'succeeded', 'failed', 'interrupted', 'cancelled'
+);
+--> statement-breakpoint
+CREATE TYPE public.companion_v3_lifecycle_intent AS ENUM (
+  'prepare', 'archive', 'recycle_pi', 'delete'
+);
+--> statement-breakpoint
+
+CREATE TABLE public.companion_v3_instances (
+  org_id uuid NOT NULL,
+  companion_id uuid NOT NULL,
+  desired_lifecycle public.companion_v3_lifecycle_intent NOT NULL DEFAULT 'prepare',
+  desired_lifecycle_revision bigint NOT NULL DEFAULT 1,
+  desired_lifecycle_actor_id text,
+  next_main_sequence bigint NOT NULL DEFAULT 1,
+  next_background_sequence bigint NOT NULL DEFAULT 1,
+  created_at timestamp with time zone NOT NULL DEFAULT now(),
+  updated_at timestamp with time zone NOT NULL DEFAULT now(),
+  CONSTRAINT companion_v3_instances_pk PRIMARY KEY (org_id, companion_id),
+  CONSTRAINT companion_v3_instances_companion_fk
+    FOREIGN KEY (org_id, companion_id)
+    REFERENCES public.companions(org_id, id) ON DELETE CASCADE,
+  CONSTRAINT companion_v3_instances_revision_check CHECK (
+    desired_lifecycle_revision >= 1
+    AND next_main_sequence >= 1
+    AND next_background_sequence >= 1
+  ),
+  CONSTRAINT companion_v3_instances_actor_check CHECK (
+    desired_lifecycle_actor_id IS NULL
+    OR (char_length(desired_lifecycle_actor_id) BETWEEN 1 AND 200
+      AND desired_lifecycle_actor_id !~ E'[\n\r]')
+  )
+);
+--> statement-breakpoint
+
+CREATE TABLE public.companion_v3_turns (
+  id uuid PRIMARY KEY NOT NULL DEFAULT gen_random_uuid(),
+  org_id uuid NOT NULL,
+  companion_id uuid NOT NULL,
+  command_id uuid NOT NULL,
+  client_message_id uuid NOT NULL,
+  message_event_id text NOT NULL,
+  actor_id text NOT NULL,
+  lane public.companion_v3_lane NOT NULL,
+  queue_sequence bigint NOT NULL,
+  state public.companion_v3_turn_state NOT NULL DEFAULT 'queued',
+  admission_state public.companion_v3_admission_state NOT NULL DEFAULT 'pending',
+  admitted_at timestamp with time zone,
+  pi_invocation_id text,
+  admission_cursor bigint,
+  activity_cursor bigint NOT NULL DEFAULT 0,
+  last_activity_at timestamp with time zone,
+  outcome public.companion_v3_turn_outcome,
+  outcome_code text,
+  outcome_message text,
+  settled_at timestamp with time zone,
+  created_at timestamp with time zone NOT NULL DEFAULT now(),
+  updated_at timestamp with time zone NOT NULL DEFAULT now(),
+  CONSTRAINT companion_v3_turns_org_companion_id_uq UNIQUE (org_id, companion_id, id),
+  CONSTRAINT companion_v3_turns_command_uq UNIQUE (companion_id, command_id),
+  CONSTRAINT companion_v3_turns_client_message_uq UNIQUE (companion_id, client_message_id),
+  CONSTRAINT companion_v3_turns_lane_sequence_uq UNIQUE (companion_id, lane, queue_sequence),
+  CONSTRAINT companion_v3_turns_instance_fk
+    FOREIGN KEY (org_id, companion_id)
+    REFERENCES public.companion_v3_instances(org_id, companion_id) ON DELETE CASCADE,
+  CONSTRAINT companion_v3_turns_sequence_check CHECK (queue_sequence >= 1),
+  CONSTRAINT companion_v3_turns_message_event_check CHECK (
+    message_event_id = 'msg:' || client_message_id::text
+  ),
+  CONSTRAINT companion_v3_turns_actor_check CHECK (
+    char_length(actor_id) BETWEEN 1 AND 200 AND actor_id !~ E'[\n\r]'
+  ),
+  CONSTRAINT companion_v3_turns_invocation_check CHECK (
+    pi_invocation_id IS NULL
+    OR (char_length(pi_invocation_id) BETWEEN 1 AND 200 AND pi_invocation_id !~ E'[\n\r]')
+  ),
+  CONSTRAINT companion_v3_turns_cursor_check CHECK (
+    activity_cursor >= 0 AND (admission_cursor IS NULL OR admission_cursor >= 0)
+  ),
+  CONSTRAINT companion_v3_turns_admission_check CHECK (
+    (admission_state = 'pending' AND admitted_at IS NULL AND pi_invocation_id IS NULL
+      AND admission_cursor IS NULL)
+    OR (admission_state IN ('accepted', 'ambiguous') AND admitted_at IS NOT NULL
+      AND pi_invocation_id IS NOT NULL AND admission_cursor IS NOT NULL)
+  ),
+  CONSTRAINT companion_v3_turns_outcome_check CHECK (
+    (outcome IS NULL AND settled_at IS NULL
+      AND outcome_code IS NULL AND outcome_message IS NULL
+      AND state IN ('queued', 'admitted', 'running', 'needs_input'))
+    OR (outcome IS NOT NULL AND settled_at IS NOT NULL AND state::text = outcome::text
+      AND ((outcome IN ('failed', 'interrupted')
+          AND outcome_code ~ '^[a-z][a-z0-9_]{0,63}$'
+          AND char_length(outcome_message) BETWEEN 1 AND 500
+          AND outcome_message !~ E'[\n\r]')
+        OR (outcome IN ('succeeded', 'cancelled')
+          AND outcome_code IS NULL AND outcome_message IS NULL)))
+  )
+);
+--> statement-breakpoint
+CREATE INDEX companion_v3_turns_fifo_idx
+  ON public.companion_v3_turns(companion_id, lane, queue_sequence, id)
+  WHERE state = 'queued';
+--> statement-breakpoint
+
+CREATE TABLE public.companion_v3_lane_leases (
+  org_id uuid NOT NULL,
+  companion_id uuid NOT NULL,
+  lane public.companion_v3_lane NOT NULL,
+  claim_token uuid,
+  claim_epoch bigint NOT NULL DEFAULT 0,
+  executor_id text,
+  turn_id uuid,
+  claimed_at timestamp with time zone,
+  renewed_at timestamp with time zone,
+  expires_at timestamp with time zone,
+  created_at timestamp with time zone NOT NULL DEFAULT now(),
+  updated_at timestamp with time zone NOT NULL DEFAULT now(),
+  CONSTRAINT companion_v3_lane_leases_pk PRIMARY KEY (org_id, companion_id, lane),
+  CONSTRAINT companion_v3_lane_leases_instance_fk
+    FOREIGN KEY (org_id, companion_id)
+    REFERENCES public.companion_v3_instances(org_id, companion_id) ON DELETE CASCADE,
+  CONSTRAINT companion_v3_lane_leases_turn_fk
+    FOREIGN KEY (org_id, companion_id, turn_id)
+    REFERENCES public.companion_v3_turns(org_id, companion_id, id) ON DELETE CASCADE,
+  CONSTRAINT companion_v3_lane_leases_epoch_check CHECK (claim_epoch >= 0),
+  CONSTRAINT companion_v3_lane_leases_executor_check CHECK (
+    executor_id IS NULL
+    OR (char_length(executor_id) BETWEEN 1 AND 200 AND executor_id !~ E'[\n\r]')
+  ),
+  CONSTRAINT companion_v3_lane_leases_claim_check CHECK (
+    (claim_token IS NULL AND executor_id IS NULL AND turn_id IS NULL
+      AND claimed_at IS NULL AND renewed_at IS NULL AND expires_at IS NULL)
+    OR (claim_token IS NOT NULL AND claim_epoch >= 1 AND executor_id IS NOT NULL
+      AND turn_id IS NOT NULL AND claimed_at IS NOT NULL AND renewed_at IS NOT NULL
+      AND expires_at > renewed_at)
+  )
+);
+--> statement-breakpoint
+CREATE INDEX companion_v3_lane_leases_expiry_idx
+  ON public.companion_v3_lane_leases(expires_at)
+  WHERE claim_token IS NOT NULL;
+--> statement-breakpoint
+
+CREATE FUNCTION public.companion_v3_admit_turn(
+  p_org_id uuid,
+  p_companion_id uuid,
+  p_client_message_id uuid,
+  p_message_event_id text,
+  p_actor_id text,
+  p_lane public.companion_v3_lane
+)
+RETURNS TABLE (
+  turn_id uuid,
+  command_id uuid,
+  lane public.companion_v3_lane,
+  state public.companion_v3_turn_state,
+  replayed boolean
+)
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = pg_catalog, public
+SET row_security = on
+AS $$
+DECLARE
+  v_turn public.companion_v3_turns%ROWTYPE;
+  v_sequence bigint;
+BEGIN
+  IF p_org_id IS NULL OR p_companion_id IS NULL OR p_client_message_id IS NULL
+    OR p_actor_id IS NULL OR char_length(p_actor_id) NOT BETWEEN 1 AND 200
+    OR p_actor_id ~ E'[\n\r]'
+    OR p_message_event_id IS DISTINCT FROM 'msg:' || p_client_message_id::text THEN
+    RAISE EXCEPTION 'invalid Runtime v3 Turn admission' USING ERRCODE = '22023';
+  END IF;
+
+  SELECT turn_row.* INTO v_turn
+  FROM public.companion_v3_turns turn_row
+  WHERE turn_row.companion_id = p_companion_id
+    AND turn_row.client_message_id = p_client_message_id;
+  IF FOUND THEN
+    IF v_turn.org_id IS DISTINCT FROM p_org_id
+      OR v_turn.actor_id IS DISTINCT FROM p_actor_id
+      OR v_turn.message_event_id IS DISTINCT FROM p_message_event_id
+      OR v_turn.lane IS DISTINCT FROM p_lane THEN
+      RAISE EXCEPTION 'client_message_id was reused with different Runtime v3 intent'
+        USING ERRCODE = '23505', CONSTRAINT = 'companion_v3_turns_client_message_uq';
+    END IF;
+    RETURN QUERY SELECT v_turn.id, v_turn.command_id, v_turn.lane, v_turn.state, true;
+    RETURN;
+  END IF;
+
+  INSERT INTO public.companion_v3_instances(org_id, companion_id)
+  VALUES (p_org_id, p_companion_id)
+  ON CONFLICT (org_id, companion_id) DO NOTHING;
+
+  IF p_lane = 'main' THEN
+    UPDATE public.companion_v3_instances instance
+    SET next_main_sequence = instance.next_main_sequence + 1,
+        updated_at = clock_timestamp()
+    WHERE instance.org_id = p_org_id AND instance.companion_id = p_companion_id
+    RETURNING instance.next_main_sequence - 1 INTO v_sequence;
+  ELSE
+    UPDATE public.companion_v3_instances instance
+    SET next_background_sequence = instance.next_background_sequence + 1,
+        updated_at = clock_timestamp()
+    WHERE instance.org_id = p_org_id AND instance.companion_id = p_companion_id
+    RETURNING instance.next_background_sequence - 1 INTO v_sequence;
+  END IF;
+
+  INSERT INTO public.companion_v3_lane_leases(org_id, companion_id, lane)
+  VALUES (p_org_id, p_companion_id, 'main'), (p_org_id, p_companion_id, 'background')
+  ON CONFLICT ON CONSTRAINT companion_v3_lane_leases_pk DO NOTHING;
+
+  INSERT INTO public.companion_v3_turns(
+    org_id, companion_id, command_id, client_message_id, message_event_id,
+    actor_id, lane, queue_sequence
+  ) VALUES (
+    p_org_id, p_companion_id, p_client_message_id, p_client_message_id,
+    p_message_event_id, p_actor_id, p_lane, v_sequence
+  ) RETURNING * INTO v_turn;
+  RETURN QUERY SELECT v_turn.id, v_turn.command_id, v_turn.lane, v_turn.state, false;
+END
+$$;
+--> statement-breakpoint
+
+CREATE FUNCTION public.companion_v3_api_admit_turn(
+  p_org_id uuid,
+  p_companion_id uuid,
+  p_client_message_id uuid,
+  p_message_event_id text
+)
+RETURNS TABLE (
+  turn_id uuid,
+  command_id uuid,
+  lane public.companion_v3_lane,
+  state public.companion_v3_turn_state,
+  replayed boolean
+)
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = pg_catalog, public
+SET row_security = on
+AS $$
+DECLARE
+  v_actor_id text := public.companion_api_actor(p_org_id);
+BEGIN
+  PERFORM public.companion_api_require_access(p_org_id, p_companion_id, 'editor');
+  RETURN QUERY SELECT * FROM public.companion_v3_admit_turn(
+    p_org_id, p_companion_id, p_client_message_id, p_message_event_id,
+    v_actor_id, 'main'
+  );
+END
+$$;
+--> statement-breakpoint
+
+CREATE FUNCTION public.companion_v3_worker_admit_turn(
+  p_org_id uuid,
+  p_companion_id uuid,
+  p_client_message_id uuid,
+  p_message_event_id text,
+  p_actor_id text
+)
+RETURNS TABLE (
+  turn_id uuid,
+  command_id uuid,
+  lane public.companion_v3_lane,
+  state public.companion_v3_turn_state,
+  replayed boolean
+)
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = pg_catalog, public
+SET row_security = on
+AS $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1
+    FROM public.companions companion
+    JOIN public.memberships membership
+      ON membership.org_id = companion.org_id
+     AND membership.user_id = companion.owner_id
+    WHERE companion.org_id = p_org_id
+      AND companion.id = p_companion_id
+      AND companion.owner_id = p_actor_id
+  ) THEN
+    RAISE EXCEPTION 'Runtime v3 background actor is not the Companion Owner'
+      USING ERRCODE = '42501';
+  END IF;
+  RETURN QUERY SELECT * FROM public.companion_v3_admit_turn(
+    p_org_id, p_companion_id, p_client_message_id, p_message_event_id,
+    p_actor_id, 'background'
+  );
+END
+$$;
+--> statement-breakpoint
+
+CREATE FUNCTION public.companion_v3_api_desire_lifecycle(
+  p_org_id uuid,
+  p_companion_id uuid,
+  p_intent public.companion_v3_lifecycle_intent
+)
+RETURNS TABLE (intent public.companion_v3_lifecycle_intent, revision bigint)
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = pg_catalog, public
+SET row_security = on
+AS $$
+DECLARE
+  v_actor_id text := public.companion_api_actor(p_org_id);
+BEGIN
+  PERFORM public.companion_api_require_access(p_org_id, p_companion_id,
+    CASE WHEN p_intent = 'delete' THEN 'owner' ELSE 'editor' END);
+  INSERT INTO public.companion_v3_instances(
+    org_id, companion_id, desired_lifecycle, desired_lifecycle_actor_id
+  ) VALUES (p_org_id, p_companion_id, p_intent, v_actor_id)
+  ON CONFLICT (org_id, companion_id) DO UPDATE
+  SET desired_lifecycle = EXCLUDED.desired_lifecycle,
+      desired_lifecycle_revision = companion_v3_instances.desired_lifecycle_revision + 1,
+      desired_lifecycle_actor_id = EXCLUDED.desired_lifecycle_actor_id,
+      updated_at = clock_timestamp()
+  RETURNING desired_lifecycle, desired_lifecycle_revision INTO intent, revision;
+  INSERT INTO public.companion_v3_lane_leases(org_id, companion_id, lane)
+  VALUES (p_org_id, p_companion_id, 'main'), (p_org_id, p_companion_id, 'background')
+  ON CONFLICT ON CONSTRAINT companion_v3_lane_leases_pk DO NOTHING;
+  RETURN NEXT;
+END
+$$;
+--> statement-breakpoint
+
+CREATE FUNCTION public.companion_v3_runtime_claim(
+  p_executor_id text,
+  p_lane public.companion_v3_lane,
+  p_lease_seconds integer,
+  p_protocol integer
+)
+RETURNS TABLE (
+  org_id uuid,
+  companion_id uuid,
+  turn_id uuid,
+  command_id uuid,
+  lane public.companion_v3_lane,
+  state public.companion_v3_turn_state,
+  claim_token uuid,
+  claim_epoch bigint
+)
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = pg_catalog, public
+SET row_security = on
+AS $$
+DECLARE
+  v_now timestamp with time zone := clock_timestamp();
+  v_lease public.companion_v3_lane_leases%ROWTYPE;
+  v_turn public.companion_v3_turns%ROWTYPE;
+BEGIN
+  IF p_protocol IS DISTINCT FROM 3 THEN
+    RAISE EXCEPTION 'Runtime v3 protocol is required' USING ERRCODE = '42501';
+  END IF;
+  IF p_executor_id IS NULL OR char_length(p_executor_id) NOT BETWEEN 1 AND 200
+    OR p_executor_id ~ E'[\n\r]' OR p_lease_seconds NOT BETWEEN 1 AND 300 THEN
+    RAISE EXCEPTION 'invalid Runtime v3 claim' USING ERRCODE = '22023';
+  END IF;
+  IF NOT EXISTS (
+    SELECT 1 FROM public.companion_runtime_control control
+    WHERE control.id = 'runtime-v2' AND control.enabled
+  ) THEN
+    RETURN;
+  END IF;
+
+  SELECT lease.* INTO v_lease
+  FROM public.companion_v3_lane_leases lease
+  JOIN public.companion_v3_turns queued
+    ON queued.org_id = lease.org_id AND queued.companion_id = lease.companion_id
+   AND queued.lane = lease.lane AND queued.state = 'queued'
+  WHERE lease.lane = p_lane
+    AND (lease.claim_token IS NULL OR lease.expires_at <= v_now)
+  ORDER BY queued.created_at, queued.queue_sequence, queued.id
+  LIMIT 1
+  FOR UPDATE OF lease SKIP LOCKED;
+  IF NOT FOUND THEN RETURN; END IF;
+
+  SELECT queued.* INTO v_turn
+  FROM public.companion_v3_turns queued
+  WHERE queued.org_id = v_lease.org_id
+    AND queued.companion_id = v_lease.companion_id
+    AND queued.lane = p_lane
+    AND queued.state = 'queued'
+  ORDER BY queued.queue_sequence, queued.id
+  LIMIT 1
+  FOR UPDATE;
+  IF NOT FOUND THEN RETURN; END IF;
+
+  UPDATE public.companion_v3_lane_leases lease
+  SET claim_token = gen_random_uuid(),
+      claim_epoch = lease.claim_epoch + 1,
+      executor_id = p_executor_id,
+      turn_id = v_turn.id,
+      claimed_at = v_now,
+      renewed_at = v_now,
+      expires_at = v_now + make_interval(secs => p_lease_seconds),
+      updated_at = v_now
+  WHERE lease.org_id = v_lease.org_id
+    AND lease.companion_id = v_lease.companion_id
+    AND lease.lane = p_lane
+  RETURNING lease.claim_token, lease.claim_epoch INTO claim_token, claim_epoch;
+
+  org_id := v_turn.org_id;
+  companion_id := v_turn.companion_id;
+  turn_id := v_turn.id;
+  command_id := v_turn.command_id;
+  lane := v_turn.lane;
+  state := v_turn.state;
+  RETURN NEXT;
+END
+$$;
+--> statement-breakpoint
+
+CREATE FUNCTION public.companion_v3_runtime_complete(
+  p_org_id uuid,
+  p_companion_id uuid,
+  p_lane public.companion_v3_lane,
+  p_turn_id uuid,
+  p_claim_token uuid,
+  p_claim_epoch bigint,
+  p_outcome text,
+  p_code text,
+  p_message text,
+  p_protocol integer
+)
+RETURNS boolean
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = pg_catalog, public
+SET row_security = on
+AS $$
+DECLARE
+  v_now timestamp with time zone := clock_timestamp();
+BEGIN
+  IF p_protocol IS DISTINCT FROM 3 THEN
+    RAISE EXCEPTION 'Runtime v3 protocol is required' USING ERRCODE = '42501';
+  END IF;
+  IF p_outcome NOT IN ('release', 'succeeded', 'failed', 'interrupted')
+    OR ((p_outcome IN ('failed', 'interrupted'))
+      <> (p_code IS NOT NULL AND p_message IS NOT NULL)) THEN
+    RAISE EXCEPTION 'invalid Runtime v3 completion' USING ERRCODE = '22023';
+  END IF;
+
+  PERFORM 1 FROM public.companion_v3_lane_leases lease
+  WHERE lease.org_id = p_org_id AND lease.companion_id = p_companion_id
+    AND lease.lane = p_lane AND lease.turn_id = p_turn_id
+    AND lease.claim_token = p_claim_token AND lease.claim_epoch = p_claim_epoch
+    AND lease.expires_at > v_now
+  FOR UPDATE;
+  IF NOT FOUND THEN RETURN false; END IF;
+
+  IF p_outcome <> 'release' THEN
+    UPDATE public.companion_v3_turns turn_row
+    SET state = p_outcome::public.companion_v3_turn_state,
+        outcome = p_outcome::public.companion_v3_turn_outcome,
+        outcome_code = p_code,
+        outcome_message = p_message,
+        settled_at = v_now,
+        updated_at = v_now
+    WHERE turn_row.org_id = p_org_id AND turn_row.companion_id = p_companion_id
+      AND turn_row.id = p_turn_id AND turn_row.state = 'queued';
+    IF NOT FOUND THEN RETURN false; END IF;
+  END IF;
+
+  UPDATE public.companion_v3_lane_leases lease
+  SET claim_token = NULL, executor_id = NULL, turn_id = NULL,
+      claimed_at = NULL, renewed_at = NULL, expires_at = NULL, updated_at = v_now
+  WHERE lease.org_id = p_org_id AND lease.companion_id = p_companion_id
+    AND lease.lane = p_lane AND lease.claim_token = p_claim_token
+    AND lease.claim_epoch = p_claim_epoch;
+  RETURN FOUND;
+END
+$$;
+--> statement-breakpoint
+
+ALTER TABLE public.companion_v3_instances ENABLE ROW LEVEL SECURITY;
+--> statement-breakpoint
+ALTER TABLE public.companion_v3_instances FORCE ROW LEVEL SECURITY;
+--> statement-breakpoint
+ALTER TABLE public.companion_v3_turns ENABLE ROW LEVEL SECURITY;
+--> statement-breakpoint
+ALTER TABLE public.companion_v3_turns FORCE ROW LEVEL SECURITY;
+--> statement-breakpoint
+ALTER TABLE public.companion_v3_lane_leases ENABLE ROW LEVEL SECURITY;
+--> statement-breakpoint
+ALTER TABLE public.companion_v3_lane_leases FORCE ROW LEVEL SECURITY;
+--> statement-breakpoint
+
+CREATE POLICY companion_v3_instances_function_owner_rls
+  ON public.companion_v3_instances FOR ALL
+  USING (current_user = pg_get_userbyid((
+    SELECT procedure.proowner FROM pg_proc procedure
+    WHERE procedure.oid = 'public.companion_v3_admit_turn(uuid,uuid,uuid,text,text,public.companion_v3_lane)'::regprocedure
+  )))
+  WITH CHECK (current_user = pg_get_userbyid((
+    SELECT procedure.proowner FROM pg_proc procedure
+    WHERE procedure.oid = 'public.companion_v3_admit_turn(uuid,uuid,uuid,text,text,public.companion_v3_lane)'::regprocedure
+  )));
+--> statement-breakpoint
+CREATE POLICY companion_v3_turns_function_owner_rls
+  ON public.companion_v3_turns FOR ALL
+  USING (current_user = pg_get_userbyid((
+    SELECT procedure.proowner FROM pg_proc procedure
+    WHERE procedure.oid = 'public.companion_v3_admit_turn(uuid,uuid,uuid,text,text,public.companion_v3_lane)'::regprocedure
+  )))
+  WITH CHECK (current_user = pg_get_userbyid((
+    SELECT procedure.proowner FROM pg_proc procedure
+    WHERE procedure.oid = 'public.companion_v3_admit_turn(uuid,uuid,uuid,text,text,public.companion_v3_lane)'::regprocedure
+  )));
+--> statement-breakpoint
+CREATE POLICY companion_v3_lane_leases_function_owner_rls
+  ON public.companion_v3_lane_leases FOR ALL
+  USING (current_user = pg_get_userbyid((
+    SELECT procedure.proowner FROM pg_proc procedure
+    WHERE procedure.oid = 'public.companion_v3_admit_turn(uuid,uuid,uuid,text,text,public.companion_v3_lane)'::regprocedure
+  )))
+  WITH CHECK (current_user = pg_get_userbyid((
+    SELECT procedure.proowner FROM pg_proc procedure
+    WHERE procedure.oid = 'public.companion_v3_admit_turn(uuid,uuid,uuid,text,text,public.companion_v3_lane)'::regprocedure
+  )));
+--> statement-breakpoint
+
+REVOKE ALL ON TABLE public.companion_v3_instances FROM PUBLIC;
+--> statement-breakpoint
+REVOKE ALL ON TABLE public.companion_v3_turns FROM PUBLIC;
+--> statement-breakpoint
+REVOKE ALL ON TABLE public.companion_v3_lane_leases FROM PUBLIC;
+--> statement-breakpoint
+REVOKE ALL ON FUNCTION public.companion_v3_admit_turn(
+  uuid,uuid,uuid,text,text,public.companion_v3_lane
+) FROM PUBLIC;
+--> statement-breakpoint
+REVOKE ALL ON FUNCTION public.companion_v3_api_admit_turn(uuid,uuid,uuid,text) FROM PUBLIC;
+--> statement-breakpoint
+REVOKE ALL ON FUNCTION public.companion_v3_worker_admit_turn(uuid,uuid,uuid,text,text) FROM PUBLIC;
+--> statement-breakpoint
+REVOKE ALL ON FUNCTION public.companion_v3_api_desire_lifecycle(
+  uuid,uuid,public.companion_v3_lifecycle_intent
+) FROM PUBLIC;
+--> statement-breakpoint
+REVOKE ALL ON FUNCTION public.companion_v3_runtime_claim(
+  text,public.companion_v3_lane,integer,integer
+) FROM PUBLIC;
+--> statement-breakpoint
+REVOKE ALL ON FUNCTION public.companion_v3_runtime_complete(
+  uuid,uuid,public.companion_v3_lane,uuid,uuid,bigint,text,text,text,integer
+) FROM PUBLIC;

--- a/packages/db/drizzle/0159_companion_runtime_v3_progression.sql
+++ b/packages/db/drizzle/0159_companion_runtime_v3_progression.sql
@@ -462,7 +462,8 @@ BEGIN
   IF p_protocol IS DISTINCT FROM 3 THEN
     RAISE EXCEPTION 'Runtime v3 protocol is required' USING ERRCODE = '42501';
   END IF;
-  IF p_outcome NOT IN ('release', 'succeeded', 'failed', 'interrupted')
+  IF p_outcome IS NULL
+    OR p_outcome NOT IN ('release', 'succeeded', 'failed', 'interrupted')
     OR (p_outcome IN ('failed', 'interrupted') AND (
       p_code IS NULL OR p_message IS NULL OR p_action IS NULL OR p_action = 'restart_box'
     ))

--- a/packages/db/drizzle/0159_companion_runtime_v3_progression.sql
+++ b/packages/db/drizzle/0159_companion_runtime_v3_progression.sql
@@ -124,6 +124,7 @@ CREATE TABLE public.companion_v3_lane_leases (
   lane public.companion_v3_lane NOT NULL,
   claim_token uuid,
   claim_epoch bigint NOT NULL DEFAULT 0,
+  gate_epoch bigint,
   executor_id text,
   turn_id uuid,
   claimed_at timestamp with time zone,
@@ -138,17 +139,20 @@ CREATE TABLE public.companion_v3_lane_leases (
   CONSTRAINT companion_v3_lane_leases_turn_fk
     FOREIGN KEY (org_id, companion_id, turn_id)
     REFERENCES public.companion_v3_turns(org_id, companion_id, id) ON DELETE CASCADE,
-  CONSTRAINT companion_v3_lane_leases_epoch_check CHECK (claim_epoch >= 0),
+  CONSTRAINT companion_v3_lane_leases_epoch_check CHECK (
+    claim_epoch >= 0 AND (gate_epoch IS NULL OR gate_epoch >= 1)
+  ),
   CONSTRAINT companion_v3_lane_leases_executor_check CHECK (
     executor_id IS NULL
     OR (char_length(executor_id) BETWEEN 1 AND 200 AND executor_id !~ E'[\n\r]')
   ),
   CONSTRAINT companion_v3_lane_leases_claim_check CHECK (
-    (claim_token IS NULL AND executor_id IS NULL AND turn_id IS NULL
+    (claim_token IS NULL AND gate_epoch IS NULL AND executor_id IS NULL AND turn_id IS NULL
       AND claimed_at IS NULL AND renewed_at IS NULL AND expires_at IS NULL)
-    OR (claim_token IS NOT NULL AND claim_epoch >= 1 AND executor_id IS NOT NULL
+    OR (claim_token IS NOT NULL AND claim_epoch >= 1 AND gate_epoch IS NOT NULL
+      AND executor_id IS NOT NULL
       AND turn_id IS NOT NULL AND claimed_at IS NOT NULL AND renewed_at IS NOT NULL
-      AND expires_at > renewed_at)
+      AND expires_at IS NOT NULL AND expires_at > renewed_at)
   )
 );
 --> statement-breakpoint
@@ -363,7 +367,8 @@ RETURNS TABLE (
   lane public.companion_v3_lane,
   state public.companion_v3_turn_state,
   claim_token uuid,
-  claim_epoch bigint
+  claim_epoch bigint,
+  gate_epoch bigint
 )
 LANGUAGE plpgsql
 SECURITY DEFINER
@@ -374,18 +379,21 @@ DECLARE
   v_now timestamp with time zone := clock_timestamp();
   v_lease public.companion_v3_lane_leases%ROWTYPE;
   v_turn public.companion_v3_turns%ROWTYPE;
+  v_gate_epoch bigint;
 BEGIN
   IF p_protocol IS DISTINCT FROM 3 THEN
     RAISE EXCEPTION 'Runtime v3 protocol is required' USING ERRCODE = '42501';
   END IF;
   IF p_executor_id IS NULL OR char_length(p_executor_id) NOT BETWEEN 1 AND 200
-    OR p_executor_id ~ E'[\n\r]' OR p_lease_seconds NOT BETWEEN 1 AND 300 THEN
+    OR p_executor_id ~ E'[\n\r]' OR p_lease_seconds IS NULL
+    OR p_lease_seconds NOT BETWEEN 1 AND 300 THEN
     RAISE EXCEPTION 'invalid Runtime v3 claim' USING ERRCODE = '22023';
   END IF;
-  IF NOT EXISTS (
-    SELECT 1 FROM public.companion_runtime_control control
-    WHERE control.id = 'runtime-v2' AND control.enabled
-  ) THEN
+  SELECT control.gate_epoch INTO v_gate_epoch
+  FROM public.companion_runtime_control control
+  WHERE control.id = 'runtime-v2' AND control.enabled
+  FOR SHARE;
+  IF NOT FOUND THEN
     RETURN;
   END IF;
 
@@ -415,6 +423,7 @@ BEGIN
   UPDATE public.companion_v3_lane_leases lease
   SET claim_token = gen_random_uuid(),
       claim_epoch = lease.claim_epoch + 1,
+      gate_epoch = v_gate_epoch,
       executor_id = p_executor_id,
       turn_id = v_turn.id,
       claimed_at = v_now,
@@ -424,7 +433,8 @@ BEGIN
   WHERE lease.org_id = v_lease.org_id
     AND lease.companion_id = v_lease.companion_id
     AND lease.lane = p_lane
-  RETURNING lease.claim_token, lease.claim_epoch INTO claim_token, claim_epoch;
+  RETURNING lease.claim_token, lease.claim_epoch, lease.gate_epoch
+  INTO claim_token, claim_epoch, gate_epoch;
 
   org_id := v_turn.org_id;
   companion_id := v_turn.companion_id;
@@ -444,6 +454,7 @@ CREATE FUNCTION public.companion_v3_runtime_complete(
   p_turn_id uuid,
   p_claim_token uuid,
   p_claim_epoch bigint,
+  p_gate_epoch bigint,
   p_outcome text,
   p_code text,
   p_message text,
@@ -462,7 +473,8 @@ BEGIN
   IF p_protocol IS DISTINCT FROM 3 THEN
     RAISE EXCEPTION 'Runtime v3 protocol is required' USING ERRCODE = '42501';
   END IF;
-  IF p_outcome IS NULL
+  IF p_gate_epoch IS NULL OR p_gate_epoch < 1
+    OR p_outcome IS NULL
     OR p_outcome NOT IN ('release', 'succeeded', 'failed', 'interrupted')
     OR (p_outcome IN ('failed', 'interrupted') AND (
       p_code IS NULL OR p_message IS NULL OR p_action IS NULL OR p_action = 'restart_box'
@@ -473,10 +485,19 @@ BEGIN
     RAISE EXCEPTION 'invalid Runtime v3 completion' USING ERRCODE = '22023';
   END IF;
 
-  PERFORM 1 FROM public.companion_v3_lane_leases lease
+  PERFORM 1
+  FROM public.companion_runtime_control control
+  WHERE control.id = 'runtime-v2' AND control.enabled
+    AND control.gate_epoch = p_gate_epoch
+  FOR SHARE;
+  IF NOT FOUND THEN RETURN false; END IF;
+
+  PERFORM 1
+  FROM public.companion_v3_lane_leases lease
   WHERE lease.org_id = p_org_id AND lease.companion_id = p_companion_id
     AND lease.lane = p_lane AND lease.turn_id = p_turn_id
     AND lease.claim_token = p_claim_token AND lease.claim_epoch = p_claim_epoch
+    AND lease.gate_epoch = p_gate_epoch
     AND lease.expires_at > v_now
   FOR UPDATE;
   IF NOT FOUND THEN RETURN false; END IF;
@@ -496,7 +517,7 @@ BEGIN
   END IF;
 
   UPDATE public.companion_v3_lane_leases lease
-  SET claim_token = NULL, executor_id = NULL, turn_id = NULL,
+  SET claim_token = NULL, gate_epoch = NULL, executor_id = NULL, turn_id = NULL,
       claimed_at = NULL, renewed_at = NULL, expires_at = NULL, updated_at = v_now
   WHERE lease.org_id = p_org_id AND lease.companion_id = p_companion_id
     AND lease.lane = p_lane AND lease.claim_token = p_claim_token
@@ -504,6 +525,50 @@ BEGIN
   RETURN FOUND;
 END
 $$;
+--> statement-breakpoint
+
+-- Keep Runtime v3 claims inside the existing emergency-stop epoch. Claimers lock the control row
+-- before lane rows, so a concurrent disable waits, advances the epoch, and then invalidates every
+-- materialized v3 token before it commits.
+CREATE FUNCTION public.companion_v3_fence_runtime_gate()
+RETURNS trigger
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = pg_catalog, public
+SET row_security = on
+AS $$
+DECLARE
+  v_now timestamp with time zone := clock_timestamp();
+BEGIN
+  IF NEW.gate_epoch IS NOT DISTINCT FROM OLD.gate_epoch THEN
+    RETURN NEW;
+  END IF;
+
+  PERFORM 1
+  FROM public.companion_v3_lane_leases lease
+  ORDER BY lease.org_id, lease.companion_id, lease.lane
+  FOR UPDATE;
+
+  UPDATE public.companion_v3_lane_leases lease
+  SET claim_token = NULL,
+      claim_epoch = lease.claim_epoch + 1,
+      gate_epoch = NULL,
+      executor_id = NULL,
+      turn_id = NULL,
+      claimed_at = NULL,
+      renewed_at = NULL,
+      expires_at = NULL,
+      updated_at = v_now
+  WHERE lease.claim_token IS NOT NULL;
+  RETURN NEW;
+END
+$$;
+--> statement-breakpoint
+CREATE TRIGGER companion_v3_runtime_gate_fence
+AFTER UPDATE OF gate_epoch ON public.companion_runtime_control
+FOR EACH ROW
+WHEN (OLD.gate_epoch IS DISTINCT FROM NEW.gate_epoch)
+EXECUTE FUNCTION public.companion_v3_fence_runtime_gate();
 --> statement-breakpoint
 
 ALTER TABLE public.companion_v3_instances ENABLE ROW LEVEL SECURITY;
@@ -576,6 +641,8 @@ REVOKE ALL ON FUNCTION public.companion_v3_runtime_claim(
 ) FROM PUBLIC;
 --> statement-breakpoint
 REVOKE ALL ON FUNCTION public.companion_v3_runtime_complete(
-  uuid,uuid,public.companion_v3_lane,uuid,uuid,bigint,text,text,text,
+  uuid,uuid,public.companion_v3_lane,uuid,uuid,bigint,bigint,text,text,text,
   public.companion_runtime_error_action,integer
 ) FROM PUBLIC;
+--> statement-breakpoint
+REVOKE ALL ON FUNCTION public.companion_v3_fence_runtime_gate() FROM PUBLIC;

--- a/packages/db/drizzle/0159_companion_runtime_v3_progression.sql
+++ b/packages/db/drizzle/0159_companion_runtime_v3_progression.sql
@@ -67,6 +67,7 @@ CREATE TABLE public.companion_v3_turns (
   outcome public.companion_v3_turn_outcome,
   outcome_code text,
   outcome_message text,
+  outcome_action public.companion_runtime_error_action,
   settled_at timestamp with time zone,
   created_at timestamp with time zone NOT NULL DEFAULT now(),
   updated_at timestamp with time zone NOT NULL DEFAULT now(),
@@ -99,15 +100,16 @@ CREATE TABLE public.companion_v3_turns (
   ),
   CONSTRAINT companion_v3_turns_outcome_check CHECK (
     (outcome IS NULL AND settled_at IS NULL
-      AND outcome_code IS NULL AND outcome_message IS NULL
+      AND outcome_code IS NULL AND outcome_message IS NULL AND outcome_action IS NULL
       AND state IN ('queued', 'admitted', 'running', 'needs_input'))
     OR (outcome IS NOT NULL AND settled_at IS NOT NULL AND state::text = outcome::text
       AND ((outcome IN ('failed', 'interrupted')
           AND outcome_code ~ '^[a-z][a-z0-9_]{0,63}$'
           AND char_length(outcome_message) BETWEEN 1 AND 500
-          AND outcome_message !~ E'[\n\r]')
+          AND outcome_message !~ E'[\n\r]'
+          AND outcome_action IS NOT NULL AND outcome_action <> 'restart_box')
         OR (outcome IN ('succeeded', 'cancelled')
-          AND outcome_code IS NULL AND outcome_message IS NULL)))
+          AND outcome_code IS NULL AND outcome_message IS NULL AND outcome_action IS NULL)))
   )
 );
 --> statement-breakpoint
@@ -186,9 +188,20 @@ BEGIN
     RAISE EXCEPTION 'invalid Runtime v3 Turn admission' USING ERRCODE = '22023';
   END IF;
 
+  INSERT INTO public.companion_v3_instances(org_id, companion_id)
+  VALUES (p_org_id, p_companion_id)
+  ON CONFLICT (org_id, companion_id) DO NOTHING;
+
+  -- Serialize idempotency lookup and sequence allocation per Companion. Concurrent retries of one
+  -- client_message_id therefore resolve to the first Turn instead of surfacing a uniqueness race.
+  PERFORM 1 FROM public.companion_v3_instances instance
+  WHERE instance.org_id = p_org_id AND instance.companion_id = p_companion_id
+  FOR UPDATE;
+
   SELECT turn_row.* INTO v_turn
   FROM public.companion_v3_turns turn_row
-  WHERE turn_row.companion_id = p_companion_id
+  WHERE turn_row.org_id = p_org_id
+    AND turn_row.companion_id = p_companion_id
     AND turn_row.client_message_id = p_client_message_id;
   IF FOUND THEN
     IF v_turn.org_id IS DISTINCT FROM p_org_id
@@ -201,10 +214,6 @@ BEGIN
     RETURN QUERY SELECT v_turn.id, v_turn.command_id, v_turn.lane, v_turn.state, true;
     RETURN;
   END IF;
-
-  INSERT INTO public.companion_v3_instances(org_id, companion_id)
-  VALUES (p_org_id, p_companion_id)
-  ON CONFLICT (org_id, companion_id) DO NOTHING;
 
   IF p_lane = 'main' THEN
     UPDATE public.companion_v3_instances instance
@@ -438,6 +447,7 @@ CREATE FUNCTION public.companion_v3_runtime_complete(
   p_outcome text,
   p_code text,
   p_message text,
+  p_action public.companion_runtime_error_action,
   p_protocol integer
 )
 RETURNS boolean
@@ -453,8 +463,12 @@ BEGIN
     RAISE EXCEPTION 'Runtime v3 protocol is required' USING ERRCODE = '42501';
   END IF;
   IF p_outcome NOT IN ('release', 'succeeded', 'failed', 'interrupted')
-    OR ((p_outcome IN ('failed', 'interrupted'))
-      <> (p_code IS NOT NULL AND p_message IS NOT NULL)) THEN
+    OR (p_outcome IN ('failed', 'interrupted') AND (
+      p_code IS NULL OR p_message IS NULL OR p_action IS NULL OR p_action = 'restart_box'
+    ))
+    OR (p_outcome IN ('release', 'succeeded') AND (
+      p_code IS NOT NULL OR p_message IS NOT NULL OR p_action IS NOT NULL
+    )) THEN
     RAISE EXCEPTION 'invalid Runtime v3 completion' USING ERRCODE = '22023';
   END IF;
 
@@ -472,6 +486,7 @@ BEGIN
         outcome = p_outcome::public.companion_v3_turn_outcome,
         outcome_code = p_code,
         outcome_message = p_message,
+        outcome_action = p_action,
         settled_at = v_now,
         updated_at = v_now
     WHERE turn_row.org_id = p_org_id AND turn_row.companion_id = p_companion_id
@@ -560,5 +575,6 @@ REVOKE ALL ON FUNCTION public.companion_v3_runtime_claim(
 ) FROM PUBLIC;
 --> statement-breakpoint
 REVOKE ALL ON FUNCTION public.companion_v3_runtime_complete(
-  uuid,uuid,public.companion_v3_lane,uuid,uuid,bigint,text,text,text,integer
+  uuid,uuid,public.companion_v3_lane,uuid,uuid,bigint,text,text,text,
+  public.companion_runtime_error_action,integer
 ) FROM PUBLIC;

--- a/packages/db/drizzle/meta/_journal.json
+++ b/packages/db/drizzle/meta/_journal.json
@@ -1114,6 +1114,13 @@
       "when": 1793300800000,
       "tag": "0158_companion_recovery_lane_interlock",
       "breakpoints": true
+    },
+    {
+      "idx": 159,
+      "version": "7",
+      "when": 1793304400000,
+      "tag": "0159_companion_runtime_v3_progression",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/db/runtime-role-grants.sql
+++ b/packages/db/runtime-role-grants.sql
@@ -951,7 +951,7 @@ BEGIN
       ];
       companion_runtime_functions := companion_runtime_functions || ARRAY[
         'public.companion_v3_runtime_claim(text,public.companion_v3_lane,integer,integer)'::regprocedure,
-        'public.companion_v3_runtime_complete(uuid,uuid,public.companion_v3_lane,uuid,uuid,bigint,text,text,text,public.companion_runtime_error_action,integer)'::regprocedure
+        'public.companion_v3_runtime_complete(uuid,uuid,public.companion_v3_lane,uuid,uuid,bigint,bigint,text,text,text,public.companion_runtime_error_action,integer)'::regprocedure
       ];
       internal_runtime_functions := internal_runtime_functions || ARRAY[
         'public.companion_v3_admit_turn(uuid,uuid,uuid,text,text,public.companion_v3_lane)'::regprocedure

--- a/packages/db/runtime-role-grants.sql
+++ b/packages/db/runtime-role-grants.sql
@@ -951,7 +951,7 @@ BEGIN
       ];
       companion_runtime_functions := companion_runtime_functions || ARRAY[
         'public.companion_v3_runtime_claim(text,public.companion_v3_lane,integer,integer)'::regprocedure,
-        'public.companion_v3_runtime_complete(uuid,uuid,public.companion_v3_lane,uuid,uuid,bigint,text,text,text,integer)'::regprocedure
+        'public.companion_v3_runtime_complete(uuid,uuid,public.companion_v3_lane,uuid,uuid,bigint,text,text,text,public.companion_runtime_error_action,integer)'::regprocedure
       ];
       internal_runtime_functions := internal_runtime_functions || ARRAY[
         'public.companion_v3_admit_turn(uuid,uuid,uuid,text,text,public.companion_v3_lane)'::regprocedure

--- a/packages/db/runtime-role-grants.sql
+++ b/packages/db/runtime-role-grants.sql
@@ -74,6 +74,9 @@ DECLARE
     'companion_turns',
     'companion_turn_attempts',
     'companion_operations',
+    'companion_v3_instances',
+    'companion_v3_turns',
+    'companion_v3_lane_leases',
     'companion_decision_deliveries',
     'companion_runtime_leases',
     'companion_runtime_duplicate_cleanups',
@@ -930,6 +933,28 @@ BEGIN
         'public.companion_revoke_inactive_control_token()'::regprocedure,
         'public.companion_enqueue_deferred_pi_restart()'::regprocedure,
         'public.companion_surface_delegation_result()'::regprocedure
+      ];
+    END IF;
+
+    -- 0159 is the dormant Runtime v3 expand seam. Each process gets only its own capability;
+    -- direct facts and the generic admission helper remain migration-owner-only. Protocol 3 is a
+    -- separate function surface, so a deployed v2 executor cannot claim these rows.
+    IF pg_catalog.to_regprocedure(
+      'public.companion_v3_runtime_claim(text,public.companion_v3_lane,integer,integer)'
+    ) IS NOT NULL THEN
+      companion_api_functions := companion_api_functions || ARRAY[
+        'public.companion_v3_api_admit_turn(uuid,uuid,uuid,text)'::regprocedure,
+        'public.companion_v3_api_desire_lifecycle(uuid,uuid,public.companion_v3_lifecycle_intent)'::regprocedure
+      ];
+      worker_functions := worker_functions || ARRAY[
+        'public.companion_v3_worker_admit_turn(uuid,uuid,uuid,text,text)'::regprocedure
+      ];
+      companion_runtime_functions := companion_runtime_functions || ARRAY[
+        'public.companion_v3_runtime_claim(text,public.companion_v3_lane,integer,integer)'::regprocedure,
+        'public.companion_v3_runtime_complete(uuid,uuid,public.companion_v3_lane,uuid,uuid,bigint,text,text,text,integer)'::regprocedure
+      ];
+      internal_runtime_functions := internal_runtime_functions || ARRAY[
+        'public.companion_v3_admit_turn(uuid,uuid,uuid,text,text,public.companion_v3_lane)'::regprocedure
       ];
     END IF;
 

--- a/packages/db/src/runtimeRole.ts
+++ b/packages/db/src/runtimeRole.ts
@@ -113,7 +113,7 @@ WITH runtime_role AS (
     ('public.companion_runtime_consume_desktop_request(text,bigint,integer)'),
     ('public.companion_runtime_record_attempt_outputs(uuid,uuid,uuid,bigint,bigint,text,public.companion_runtime_work_kind,uuid,jsonb,timestamp with time zone)'),
     ('public.companion_v3_runtime_claim(text,public.companion_v3_lane,integer,integer)'),
-    ('public.companion_v3_runtime_complete(uuid,uuid,public.companion_v3_lane,uuid,uuid,bigint,text,text,text,integer)')
+    ('public.companion_v3_runtime_complete(uuid,uuid,public.companion_v3_lane,uuid,uuid,bigint,text,text,text,public.companion_runtime_error_action,integer)')
 ), required_functions AS (
   SELECT signature, pg_catalog.to_regprocedure(signature) AS oid
   FROM required

--- a/packages/db/src/runtimeRole.ts
+++ b/packages/db/src/runtimeRole.ts
@@ -111,7 +111,9 @@ WITH runtime_role AS (
     ('public.companion_runtime_image_record_failure(text,bigint,text,text)'),
     ('public.companion_runtime_authorize_desktop(uuid,uuid,text)'),
     ('public.companion_runtime_consume_desktop_request(text,bigint,integer)'),
-    ('public.companion_runtime_record_attempt_outputs(uuid,uuid,uuid,bigint,bigint,text,public.companion_runtime_work_kind,uuid,jsonb,timestamp with time zone)')
+    ('public.companion_runtime_record_attempt_outputs(uuid,uuid,uuid,bigint,bigint,text,public.companion_runtime_work_kind,uuid,jsonb,timestamp with time zone)'),
+    ('public.companion_v3_runtime_claim(text,public.companion_v3_lane,integer,integer)'),
+    ('public.companion_v3_runtime_complete(uuid,uuid,public.companion_v3_lane,uuid,uuid,bigint,text,text,text,integer)')
 ), required_functions AS (
   SELECT signature, pg_catalog.to_regprocedure(signature) AS oid
   FROM required
@@ -142,7 +144,10 @@ WITH runtime_role AS (
       'companion_routine_context_substrates',
       'companion_mcp_broker_tokens',
       'companion_control_tokens',
-      'companion_message_attachments'
+      'companion_message_attachments',
+      'companion_v3_instances',
+      'companion_v3_turns',
+      'companion_v3_lane_leases'
     ]::text[])
 )
 SELECT
@@ -244,7 +249,7 @@ export async function verifyRuntimeDatabaseRole(
     || profile.ownsRelations !== false
     || profile.ownsFunctionsOrTypes !== false
   ) throw new RuntimeDatabaseRoleError("object_ownership");
-  if (profile.protectedRelationCount !== 15 || profile.requiredFunctionsReady !== true) {
+  if (profile.protectedRelationCount !== 18 || profile.requiredFunctionsReady !== true) {
     throw new RuntimeDatabaseRoleError("release_schema_incomplete");
   }
   if (profile.hasPublicRelationPrivileges !== false) {

--- a/packages/db/src/runtimeRole.ts
+++ b/packages/db/src/runtimeRole.ts
@@ -113,7 +113,7 @@ WITH runtime_role AS (
     ('public.companion_runtime_consume_desktop_request(text,bigint,integer)'),
     ('public.companion_runtime_record_attempt_outputs(uuid,uuid,uuid,bigint,bigint,text,public.companion_runtime_work_kind,uuid,jsonb,timestamp with time zone)'),
     ('public.companion_v3_runtime_claim(text,public.companion_v3_lane,integer,integer)'),
-    ('public.companion_v3_runtime_complete(uuid,uuid,public.companion_v3_lane,uuid,uuid,bigint,text,text,text,public.companion_runtime_error_action,integer)')
+    ('public.companion_v3_runtime_complete(uuid,uuid,public.companion_v3_lane,uuid,uuid,bigint,bigint,text,text,text,public.companion_runtime_error_action,integer)')
 ), required_functions AS (
   SELECT signature, pg_catalog.to_regprocedure(signature) AS oid
   FROM required

--- a/packages/db/src/schema.ts
+++ b/packages/db/src/schema.ts
@@ -1307,6 +1307,7 @@ export const companionV3LaneLeases = pgTable(
     lane: companionV3LaneEnum("lane").notNull(),
     claimToken: uuid("claim_token"),
     claimEpoch: bigint("claim_epoch", { mode: "number" }).notNull().default(0),
+    gateEpoch: bigint("gate_epoch", { mode: "number" }),
     executorId: text("executor_id"),
     turnId: uuid("turn_id"),
     claimedAt: timestamp("claimed_at", { withTimezone: true }),
@@ -1329,14 +1330,17 @@ export const companionV3LaneLeases = pgTable(
     }).onDelete("cascade"),
     expiry: index("companion_v3_lane_leases_expiry_idx")
       .on(t.expiresAt).where(sql`${t.claimToken} is not null`),
-    epochCheck: check("companion_v3_lane_leases_epoch_check", sql`${t.claimEpoch} >= 0`),
+    epochCheck: check(
+      "companion_v3_lane_leases_epoch_check",
+      sql`${t.claimEpoch} >= 0 and (${t.gateEpoch} is null or ${t.gateEpoch} >= 1)`,
+    ),
     executorCheck: check(
       "companion_v3_lane_leases_executor_check",
       sql`${t.executorId} is null or (char_length(${t.executorId}) between 1 and 200 and ${t.executorId} !~ E'[\n\r]')`,
     ),
     claimCheck: check(
       "companion_v3_lane_leases_claim_check",
-      sql`(${t.claimToken} is null and ${t.executorId} is null and ${t.turnId} is null and ${t.claimedAt} is null and ${t.renewedAt} is null and ${t.expiresAt} is null) or (${t.claimToken} is not null and ${t.claimEpoch} >= 1 and ${t.executorId} is not null and ${t.turnId} is not null and ${t.claimedAt} is not null and ${t.renewedAt} is not null and ${t.expiresAt} > ${t.renewedAt})`,
+      sql`(${t.claimToken} is null and ${t.gateEpoch} is null and ${t.executorId} is null and ${t.turnId} is null and ${t.claimedAt} is null and ${t.renewedAt} is null and ${t.expiresAt} is null) or (${t.claimToken} is not null and ${t.claimEpoch} >= 1 and ${t.gateEpoch} is not null and ${t.executorId} is not null and ${t.turnId} is not null and ${t.claimedAt} is not null and ${t.renewedAt} is not null and ${t.expiresAt} is not null and ${t.expiresAt} > ${t.renewedAt})`,
     ),
   }),
 );

--- a/packages/db/src/schema.ts
+++ b/packages/db/src/schema.ts
@@ -1249,6 +1249,7 @@ export const companionV3Turns = pgTable(
     outcome: companionV3TurnOutcomeEnum("outcome"),
     outcomeCode: text("outcome_code"),
     outcomeMessage: text("outcome_message"),
+    outcomeAction: companionRuntimeErrorActionEnum("outcome_action"),
     settledAt: timestamp("settled_at", { withTimezone: true }),
     createdAt: now(),
     updatedAt: updatedAt(),
@@ -1292,7 +1293,7 @@ export const companionV3Turns = pgTable(
     ),
     outcomeCheck: check(
       "companion_v3_turns_outcome_check",
-      sql`(${t.outcome} is null and ${t.settledAt} is null and ${t.outcomeCode} is null and ${t.outcomeMessage} is null and ${t.state} in ('queued', 'admitted', 'running', 'needs_input')) or (${t.outcome} is not null and ${t.settledAt} is not null and ${t.state}::text = ${t.outcome}::text and ((${t.outcome} in ('failed', 'interrupted') and ${t.outcomeCode} ~ '^[a-z][a-z0-9_]{0,63}$' and char_length(${t.outcomeMessage}) between 1 and 500 and ${t.outcomeMessage} !~ E'[\n\r]') or (${t.outcome} in ('succeeded', 'cancelled') and ${t.outcomeCode} is null and ${t.outcomeMessage} is null)))`,
+      sql`(${t.outcome} is null and ${t.settledAt} is null and ${t.outcomeCode} is null and ${t.outcomeMessage} is null and ${t.outcomeAction} is null and ${t.state} in ('queued', 'admitted', 'running', 'needs_input')) or (${t.outcome} is not null and ${t.settledAt} is not null and ${t.state}::text = ${t.outcome}::text and ((${t.outcome} in ('failed', 'interrupted') and ${t.outcomeCode} ~ '^[a-z][a-z0-9_]{0,63}$' and char_length(${t.outcomeMessage}) between 1 and 500 and ${t.outcomeMessage} !~ E'[\n\r]' and ${t.outcomeAction} is not null and ${t.outcomeAction} <> 'restart_box') or (${t.outcome} in ('succeeded', 'cancelled') and ${t.outcomeCode} is null and ${t.outcomeMessage} is null and ${t.outcomeAction} is null)))`,
     ),
   }),
 );

--- a/packages/db/src/schema.ts
+++ b/packages/db/src/schema.ts
@@ -83,6 +83,20 @@ export const companionRuntimeErrorActionEnum = pgEnum("companion_runtime_error_a
 export const companionRuntimeWorkKindEnum = pgEnum("companion_runtime_work_kind", [
   "operation", "decision", "attempt", "settings", "health",
 ]);
+export const companionV3LaneEnum = pgEnum("companion_v3_lane", ["main", "background"]);
+export const companionV3TurnStateEnum = pgEnum("companion_v3_turn_state", [
+  "queued", "admitted", "running", "needs_input",
+  "succeeded", "failed", "interrupted", "cancelled",
+]);
+export const companionV3AdmissionStateEnum = pgEnum("companion_v3_admission_state", [
+  "pending", "accepted", "ambiguous",
+]);
+export const companionV3TurnOutcomeEnum = pgEnum("companion_v3_turn_outcome", [
+  "succeeded", "failed", "interrupted", "cancelled",
+]);
+export const companionV3LifecycleIntentEnum = pgEnum("companion_v3_lifecycle_intent", [
+  "prepare", "archive", "recycle_pi", "delete",
+]);
 export const companionDecisionStatusEnum = pgEnum("companion_decision_status", [
   "pending", "allowed", "denied", "answered", "expired", "cancelled",
 ]);
@@ -1177,6 +1191,152 @@ export const companionTurns = pgTable(
     routineSnapshot: index("companion_turns_routine_snapshot_idx").on(t.orgId, t.companionId, t.routineSnapshotId, t.queueSequence, t.id).where(sql`${t.routineSnapshotId} is not null`),
     triggerOriginCheck: check("companion_turns_trigger_origin_check", sql`(${t.triggerId} is null or ${t.triggerName} is not null) and (${t.triggerName} is null or (char_length(${t.triggerName}) between 1 and 80 and ${t.triggerName} !~ E'[\\n\\r]')) and (${t.triggerName} is null or ${t.routineId} is null)`),
     triggerModeCheck: check("companion_turns_trigger_mode_check", sql`(${t.triggerName} is null and ${t.triggerMode} is null) or (${t.triggerName} is not null and ${t.triggerMode} in ('notify', 'relay'))`),
+  }),
+);
+
+/** Dormant Runtime v3 aggregate facts; no production composition root reads these yet. */
+export const companionV3Instances = pgTable(
+  "companion_v3_instances",
+  {
+    orgId: uuid("org_id").notNull(),
+    companionId: uuid("companion_id").notNull(),
+    desiredLifecycle: companionV3LifecycleIntentEnum("desired_lifecycle").notNull().default("prepare"),
+    desiredLifecycleRevision: bigint("desired_lifecycle_revision", { mode: "number" }).notNull().default(1),
+    desiredLifecycleActorId: text("desired_lifecycle_actor_id"),
+    nextMainSequence: bigint("next_main_sequence", { mode: "number" }).notNull().default(1),
+    nextBackgroundSequence: bigint("next_background_sequence", { mode: "number" }).notNull().default(1),
+    createdAt: now(),
+    updatedAt: updatedAt(),
+  },
+  (t) => ({
+    pk: primaryKey({ columns: [t.orgId, t.companionId] }),
+    companionFk: foreignKey({
+      columns: [t.orgId, t.companionId],
+      foreignColumns: [companions.orgId, companions.id],
+      name: "companion_v3_instances_companion_fk",
+    }).onDelete("cascade"),
+    revisionCheck: check(
+      "companion_v3_instances_revision_check",
+      sql`${t.desiredLifecycleRevision} >= 1 and ${t.nextMainSequence} >= 1 and ${t.nextBackgroundSequence} >= 1`,
+    ),
+    actorCheck: check(
+      "companion_v3_instances_actor_check",
+      sql`${t.desiredLifecycleActorId} is null or (char_length(${t.desiredLifecycleActorId}) between 1 and 200 and ${t.desiredLifecycleActorId} !~ E'[\n\r]')`,
+    ),
+  }),
+);
+
+/** One Runtime v3 Turn owns command identity, admission facts, activity, outcome, and lane. */
+export const companionV3Turns = pgTable(
+  "companion_v3_turns",
+  {
+    id: uuid("id").primaryKey().notNull().defaultRandom(),
+    orgId: uuid("org_id").notNull(),
+    companionId: uuid("companion_id").notNull(),
+    commandId: uuid("command_id").notNull(),
+    clientMessageId: uuid("client_message_id").notNull(),
+    messageEventId: text("message_event_id").notNull(),
+    actorId: text("actor_id").notNull(),
+    lane: companionV3LaneEnum("lane").notNull(),
+    queueSequence: bigint("queue_sequence", { mode: "number" }).notNull(),
+    state: companionV3TurnStateEnum("state").notNull().default("queued"),
+    admissionState: companionV3AdmissionStateEnum("admission_state").notNull().default("pending"),
+    admittedAt: timestamp("admitted_at", { withTimezone: true }),
+    piInvocationId: text("pi_invocation_id"),
+    admissionCursor: bigint("admission_cursor", { mode: "number" }),
+    activityCursor: bigint("activity_cursor", { mode: "number" }).notNull().default(0),
+    lastActivityAt: timestamp("last_activity_at", { withTimezone: true }),
+    outcome: companionV3TurnOutcomeEnum("outcome"),
+    outcomeCode: text("outcome_code"),
+    outcomeMessage: text("outcome_message"),
+    settledAt: timestamp("settled_at", { withTimezone: true }),
+    createdAt: now(),
+    updatedAt: updatedAt(),
+  },
+  (t) => ({
+    uniqueOrgCompanionId: unique("companion_v3_turns_org_companion_id_uq")
+      .on(t.orgId, t.companionId, t.id),
+    commandUnique: unique("companion_v3_turns_command_uq").on(t.companionId, t.commandId),
+    clientMessageUnique: unique("companion_v3_turns_client_message_uq")
+      .on(t.companionId, t.clientMessageId),
+    laneSequenceUnique: unique("companion_v3_turns_lane_sequence_uq")
+      .on(t.companionId, t.lane, t.queueSequence),
+    instanceFk: foreignKey({
+      columns: [t.orgId, t.companionId],
+      foreignColumns: [companionV3Instances.orgId, companionV3Instances.companionId],
+      name: "companion_v3_turns_instance_fk",
+    }).onDelete("cascade"),
+    fifo: index("companion_v3_turns_fifo_idx")
+      .on(t.companionId, t.lane, t.queueSequence, t.id)
+      .where(sql`${t.state} = 'queued'`),
+    sequenceCheck: check("companion_v3_turns_sequence_check", sql`${t.queueSequence} >= 1`),
+    messageEventCheck: check(
+      "companion_v3_turns_message_event_check",
+      sql`${t.messageEventId} = 'msg:' || ${t.clientMessageId}::text`,
+    ),
+    actorCheck: check(
+      "companion_v3_turns_actor_check",
+      sql`char_length(${t.actorId}) between 1 and 200 and ${t.actorId} !~ E'[\n\r]'`,
+    ),
+    invocationCheck: check(
+      "companion_v3_turns_invocation_check",
+      sql`${t.piInvocationId} is null or (char_length(${t.piInvocationId}) between 1 and 200 and ${t.piInvocationId} !~ E'[\n\r]')`,
+    ),
+    cursorCheck: check(
+      "companion_v3_turns_cursor_check",
+      sql`${t.activityCursor} >= 0 and (${t.admissionCursor} is null or ${t.admissionCursor} >= 0)`,
+    ),
+    admissionCheck: check(
+      "companion_v3_turns_admission_check",
+      sql`(${t.admissionState} = 'pending' and ${t.admittedAt} is null and ${t.piInvocationId} is null and ${t.admissionCursor} is null) or (${t.admissionState} in ('accepted', 'ambiguous') and ${t.admittedAt} is not null and ${t.piInvocationId} is not null and ${t.admissionCursor} is not null)`,
+    ),
+    outcomeCheck: check(
+      "companion_v3_turns_outcome_check",
+      sql`(${t.outcome} is null and ${t.settledAt} is null and ${t.outcomeCode} is null and ${t.outcomeMessage} is null and ${t.state} in ('queued', 'admitted', 'running', 'needs_input')) or (${t.outcome} is not null and ${t.settledAt} is not null and ${t.state}::text = ${t.outcome}::text and ((${t.outcome} in ('failed', 'interrupted') and ${t.outcomeCode} ~ '^[a-z][a-z0-9_]{0,63}$' and char_length(${t.outcomeMessage}) between 1 and 500 and ${t.outcomeMessage} !~ E'[\n\r]') or (${t.outcome} in ('succeeded', 'cancelled') and ${t.outcomeCode} is null and ${t.outcomeMessage} is null)))`,
+    ),
+  }),
+);
+
+/** Retained per-lane rows keep v3 executor epochs monotonic across release and takeover. */
+export const companionV3LaneLeases = pgTable(
+  "companion_v3_lane_leases",
+  {
+    orgId: uuid("org_id").notNull(),
+    companionId: uuid("companion_id").notNull(),
+    lane: companionV3LaneEnum("lane").notNull(),
+    claimToken: uuid("claim_token"),
+    claimEpoch: bigint("claim_epoch", { mode: "number" }).notNull().default(0),
+    executorId: text("executor_id"),
+    turnId: uuid("turn_id"),
+    claimedAt: timestamp("claimed_at", { withTimezone: true }),
+    renewedAt: timestamp("renewed_at", { withTimezone: true }),
+    expiresAt: timestamp("expires_at", { withTimezone: true }),
+    createdAt: now(),
+    updatedAt: updatedAt(),
+  },
+  (t) => ({
+    pk: primaryKey({ columns: [t.orgId, t.companionId, t.lane] }),
+    instanceFk: foreignKey({
+      columns: [t.orgId, t.companionId],
+      foreignColumns: [companionV3Instances.orgId, companionV3Instances.companionId],
+      name: "companion_v3_lane_leases_instance_fk",
+    }).onDelete("cascade"),
+    turnFk: foreignKey({
+      columns: [t.orgId, t.companionId, t.turnId],
+      foreignColumns: [companionV3Turns.orgId, companionV3Turns.companionId, companionV3Turns.id],
+      name: "companion_v3_lane_leases_turn_fk",
+    }).onDelete("cascade"),
+    expiry: index("companion_v3_lane_leases_expiry_idx")
+      .on(t.expiresAt).where(sql`${t.claimToken} is not null`),
+    epochCheck: check("companion_v3_lane_leases_epoch_check", sql`${t.claimEpoch} >= 0`),
+    executorCheck: check(
+      "companion_v3_lane_leases_executor_check",
+      sql`${t.executorId} is null or (char_length(${t.executorId}) between 1 and 200 and ${t.executorId} !~ E'[\n\r]')`,
+    ),
+    claimCheck: check(
+      "companion_v3_lane_leases_claim_check",
+      sql`(${t.claimToken} is null and ${t.executorId} is null and ${t.turnId} is null and ${t.claimedAt} is null and ${t.renewedAt} is null and ${t.expiresAt} is null) or (${t.claimToken} is not null and ${t.claimEpoch} >= 1 and ${t.executorId} is not null and ${t.turnId} is not null and ${t.claimedAt} is not null and ${t.renewedAt} is not null and ${t.expiresAt} > ${t.renewedAt})`,
+    ),
   }),
 );
 


### PR DESCRIPTION
## Summary

- Introduce the closed Runtime v3 progression interface for admission, bounded desired lifecycle, and autonomous convergence while keeping claim/complete choreography internal.
- Add dormant Runtime v3 PostgreSQL facts with independent `main`/`background` FIFO lanes, monotonic lease and shared kill-switch fencing, forced RLS, and split API/worker/runtime capabilities.
- Preserve the live Runtime v2 path and document the expand seam and its behavior-level proof.

## Linear scope

- Implements THE-510.
- First stack layer under parent THE-509; this PR targets `main` and does not implement later Runtime v3 tickets.

## Verification

- `pnpm verify:change` — all fast checks passed (40/40 quality tasks, 6/6 builds); exit 2 only for its five listed environment-dependent follow-ups.
- `pnpm --filter @companion/companion-runtime test` — 320 passed.
- `pnpm --filter @companion/runtime test` — 220 passed.
- Runtime v3 real-PostgreSQL integration — 11 passed, including two background Turns settling while main remains blocked, FIFO, fencing, forced RLS, split grants, invalid boundary inputs, and gate invalidation.
- Dedicated migration-owner fresh replay — 1 passed.
- Runtime v2 real-process HTTP/PostgreSQL/deterministic Box/Pi topology — 1 passed.
- Runtime and database typechecks, anti-slop, `git diff --check`, and production dependency audit passed.
- Gitleaks v8.30.1 scanned `origin/main..HEAD` (five commits, about 89 KB) with no leaks after three exact-value fixture allowlist entries resolved the initial false positives without rewriting history.
- Local browser smoke could not complete because this cloud workspace has no MinIO; the latest-SHA Browser Critical Flows CI check passed.

## Review gates

- `/code-review` Standards: pass, 0 findings.
- `/code-review` Spec: pass, 0 findings.
- Independent `/review-code-dev`: three P2 boundary/fencing findings fixed; targeted post-fix validation reports 0 remaining findings.

## Risk and rollout

- The new seam is dormant and absent from API, worker, and runtime production composition roots.
- Protocol-3 functions are separately named and inaccessible to old executors; the existing runtime gate fences both claim and completion.
- This is an additive expand/refactor layer. Runtime v2 remains the only live executor behavior.

## CI

- All 12 visible, non-skipped checks/statuses passed on `930081260fb6e1c973b614467e34233258cbe66e`: Scope, Hygiene, Apple Quality, Quality Node 22, Application Build, Database Integration, Railway Containers, Browser Critical Flows, CI Gate, Greptile Review, Vercel, and Vercel Preview Comments.


<!-- conductor-workspace-link -->

---

[Open workspace in Conductor](https://app.conductor.build/workspace/b4bb19ab-850d-493d-94f2-d5bfa52b5eb8)


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/The-Vibe-Company/companion/pull/711?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

The PR adds a dormant Runtime v3 progression seam while preserving Runtime v2 as the live executor.

- Defines a closed TypeScript interface for admission, desired lifecycle, and autonomous per-lane convergence.
- Adds PostgreSQL-backed v3 instance, turn, and lane-lease facts with FIFO claims, monotonic fencing, forced RLS, and split process capabilities.
- Extends runtime-role verification, schema declarations, migration metadata, tests, and architectural documentation for the new seam.
</details>


<details><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge because no concrete blocking or independently actionable non-blocking defect remains on a reachable changed path.

The new progression implementation is dormant, its database capabilities are explicitly partitioned and revoked from unauthorized roles, and the changed claim, completion, and gate paths preserve the documented fencing and FIFO invariants.
</details>


<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| packages/companion-runtime/src/v3/progression.ts | Adds the closed Runtime v3 API and independent bounded convergence loops; no current production composition root activates them. |
| apps/runtime/src/runtimeV3ProgressionStore.ts | Implements the internal PostgreSQL claim and completion adapter with explicit protocol and fence values. |
| packages/db/drizzle/0159_companion_runtime_v3_progression.sql | Adds dormant v3 facts and capability functions with per-lane FIFO leases, gate fencing, forced RLS, and explicit PUBLIC revocations. |
| packages/db/runtime-role-grants.sql | Splits v3 admission and execution functions across API, worker, and runtime roles while retaining the generic helper internally. |
| packages/db/src/runtimeRole.ts | Extends runtime startup verification to include the three v3 relations and two runtime-only functions. |
| packages/db/src/schema.ts | Declares the new v3 enums, tables, constraints, indexes, and relations for typed database access. |
| apps/runtime/test/integration/runtimeV3Progression.integration.test.ts | Exercises admission idempotency, independent lanes, FIFO, takeover fencing, gate invalidation, RLS, grants, and invalid boundaries against PostgreSQL. |

</details>


<details open><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant Caller
    participant Progression as Runtime v3 Progression
    participant Store as PostgreSQL Adapter
    participant DB as PostgreSQL
    Caller->>Progression: admit / desire
    Progression->>Store: persistence operation
    Store->>DB: authorized SECURITY DEFINER function
    DB-->>Store: durable v3 fact
    Store-->>Progression: bounded result
    Caller->>Progression: converge(executorId)
    par Main lane
        Progression->>Store: claimLane(main)
        Store->>DB: fenced claim
        Progression->>Store: completeProgression
    and Background lane
        Progression->>Store: claimLane(background)
        Store->>DB: fenced claim
        Progression->>Store: completeProgression
    end
    DB-->>Progression: persisted outcomes
```
</details>

<sub>Reviews (1): Last reviewed commit: ["chore(ci): allow synthetic v3 fence fixt..."](https://github.com/the-vibe-company/companion/commit/930081260fb6e1c973b614467e34233258cbe66e) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=59471907)</sub>

<!-- /greptile_comment -->