### PR TITLE
feat(runtime): measure acceptance through Pi admission and settlement

### DIFF
--- a/apps/runtime/package.json
+++ b/apps/runtime/package.json
@@ -8,6 +8,7 @@
     "build": "tsup",
     "companion-purge": "node dist/companionPurge.js",
     "companion-v2-purge": "node dist/companionV2Purge.js",
+    "acceptance-report": "node dist/runtimeV3AcceptanceReport.js",
     "start": "node dist/index.js",
     "typecheck": "tsc --noEmit && tsc -p tsconfig.test.json",
     "test": "vitest run",

--- a/apps/runtime/src/runtimeV3AcceptanceReport.ts
+++ b/apps/runtime/src/runtimeV3AcceptanceReport.ts
@@ -9,6 +9,7 @@ import {
 import postgres, { type Sql } from "postgres";
 
 interface MeasurementRow {
+  inProductWindow: boolean;
   lane: RuntimeV3MeasurementFact["lane"];
   wakePath: RuntimeV3MeasurementFact["wakePath"];
   boxProvider: string;
@@ -33,7 +34,8 @@ export async function runtimeV3AcceptanceReport(
   input: { since: Date; until: Date },
 ) {
   const facts = await sql<MeasurementRow[]>`
-    select lane::text, wake_path::text as "wakePath", box_provider as "boxProvider",
+    select in_product_window as "inProductWindow", lane::text,
+      wake_path::text as "wakePath", box_provider as "boxProvider",
       model_provider as "modelProvider", model_id as "modelId", state::text,
       accepted_at as "acceptedAt", first_claimed_at as "firstClaimedAt",
       box_ready_at as "boxReadyAt", staging_completed_at as "stagingCompletedAt",

--- a/apps/runtime/src/runtimeV3AcceptanceReport.ts
+++ b/apps/runtime/src/runtimeV3AcceptanceReport.ts
@@ -1,0 +1,95 @@
+#!/usr/bin/env node
+import { pathToFileURL } from "node:url";
+
+import { verifyRuntimeDatabaseRole } from "@companion/db/runtime-role";
+import {
+  createRuntimeV3AcceptanceReport,
+  type RuntimeV3MeasurementFact,
+} from "@companion/companion-runtime/v3/measurement";
+import postgres, { type Sql } from "postgres";
+
+interface MeasurementRow {
+  lane: RuntimeV3MeasurementFact["lane"];
+  wakePath: RuntimeV3MeasurementFact["wakePath"];
+  boxProvider: string;
+  modelProvider: string;
+  modelId: string;
+  state: RuntimeV3MeasurementFact["state"];
+  acceptedAt: Date | null;
+  firstClaimedAt: Date | null;
+  boxReadyAt: Date | null;
+  stagingCompletedAt: Date | null;
+  piReadyAt: Date | null;
+  admissionKind: RuntimeV3MeasurementFact["admissionKind"];
+  admittedAt: Date | null;
+  firstActivityAt: Date | null;
+  lastActivityAt: Date | null;
+  settledAt: Date | null;
+  claimCount: number;
+}
+
+export async function runtimeV3AcceptanceReport(
+  sql: Sql,
+  input: { since: Date; until: Date },
+) {
+  const facts = await sql<MeasurementRow[]>`
+    select lane::text, wake_path::text as "wakePath", box_provider as "boxProvider",
+      model_provider as "modelProvider", model_id as "modelId", state::text,
+      accepted_at as "acceptedAt", first_claimed_at as "firstClaimedAt",
+      box_ready_at as "boxReadyAt", staging_completed_at as "stagingCompletedAt",
+      pi_ready_at as "piReadyAt", admission_kind::text as "admissionKind",
+      admitted_at as "admittedAt", first_activity_at as "firstActivityAt",
+      last_activity_at as "lastActivityAt", settled_at as "settledAt",
+      claim_count as "claimCount"
+    from public.companion_v3_runtime_measurement_facts(${input.since}, ${input.until}, 3)
+  `;
+  return createRuntimeV3AcceptanceReport(facts, input.until);
+}
+
+async function main(): Promise<void> {
+  const databaseUrl = process.env.DATABASE_COMPANION_RUNTIME_URL?.trim();
+  if (!databaseUrl) throw new Error("DATABASE_COMPANION_RUNTIME_URL is required");
+  const hours = reportHours(process.argv[2]);
+  const until = new Date();
+  const since = new Date(until.getTime() - hours * 60 * 60_000);
+  const role = databaseRole(databaseUrl);
+  const sql = postgres(databaseUrl, { prepare: false, max: 2 });
+  try {
+    await verifyRuntimeDatabaseRole(sql, role);
+    const report = await runtimeV3AcceptanceReport(sql, { since, until });
+    process.stdout.write(`${JSON.stringify({
+      event: "runtime.v3.acceptance_report",
+      window: { since: since.toISOString(), until: until.toISOString() },
+      ...report,
+    })}\n`);
+    if (!report.releaseMeasurementReady) process.exitCode = 2;
+  } finally {
+    await sql.end({ timeout: 5 });
+  }
+}
+
+function reportHours(value: string | undefined): number {
+  if (value === undefined) return 24;
+  const hours = Number(value);
+  if (!Number.isSafeInteger(hours) || hours < 1 || hours > 31 * 24) {
+    throw new Error("report window must be an integer from 1 to 744 hours");
+  }
+  return hours;
+}
+
+function databaseRole(databaseUrl: string): string {
+  try {
+    const role = decodeURIComponent(new URL(databaseUrl).username);
+    if (role) return role;
+  } catch {
+    // The generic message below intentionally omits the credential-bearing URL.
+  }
+  throw new Error("runtime database URL must include its login role");
+}
+
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+  void main().catch((error) => {
+    process.stderr.write(`${error instanceof Error ? error.message : "acceptance report failed"}\n`);
+    process.exitCode = 1;
+  });
+}

--- a/apps/runtime/src/schedulerAdapter.test.ts
+++ b/apps/runtime/src/schedulerAdapter.test.ts
@@ -40,4 +40,45 @@ describe("runtime scheduler composition adapter", () => {
       activeCount: 2,
     });
   });
+
+  it("keeps health stale while the Runtime v3 claim sweep is blocked", async () => {
+    const kernelCompletedAt = new Date("2027-01-01T00:00:00.000Z");
+    let releaseSweep!: () => void;
+    const blocked = new Promise<void>((resolve) => { releaseSweep = resolve; });
+    const scheduler: RuntimeKernelScheduler = {
+      start: vi.fn(),
+      stopClaims: vi.fn(),
+      shutdown: vi.fn(async () => undefined),
+      snapshot: () => ({
+        claimLoopAlive: true,
+        acceptingClaims: true,
+        claimsEnabled: true,
+        gateEnabled: true,
+        lastSweepStartedAt: kernelCompletedAt,
+        lastSweepCompletedAt: kernelCompletedAt,
+        claimLoopErrorAt: null,
+        activeCount: 0,
+        concurrency: 8,
+        sweepIntervalMs: 2_000,
+      }),
+    };
+    const converge = vi.fn(async () => {
+      await blocked;
+      return { progressed: 0, exhausted: false };
+    });
+    const adapter = createRuntimeSchedulerAdapter(scheduler, {
+      convergence: { converge },
+      executorId: "runtime-v3-health",
+      sweepIntervalMs: 2_000,
+    });
+
+    adapter.start();
+    await vi.waitFor(() => expect(converge).toHaveBeenCalledOnce());
+    expect(adapter.snapshot().lastSweepCompletedAt).toBeNull();
+
+    releaseSweep();
+    await vi.waitFor(() => expect(adapter.snapshot().lastSweepCompletedAt).toBeInstanceOf(Date));
+    adapter.stopClaims();
+    await adapter.shutdown({ drainTimeoutMs: 1_000 });
+  });
 });

--- a/apps/runtime/src/schedulerAdapter.test.ts
+++ b/apps/runtime/src/schedulerAdapter.test.ts
@@ -82,6 +82,41 @@ describe("runtime scheduler composition adapter", () => {
     await adapter.shutdown({ drainTimeoutMs: 1_000 });
   });
 
+  it("does not mark a rejected Runtime v3 sweep as completed", async () => {
+    const kernelCompletedAt = new Date("2027-01-01T00:00:00.000Z");
+    const scheduler: RuntimeKernelScheduler = {
+      start: vi.fn(),
+      stopClaims: vi.fn(),
+      shutdown: vi.fn(async () => undefined),
+      snapshot: () => ({
+        claimLoopAlive: true,
+        acceptingClaims: true,
+        claimsEnabled: true,
+        gateEnabled: true,
+        lastSweepStartedAt: kernelCompletedAt,
+        lastSweepCompletedAt: kernelCompletedAt,
+        claimLoopErrorAt: null,
+        activeCount: 0,
+        concurrency: 8,
+        sweepIntervalMs: 2_000,
+      }),
+    };
+    const converge = vi.fn(async () => {
+      throw new Error("redacted claim failure");
+    });
+    const adapter = createRuntimeSchedulerAdapter(scheduler, {
+      convergence: { converge },
+      executorId: "runtime-v3-error-health",
+      sweepIntervalMs: 2_000,
+    });
+
+    adapter.start();
+    await vi.waitFor(() => expect(adapter.snapshot().claimLoopErrorAt).toBeInstanceOf(Date));
+    expect(adapter.snapshot().lastSweepCompletedAt).toBeNull();
+    adapter.stopClaims();
+    await adapter.shutdown({ drainTimeoutMs: 1_000 });
+  });
+
   it("bounds a pending Runtime v3 sweep inside the shutdown drain timeout", async () => {
     vi.useFakeTimers();
     try {

--- a/apps/runtime/src/schedulerAdapter.ts
+++ b/apps/runtime/src/schedulerAdapter.ts
@@ -53,13 +53,13 @@ export function createRuntimeSchedulerAdapter(
       v3Sweep = runtimeV3.convergence.converge({ executorId: runtimeV3.executorId })
         .then((result) => {
           v3ErrorAt = null;
+          v3LastSweepCompletedAt = new Date();
           if (result.exhausted) scheduleV3(0);
         })
         .catch(() => {
           v3ErrorAt = new Date();
         })
         .finally(() => {
-          v3LastSweepCompletedAt = new Date();
           v3Sweep = null;
           if (!v3Timer) scheduleV3(runtimeV3.sweepIntervalMs);
         });

--- a/apps/runtime/src/schedulerAdapter.ts
+++ b/apps/runtime/src/schedulerAdapter.ts
@@ -27,11 +27,14 @@ export function createRuntimeSchedulerAdapter(
   let v3Sweep: Promise<void> | null = null;
   let v3Stopped = true;
   let v3ErrorAt: Date | null = null;
+  let v3LastSweepStartedAt: Date | null = null;
+  let v3LastSweepCompletedAt: Date | null = null;
 
   const scheduleV3 = (delayMs: number): void => {
     if (!runtimeV3 || v3Stopped) return;
     v3Timer = setTimeout(() => {
       v3Timer = null;
+      v3LastSweepStartedAt = new Date();
       v3Sweep = runtimeV3.convergence.converge({ executorId: runtimeV3.executorId })
         .then((result) => {
           v3ErrorAt = null;
@@ -41,6 +44,7 @@ export function createRuntimeSchedulerAdapter(
           v3ErrorAt = new Date();
         })
         .finally(() => {
+          v3LastSweepCompletedAt = new Date();
           v3Sweep = null;
           if (!v3Timer) scheduleV3(runtimeV3.sweepIntervalMs);
         });
@@ -70,16 +74,26 @@ export function createRuntimeSchedulerAdapter(
     },
     snapshot: () => {
       const snapshot = scheduler.snapshot();
+      const v3Alive = !runtimeV3 || !v3Stopped;
       return {
-        claimLoopAlive: snapshot.claimLoopAlive,
+        claimLoopAlive: snapshot.claimLoopAlive && v3Alive,
         // RuntimeScheduler contains no terminal loop state: sweep errors are recoverable and carry
         // their timestamp. A process-level fatal error rejects startup instead of reaching here.
         fatal: false,
-        lastSweepStartedAt: snapshot.lastSweepStartedAt,
-        lastSweepCompletedAt: snapshot.lastSweepCompletedAt,
+        lastSweepStartedAt: runtimeV3
+          ? earlierDate(snapshot.lastSweepStartedAt, v3LastSweepStartedAt)
+          : snapshot.lastSweepStartedAt,
+        lastSweepCompletedAt: runtimeV3
+          ? earlierDate(snapshot.lastSweepCompletedAt, v3LastSweepCompletedAt)
+          : snapshot.lastSweepCompletedAt,
         claimLoopErrorAt: v3ErrorAt ?? snapshot.claimLoopErrorAt,
         activeCount: snapshot.activeCount,
       };
     },
   };
+}
+
+function earlierDate(left: Date | null, right: Date | null): Date | null {
+  if (!left || !right) return null;
+  return left.getTime() <= right.getTime() ? left : right;
 }

--- a/apps/runtime/test/integration/runtimeV3Progression.integration.test.ts
+++ b/apps/runtime/test/integration/runtimeV3Progression.integration.test.ts
@@ -23,6 +23,7 @@ import {
   createRuntimeV3PostgresWarmConvergence,
   createRuntimeV3PostgresWarmTurnPersistence,
 } from "../../src/runtimeV3ProgressionStore";
+import { runtimeV3AcceptanceReport } from "../../src/runtimeV3AcceptanceReport";
 
 const ownerUrl = process.env.DATABASE_MIGRATION_URL ?? process.env.DATABASE_URL;
 const apiUrl = process.env.DATABASE_API_URL;
@@ -530,21 +531,90 @@ describe("Runtime v3 progression facts", () => {
       state: string;
       claimToken: string | null;
       assistantCount: number;
+      wakePath: string;
+      boxProvider: string;
+      modelProvider: string;
+      modelId: string;
+      admissionKind: string;
+      acceptedAt: Date;
+      firstClaimedAt: Date;
+      boxReadyAt: Date;
+      stagingCompletedAt: Date;
+      piReadyAt: Date;
+      admittedAt: Date;
+      firstActivityAt: Date;
+      settledAt: Date;
+      claimCount: number;
     }>>`
       select turn_row.state::text, lease.claim_token::text as "claimToken",
         (select count(*)::integer from public.companion_transcript_entries entry
           where entry.org_id = turn_row.org_id and entry.companion_id = turn_row.companion_id
-            and entry.role = 'assistant') as "assistantCount"
+            and entry.role = 'assistant') as "assistantCount",
+        turn_row.wake_path::text as "wakePath", turn_row.box_provider as "boxProvider",
+        turn_row.model_provider as "modelProvider", turn_row.model_id as "modelId",
+        turn_row.admission_kind::text as "admissionKind",
+        turn_row.accepted_at as "acceptedAt", turn_row.first_claimed_at as "firstClaimedAt",
+        turn_row.box_ready_at as "boxReadyAt",
+        turn_row.staging_completed_at as "stagingCompletedAt",
+        turn_row.pi_ready_at as "piReadyAt", turn_row.admitted_at as "admittedAt",
+        turn_row.first_activity_at as "firstActivityAt", turn_row.settled_at as "settledAt",
+        turn_row.claim_count as "claimCount"
       from public.companion_v3_turns turn_row
       join public.companion_v3_lane_leases lease
         on lease.org_id = turn_row.org_id and lease.companion_id = turn_row.companion_id
           and lease.lane = turn_row.lane
       where turn_row.command_id in (${first}::uuid, ${second}::uuid)
       order by turn_row.queue_sequence`;
-    expect(facts).toEqual([
+    expect(facts.map(({ state, claimToken, assistantCount }) => ({
+      state,
+      claimToken,
+      assistantCount,
+    }))).toEqual([
       { state: "failed", claimToken: null, assistantCount: 1 },
       { state: "succeeded", claimToken: null, assistantCount: 1 },
     ]);
+    for (const measured of facts) {
+      expect(measured).toMatchObject({
+        wakePath: "warm",
+        boxProvider: "ascii",
+        modelProvider: "anthropic",
+        modelId: "claude-test",
+        admissionKind: "prompt",
+        claimCount: 1,
+      });
+      for (const timestamp of [
+        measured.acceptedAt,
+        measured.firstClaimedAt,
+        measured.boxReadyAt,
+        measured.stagingCompletedAt,
+        measured.piReadyAt,
+        measured.admittedAt,
+        measured.firstActivityAt,
+        measured.settledAt,
+      ]) expect(timestamp).toBeInstanceOf(Date);
+      expect(measured.admittedAt.getTime()).toBeGreaterThanOrEqual(measured.acceptedAt.getTime());
+      expect(measured.settledAt.getTime()).toBeGreaterThanOrEqual(measured.admittedAt.getTime());
+    }
+    const report = await runtimeV3AcceptanceReport(runtimeSql, {
+      since: new Date(Date.now() - 60_000),
+      until: new Date(Date.now() + 60_000),
+    });
+    expect(report).toMatchObject({
+      releaseMeasurementReady: true,
+      correlation: { acknowledged: 2, complete: 2, missing: 0 },
+      safety: { queued: 0, stalled: 0, takeovers: 0 },
+      product: [expect.objectContaining({
+        lane: "main",
+        wakePath: "warm",
+        boxProvider: "ascii",
+        modelProvider: "anthropic",
+        modelId: "claude-test",
+        sampleCount: 2,
+      })],
+    });
+    expect(JSON.stringify(report)).not.toMatch(
+      /orgId|companionId|actorId|transcript|url|token|payload|invocation|eventId/i,
+    );
     let terminal: Array<{ activeTurn: unknown; queuedCount: number; isReplying: boolean }> = [];
     await asApi(async (sql) => {
       terminal = await sql<Array<{ activeTurn: unknown; queuedCount: number; isReplying: boolean }>>`

--- a/apps/runtime/test/integration/runtimeV3Progression.integration.test.ts
+++ b/apps/runtime/test/integration/runtimeV3Progression.integration.test.ts
@@ -270,6 +270,41 @@ describe("Runtime v3 progression facts", () => {
     expect(prepared).toEqual([{ commandId: command }]);
   });
 
+  it("preserves the acceptance wake path when a created Box later reaches Pi admission", async () => {
+    const command = randomUUID();
+    await admitMain(command);
+    await ownerSql`update public.companion_v3_instances
+      set box_id = 'bx_23456789', pi_invocation_id = 'invocation-created',
+        prepared_at = clock_timestamp()
+      where org_id = ${ids.org}::uuid and companion_id = ${ids.companion}::uuid`;
+    const convergence = createRuntimeV3PostgresWarmConvergence(runtimeSql);
+    const claim = await convergence.claimLane({ executorId: "runtime-created-path", lane: "main" });
+    expect(claim).not.toBeNull();
+    const persistence = createRuntimeV3PostgresWarmTurnPersistence(runtimeSql);
+    await expect(persistence.recordAdmission(claim!, {
+      invocationId: "invocation-created",
+      cursor: 0n,
+    })).resolves.toBe(true);
+
+    const measured = await ownerSql<Array<{ wakePath: string }>>`
+      select wake_path::text as "wakePath" from public.companion_v3_turns
+      where command_id = ${command}::uuid`;
+    expect(measured).toEqual([{ wakePath: "creation" }]);
+  });
+
+  it("classifies acceptance against an archived instance as an archived wake", async () => {
+    await ownerSql`insert into public.companion_v3_instances(
+      org_id, companion_id, desired_lifecycle
+    ) values (${ids.org}::uuid, ${ids.companion}::uuid, 'archive')`;
+    const command = randomUUID();
+    await admitMain(command);
+
+    const measured = await ownerSql<Array<{ wakePath: string }>>`
+      select wake_path::text as "wakePath" from public.companion_v3_turns
+      where command_id = ${command}::uuid`;
+    expect(measured).toEqual([{ wakePath: "archived_wake" }]);
+  });
+
   it("fails closed before Pi when current provider authority is revoked", async () => {
     await ownerSql`insert into public.companion_v3_instances(
       org_id, companion_id, box_id, pi_invocation_id, prepared_at

--- a/apps/runtime/tsup.config.ts
+++ b/apps/runtime/tsup.config.ts
@@ -8,12 +8,17 @@ const bundledSkillSource = resolve(configDir, "../../packages/companion-skill/sk
 const excludedSkillAsset = /(?:^|\/)(?:\.git|node_modules|__pycache__|__MACOSX|\.companion)(?:\/|$)|(?:^|\/)\.DS_Store$|\.pyc$|(?:^|\/)(?:\.companion\.lock|companion\.lock)$/;
 
 export default defineConfig({
-  entry: ["src/index.ts", "src/companionPurge.ts", "src/companionV2Purge.ts"],
+  entry: [
+    "src/index.ts",
+    "src/companionPurge.ts",
+    "src/companionV2Purge.ts",
+    "src/runtimeV3AcceptanceReport.ts",
+  ],
   banner: {
     js: 'import { createRequire as __companionCreateRequire } from "node:module"; const require = __companionCreateRequire(import.meta.url);',
   },
   format: ["esm"],
-  // Both files are direct Node entrypoints. Keeping them self-contained preserves the
+  // Every file is a direct Node entrypoint. Keeping them self-contained preserves the
   // `import.meta.url` CLI guard used by the one-shot purge command.
   splitting: false,
   noExternal: [/^@companion\//],

--- a/docs/companions-runtime.md
+++ b/docs/companions-runtime.md
@@ -1477,6 +1477,16 @@ attempt duration, lease takeover, deadline settlement, unknown/malformed event c
 duplicate Box discovery, permanent-delete progress, and expurgated failure codes without accessing
 secret payloads.
 
+Runtime v3 uses one durable Turn measurement for the full accepted occurrence: acceptance,
+first/latest claim and takeover count, Box ready, staging complete, Pi ready, prompt/steer ACK,
+first correlated activity, and settlement. Its dimensions are only lane, wake path, Box provider,
+model provider, and model id. The runtime-role command
+`pnpm --filter @companion/runtime acceptance-report [hours]`
+emits aggregate-only JSON with P50/P95 create, preparation, send-to-ACK, wake-to-ACK, and
+terminalization plus oldest queue age, stalls, and takeovers. Missing acceptance-to-ACK correlation
+makes the report fail its release measurement. The combined health snapshot uses the least-recent
+v2/v3 sweep completion, so a blocked v3 claim loop cannot hide behind a fresh v2 sweep.
+
 Protocol 7 emits aggregate-only recovery telemetry once per minute: pending recovery count, oldest
 recovery age, count older than 15 minutes, maximum attempt count, and cumulative `auto_abandoned`
 count. A nonzero stalled count emits `runtime.recovery.stalled` as a warning, never as a claim gate

--- a/docs/design.md
+++ b/docs/design.md
@@ -227,6 +227,17 @@ files, routines, and background work remain on their prior paths in this stack. 
 still fail closed under the shared runtime gate and carry its epoch, so stale executors cannot
 project or settle. There is still no v3 attempt table or derived Start operation.
 
+Migration 0162 keeps release measurement on that same Turn instead of adding an observability
+attempt model. Acceptance, first/latest claim, Box ready, staging complete, Pi ready, prompt/steer
+admission, first correlated activity, and settlement are durable timestamps. Stable dimensions are
+limited to `main|background`, `warm|creation|archived_wake`, Box provider, model provider, and model
+id. The runtime-only measurement function omits organization, Companion, actor, command, transcript,
+URL, credential, provider payload, and Pi-event identities.
+`pnpm --filter @companion/runtime acceptance-report [hours]`
+reproduces P50/P95 create, preparation, send-to-ACK, wake-to-ACK, and terminalization distributions
+plus oldest queue age, stalls, and takeovers. It exits 2 when an ACK is not fully correlated, making
+the acceptance-to-ACK chain a release measurement rather than an internal safety timer.
+
 Migration 0160 adds the separate one-shot Runtime v2 purge needed before a later v3 cutover. Its
 operator module is dormant: no service composition root calls it. `report` and `purge --dry-run`
 only read PostgreSQL, Box/named-snapshot inventory, and the `companion-attachments/` object prefix;

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -66,6 +66,11 @@ production HTTP API and runtime as separate processes against a fresh migrated P
 and the deterministic Box/Pi simulator. It stops runtime across the public send to prove the `202`
 has no provider dependency, replays the same `client_message_id`, then verifies positive admission,
 exactly one durable assistant entry, terminal projection, and lane release after runtime restart.
+The acceptance-measurement test fixes worked timestamp examples for all three wake paths and both
+lanes, verifies P50/P95 product clocks separately from queue/stall/takeover safety clocks, and proves
+that deleting acceptance-to-ACK correlation makes the release report fail. The PostgreSQL seam
+proves warm admission writes every durable milestone and exposes only stable dimensions; the
+scheduler test blocks v3 convergence and requires the shared health snapshot to remain stale.
 
 The Runtime v2 purge suite creates a disposable database, replays the complete migration history,
 and uses deterministic trigger, object-store, named-snapshot, and Box adapters. It proves inventory

--- a/packages/companion-runtime/package.json
+++ b/packages/companion-runtime/package.json
@@ -5,7 +5,8 @@
   "type": "module",
   "exports": {
     ".": "./src/index.ts",
-    "./v3/internal": "./src/v3/progression.ts"
+    "./v3/internal": "./src/v3/progression.ts",
+    "./v3/measurement": "./src/v3/measurement.ts"
   },
   "scripts": {
     "typecheck": "tsc --noEmit",

--- a/packages/companion-runtime/src/v3/measurement.test.ts
+++ b/packages/companion-runtime/src/v3/measurement.test.ts
@@ -120,6 +120,15 @@ describe("Runtime v3 acceptance measurement report", () => {
     expect(report.correlation).toEqual({ acknowledged: 1, complete: 0, missing: 1 });
   });
 
+  it("keeps a settled missing-activity terminal correlated to its durable ACK", () => {
+    const report = createRuntimeV3AcceptanceReport([
+      fact({ state: "failed", firstActivityAt: null, lastActivityAt: null }),
+    ], now);
+
+    expect(report.releaseMeasurementReady).toBe(true);
+    expect(report.correlation).toEqual({ acknowledged: 1, complete: 1, missing: 0 });
+  });
+
   it("keeps old active safety facts out of the bounded product cohort", () => {
     const report = createRuntimeV3AcceptanceReport([
       fact({

--- a/packages/companion-runtime/src/v3/measurement.test.ts
+++ b/packages/companion-runtime/src/v3/measurement.test.ts
@@ -1,0 +1,121 @@
+/**
+ * Product promise: Runtime v3 release measurement follows the accepted user occurrence through
+ * Pi acknowledgement and settlement without exposing tenant or conversation identities.
+ * Regression guarded: losing acceptance-to-ACK correlation must fail the release measurement.
+ * Why unit-level: the report is a pure public seam over durable timestamp rows.
+ * Sensitivity: removing correlation validation or changing the percentile inputs makes this fail.
+ */
+import { describe, expect, it } from "vitest";
+
+import {
+  createRuntimeV3AcceptanceReport,
+  type RuntimeV3MeasurementFact,
+} from "./measurement";
+
+const minute = 60_000;
+const now = new Date("2027-01-01T01:00:00.000Z");
+
+function fact(overrides: Partial<RuntimeV3MeasurementFact> = {}): RuntimeV3MeasurementFact {
+  return {
+    lane: "main",
+    wakePath: "creation",
+    boxProvider: "ascii",
+    modelProvider: "anthropic",
+    modelId: "claude-test",
+    state: "succeeded",
+    acceptedAt: new Date("2027-01-01T00:00:00.000Z"),
+    firstClaimedAt: new Date("2027-01-01T00:00:01.000Z"),
+    boxReadyAt: new Date("2027-01-01T00:00:03.000Z"),
+    stagingCompletedAt: new Date("2027-01-01T00:00:05.000Z"),
+    piReadyAt: new Date("2027-01-01T00:00:07.000Z"),
+    admissionKind: "prompt",
+    admittedAt: new Date("2027-01-01T00:00:09.000Z"),
+    firstActivityAt: new Date("2027-01-01T00:00:10.000Z"),
+    lastActivityAt: new Date("2027-01-01T00:00:10.000Z"),
+    settledAt: new Date("2027-01-01T00:00:13.000Z"),
+    claimCount: 1,
+    ...overrides,
+  };
+}
+
+describe("Runtime v3 acceptance measurement report", () => {
+  it("reports product percentiles separately from queue, stall, and takeover safety clocks", () => {
+    const report = createRuntimeV3AcceptanceReport([
+      fact(),
+      fact({
+        wakePath: "archived_wake",
+        acceptedAt: new Date("2027-01-01T00:10:00.000Z"),
+        firstClaimedAt: new Date("2027-01-01T00:10:02.000Z"),
+        boxReadyAt: new Date("2027-01-01T00:10:06.000Z"),
+        stagingCompletedAt: new Date("2027-01-01T00:10:09.000Z"),
+        piReadyAt: new Date("2027-01-01T00:10:11.000Z"),
+        admittedAt: new Date("2027-01-01T00:10:14.000Z"),
+        firstActivityAt: new Date("2027-01-01T00:10:15.000Z"),
+        lastActivityAt: new Date("2027-01-01T00:10:15.000Z"),
+        settledAt: new Date("2027-01-01T00:10:20.000Z"),
+        claimCount: 2,
+      }),
+      fact({
+        lane: "background",
+        wakePath: "warm",
+        state: "queued",
+        acceptedAt: new Date(now.getTime() - 12 * minute),
+        firstClaimedAt: null,
+        boxReadyAt: null,
+        stagingCompletedAt: null,
+        piReadyAt: null,
+        admissionKind: null,
+        admittedAt: null,
+        firstActivityAt: null,
+        lastActivityAt: null,
+        settledAt: null,
+        claimCount: 0,
+      }),
+      fact({
+        wakePath: "warm",
+        state: "running",
+        acceptedAt: new Date(now.getTime() - 20 * minute),
+        firstClaimedAt: new Date(now.getTime() - 19 * minute),
+        boxReadyAt: new Date(now.getTime() - 21 * minute),
+        stagingCompletedAt: new Date(now.getTime() - 21 * minute),
+        piReadyAt: new Date(now.getTime() - 21 * minute),
+        admittedAt: new Date(now.getTime() - 18 * minute),
+        firstActivityAt: new Date(now.getTime() - 17 * minute),
+        lastActivityAt: new Date(now.getTime() - 11 * minute),
+        settledAt: null,
+      }),
+    ], now);
+
+    expect(report.releaseMeasurementReady).toBe(true);
+    expect(report.product).toEqual(expect.arrayContaining([
+      expect.objectContaining({
+        lane: "main",
+        wakePath: "creation",
+        sampleCount: 1,
+        create: { samples: 1, p50Ms: 2_000, p95Ms: 2_000 },
+        preparation: { samples: 1, p50Ms: 4_000, p95Ms: 4_000 },
+        sendToAck: { samples: 1, p50Ms: 9_000, p95Ms: 9_000 },
+        wakeToAck: { samples: 1, p50Ms: 8_000, p95Ms: 8_000 },
+        terminalization: { samples: 1, p50Ms: 4_000, p95Ms: 4_000 },
+      }),
+    ]));
+    expect(report.safety).toEqual({
+      oldestQueueAgeMs: 12 * minute,
+      queued: 1,
+      stalled: 1,
+      takeovers: 1,
+    });
+    expect(JSON.stringify(report)).not.toMatch(
+      /orgId|companionId|actorId|transcript|url|token|payload|invocation|eventId/i,
+    );
+  });
+
+  it("fails the release measurement when an ACK loses its acceptance correlation", () => {
+    const report = createRuntimeV3AcceptanceReport([
+      fact({ acceptedAt: null }),
+    ], now);
+
+    expect(report.releaseMeasurementReady).toBe(false);
+    expect(report.correlation).toEqual({ acknowledged: 1, complete: 0, missing: 1 });
+  });
+});

--- a/packages/companion-runtime/src/v3/measurement.test.ts
+++ b/packages/companion-runtime/src/v3/measurement.test.ts
@@ -17,6 +17,7 @@ const now = new Date("2027-01-01T01:00:00.000Z");
 
 function fact(overrides: Partial<RuntimeV3MeasurementFact> = {}): RuntimeV3MeasurementFact {
   return {
+    inProductWindow: true,
     lane: "main",
     wakePath: "creation",
     boxProvider: "ascii",
@@ -117,5 +118,41 @@ describe("Runtime v3 acceptance measurement report", () => {
 
     expect(report.releaseMeasurementReady).toBe(false);
     expect(report.correlation).toEqual({ acknowledged: 1, complete: 0, missing: 1 });
+  });
+
+  it("keeps old active safety facts out of the bounded product cohort", () => {
+    const report = createRuntimeV3AcceptanceReport([
+      fact({
+        inProductWindow: false,
+        state: "queued",
+        acceptedAt: new Date(now.getTime() - 40 * 24 * 60 * minute),
+        firstClaimedAt: null,
+        boxReadyAt: null,
+        stagingCompletedAt: null,
+        piReadyAt: null,
+        admissionKind: null,
+        admittedAt: null,
+        firstActivityAt: null,
+        lastActivityAt: null,
+        settledAt: null,
+        claimCount: 0,
+      }),
+      fact({
+        inProductWindow: false,
+        state: "running",
+        acceptedAt: new Date(now.getTime() - 20 * minute),
+        lastActivityAt: new Date(now.getTime() - 11 * minute),
+        settledAt: null,
+      }),
+    ], now);
+
+    expect(report.product).toEqual([]);
+    expect(report.correlation).toEqual({ acknowledged: 0, complete: 0, missing: 0 });
+    expect(report.safety).toEqual({
+      oldestQueueAgeMs: 40 * 24 * 60 * minute,
+      queued: 1,
+      stalled: 1,
+      takeovers: 0,
+    });
   });
 });

--- a/packages/companion-runtime/src/v3/measurement.ts
+++ b/packages/companion-runtime/src/v3/measurement.ts
@@ -121,7 +121,7 @@ function completeCorrelation(fact: RuntimeV3MeasurementFact): boolean {
     && fact.admissionKind !== null;
   if (!admissionComplete) return false;
   return !TERMINAL_STATES.has(fact.state)
-    || (validDate(fact.firstActivityAt) !== null && validDate(fact.settledAt) !== null);
+    || validDate(fact.settledAt) !== null;
 }
 
 function series(facts: RuntimeV3MeasurementFact[]): RuntimeV3AcceptanceSeries {

--- a/packages/companion-runtime/src/v3/measurement.ts
+++ b/packages/companion-runtime/src/v3/measurement.ts
@@ -1,0 +1,180 @@
+export const RUNTIME_V3_WAKE_PATHS = ["warm", "creation", "archived_wake"] as const;
+export type RuntimeV3WakePath = (typeof RUNTIME_V3_WAKE_PATHS)[number];
+
+export interface RuntimeV3MeasurementFact {
+  lane: "main" | "background";
+  wakePath: RuntimeV3WakePath;
+  boxProvider: string;
+  modelProvider: string;
+  modelId: string;
+  state: "queued" | "admitted" | "running" | "needs_input"
+    | "succeeded" | "failed" | "interrupted" | "cancelled";
+  acceptedAt: Date | null;
+  firstClaimedAt: Date | null;
+  boxReadyAt: Date | null;
+  stagingCompletedAt: Date | null;
+  piReadyAt: Date | null;
+  admissionKind: "prompt" | "steer" | null;
+  admittedAt: Date | null;
+  firstActivityAt: Date | null;
+  lastActivityAt: Date | null;
+  settledAt: Date | null;
+  claimCount: number;
+}
+
+export interface RuntimeV3Percentiles {
+  samples: number;
+  p50Ms: number | null;
+  p95Ms: number | null;
+}
+
+export interface RuntimeV3AcceptanceSeries {
+  lane: RuntimeV3MeasurementFact["lane"];
+  wakePath: RuntimeV3WakePath;
+  boxProvider: string;
+  modelProvider: string;
+  modelId: string;
+  sampleCount: number;
+  create: RuntimeV3Percentiles;
+  preparation: RuntimeV3Percentiles;
+  sendToAck: RuntimeV3Percentiles;
+  wakeToAck: RuntimeV3Percentiles;
+  terminalization: RuntimeV3Percentiles;
+}
+
+export interface RuntimeV3AcceptanceReport {
+  releaseMeasurementReady: boolean;
+  correlation: { acknowledged: number; complete: number; missing: number };
+  product: RuntimeV3AcceptanceSeries[];
+  safety: {
+    oldestQueueAgeMs: number | null;
+    queued: number;
+    stalled: number;
+    takeovers: number;
+  };
+}
+
+const STALL_AFTER_MS = 10 * 60_000;
+const TERMINAL_STATES = new Set<RuntimeV3MeasurementFact["state"]>([
+  "succeeded",
+  "failed",
+  "interrupted",
+  "cancelled",
+]);
+
+/**
+ * Aggregate-only Runtime v3 release measurement. Identifiers never enter the interface, so every
+ * adapter and caller receives the same expurgated report shape by construction.
+ */
+export function createRuntimeV3AcceptanceReport(
+  facts: readonly RuntimeV3MeasurementFact[],
+  now = new Date(),
+): RuntimeV3AcceptanceReport {
+  const acknowledged = facts.filter((fact) => validDate(fact.admittedAt));
+  const complete = acknowledged.filter(completeCorrelation);
+  const groups = new Map<string, RuntimeV3MeasurementFact[]>();
+  for (const fact of acknowledged) {
+    const key = [
+      fact.lane,
+      fact.wakePath,
+      fact.boxProvider,
+      fact.modelProvider,
+      fact.modelId,
+    ].join("\u001f");
+    const group = groups.get(key) ?? [];
+    group.push(fact);
+    groups.set(key, group);
+  }
+  const product = [...groups.values()].map(series).sort((left, right) =>
+    seriesKey(left).localeCompare(seriesKey(right)));
+  const queued = facts.filter((fact) => fact.state === "queued");
+  const queueAges = queued.flatMap((fact) => {
+    const acceptedAt = validDate(fact.acceptedAt);
+    return acceptedAt ? [duration(acceptedAt, now)] : [];
+  });
+  const stalled = facts.filter((fact) =>
+    (fact.state === "admitted" || fact.state === "running")
+    && validDate(fact.lastActivityAt) !== null
+    && duration(fact.lastActivityAt!, now) >= STALL_AFTER_MS).length;
+  const missing = acknowledged.length - complete.length;
+  return {
+    releaseMeasurementReady: missing === 0,
+    correlation: { acknowledged: acknowledged.length, complete: complete.length, missing },
+    product,
+    safety: {
+      oldestQueueAgeMs: queueAges.length > 0 ? Math.max(...queueAges) : null,
+      queued: queued.length,
+      stalled,
+      takeovers: facts.reduce((count, fact) => count + Math.max(0, fact.claimCount - 1), 0),
+    },
+  };
+}
+
+function completeCorrelation(fact: RuntimeV3MeasurementFact): boolean {
+  const admissionComplete = validDate(fact.acceptedAt) !== null
+    && validDate(fact.firstClaimedAt) !== null
+    && validDate(fact.boxReadyAt) !== null
+    && validDate(fact.stagingCompletedAt) !== null
+    && validDate(fact.piReadyAt) !== null
+    && fact.admissionKind !== null;
+  if (!admissionComplete) return false;
+  return !TERMINAL_STATES.has(fact.state)
+    || (validDate(fact.firstActivityAt) !== null && validDate(fact.settledAt) !== null);
+}
+
+function series(facts: RuntimeV3MeasurementFact[]): RuntimeV3AcceptanceSeries {
+  const first = facts[0]!;
+  return {
+    lane: first.lane,
+    wakePath: first.wakePath,
+    boxProvider: first.boxProvider,
+    modelProvider: first.modelProvider,
+    modelId: first.modelId,
+    sampleCount: facts.length,
+    create: percentiles(facts.flatMap((fact) =>
+      fact.wakePath === "creation" ? between(fact.firstClaimedAt, fact.boxReadyAt) : [])),
+    preparation: percentiles(facts.flatMap((fact) =>
+      between(fact.boxReadyAt, fact.piReadyAt))),
+    sendToAck: percentiles(facts.flatMap((fact) =>
+      between(fact.acceptedAt, fact.admittedAt))),
+    wakeToAck: percentiles(facts.flatMap((fact) =>
+      between(fact.firstClaimedAt, fact.admittedAt))),
+    terminalization: percentiles(facts.flatMap((fact) =>
+      between(fact.admittedAt, fact.settledAt))),
+  };
+}
+
+function between(start: Date | null, end: Date | null): number[] {
+  const validStart = validDate(start);
+  const validEnd = validDate(end);
+  if (!validStart || !validEnd || validEnd < validStart) return [];
+  return [duration(validStart, validEnd)];
+}
+
+function duration(start: Date, end: Date): number {
+  return Math.max(0, end.getTime() - start.getTime());
+}
+
+function percentiles(values: number[]): RuntimeV3Percentiles {
+  if (values.length === 0) return { samples: 0, p50Ms: null, p95Ms: null };
+  const sorted = [...values].sort((left, right) => left - right);
+  return {
+    samples: sorted.length,
+    p50Ms: nearestRank(sorted, 0.5),
+    p95Ms: nearestRank(sorted, 0.95),
+  };
+}
+
+function nearestRank(sorted: number[], percentile: number): number {
+  return sorted[Math.max(0, Math.ceil(percentile * sorted.length) - 1)]!;
+}
+
+function validDate(value: Date | null): Date | null {
+  return value instanceof Date && Number.isFinite(value.getTime()) ? value : null;
+}
+
+function seriesKey(value: Pick<RuntimeV3AcceptanceSeries,
+  "lane" | "wakePath" | "boxProvider" | "modelProvider" | "modelId">): string {
+  return [value.lane, value.wakePath, value.boxProvider, value.modelProvider, value.modelId]
+    .join("\u001f");
+}

--- a/packages/companion-runtime/src/v3/measurement.ts
+++ b/packages/companion-runtime/src/v3/measurement.ts
@@ -2,6 +2,7 @@ export const RUNTIME_V3_WAKE_PATHS = ["warm", "creation", "archived_wake"] as co
 export type RuntimeV3WakePath = (typeof RUNTIME_V3_WAKE_PATHS)[number];
 
 export interface RuntimeV3MeasurementFact {
+  inProductWindow: boolean;
   lane: "main" | "background";
   wakePath: RuntimeV3WakePath;
   boxProvider: string;
@@ -70,7 +71,8 @@ export function createRuntimeV3AcceptanceReport(
   facts: readonly RuntimeV3MeasurementFact[],
   now = new Date(),
 ): RuntimeV3AcceptanceReport {
-  const acknowledged = facts.filter((fact) => validDate(fact.admittedAt));
+  const productFacts = facts.filter((fact) => fact.inProductWindow);
+  const acknowledged = productFacts.filter((fact) => validDate(fact.admittedAt));
   const complete = acknowledged.filter(completeCorrelation);
   const groups = new Map<string, RuntimeV3MeasurementFact[]>();
   for (const fact of acknowledged) {

--- a/packages/contracts/src/companionBudgets.ts
+++ b/packages/contracts/src/companionBudgets.ts
@@ -207,9 +207,10 @@ export const COMPANION_SQL_BUDGET_CONTRACT: Readonly<Record<string, readonly str
 
 /**
  * `companion%` functions that carry `interval` literals but belong to *other* subsystems (skill
- * runs, projects, GitHub mirrors, billing, notifications, tickets, tokens, desktop replay) — outside the
- * Companions-runtime budget contract. Listing them explicitly keeps the integration test's default
- * strict: a brand-new interval literal in any unlisted function fails until it is registered here
+ * runs, projects, GitHub mirrors, billing, notifications, tickets, tokens, desktop replay, and
+ * reporting windows) — outside the Companions-runtime budget contract. Listing them explicitly
+ * keeps the integration test's default strict: a brand-new interval literal in any unlisted
+ * function fails until it is registered here
  * or in {@link COMPANION_SQL_BUDGET_CONTRACT}.
  */
 export const COMPANION_SQL_UNTRACKED_INTERVAL_FUNCTIONS: readonly string[] = [
@@ -219,6 +220,7 @@ export const COMPANION_SQL_UNTRACKED_INTERVAL_FUNCTIONS: readonly string[] = [
   "companion_lock_api_token_for_refresh",
   "companion_notification_enqueue",
   "companion_runtime_consume_desktop_request",
+  "companion_v3_runtime_measurement_facts",
 ];
 
 /**

--- a/packages/db/drizzle/0162_companion_runtime_v3_acceptance_measurement.sql
+++ b/packages/db/drizzle/0162_companion_runtime_v3_acceptance_measurement.sql
@@ -1,0 +1,208 @@
+-- Runtime v3 acceptance measurement stays on the Turn: one durable chronology follows the user
+-- occurrence from API acceptance through the current claim, prepared Box/Pi proof, admission,
+-- first correlated activity, and settlement. The only read surface omits tenant/conversation ids.
+CREATE TYPE public.companion_v3_wake_path AS ENUM ('warm', 'creation', 'archived_wake');
+--> statement-breakpoint
+CREATE TYPE public.companion_v3_admission_kind AS ENUM ('prompt', 'steer');
+--> statement-breakpoint
+
+ALTER TABLE public.companion_v3_turns
+  ADD COLUMN accepted_at timestamp with time zone,
+  ADD COLUMN first_claimed_at timestamp with time zone,
+  ADD COLUMN last_claimed_at timestamp with time zone,
+  ADD COLUMN claim_count integer NOT NULL DEFAULT 0,
+  ADD COLUMN wake_path public.companion_v3_wake_path NOT NULL DEFAULT 'creation',
+  ADD COLUMN box_provider text NOT NULL DEFAULT 'ascii',
+  ADD COLUMN model_provider text NOT NULL DEFAULT 'unconfigured',
+  ADD COLUMN model_id text NOT NULL DEFAULT 'unconfigured',
+  ADD COLUMN box_ready_at timestamp with time zone,
+  ADD COLUMN staging_completed_at timestamp with time zone,
+  ADD COLUMN pi_ready_at timestamp with time zone,
+  ADD COLUMN admission_kind public.companion_v3_admission_kind,
+  ADD COLUMN first_activity_at timestamp with time zone,
+  ADD CONSTRAINT companion_v3_turns_measurement_check CHECK (
+    claim_count >= 0
+    AND ((claim_count = 0 AND first_claimed_at IS NULL AND last_claimed_at IS NULL)
+      OR (claim_count > 0 AND first_claimed_at IS NOT NULL AND last_claimed_at IS NOT NULL
+        AND last_claimed_at >= first_claimed_at))
+    AND char_length(box_provider) BETWEEN 1 AND 40 AND box_provider !~ E'[\n\r]'
+    AND char_length(model_provider) BETWEEN 1 AND 80 AND model_provider !~ E'[\n\r]'
+    AND char_length(model_id) BETWEEN 1 AND 200 AND model_id !~ E'[\n\r]'
+    AND (admission_kind IS NULL OR admission_state = 'accepted')
+    AND (box_ready_at IS NULL OR staging_completed_at IS NULL
+      OR staging_completed_at >= box_ready_at)
+    AND (staging_completed_at IS NULL OR pi_ready_at IS NULL
+      OR pi_ready_at >= staging_completed_at)
+    AND (first_activity_at IS NULL OR admitted_at IS NULL OR first_activity_at >= admitted_at)
+  );
+--> statement-breakpoint
+UPDATE public.companion_v3_turns SET accepted_at = created_at WHERE accepted_at IS NULL;
+--> statement-breakpoint
+ALTER TABLE public.companion_v3_turns
+  ALTER COLUMN accepted_at SET NOT NULL,
+  ALTER COLUMN accepted_at SET DEFAULT clock_timestamp();
+--> statement-breakpoint
+CREATE INDEX companion_v3_turns_measurement_window_idx
+  ON public.companion_v3_turns(accepted_at, lane, wake_path);
+--> statement-breakpoint
+
+-- Populate stable attribution before the row exists. Neither this trigger nor the report surface
+-- copies organization, Companion, actor, transcript, URL, credential, or provider payload values.
+CREATE FUNCTION public.companion_v3_measure_acceptance()
+RETURNS trigger
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = pg_catalog, public
+SET row_security = on
+AS $$
+DECLARE
+  v_instance public.companion_v3_instances%ROWTYPE;
+  v_model_id text;
+  v_model_provider text;
+BEGIN
+  SELECT instance.* INTO v_instance
+  FROM public.companion_v3_instances instance
+  WHERE instance.org_id = NEW.org_id AND instance.companion_id = NEW.companion_id;
+  SELECT companion.model_id, companion.provider_ids->>0
+    INTO v_model_id, v_model_provider
+  FROM public.companions companion
+  WHERE companion.org_id = NEW.org_id AND companion.id = NEW.companion_id;
+  NEW.accepted_at := coalesce(NEW.accepted_at, clock_timestamp());
+  NEW.wake_path := CASE WHEN v_instance.prepared_at IS NOT NULL
+    THEN 'warm'::public.companion_v3_wake_path
+    ELSE 'creation'::public.companion_v3_wake_path END;
+  NEW.box_provider := 'ascii';
+  NEW.model_provider := coalesce(nullif(v_model_provider, ''), 'unconfigured');
+  NEW.model_id := coalesce(nullif(v_model_id, ''), 'unconfigured');
+  RETURN NEW;
+END
+$$;
+--> statement-breakpoint
+CREATE TRIGGER companion_v3_measure_acceptance
+BEFORE INSERT ON public.companion_v3_turns
+FOR EACH ROW EXECUTE FUNCTION public.companion_v3_measure_acceptance();
+--> statement-breakpoint
+
+-- Every claim implementation crosses the retained lane row, so claim/takeover measurement is
+-- centralized here instead of being copied into generic and warm claim functions.
+CREATE FUNCTION public.companion_v3_measure_claim()
+RETURNS trigger
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = pg_catalog, public
+SET row_security = on
+AS $$
+BEGIN
+  IF NEW.claim_token IS NOT NULL AND NEW.turn_id IS NOT NULL
+    AND (OLD.claim_token IS DISTINCT FROM NEW.claim_token
+      OR OLD.claim_epoch IS DISTINCT FROM NEW.claim_epoch) THEN
+    UPDATE public.companion_v3_turns turn_row
+    SET first_claimed_at = coalesce(turn_row.first_claimed_at, NEW.claimed_at),
+        last_claimed_at = NEW.claimed_at,
+        claim_count = turn_row.claim_count + 1
+    WHERE turn_row.org_id = NEW.org_id AND turn_row.companion_id = NEW.companion_id
+      AND turn_row.id = NEW.turn_id;
+  END IF;
+  RETURN NEW;
+END
+$$;
+--> statement-breakpoint
+CREATE TRIGGER companion_v3_measure_claim
+AFTER UPDATE OF claim_token, claim_epoch ON public.companion_v3_lane_leases
+FOR EACH ROW EXECUTE FUNCTION public.companion_v3_measure_claim();
+--> statement-breakpoint
+
+-- Admission snapshots the runtime-owned warm preparation proof. Activity stays distinct from ACK:
+-- only a later correlated cursor advances first_activity_at.
+CREATE FUNCTION public.companion_v3_measure_progress()
+RETURNS trigger
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = pg_catalog, public
+SET row_security = on
+AS $$
+DECLARE v_prepared_at timestamp with time zone;
+BEGIN
+  IF OLD.admission_state <> 'accepted' AND NEW.admission_state = 'accepted' THEN
+    SELECT instance.prepared_at INTO v_prepared_at
+    FROM public.companion_v3_instances instance
+    WHERE instance.org_id = NEW.org_id AND instance.companion_id = NEW.companion_id;
+    NEW.wake_path := 'warm';
+    NEW.box_ready_at := coalesce(NEW.box_ready_at, v_prepared_at);
+    NEW.staging_completed_at := coalesce(NEW.staging_completed_at, v_prepared_at);
+    NEW.pi_ready_at := coalesce(NEW.pi_ready_at, v_prepared_at);
+    NEW.admission_kind := coalesce(NEW.admission_kind, 'prompt');
+  END IF;
+  IF NEW.admission_state = 'accepted'
+    AND NEW.activity_cursor > coalesce(NEW.admission_cursor, NEW.activity_cursor)
+    AND NEW.activity_cursor > OLD.activity_cursor THEN
+    NEW.first_activity_at := coalesce(OLD.first_activity_at, clock_timestamp());
+  END IF;
+  RETURN NEW;
+END
+$$;
+--> statement-breakpoint
+CREATE TRIGGER companion_v3_measure_progress
+BEFORE UPDATE OF admission_state, activity_cursor ON public.companion_v3_turns
+FOR EACH ROW EXECUTE FUNCTION public.companion_v3_measure_progress();
+--> statement-breakpoint
+
+-- This is the sole telemetry adapter. It returns stable dimensions and clocks only; aggregation
+-- happens in the shared measurement module, and direct runtime tables remain inaccessible.
+CREATE FUNCTION public.companion_v3_runtime_measurement_facts(
+  p_since timestamp with time zone,
+  p_until timestamp with time zone,
+  p_protocol integer
+)
+RETURNS TABLE (
+  lane public.companion_v3_lane,
+  wake_path public.companion_v3_wake_path,
+  box_provider text,
+  model_provider text,
+  model_id text,
+  state public.companion_v3_turn_state,
+  accepted_at timestamp with time zone,
+  first_claimed_at timestamp with time zone,
+  box_ready_at timestamp with time zone,
+  staging_completed_at timestamp with time zone,
+  pi_ready_at timestamp with time zone,
+  admission_kind public.companion_v3_admission_kind,
+  admitted_at timestamp with time zone,
+  first_activity_at timestamp with time zone,
+  last_activity_at timestamp with time zone,
+  settled_at timestamp with time zone,
+  claim_count integer
+)
+LANGUAGE plpgsql
+STABLE
+SECURITY DEFINER
+SET search_path = pg_catalog, public
+SET row_security = on
+AS $$
+BEGIN
+  IF p_protocol IS DISTINCT FROM 3 OR p_since IS NULL OR p_until IS NULL
+    OR p_since > p_until OR p_until - p_since > interval '31 days' THEN
+    RAISE EXCEPTION 'invalid Runtime v3 measurement window' USING ERRCODE = '22023';
+  END IF;
+  RETURN QUERY SELECT
+    turn_row.lane, turn_row.wake_path, turn_row.box_provider,
+    turn_row.model_provider, turn_row.model_id, turn_row.state,
+    turn_row.accepted_at, turn_row.first_claimed_at, turn_row.box_ready_at,
+    turn_row.staging_completed_at, turn_row.pi_ready_at, turn_row.admission_kind,
+    turn_row.admitted_at, turn_row.first_activity_at, turn_row.last_activity_at,
+    turn_row.settled_at, turn_row.claim_count
+  FROM public.companion_v3_turns turn_row
+  WHERE turn_row.accepted_at >= p_since AND turn_row.accepted_at <= p_until;
+END
+$$;
+--> statement-breakpoint
+
+REVOKE ALL ON FUNCTION public.companion_v3_measure_acceptance() FROM PUBLIC;
+--> statement-breakpoint
+REVOKE ALL ON FUNCTION public.companion_v3_measure_claim() FROM PUBLIC;
+--> statement-breakpoint
+REVOKE ALL ON FUNCTION public.companion_v3_measure_progress() FROM PUBLIC;
+--> statement-breakpoint
+REVOKE ALL ON FUNCTION public.companion_v3_runtime_measurement_facts(
+  timestamp with time zone,timestamp with time zone,integer
+) FROM PUBLIC;

--- a/packages/db/drizzle/0162_companion_runtime_v3_acceptance_measurement.sql
+++ b/packages/db/drizzle/0162_companion_runtime_v3_acceptance_measurement.sql
@@ -68,8 +68,9 @@ BEGIN
   FROM public.companions companion
   WHERE companion.org_id = NEW.org_id AND companion.id = NEW.companion_id;
   NEW.accepted_at := coalesce(NEW.accepted_at, clock_timestamp());
-  NEW.wake_path := CASE WHEN v_instance.prepared_at IS NOT NULL
-    THEN 'warm'::public.companion_v3_wake_path
+  NEW.wake_path := CASE
+    WHEN v_instance.prepared_at IS NOT NULL THEN 'warm'::public.companion_v3_wake_path
+    WHEN v_instance.desired_lifecycle = 'archive' THEN 'archived_wake'::public.companion_v3_wake_path
     ELSE 'creation'::public.companion_v3_wake_path END;
   NEW.box_provider := 'ascii';
   NEW.model_provider := coalesce(nullif(v_model_provider, ''), 'unconfigured');
@@ -127,7 +128,6 @@ BEGIN
     SELECT instance.prepared_at INTO v_prepared_at
     FROM public.companion_v3_instances instance
     WHERE instance.org_id = NEW.org_id AND instance.companion_id = NEW.companion_id;
-    NEW.wake_path := 'warm';
     NEW.box_ready_at := coalesce(NEW.box_ready_at, v_prepared_at);
     NEW.staging_completed_at := coalesce(NEW.staging_completed_at, v_prepared_at);
     NEW.pi_ready_at := coalesce(NEW.pi_ready_at, v_prepared_at);
@@ -155,6 +155,7 @@ CREATE FUNCTION public.companion_v3_runtime_measurement_facts(
   p_protocol integer
 )
 RETURNS TABLE (
+  in_product_window boolean,
   lane public.companion_v3_lane,
   wake_path public.companion_v3_wake_path,
   box_provider text,
@@ -185,6 +186,7 @@ BEGIN
     RAISE EXCEPTION 'invalid Runtime v3 measurement window' USING ERRCODE = '22023';
   END IF;
   RETURN QUERY SELECT
+    turn_row.accepted_at >= p_since AND turn_row.accepted_at <= p_until,
     turn_row.lane, turn_row.wake_path, turn_row.box_provider,
     turn_row.model_provider, turn_row.model_id, turn_row.state,
     turn_row.accepted_at, turn_row.first_claimed_at, turn_row.box_ready_at,
@@ -192,7 +194,8 @@ BEGIN
     turn_row.admitted_at, turn_row.first_activity_at, turn_row.last_activity_at,
     turn_row.settled_at, turn_row.claim_count
   FROM public.companion_v3_turns turn_row
-  WHERE turn_row.accepted_at >= p_since AND turn_row.accepted_at <= p_until;
+  WHERE (turn_row.accepted_at >= p_since AND turn_row.accepted_at <= p_until)
+    OR turn_row.state IN ('queued', 'admitted', 'running', 'needs_input');
 END
 $$;
 --> statement-breakpoint

--- a/packages/db/drizzle/meta/_journal.json
+++ b/packages/db/drizzle/meta/_journal.json
@@ -1135,6 +1135,13 @@
       "when": 1793311600000,
       "tag": "0161_companion_runtime_v3_warm_turn",
       "breakpoints": true
+    },
+    {
+      "idx": 162,
+      "version": "7",
+      "when": 1793315200000,
+      "tag": "0162_companion_runtime_v3_acceptance_measurement",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/db/runtime-role-grants.sql
+++ b/packages/db/runtime-role-grants.sql
@@ -957,7 +957,8 @@ BEGIN
         'public.companion_v3_runtime_complete(uuid,uuid,public.companion_v3_lane,uuid,uuid,bigint,bigint,text,text,text,public.companion_runtime_error_action,integer)'::regprocedure,
         'public.companion_v3_runtime_authorize_warm_turn(uuid,uuid,public.companion_v3_lane,uuid,uuid,bigint,bigint,integer)'::regprocedure,
         'public.companion_v3_runtime_record_admission(uuid,uuid,public.companion_v3_lane,uuid,uuid,bigint,bigint,text,bigint,integer)'::regprocedure,
-        'public.companion_v3_runtime_project_page(uuid,uuid,public.companion_v3_lane,uuid,uuid,bigint,bigint,bigint,jsonb,boolean,boolean,integer)'::regprocedure
+        'public.companion_v3_runtime_project_page(uuid,uuid,public.companion_v3_lane,uuid,uuid,bigint,bigint,bigint,jsonb,boolean,boolean,integer)'::regprocedure,
+        'public.companion_v3_runtime_measurement_facts(timestamp with time zone,timestamp with time zone,integer)'::regprocedure
       ];
       internal_runtime_functions := internal_runtime_functions || ARRAY[
         'public.companion_v3_admit_turn(uuid,uuid,uuid,text,text,public.companion_v3_lane)'::regprocedure,

--- a/packages/db/src/runtimeRole.ts
+++ b/packages/db/src/runtimeRole.ts
@@ -117,7 +117,8 @@ WITH runtime_role AS (
     ('public.companion_v3_runtime_complete(uuid,uuid,public.companion_v3_lane,uuid,uuid,bigint,bigint,text,text,text,public.companion_runtime_error_action,integer)'),
     ('public.companion_v3_runtime_authorize_warm_turn(uuid,uuid,public.companion_v3_lane,uuid,uuid,bigint,bigint,integer)'),
     ('public.companion_v3_runtime_record_admission(uuid,uuid,public.companion_v3_lane,uuid,uuid,bigint,bigint,text,bigint,integer)'),
-    ('public.companion_v3_runtime_project_page(uuid,uuid,public.companion_v3_lane,uuid,uuid,bigint,bigint,bigint,jsonb,boolean,boolean,integer)')
+    ('public.companion_v3_runtime_project_page(uuid,uuid,public.companion_v3_lane,uuid,uuid,bigint,bigint,bigint,jsonb,boolean,boolean,integer)'),
+    ('public.companion_v3_runtime_measurement_facts(timestamp with time zone,timestamp with time zone,integer)')
 ), required_functions AS (
   SELECT signature, pg_catalog.to_regprocedure(signature) AS oid
   FROM required

--- a/packages/db/src/schema.ts
+++ b/packages/db/src/schema.ts
@@ -97,6 +97,12 @@ export const companionV3TurnOutcomeEnum = pgEnum("companion_v3_turn_outcome", [
 export const companionV3LifecycleIntentEnum = pgEnum("companion_v3_lifecycle_intent", [
   "prepare", "archive", "recycle_pi", "delete",
 ]);
+export const companionV3WakePathEnum = pgEnum("companion_v3_wake_path", [
+  "warm", "creation", "archived_wake",
+]);
+export const companionV3AdmissionKindEnum = pgEnum("companion_v3_admission_kind", [
+  "prompt", "steer",
+]);
 export const companionDecisionStatusEnum = pgEnum("companion_decision_status", [
   "pending", "allowed", "denied", "answered", "expired", "cancelled",
 ]);
@@ -1342,11 +1348,24 @@ export const companionV3Turns = pgTable(
     queueSequence: bigint("queue_sequence", { mode: "number" }).notNull(),
     state: companionV3TurnStateEnum("state").notNull().default("queued"),
     admissionState: companionV3AdmissionStateEnum("admission_state").notNull().default("pending"),
+    acceptedAt: timestamp("accepted_at", { withTimezone: true }).notNull().defaultNow(),
+    firstClaimedAt: timestamp("first_claimed_at", { withTimezone: true }),
+    lastClaimedAt: timestamp("last_claimed_at", { withTimezone: true }),
+    claimCount: integer("claim_count").notNull().default(0),
+    wakePath: companionV3WakePathEnum("wake_path").notNull().default("creation"),
+    boxProvider: text("box_provider").notNull().default("ascii"),
+    modelProvider: text("model_provider").notNull().default("unconfigured"),
+    modelId: text("model_id").notNull().default("unconfigured"),
+    boxReadyAt: timestamp("box_ready_at", { withTimezone: true }),
+    stagingCompletedAt: timestamp("staging_completed_at", { withTimezone: true }),
+    piReadyAt: timestamp("pi_ready_at", { withTimezone: true }),
+    admissionKind: companionV3AdmissionKindEnum("admission_kind"),
     admittedAt: timestamp("admitted_at", { withTimezone: true }),
     piInvocationId: text("pi_invocation_id"),
     admissionCursor: bigint("admission_cursor", { mode: "number" }),
     activityCursor: bigint("activity_cursor", { mode: "number" }).notNull().default(0),
     lastActivityAt: timestamp("last_activity_at", { withTimezone: true }),
+    firstActivityAt: timestamp("first_activity_at", { withTimezone: true }),
     outcome: companionV3TurnOutcomeEnum("outcome"),
     outcomeCode: text("outcome_code"),
     outcomeMessage: text("outcome_message"),
@@ -1371,6 +1390,8 @@ export const companionV3Turns = pgTable(
     fifo: index("companion_v3_turns_fifo_idx")
       .on(t.companionId, t.lane, t.queueSequence, t.id)
       .where(sql`${t.state} = 'queued'`),
+    measurementWindow: index("companion_v3_turns_measurement_window_idx")
+      .on(t.acceptedAt, t.lane, t.wakePath),
     sequenceCheck: check("companion_v3_turns_sequence_check", sql`${t.queueSequence} >= 1`),
     messageEventCheck: check(
       "companion_v3_turns_message_event_check",
@@ -1395,6 +1416,10 @@ export const companionV3Turns = pgTable(
     outcomeCheck: check(
       "companion_v3_turns_outcome_check",
       sql`(${t.outcome} is null and ${t.settledAt} is null and ${t.outcomeCode} is null and ${t.outcomeMessage} is null and ${t.outcomeAction} is null and ${t.state} in ('queued', 'admitted', 'running', 'needs_input')) or (${t.outcome} is not null and ${t.settledAt} is not null and ${t.state}::text = ${t.outcome}::text and ((${t.outcome} in ('failed', 'interrupted') and ${t.outcomeCode} ~ '^[a-z][a-z0-9_]{0,63}$' and char_length(${t.outcomeMessage}) between 1 and 500 and ${t.outcomeMessage} !~ E'[\n\r]' and ${t.outcomeAction} is not null and ${t.outcomeAction} <> 'restart_box') or (${t.outcome} in ('succeeded', 'cancelled') and ${t.outcomeCode} is null and ${t.outcomeMessage} is null and ${t.outcomeAction} is null)))`,
+    ),
+    measurementCheck: check(
+      "companion_v3_turns_measurement_check",
+      sql`${t.claimCount} >= 0 and ((${t.claimCount} = 0 and ${t.firstClaimedAt} is null and ${t.lastClaimedAt} is null) or (${t.claimCount} > 0 and ${t.firstClaimedAt} is not null and ${t.lastClaimedAt} is not null and ${t.lastClaimedAt} >= ${t.firstClaimedAt})) and char_length(${t.boxProvider}) between 1 and 40 and ${t.boxProvider} !~ E'[\n\r]' and char_length(${t.modelProvider}) between 1 and 80 and ${t.modelProvider} !~ E'[\n\r]' and char_length(${t.modelId}) between 1 and 200 and ${t.modelId} !~ E'[\n\r]' and (${t.admissionKind} is null or ${t.admissionState} = 'accepted') and (${t.boxReadyAt} is null or ${t.stagingCompletedAt} is null or ${t.stagingCompletedAt} >= ${t.boxReadyAt}) and (${t.stagingCompletedAt} is null or ${t.piReadyAt} is null or ${t.piReadyAt} >= ${t.stagingCompletedAt}) and (${t.firstActivityAt} is null or ${t.admittedAt} is null or ${t.firstActivityAt} >= ${t.admittedAt})`,
     ),
   }),
 );


### PR DESCRIPTION
## Summary

- persist one expurgated Runtime v3 acceptance chronology from API acceptance through claim, preparation, Pi admission/activity, and settlement
- expose a runtime-role-only reproducible aggregate report with product percentiles and separate queue/stall/takeover safety clocks
- combine Runtime v2/v3 scheduler progress so PostgreSQL failure, blocked claim work, and stale sweeps make `/healthz` unhealthy

## Ticket evidence

- dimensions are limited to lane, wake path, Box provider, model provider, and model id; the report surface contains no tenant or conversation identifiers
- warm, creation, and archived-wake paths remain stable from acceptance through ACK
- product cohorts are bounded by acceptance time while active safety facts remain unbounded, preserving true oldest queue age and stalls
- removing acceptance-to-ACK correlation makes `releaseMeasurementReady` false

## Review

Spec-only review against `origin/conductor/runtime-v3-stack-03-the-512` found three applicable P1s. All are fixed in `92b6b7a` with targeted regression tests: wake-path reclassification, rejected-sweep health recovery, and window-truncated safety facts. No Standards/style pass was run.

Greptile P1 `#3918271701` was verified and fixed in `6157f2d`: a terminal `pi_settlement_missing` with no Pi activity now remains correlated to its durable ACK and settlement. The focused regression test was red before the fix and passes afterward.

The first CI run also found the new 31-day reporting window missing from the explicit SQL interval allowlist. `04a7ca1` registers it as a reporting window outside runtime safety budgets; the focused contract suites pass (22 unit + 5 PostgreSQL integration tests).

Parent `dff0159a` is merged in `8e9eaec`; the mechanical scheduler conflict preserves both active-sweep cancellation from THE-512 and THE-513 health timestamps. The focused scheduler suite (4 tests) and runtime typecheck pass after the merge.

## Validation

- `pnpm --filter @companion/companion-runtime test -- src/v3/measurement.test.ts`
- `pnpm --filter @companion/runtime test -- src/schedulerAdapter.test.ts`
- `pnpm --filter @companion/runtime typecheck`
- fresh PostgreSQL migration replay through 0162
- focused Runtime v3 PostgreSQL progression integration suite (16 tests before the review fixes; latest migration-specific additions are delegated to CI)
- full `@companion/companion-runtime` and `@companion/runtime` package suites before the final parent merge
- `pnpm verify:change -- --base origin/conductor/runtime-v3-stack-03-the-512` once; targeted non-Docker follow-ups passed. Local Docker/container validation is intentionally deferred to THE-528.


<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

The PR adds durable Runtime v3 acceptance chronology, an aggregate runtime-role reporting command, and combined v2/v3 scheduler health tracking. The previously reported terminal ACK-correlation defect is fixed by recognizing settled terminal turns without requiring Pi activity.
- Persists acceptance, claim, preparation, admission, activity, and settlement milestones.
- Produces bounded product percentiles alongside unbounded queue, stall, and takeover safety facts.
- Makes scheduler health reflect blocked or failed Runtime v3 convergence.
</details>


<details><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge.

No blocking failure remains.
</details>


<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| packages/companion-runtime/src/v3/measurement.ts | Builds aggregate acceptance and safety measurements; the revised terminal-correlation predicate correctly accepts settled ACKs without requiring activity. |
| packages/db/drizzle/0162_companion_runtime_v3_acceptance_measurement.sql | Adds durable measurement columns, attribution/progression triggers, and the expurgated runtime reporting function. |
| apps/runtime/src/runtimeV3AcceptanceReport.ts | Adds the runtime-role-only CLI that queries measurement facts and exits nonzero when correlation is incomplete. |
| apps/runtime/src/schedulerAdapter.ts | Combines v2 and v3 scheduler timestamps so blocked or rejected v3 sweeps remain visible to health checks. |
| packages/companion-runtime/src/v3/measurement.test.ts | Covers aggregate clocks, bounded product cohorts, missing correlation, and settled terminal ACKs without activity. |

</details>


<details open><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant API
    participant Turn as Runtime v3 Turn
    participant Pi
    participant Report
    API->>Turn: Persist acceptance and dimensions
    Turn->>Turn: Record claim and preparation milestones
    Turn->>Pi: Admit prompt or steer
    Pi-->>Turn: Durable ACK
    alt Correlated activity occurs
        Pi-->>Turn: Record first/latest activity
    else No activity before terminal failure
        Turn->>Turn: Persist settlement with null activity
    end
    Report->>Turn: Read expurgated measurement facts
    Report-->>Report: Aggregate percentiles and safety clocks
```
</details>

<sub>Reviews (3): Last reviewed commit: ["Merge remote-tracking branch &#39;origin/con..."](https://github.com/the-vibe-company/companion/commit/8e9eaeca7c7f10cf977fed7c6bd6a143f21363c5) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=59673854)</sub>

<!-- /greptile_comment -->