### PR TITLE
fix(webhooks): surface actionable GitHub and Sentry API errors

### DIFF
--- a/packages/core/src/companionTriggerWebhookRegistration.ts
+++ b/packages/core/src/companionTriggerWebhookRegistration.ts
@@ -826,7 +826,7 @@ export async function registerCompanionTriggerWebhookV2(input: {
 
   // Pass the already-extracted body to Zod for validation on success
   
-  const created = z.object({ id: z.number().int() }).safeParse(await response.json().catch(() => null));
+  const created = z.object({ id: z.number().int() }).safeParse(responseBody);
   if (!created.success) {
     return recoverGitHubRegistration(input, trigger, account.id, token, repoPath, doFetch,
       "github returned an unreadable webhook payload");

--- a/packages/core/src/companionTriggerWebhookRegistration.ts
+++ b/packages/core/src/companionTriggerWebhookRegistration.ts
@@ -579,10 +579,40 @@ async function registerSentryTriggerWebhook(
     return recoverSentryRegistration(input, trigger, account.id, token, projectPath, doFetch,
       "Sentry webhook registration could not reach the provider");
   }
-  const created = z.object({ id: z.string().min(1).max(200) })
-    .safeParse(await response.json().catch(() => null));
-  if (!response.ok || !created.success) {
-    const error = sanitizeCompanionRuntimeError(`Sentry rejected the webhook (${response.status})`).slice(0, 500);
+  const responseBody = await response.json().catch(() => null);
+
+  if (!response.ok) {
+    let detailedReason = "Unknown error";
+    
+    // Extract Sentry's specific error message
+    if (responseBody) {
+      if (typeof responseBody.detail === "string") {
+        detailedReason = responseBody.detail;
+      } else if (typeof responseBody.message === "string") {
+        detailedReason = responseBody.message;
+      }
+    }
+
+    // Map common Sentry API rejection scenarios
+    if (response.status === 401) {
+      detailedReason = "Unauthorized. The Sentry integration token is invalid or expired.";
+    } else if (response.status === 403) {
+      detailedReason = "Access forbidden. Ensure the token has 'project:write' or 'project:admin' permissions.";
+    } else if (response.status === 404) {
+      detailedReason = "Organization or project not found. Verify the target project path.";
+    }
+
+    const error = sanitizeCompanionRuntimeError(
+      `Sentry rejected the webhook (${response.status}): ${detailedReason}`
+    ).slice(0, 500);
+    
+    return recoverSentryRegistration(input, trigger, account.id, token, projectPath, doFetch, error);
+  }
+
+  const created = z.object({ id: z.string().min(1).max(200) }).safeParse(responseBody);
+  
+  if (!created.success) {
+    const error = sanitizeCompanionRuntimeError("Sentry returned an unreadable webhook payload").slice(0, 500);
     return recoverSentryRegistration(input, trigger, account.id, token, projectPath, doFetch, error);
   }
   await persistRegistration({
@@ -767,13 +797,35 @@ export async function registerCompanionTriggerWebhookV2(input: {
     return recoverGitHubRegistration(input, trigger, account.id, token, repoPath, doFetch,
       "github webhook registration could not reach the provider");
   }
+  const responseBody = await response.json().catch(() => null);
+
   if (!response.ok) {
-    // The provider has the final word on unknown event names and missing permissions.
+    let detailedReason = "Unknown error";
+    
+    if (responseBody?.message) {
+      detailedReason = responseBody.message;
+    }
+
+    // Map common GitHub webhook rejection scenarios
+    if (response.status === 404) {
+      detailedReason = "Repository not found or token lacks 'admin:repo_hook' permission.";
+    } else if (response.status === 403) {
+      detailedReason = "Access forbidden. Check if the organization restricts third-party OAuth apps.";
+    } else if (response.status === 422) {
+      detailedReason = responseBody?.errors 
+        ? `Validation failed: ${JSON.stringify(responseBody.errors)}` 
+        : "Validation failed (maximum of 20 webhooks per repository reached).";
+    }
+
     const message = sanitizeCompanionRuntimeError(
-      `github rejected the webhook (${response.status})`,
+      `github rejected the webhook (${response.status}): ${detailedReason}`
     ).slice(0, 500);
+
     return recoverGitHubRegistration(input, trigger, account.id, token, repoPath, doFetch, message);
   }
+
+  // Pass the already-extracted body to Zod for validation on success
+  
   const created = z.object({ id: z.number().int() }).safeParse(await response.json().catch(() => null));
   if (!created.success) {
     return recoverGitHubRegistration(input, trigger, account.id, token, repoPath, doFetch,

--- a/packages/core/src/companionTriggerWebhookRegistration.ts
+++ b/packages/core/src/companionTriggerWebhookRegistration.ts
@@ -812,9 +812,7 @@ export async function registerCompanionTriggerWebhookV2(input: {
     } else if (response.status === 403) {
       detailedReason = "Access forbidden. Check if the organization restricts third-party OAuth apps.";
     } else if (response.status === 422) {
-      detailedReason = responseBody?.errors 
-        ? `Validation failed: ${JSON.stringify(responseBody.errors)}` 
-        : "Validation failed (maximum of 20 webhooks per repository reached).";
+      detailedReason = "Validation failed. Check the webhook configuration and repository webhook limit.";
     }
 
     const message = sanitizeCompanionRuntimeError(


### PR DESCRIPTION
# Fix: Surface actionable API errors for GitHub and Sentry trigger proposals

## Description
This PR resolves an issue where failing trigger proposals (specifically for GitHub and Sentry) resulted in a generic UI timeout/error: *"Unable to apply the trigger proposal. Please try again."* 

By capturing and parsing the upstream API error bodies, this update bubbles up actionable error messages to the frontend, allowing users to unblock themselves when facing permission or configuration issues.

## Root Cause
In `registerCompanionTriggerWebhookV2`, the API request's `response.json()` body was being consumed *after* the `!response.ok` evaluation block. Because the error details were discarded, backend failures defaulted to generic status code strings which ultimately surfaced as unhelpful timeouts or generic errors in the user interface.

## Changes Made
* **GitHub Integration:** 
  * Extracted the JSON response body prior to the success evaluation.
  * Mapped `404` errors to missing `admin:repo_hook` permissions or missing repositories.
  * Mapped `403` errors to organization third-party OAuth app restrictions.
  * Mapped `422` errors to capture configuration limits (e.g., exceeding the 20 webhooks per repository limit).
* **Sentry Integration:** 
  * Extracted the JSON response body to capture Sentry's `detail` and `message` properties.
  * Mapped `401` errors to invalid/expired tokens.
  * Mapped `403` errors to missing `project:write` scopes.
  * Mapped `404` errors to invalid project/organization paths.

## Impact
Users configuring `companion-main-merges` (or similar triggers) will no longer be left in the dark. Instead of a generic failure, the UI will surface exact reasons, such as:
> *"github rejected the webhook (403): Access forbidden. Check if the organization restricts third-party OAuth apps."*

## How to Test
1. Attempt to create a GitHub trigger proposal using a repository where your token lacks the `admin:repo_hook` scope.
2. Click **Approve** in the UI.
3. Verify that the UI displays the specific permission error rather than a generic timeout.
4. Repeat with a Sentry trigger using an invalid project path to verify the `404` organization mapping.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/The-Vibe-Company/companion/pull/730?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->





<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

The PR improves webhook-registration failures by parsing GitHub and Sentry responses once and returning status-specific, actionable error messages.
- Reuses parsed response bodies for successful webhook validation.
- Maps common GitHub and Sentry rejection statuses to user-facing guidance.
- Replaces GitHub 422 provider error structures with a stable local message.
</details>


<details><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge.

No blocking failure remains.
</details>


<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| packages/core/src/companionTriggerWebhookRegistration.ts | Adds actionable provider-error handling while resolving both previously reported GitHub response-consumption and 422 persistence issues. |

</details>

<sub>Reviews (2): Last reviewed commit: ["Update packages/core/src/companionTrigge..."](https://github.com/the-vibe-company/companion/commit/b1cacf14543b99697dc92c708578f0c8955e39a5) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=59906572)</sub>

<!-- /greptile_comment -->