### PR TITLE
fix(runtime): recover terminal replies and baker readiness

### DIFF
--- a/apps/api/src/runtimeRoleGrants.test.ts
+++ b/apps/api/src/runtimeRoleGrants.test.ts
@@ -69,6 +69,9 @@ describe("Skills Hub runtime-role grants", () => {
       "companion_v3_runtime_sweep_decisions(public.companion_v3_lane,integer)",
       "companion_v3_runtime_record_native_fallback_v8(uuid,uuid,public.companion_v3_lane,uuid,uuid,bigint,bigint,jsonb,integer)",
       "companion_v3_runtime_read_native_fallback_v8(uuid,uuid,public.companion_v3_lane,uuid,uuid,bigint,bigint,integer)",
+      "companion_v3_runtime_record_terminal_model_error_v9(uuid,uuid,public.companion_v3_lane,uuid,uuid,bigint,bigint,jsonb,integer)",
+      "companion_v3_runtime_project_native_page_v8(uuid,uuid,public.companion_v3_lane,uuid,uuid,bigint,bigint,bigint,jsonb,jsonb,jsonb,boolean,boolean,text,integer)",
+      "companion_v3_runtime_project_background_page_v10(uuid,uuid,uuid,uuid,bigint,bigint,bigint,jsonb,jsonb,jsonb,boolean,boolean,text,integer)",
     ]) expect(sql).toContain(signature);
     expect(runtimeFunctions).not.toContain("companion_runtime_enable");
     expect(sql).toContain(

--- a/apps/api/src/runtimeRoleGrants.test.ts
+++ b/apps/api/src/runtimeRoleGrants.test.ts
@@ -67,6 +67,8 @@ describe("Skills Hub runtime-role grants", () => {
       "companion_v3_runtime_finish_decision_action(uuid,uuid,public.companion_v3_lane,uuid,uuid,bigint,bigint,uuid,text,text,integer)",
       "companion_v3_runtime_complete_v6(uuid,uuid,public.companion_v3_lane,uuid,uuid,bigint,bigint,text,text,text,public.companion_runtime_error_action,integer)",
       "companion_v3_runtime_sweep_decisions(public.companion_v3_lane,integer)",
+      "companion_v3_runtime_record_native_fallback_v8(uuid,uuid,public.companion_v3_lane,uuid,uuid,bigint,bigint,jsonb,integer)",
+      "companion_v3_runtime_read_native_fallback_v8(uuid,uuid,public.companion_v3_lane,uuid,uuid,bigint,bigint,integer)",
     ]) expect(sql).toContain(signature);
     expect(runtimeFunctions).not.toContain("companion_runtime_enable");
     expect(sql).toContain(

--- a/apps/api/test/integration/skillsHubOnlyMigration.integration.test.ts
+++ b/apps/api/test/integration/skillsHubOnlyMigration.integration.test.ts
@@ -61,10 +61,12 @@ describe("Skills Hub-only database migration", () => {
               'companion_v3_runtime_project_native_page_v5',
               'companion_v3_runtime_project_native_page_v6',
               'companion_v3_runtime_project_native_page_v7',
+              'companion_v3_runtime_project_native_page_v8',
               'companion_v3_runtime_project_routine_page',
               'companion_v3_runtime_project_background_page_v7',
               'companion_v3_runtime_project_background_page_v8',
-              'companion_v3_runtime_project_background_page_v9'
+              'companion_v3_runtime_project_background_page_v9',
+              'companion_v3_runtime_project_background_page_v10'
             )
         ) as "runtimeFunctions",
         (

--- a/apps/runtime/src/imageBuildWorker.test.ts
+++ b/apps/runtime/src/imageBuildWorker.test.ts
@@ -247,6 +247,73 @@ describe("image build worker", () => {
     })]);
   });
 
+  it("logs the newly created Box identity when baker cleanup fails", async () => {
+    vi.mocked(bakeCompanionRuntimeImageOnce).mockImplementation(async (input) => {
+      await input.onBoxCreated?.({ boxId: "bx_newbaker", parentImageName: null });
+      await input.onBoxDeletionIntentRecorded?.({ boxId: "bx_newbaker" });
+      await input.onBoxDeletionRequested?.({
+        boxId: "bx_newbaker",
+        operationId: "bdop_00000000000000000000000000000001",
+      });
+      input.onCleanupError?.(new Error("cleanup failed"), "baker_box_delete");
+      return {
+        name: IDENTITY.imageName,
+        ready: true,
+        parentImageName: null,
+      };
+    });
+    const { calls, controller, done, log } = harness();
+    await vi.waitFor(() => expect(calls.outcomes).toHaveLength(1));
+    controller.abort();
+    await done;
+
+    expect(log?.records).toContainEqual(expect.objectContaining({
+      event: "runtime.image_build_cleanup_failed",
+      buildBoxId: "bx_newbaker",
+      buildDeleteIntentRecorded: true,
+      buildDeleteOperationId: "bdop_00000000000000000000000000000001",
+    }));
+  });
+
+  it("keeps image readiness independent from a cold create fallback", async () => {
+    const getByDigest = vi.fn(async () => ({
+      digest: IDENTITY.imageMarker,
+      imageName: IDENTITY.imageName,
+      status: "building" as const,
+      parentImageName: null,
+      buildBoxId: null,
+      buildDeleteIntentRecorded: false,
+      buildDeleteOperationId: null,
+      attemptCount: 1,
+      lastErrorCode: null,
+      lastErrorMessage: null,
+      leaseExpiresAt: null,
+    }));
+    const worker = createImageBuildWorker({
+      registry: {
+        async requestImage() {
+          throw new Error("not used");
+        },
+        async claimImageBuild() {
+          throw new Error("not used");
+        },
+        getByDigest,
+      } as never,
+      identity: IDENTITY,
+      lifecycle: {} as never,
+      runtime: () => {
+        throw new Error("cold fallback must not contact runtime image builder");
+      },
+      executorId: "executor-1",
+      bakeOnce: bakeCompanionRuntimeImageOnce as never,
+      log: capturingLog(),
+    });
+
+    await expect(worker.source().availability(new AbortController().signal)).resolves.toBe("building");
+    expect(getByDigest).toHaveBeenCalledOnce();
+    expect(bakeCompanionRuntimeImageOnce).not.toHaveBeenCalled();
+  });
+
   it("persists a failure instead of publishing a snapshot that never became ready", async () => {
     vi.mocked(bakeCompanionRuntimeImageOnce).mockResolvedValue({
       name: IDENTITY.imageName,

--- a/apps/runtime/src/imageBuildWorker.ts
+++ b/apps/runtime/src/imageBuildWorker.ts
@@ -96,6 +96,12 @@ export function createImageBuildWorker(options: ImageBuildWorkerOptions): ImageB
           attemptController.abort(new Error("The image build attempt exceeded its budget."));
         }, attemptBudgetMs);
         const bake = options.bakeOnce ?? bakeCompanionRuntimeImageOnce;
+        // The claim may still point at no Box when this attempt creates one. Keep the provider
+        // identity and cleanup checkpoints local to this attempt so failure logs never regress to
+        // the stale nullable claim projection.
+        let buildBoxId = claim.buildBoxId;
+        let buildDeleteIntentRecorded = claim.buildDeleteIntentRecorded;
+        let buildDeleteOperationId = claim.buildDeleteOperationId;
         const bakeInput: Parameters<typeof bakeCompanionRuntimeImageOnce>[0] = {
           identity: options.identity,
           lifecycle: options.lifecycle,
@@ -111,7 +117,9 @@ export function createImageBuildWorker(options: ImageBuildWorkerOptions): ImageB
             ) => options.runtime().prepareRuntimeImage?.(input),
           },
           signal: attemptController.signal,
+          deadlineAt: now() + attemptBudgetMs,
           onBoxCreated: async ({ boxId }) => {
+            buildBoxId = boxId;
             const marked = await options.registry.markBuildingBox({
               digest: claim.digest,
               claimEpoch: claim.claimEpoch,
@@ -130,6 +138,7 @@ export function createImageBuildWorker(options: ImageBuildWorkerOptions): ImageB
             }
           },
           onBoxDeleted: async ({ boxId }) => {
+            buildBoxId = boxId;
             const cleared = await options.registry.clearBuildingBox({
               digest: claim.digest,
               claimEpoch: claim.claimEpoch,
@@ -138,6 +147,8 @@ export function createImageBuildWorker(options: ImageBuildWorkerOptions): ImageB
             if (!cleared) throw new Error("The image build lease was lost after Box cleanup.");
           },
           onBoxDeletionIntentRecorded: async ({ boxId }) => {
+            buildBoxId = boxId;
+            buildDeleteIntentRecorded = true;
             const marked = await options.registry.markBuildingBoxDeletionIntent({
               digest: claim.digest,
               claimEpoch: claim.claimEpoch,
@@ -148,6 +159,8 @@ export function createImageBuildWorker(options: ImageBuildWorkerOptions): ImageB
             }
           },
           onBoxDeletionRequested: async ({ boxId, operationId }) => {
+            buildBoxId = boxId;
+            buildDeleteOperationId = operationId;
             const marked = await options.registry.markBuildingBoxDeletion({
               digest: claim.digest,
               claimEpoch: claim.claimEpoch,
@@ -164,8 +177,9 @@ export function createImageBuildWorker(options: ImageBuildWorkerOptions): ImageB
               ts: new Date(now()).toISOString(),
               event: "runtime.image_build_cleanup_failed",
               digest: claim.digest,
-              buildBoxId: claim.buildBoxId,
-              buildDeleteOperationId: claim.buildDeleteOperationId,
+              buildBoxId,
+              buildDeleteIntentRecorded,
+              buildDeleteOperationId,
               error: IMAGE_BUILD_CLEANUP_FAILURE_MESSAGE,
             });
           },

--- a/apps/runtime/src/runtimeV3ProgressionStore.ts
+++ b/apps/runtime/src/runtimeV3ProgressionStore.ts
@@ -792,6 +792,46 @@ export function createRuntimeV3PostgresWarmTurnPersistence(
       return rows[0]?.recorded === true;
     },
     async project(claim, projection, signal) {
+      const fallbacks = projection.assistantFallbacks ?? [];
+      if (fallbacks.length > 0) {
+        const recorded = await abortable(sql<Array<{ recorded: boolean }>>`
+          select public.companion_v3_runtime_record_native_fallback_v8(
+            ${claim.orgId}::uuid,
+            ${claim.companionId}::uuid,
+            ${claim.turn.lane},
+            ${claim.turn.id}::uuid,
+            ${claim.fence.token}::uuid,
+            ${claim.fence.epoch.toString()}::bigint,
+            ${claim.fence.gateEpoch.toString()}::bigint,
+            ${sql.json(fallbacks.map((fallback) => ({
+              ...fallback,
+              sequence: fallback.sequence.toString(),
+            })))}::jsonb,
+            8
+          ) as recorded
+        `, signal);
+        if (recorded[0]?.recorded !== true) return false;
+      }
+      let assistant = projection.assistant;
+      if (projection.settled && assistant.length === 0) {
+        const fallback = await abortable(sql<Array<{ sequence: string; content: string }>>`
+          select sequence::text, content
+          from public.companion_v3_runtime_read_native_fallback_v8(
+            ${claim.orgId}::uuid,
+            ${claim.companionId}::uuid,
+            ${claim.turn.lane},
+            ${claim.turn.id}::uuid,
+            ${claim.fence.token}::uuid,
+            ${claim.fence.epoch.toString()}::bigint,
+            ${claim.fence.gateEpoch.toString()}::bigint,
+            8
+          )
+        `, signal);
+        assistant = fallback.map((item) => ({
+          eventId: `v3:${claim.turn.id}:${item.sequence}`,
+          content: item.content,
+        }));
+      }
       const rows = await abortable(sql<Array<{ projected: string | null }>>`
         select public.companion_v3_runtime_project_native_page_v7(
           ${claim.orgId}::uuid,
@@ -802,7 +842,7 @@ export function createRuntimeV3PostgresWarmTurnPersistence(
           ${claim.fence.epoch.toString()}::bigint,
           ${claim.fence.gateEpoch.toString()}::bigint,
           ${projection.throughCursor.toString()}::bigint,
-          ${sql.json(projection.assistant)}::jsonb,
+          ${sql.json(assistant)}::jsonb,
           ${sql.json((projection.compactions ?? []).map((item) => ({
             ...item,
             cursor: item.cursor.toString(),
@@ -961,13 +1001,49 @@ export function createRuntimeV3PostgresBackgroundTurnPersistence(
       return rows[0]?.begun === true;
     },
     async project(claim, projection, signal) {
+      const fallbacks = projection.assistantFallbacks ?? [];
+      if (fallbacks.length > 0) {
+        const recorded = await abortable(sql<Array<{ recorded: boolean }>>`
+          select public.companion_v3_runtime_record_native_fallback_v8(
+            ${claim.orgId}::uuid, ${claim.companionId}::uuid, ${claim.turn.lane},
+            ${claim.turn.id}::uuid, ${claim.fence.token}::uuid,
+            ${claim.fence.epoch.toString()}::bigint,
+            ${claim.fence.gateEpoch.toString()}::bigint,
+            ${sql.json(fallbacks.map((fallback) => ({
+              ...fallback, sequence: fallback.sequence.toString(),
+            })))}::jsonb, 8
+          ) as recorded
+        `, signal);
+        if (recorded[0]?.recorded !== true) return false;
+      }
+      let privateEntries = projection.privateEntries ?? [];
+      if (projection.settled && !privateEntries.some((item) => item.type === "assistant")) {
+        const fallback = await abortable(sql<Array<{ sequence: string; content: string }>>`
+          select sequence::text, content
+          from public.companion_v3_runtime_read_native_fallback_v8(
+            ${claim.orgId}::uuid, ${claim.companionId}::uuid, ${claim.turn.lane},
+            ${claim.turn.id}::uuid, ${claim.fence.token}::uuid,
+            ${claim.fence.epoch.toString()}::bigint,
+            ${claim.fence.gateEpoch.toString()}::bigint, 8
+          )
+        `, signal);
+        privateEntries = [...privateEntries, ...fallback.map((item) => {
+          const sequence = BigInt(item.sequence);
+          return {
+            sequence,
+            type: "assistant" as const,
+            entry_key: `assistant:${item.sequence}`,
+            content: item.content,
+          };
+        })].sort((left, right) => left.sequence < right.sequence ? -1 : 1);
+      }
       const rows = await abortable(sql<Array<{ projected: string | null }>>`
         select public.companion_v3_runtime_project_background_page_v9(
           ${claim.orgId}::uuid, ${claim.companionId}::uuid, ${claim.turn.id}::uuid,
           ${claim.fence.token}::uuid, ${claim.fence.epoch.toString()}::bigint,
           ${claim.fence.gateEpoch.toString()}::bigint,
           ${projection.throughCursor.toString()}::bigint,
-          ${sql.json((projection.privateEntries ?? []).map((item) => ({
+          ${sql.json(privateEntries.map((item) => ({
             ...item, sequence: item.sequence.toString(),
           })))}::jsonb,
           ${sql.json((projection.decisions ?? []).map((item) => ({

--- a/apps/runtime/src/runtimeV3ProgressionStore.ts
+++ b/apps/runtime/src/runtimeV3ProgressionStore.ts
@@ -812,6 +812,25 @@ export function createRuntimeV3PostgresWarmTurnPersistence(
         `, signal);
         if (recorded[0]?.recorded !== true) return false;
       }
+      if (projection.terminalError) {
+        const recorded = await abortable(sql<Array<{ recorded: boolean }>>`
+          select public.companion_v3_runtime_record_terminal_model_error_v9(
+            ${claim.orgId}::uuid,
+            ${claim.companionId}::uuid,
+            ${claim.turn.lane},
+            ${claim.turn.id}::uuid,
+            ${claim.fence.token}::uuid,
+            ${claim.fence.epoch.toString()}::bigint,
+            ${claim.fence.gateEpoch.toString()}::bigint,
+            ${sql.json({
+              ...projection.terminalError,
+              sequence: projection.terminalError.sequence.toString(),
+            })}::jsonb,
+            9
+          ) as recorded
+        `, signal);
+        if (recorded[0]?.recorded !== true) return false;
+      }
       let assistant = projection.assistant;
       if (projection.settled && assistant.length === 0) {
         const fallback = await abortable(sql<Array<{ sequence: string; content: string }>>`
@@ -833,7 +852,7 @@ export function createRuntimeV3PostgresWarmTurnPersistence(
         }));
       }
       const rows = await abortable(sql<Array<{ projected: string | null }>>`
-        select public.companion_v3_runtime_project_native_page_v7(
+        select public.companion_v3_runtime_project_native_page_v8(
           ${claim.orgId}::uuid,
           ${claim.companionId}::uuid,
           ${claim.turn.lane},
@@ -854,7 +873,7 @@ export function createRuntimeV3PostgresWarmTurnPersistence(
           ${projection.needsInput},
           ${projection.activity},
           ${projection.processExited ? "process_exit" : projection.settled ? "settled" : null},
-          7
+          8
         ) as projected
       `, signal);
       const projected = rows[0]?.projected;
@@ -1016,6 +1035,21 @@ export function createRuntimeV3PostgresBackgroundTurnPersistence(
         `, signal);
         if (recorded[0]?.recorded !== true) return false;
       }
+      if (projection.terminalError) {
+        const recorded = await abortable(sql<Array<{ recorded: boolean }>>`
+          select public.companion_v3_runtime_record_terminal_model_error_v9(
+            ${claim.orgId}::uuid, ${claim.companionId}::uuid, ${claim.turn.lane},
+            ${claim.turn.id}::uuid, ${claim.fence.token}::uuid,
+            ${claim.fence.epoch.toString()}::bigint,
+            ${claim.fence.gateEpoch.toString()}::bigint,
+            ${sql.json({
+              ...projection.terminalError,
+              sequence: projection.terminalError.sequence.toString(),
+            })}::jsonb, 9
+          ) as recorded
+        `, signal);
+        if (recorded[0]?.recorded !== true) return false;
+      }
       let privateEntries = projection.privateEntries ?? [];
       if (projection.settled && !privateEntries.some((item) => item.type === "assistant")) {
         const fallback = await abortable(sql<Array<{ sequence: string; content: string }>>`
@@ -1038,7 +1072,7 @@ export function createRuntimeV3PostgresBackgroundTurnPersistence(
         })].sort((left, right) => left.sequence < right.sequence ? -1 : 1);
       }
       const rows = await abortable(sql<Array<{ projected: string | null }>>`
-        select public.companion_v3_runtime_project_background_page_v9(
+        select public.companion_v3_runtime_project_background_page_v10(
           ${claim.orgId}::uuid, ${claim.companionId}::uuid, ${claim.turn.id}::uuid,
           ${claim.fence.token}::uuid, ${claim.fence.epoch.toString()}::bigint,
           ${claim.fence.gateEpoch.toString()}::bigint,
@@ -1054,7 +1088,7 @@ export function createRuntimeV3PostgresBackgroundTurnPersistence(
           })))}::jsonb,
           ${projection.needsInput}, ${projection.activity},
           ${projection.processExited ? "process_exit" : projection.settled ? "settled" : null},
-          9
+          10
         ) as projected
       `, signal);
       const projected = rows[0]?.projected;

--- a/apps/runtime/test/integration/runtimeV3Progression.integration.test.ts
+++ b/apps/runtime/test/integration/runtimeV3Progression.integration.test.ts
@@ -2992,6 +2992,12 @@ describe("Runtime v3 progression facts", () => {
           { sequence: 1n, source: "turn_end" as const, content: `turn fallback ${lane}` },
           { sequence: 2n, source: "agent_end" as const, content: `agent fallback ${lane}` },
         ],
+        terminalError: {
+          sequence: 2n,
+          code: "model_unavailable" as const,
+          message: "The selected model is unavailable. Choose a different model and try again." as const,
+          action: "switch_model" as const,
+        },
         privateEntries: lane === "background" ? [] : undefined,
         decisions: [],
         routineReturns: [],
@@ -3043,6 +3049,142 @@ describe("Runtime v3 progression facts", () => {
           where org_id=${ids.org}::uuid and companion_id=${ids.companion}::uuid
             and run_id=${turnId}::uuid and role='assistant'`;
       expect(result).toEqual([{ content: `turn fallback ${lane}` }]);
+    },
+  );
+
+  it.each(["main", "background"] as const)(
+    "durably surfaces a cross-page terminal model error for the %s lane",
+    async (lane) => {
+      const invocationId = `invocation-terminal-model-error-${lane}`;
+      const messageId = randomUUID();
+      await seedPreparedV3(invocationId);
+      let turnId = "";
+      let correlatedTurnId: string | null = null;
+      if (lane === "main") {
+        await asApi(async (sql) => {
+          const rows = await sql<Array<{ turn: { id: string } }>>`
+            select turn from public.companion_v3_api_enqueue_warm_turn(
+              ${ids.org}::uuid,${ids.companion}::uuid,${messageId}::uuid,
+              'surface the terminal model error')`;
+          turnId = rows[0]!.turn.id;
+          const correlated = await sql<Array<{ turn: { id: string } }>>`
+            select turn from public.companion_v3_api_enqueue_warm_turn(
+              ${ids.org}::uuid,${ids.companion}::uuid,${randomUUID()}::uuid,
+              'correlated steer sees the same terminal model error')`;
+          correlatedTurnId = correlated[0]!.turn.id;
+        });
+      } else {
+        const eventId = `msg:${messageId}`;
+        await ownerSql`insert into public.companion_threads(org_id,companion_id)
+          values(${ids.org}::uuid,${ids.companion}::uuid) on conflict do nothing`;
+        await ownerSql`with advanced as (
+          update public.companion_threads set next_ordinal=next_ordinal+1,
+            projection_sequence=projection_sequence+1,updated_at=clock_timestamp()
+          where org_id=${ids.org}::uuid and companion_id=${ids.companion}::uuid
+          returning next_ordinal-1 as ordinal,projection_sequence
+        ) insert into public.companion_transcript_entries(
+          org_id,companion_id,event_id,ordinal,projection_sequence,role,content,author_id)
+        select ${ids.org}::uuid,${ids.companion}::uuid,${eventId},ordinal,projection_sequence,
+          'user','surface the routine terminal model error',${ids.owner} from advanced`;
+        const admitted = await ownerSql<Array<{ turnId: string }>>`
+          select turn_id as "turnId" from public.companion_v3_admit_turn(
+            ${ids.org}::uuid,${ids.companion}::uuid,${messageId}::uuid,${eventId},
+            ${ids.owner},'background')`;
+        turnId = admitted[0]!.turnId;
+        await seedBackgroundRun(turnId, "Terminal model error fixture");
+      }
+
+      const convergence = lane === "main"
+        ? createRuntimeV3PostgresWarmConvergence(runtimeSql, { enabledLanes: new Set(["main"]) })
+        : createRuntimeV3PostgresRoutineConvergence(runtimeSql);
+      const persistence = lane === "main"
+        ? createRuntimeV3PostgresWarmTurnPersistence(runtimeSql)
+        : createRuntimeV3PostgresRoutineTurnPersistence(runtimeSql);
+      const claim = await convergence.claimLane({
+        executorId: `runtime-terminal-model-error-${lane}`, lane,
+      });
+      const material = await persistence.authorize(claim!);
+      await persistence.beginAdmission(claim!, {
+        invocationId: material!.piInvocationId, cursor: 0n,
+      });
+      await persistence.recordAdmission(claim!, {
+        invocationId: material!.piInvocationId, responseTurnId: turnId, cursor: 0n,
+      });
+      if (correlatedTurnId) {
+        await ownerSql`update public.companion_v3_turns set
+          state='admitted',admission_state='accepted',admission_started_at=clock_timestamp(),
+          admitted_at=clock_timestamp(),admission_kind='steer',pi_invocation_id=${invocationId},
+          response_turn_id=${turnId}::uuid,admission_cursor=0,activity_cursor=0,
+          correlated_activity_cursor=0,last_activity_at=clock_timestamp(),
+          inactivity_deadline_at=clock_timestamp()+interval '10 minutes',
+          absolute_deadline_at=clock_timestamp()+interval '2 hours'
+          where org_id=${ids.org}::uuid and companion_id=${ids.companion}::uuid
+            and id=${correlatedTurnId}::uuid`;
+      }
+
+      await expect(persistence.project(claim!, {
+        throughCursor: 17n,
+        assistant: [],
+        assistantFallbacks: [],
+        terminalError: {
+          sequence: 17n,
+          code: "model_unavailable",
+          message: "The selected model is unavailable. Choose a different model and try again.",
+          action: "switch_model",
+        },
+        privateEntries: lane === "background" ? [] : undefined,
+        decisions: [],
+        routineReturns: [],
+        needsInput: false,
+        settled: false,
+        processExited: false,
+        activity: true,
+      })).resolves.toBe(true);
+      await convergence.completeProgression(claim!, { kind: "release" });
+
+      const takeover = await convergence.claimLane({
+        executorId: `runtime-terminal-model-error-takeover-${lane}`, lane,
+      });
+      await expect(persistence.project(takeover!, {
+        throughCursor: 18n,
+        assistant: [],
+        assistantFallbacks: [],
+        terminalError: null,
+        privateEntries: lane === "background" ? [] : undefined,
+        decisions: [],
+        routineReturns: [],
+        needsInput: false,
+        settled: true,
+        processExited: false,
+        activity: false,
+      })).resolves.toBe("failed");
+      await convergence.completeProgression(takeover!, { kind: "ack_completed" });
+
+      const outcome = await ownerSql<Array<{ id: string; code: string; message: string; action: string }>>`
+        select id,outcome_code as code,outcome_message as message,outcome_action::text as action
+        from public.companion_v3_turns where org_id=${ids.org}::uuid
+          and companion_id=${ids.companion}::uuid
+          and id=any(${correlatedTurnId ? [turnId, correlatedTurnId] : [turnId]}::uuid[])
+        order by queue_sequence`;
+      expect(outcome).toEqual((correlatedTurnId ? [turnId, correlatedTurnId] : [turnId]).map((id) => ({
+        id,
+        code: "model_unavailable",
+        message: "The selected model is unavailable. Choose a different model and try again.",
+        action: "switch_model",
+      })));
+      const visible = lane === "main"
+        ? await ownerSql<Array<{ role: string; content: string }>>`
+          select role::text,content from public.companion_transcript_entries
+          where org_id=${ids.org}::uuid and companion_id=${ids.companion}::uuid
+            and event_id=${`v3:${turnId}:error:17`}`
+        : await ownerSql<Array<{ role: string; content: string }>>`
+          select role::text,content from public.companion_v3_routine_run_entries
+          where org_id=${ids.org}::uuid and companion_id=${ids.companion}::uuid
+            and run_id=${turnId}::uuid and event_id='error:17'`;
+      expect(visible).toEqual([{
+        role: "system",
+        content: "The selected model is unavailable. Choose a different model and try again.",
+      }]);
     },
   );
 

--- a/apps/runtime/test/integration/runtimeV3Progression.integration.test.ts
+++ b/apps/runtime/test/integration/runtimeV3Progression.integration.test.ts
@@ -2908,6 +2908,187 @@ describe("Runtime v3 progression facts", () => {
     expect(terminal).toEqual([{ activeTurn: null, queuedCount: 0, isReplying: false }]);
   });
 
+  it("rejects partially populated terminal fallback checkpoints", async () => {
+    await seedPreparedV3("invocation-partial-terminal-fallback");
+    const messageId = randomUUID();
+    let turnId = "";
+    await asApi(async (sql) => {
+      const rows = await sql<Array<{ turn: { id: string } }>>`
+        select turn from public.companion_v3_api_enqueue_warm_turn(
+          ${ids.org}::uuid,${ids.companion}::uuid,${messageId}::uuid,
+          'reject a partial terminal fallback')`;
+      turnId = rows[0]!.turn.id;
+    });
+
+    await expect(ownerSql`
+      update public.companion_v3_turns set
+        terminal_assistant_fallback_cursor=1,
+        terminal_assistant_fallback_content='partial',
+        terminal_assistant_fallback_admitted_at=clock_timestamp()
+      where org_id=${ids.org}::uuid and companion_id=${ids.companion}::uuid
+        and id=${turnId}::uuid
+    `).rejects.toMatchObject({ code: "23514" });
+  });
+
+  it.each(["main", "background"] as const)(
+    "retains and idempotently promotes a cross-page terminal fallback for the %s lane",
+    async (lane) => {
+      const invocationId = `invocation-terminal-fallback-${lane}`;
+      const messageId = randomUUID();
+      await seedPreparedV3(invocationId);
+      let turnId = "";
+      if (lane === "main") {
+        await asApi(async (sql) => {
+          const rows = await sql<Array<{ turn: { id: string } }>>`
+            select turn from public.companion_v3_api_enqueue_warm_turn(
+              ${ids.org}::uuid,${ids.companion}::uuid,${messageId}::uuid,
+              'recover the documented terminal answer')`;
+          turnId = rows[0]!.turn.id;
+        });
+      } else {
+        const eventId = `msg:${messageId}`;
+        await ownerSql`insert into public.companion_threads(org_id,companion_id)
+          values(${ids.org}::uuid,${ids.companion}::uuid) on conflict do nothing`;
+        await ownerSql`with advanced as (
+          update public.companion_threads set next_ordinal=next_ordinal+1,
+            projection_sequence=projection_sequence+1,updated_at=clock_timestamp()
+          where org_id=${ids.org}::uuid and companion_id=${ids.companion}::uuid
+          returning next_ordinal-1 as ordinal,projection_sequence
+        ) insert into public.companion_transcript_entries(
+          org_id,companion_id,event_id,ordinal,projection_sequence,role,content,author_id)
+        select ${ids.org}::uuid,${ids.companion}::uuid,${eventId},ordinal,projection_sequence,
+          'user','recover the routine terminal answer',${ids.owner} from advanced`;
+        const admitted = await ownerSql<Array<{ turnId: string }>>`
+          select turn_id as "turnId" from public.companion_v3_admit_turn(
+            ${ids.org}::uuid,${ids.companion}::uuid,${messageId}::uuid,${eventId},
+            ${ids.owner},'background')`;
+        turnId = admitted[0]!.turnId;
+        await seedBackgroundRun(turnId, "Terminal fallback fixture");
+      }
+
+      const convergence = lane === "main"
+        ? createRuntimeV3PostgresWarmConvergence(runtimeSql, { enabledLanes: new Set(["main"]) })
+        : createRuntimeV3PostgresRoutineConvergence(runtimeSql);
+      const persistence = lane === "main"
+        ? createRuntimeV3PostgresWarmTurnPersistence(runtimeSql)
+        : createRuntimeV3PostgresRoutineTurnPersistence(runtimeSql);
+      const claim = await convergence.claimLane({
+        executorId: `runtime-terminal-fallback-${lane}`, lane,
+      });
+      expect(claim?.turn.id).toBe(turnId);
+      const material = await persistence.authorize(claim!);
+      expect(material).not.toBeNull();
+      await expect(persistence.beginAdmission(claim!, {
+        invocationId: material!.piInvocationId, cursor: 0n,
+      })).resolves.toBe(true);
+      await expect(persistence.recordAdmission(claim!, {
+        invocationId: material!.piInvocationId, responseTurnId: turnId, cursor: 0n,
+      })).resolves.toBe(true);
+
+      const candidatePage = {
+        throughCursor: 2n,
+        assistant: [],
+        assistantFallbacks: [
+          { sequence: 1n, source: "turn_end" as const, content: `turn fallback ${lane}` },
+          { sequence: 2n, source: "agent_end" as const, content: `agent fallback ${lane}` },
+        ],
+        privateEntries: lane === "background" ? [] : undefined,
+        decisions: [],
+        routineReturns: [],
+        needsInput: false,
+        settled: false,
+        processExited: false,
+        activity: true,
+      };
+      const fallbackJson = runtimeSql.json(candidatePage.assistantFallbacks.map((fallback) => ({
+        ...fallback, sequence: fallback.sequence.toString(),
+      })));
+      for (let replay = 0; replay < 2; replay += 1) {
+        await expect(runtimeSql<Array<{ recorded: boolean }>>`
+          select public.companion_v3_runtime_record_native_fallback_v8(
+            ${claim!.orgId}::uuid,${claim!.companionId}::uuid,${lane},${turnId}::uuid,
+            ${claim!.fence.token}::uuid,${claim!.fence.epoch.toString()}::bigint,
+            ${claim!.fence.gateEpoch.toString()}::bigint,${fallbackJson}::jsonb,8) as recorded`
+        ).resolves.toEqual([{ recorded: true }]);
+      }
+      await expect(persistence.project(claim!, candidatePage)).resolves.toBe(true);
+      await expect(convergence.completeProgression(claim!, { kind: "release" }))
+        .resolves.toBe(true);
+
+      const takeover = await convergence.claimLane({
+        executorId: `runtime-terminal-fallback-takeover-${lane}`, lane,
+      });
+      expect(takeover?.turn.id).toBe(turnId);
+      await expect(persistence.project(takeover!, {
+        throughCursor: 3n,
+        assistant: [],
+        privateEntries: lane === "background" ? [] : undefined,
+        decisions: [],
+        routineReturns: [],
+        needsInput: false,
+        settled: true,
+        processExited: false,
+        activity: false,
+      })).resolves.toBe("succeeded");
+      await expect(convergence.completeProgression(takeover!, { kind: "ack_completed" }))
+        .resolves.toBe(true);
+
+      const result = lane === "main"
+        ? await ownerSql<Array<{ content: string }>>`
+          select content from public.companion_transcript_entries
+          where org_id=${ids.org}::uuid and companion_id=${ids.companion}::uuid
+            and role='assistant' and event_id like ${`v3:${turnId}:%`}`
+        : await ownerSql<Array<{ content: string }>>`
+          select content from public.companion_v3_routine_run_entries
+          where org_id=${ids.org}::uuid and companion_id=${ids.companion}::uuid
+            and run_id=${turnId}::uuid and role='assistant'`;
+      expect(result).toEqual([{ content: `turn fallback ${lane}` }]);
+    },
+  );
+
+  it("never duplicates the primary message_end result with a terminal-envelope copy", async () => {
+    const invocationId = "invocation-primary-terminal-copy";
+    const messageId = randomUUID();
+    await seedPreparedV3(invocationId);
+    let turnId = "";
+    await asApi(async (sql) => {
+      const rows = await sql<Array<{ turn: { id: string } }>>`
+        select turn from public.companion_v3_api_enqueue_warm_turn(
+          ${ids.org}::uuid,${ids.companion}::uuid,${messageId}::uuid,'keep the primary answer')`;
+      turnId = rows[0]!.turn.id;
+    });
+    const convergence = createRuntimeV3PostgresWarmConvergence(runtimeSql, {
+      enabledLanes: new Set(["main"]),
+    });
+    const persistence = createRuntimeV3PostgresWarmTurnPersistence(runtimeSql);
+    const claim = await convergence.claimLane({ executorId: "runtime-primary-copy", lane: "main" });
+    const material = await persistence.authorize(claim!);
+    await persistence.beginAdmission(claim!, { invocationId: material!.piInvocationId, cursor: 0n });
+    await persistence.recordAdmission(claim!, {
+      invocationId: material!.piInvocationId, responseTurnId: turnId, cursor: 0n,
+    });
+
+    await expect(persistence.project(claim!, {
+      throughCursor: 3n,
+      assistant: [{ eventId: `v3:${turnId}:1`, content: "Primary answer" }],
+      assistantFallbacks: [
+        { sequence: 2n, source: "turn_end", content: "Copied answer" },
+      ],
+      decisions: [],
+      needsInput: false,
+      settled: true,
+      processExited: false,
+      activity: true,
+    })).resolves.toBe("succeeded");
+    await convergence.completeProgression(claim!, { kind: "ack_completed" });
+
+    const assistant = await ownerSql<Array<{ content: string }>>`
+      select content from public.companion_transcript_entries
+      where org_id=${ids.org}::uuid and companion_id=${ids.companion}::uuid
+        and role='assistant' and event_id like ${`v3:${turnId}:%`}`;
+    expect(assistant).toEqual([{ content: "Primary answer" }]);
+  });
+
   it("queues the shared Pi-only Restart while cold and joins the resulting Runtime v3 repair", async () => {
     await seedPreparedV3("invocation-manual-restart");
     // A staged, not-yet-prepared instance is cold. Advanced recovery must remain requestable and

--- a/apps/web/src/components/assistant-ui/thread.tsx
+++ b/apps/web/src/components/assistant-ui/thread.tsx
@@ -63,6 +63,8 @@ export type ThreadComponents = {
   UserMessageFrame?: ComponentType<{ children: ReactNode }> | undefined;
   /** Rendered around a Companion turn, for the same reason. */
   AssistantMessageFrame?: ComponentType<{ children: ReactNode }> | undefined;
+  /** Rendered around a control-plane note when the owning surface offers a recovery action. */
+  SystemMessageFrame?: ComponentType<{ children: ReactNode }> | undefined;
   /** Tool UIs by name. An unregistered tool name renders nothing — see `AssistantMessage`. */
   tools?: Record<string, ToolCallMessagePartComponent | undefined> | undefined;
 };
@@ -242,12 +244,17 @@ const UserMessage: FC = () => {
  * nothing to show. It stays a quiet line rather than an error banner, because the conversation
  * continues around it.
  */
-const SystemMessage: FC = () => (
-  <MessagePrimitive.Root
-    data-slot="aui_system-message-root"
-    data-role="system"
-    className="text-muted-foreground text-center text-xs"
-  >
-    <MessagePrimitive.Parts />
-  </MessagePrimitive.Root>
-);
+const SystemMessage: FC = () => {
+  const { SystemMessageFrame: Frame = Passthrough } = useContext(ThreadComponentsContext);
+  return (
+    <MessagePrimitive.Root
+      data-slot="aui_system-message-root"
+      data-role="system"
+      className="text-muted-foreground text-center text-xs"
+    >
+      <Frame>
+        <MessagePrimitive.Parts />
+      </Frame>
+    </MessagePrimitive.Root>
+  );
+};

--- a/apps/web/src/components/companions/CompanionSettings.client.test.ts
+++ b/apps/web/src/components/companions/CompanionSettings.client.test.ts
@@ -197,11 +197,46 @@ describe("CompanionSettings", () => {
 
   afterEach(async () => {
     vi.useRealTimers();
+    window.location.hash = "";
     while (roots.length) {
       const root = roots.pop();
       await act(async () => root?.unmount());
     }
     document.body.replaceChildren();
+  });
+
+  it("focuses the existing model picker when opened from a terminal model error", async () => {
+    window.location.hash = "#companion-model";
+    const { container } = await mount(companion("editor"));
+    const selected = container.querySelector<HTMLInputElement>(
+      'input[name="companion-settings-model"]:checked',
+    );
+
+    expect(selected).not.toBeNull();
+    expect(document.activeElement).toBe(selected);
+    expect(container.querySelector("form")?.getAttribute("aria-busy")).toBeNull();
+  });
+
+  it("announces model-save loading and failure from the existing settings flow", async () => {
+    let rejectSave: (cause: Error) => void = () => undefined;
+    companionApi.updateCompanion.mockReturnValue(new Promise((_resolve, reject) => {
+      rejectSave = reject;
+    }));
+    const { container } = await mount(companion("editor"));
+    const form = container.querySelector("form")!;
+    const sonnet = form.querySelector<HTMLInputElement>('input[value="claude-sonnet-4-6"]')!;
+
+    await act(async () => sonnet.click());
+    act(() => form.dispatchEvent(new Event("submit", { bubbles: true, cancelable: true })));
+
+    expect(form.getAttribute("aria-busy")).toBe("true");
+    expect(button(container, "Saving...").disabled).toBe(true);
+
+    await act(async () => rejectSave(new Error("Model settings could not be saved.")));
+    expect(container.querySelector("[role='alert']")?.textContent).toContain(
+      "Model settings could not be saved.",
+    );
+    expect(form.getAttribute("aria-busy")).toBeNull();
   });
 
   it("persists editable settings while preserving Owner-only deletion", async () => {

--- a/apps/web/src/components/companions/CompanionSettings.tsx
+++ b/apps/web/src/components/companions/CompanionSettings.tsx
@@ -76,6 +76,7 @@ export function CompanionSettings({
   // an apply is in flight on an awake Box a short poll keeps it moving without waking anything.
   const [latest, setLatest] = useState(companion);
   const syncReadRef = useRef(0);
+  const modelPickerRef = useRef<HTMLDivElement>(null);
   const deleteRequestIdRef = useRef<string | null>(null);
   const restartRequestIdRef = useRef<string | null>(null);
   const onSavedRef = useRef(onSaved);
@@ -98,6 +99,15 @@ export function CompanionSettings({
   useEffect(() => {
     setLatest(companion);
   }, [companion]);
+
+  // A terminal model-error CTA lands here after provider settings load. Put keyboard focus on the
+  // current model so the destination is immediate and the existing save flow remains unchanged.
+  useEffect(() => {
+    if (window.location.hash !== "#companion-model") return;
+    modelPickerRef.current
+      ?.querySelector<HTMLInputElement>('input[name="companion-settings-model"]:checked')
+      ?.focus();
+  }, []);
 
   const restartActive = runtimeSnapshot.lifecycle_intent === "recycle_pi";
   const deletionActive = runtimeSnapshot.lifecycle_intent === "delete";
@@ -349,7 +359,11 @@ export function CompanionSettings({
           </div>
         )}
 
-        <form className="companions-settings__form" onSubmit={submit}>
+        <form
+          className="companions-settings__form"
+          aria-busy={busy || undefined}
+          onSubmit={submit}
+        >
           {/* The face leads the form, exactly where the creation dialog put it. */}
           {canEdit && (
             <CompanionIconPicker
@@ -395,19 +409,21 @@ export function CompanionSettings({
             Applied after the active turn settles and before the next turn starts.
           </p>
 
-          <CompanionProviderModelPicker
-            providers={providers}
-            providerId={providerId}
-            modelId={modelId}
-            namePrefix="companion-settings"
-            descriptionId="companion-provider-hint"
-            disabled={!canEdit || busy || deletionActive}
-            onChange={(selection) => {
-              setProviderId(selection.providerId);
-              setModelId(selection.modelId);
-              setSaved(false);
-            }}
-          />
+          <div id="companion-model" ref={modelPickerRef}>
+            <CompanionProviderModelPicker
+              providers={providers}
+              providerId={providerId}
+              modelId={modelId}
+              namePrefix="companion-settings"
+              descriptionId="companion-provider-hint"
+              disabled={!canEdit || busy || deletionActive}
+              onChange={(selection) => {
+                setProviderId(selection.providerId);
+                setModelId(selection.modelId);
+                setSaved(false);
+              }}
+            />
+          </div>
           <p className="companions-settings__hint" id="companion-provider-hint">
             Provider, model, skills, and plugin changes are applied in order between turns.
           </p>

--- a/apps/web/src/components/companions/CompanionThread.tsx
+++ b/apps/web/src/components/companions/CompanionThread.tsx
@@ -111,6 +111,7 @@ export function CompanionThread({
   onBack,
   onSend,
   onSettings,
+  onChangeModel = null,
   onThread,
   onDesktop,
   onCancelTurn,
@@ -153,6 +154,8 @@ export function CompanionThread({
   onSend: (content: string, clientMessageId: string, files: readonly File[]) => Promise<boolean>;
   /** Null for a Viewer: read-only settings remain available from the workspace list, not the thread. */
   onSettings: (() => void) | null;
+  /** Opens settings at the existing model picker without sending or replaying a turn. */
+  onChangeModel?: (() => void) | null;
   onThread: (thread: Thread) => void;
   onDesktop: () => void;
   /** Stop an active turn or remove a queued follow-up. */
@@ -439,6 +442,7 @@ export function CompanionThread({
           onStop={onCancelTurn}
           onCancelQueued={onCancelTurn}
           onOpenRoutineRun={openRoutineRun}
+          onChangeModel={onChangeModel ?? undefined}
           onThread={onThread}
         />
         {showContext && overlay && (

--- a/apps/web/src/components/companions/CompanionTranscript.client.test.ts
+++ b/apps/web/src/components/companions/CompanionTranscript.client.test.ts
@@ -187,6 +187,7 @@ function mount(
     onStop?: (turnId: string) => Promise<void>;
     onCancelQueued?: (turnId: string) => Promise<void>;
     onOpenRoutineRun?: (routine: NonNullable<CompanionTranscriptEntry["routine"]>) => void;
+    onChangeModel?: () => void;
   } = {},
 ) {
   const container = document.createElement("div");
@@ -206,6 +207,7 @@ function mount(
       onStop: extras.onStop,
       onCancelQueued: extras.onCancelQueued,
       onOpenRoutineRun: extras.onOpenRoutineRun,
+      onChangeModel: extras.onChangeModel,
       onThread: (next: Thread) => threads.push(next),
     }));
   });
@@ -280,6 +282,35 @@ beforeEach(() => {
 afterEach(() => {
   act(() => roots.splice(0).forEach((root) => root.unmount()));
   document.body.innerHTML = "";
+});
+
+describe("terminal model errors", () => {
+  it("offers the existing model-settings flow without sending or replaying the prompt", () => {
+    const onSend = vi.fn(async () => true);
+    const onChangeModel = vi.fn();
+    const container = mount(thread([
+      entry({
+        event_id: "v3:22222222-2222-4222-8222-222222222222:error:17",
+        role: "system",
+        content: "The selected model is unavailable. Choose a different model and try again.",
+      }),
+    ]), undefined, onSend, { onChangeModel });
+
+    const action = buttonNamed(container, "Change model");
+    expect(action).toBeDefined();
+    click(action!);
+
+    expect(onChangeModel).toHaveBeenCalledOnce();
+    expect(onSend).not.toHaveBeenCalled();
+  });
+
+  it("does not attach the model action to unrelated system notes", () => {
+    const container = mount(thread([
+      entry({ event_id: "v3:turn:error:18", role: "system", content: "Turn cancelled." }),
+    ]), undefined, undefined, { onChangeModel: vi.fn() });
+
+    expect(buttonNamed(container, "Change model")).toBeUndefined();
+  });
 });
 
 describe("a Companion turn's reasoning", () => {

--- a/apps/web/src/components/companions/CompanionTranscript.tsx
+++ b/apps/web/src/components/companions/CompanionTranscript.tsx
@@ -59,6 +59,7 @@ import {
   COMPANION_TOOL_NAME,
   attachmentsOf,
   groupTranscriptEntries,
+  isModelUnavailableMessage,
   toThreadMessageLike,
   useStableEntries,
   useStableGroups,
@@ -125,6 +126,8 @@ interface TranscriptChrome {
   expandedRoutineNotifyGroups: ReadonlySet<string>;
   onToggleRoutineNotifyGroup: (eventId: string) => void;
   dequeueingTurnId: string | null;
+  /** Opens the existing settings model picker; it never sends or replays a turn. */
+  onChangeModel?: () => void;
 }
 
 const ChromeContext = createContext<TranscriptChrome | null>(null);
@@ -397,6 +400,25 @@ function UserFrame({ children }: { children: ReactNode }) {
   );
 }
 
+/** Keep the terminal note in the thread and put its one safe recovery action beside it. */
+function SystemFrame({ children }: { children: ReactNode }) {
+  const message = useTranscriptMessage();
+  const { onChangeModel } = useChrome();
+  if (!isModelUnavailableMessage(message) || !onChangeModel) return <>{children}</>;
+  return (
+    <div className="flex flex-col items-center gap-2">
+      <div>{children}</div>
+      <button
+        type="button"
+        className="cds-btn cds-btn--secondary cds-btn--sm"
+        onClick={onChangeModel}
+      >
+        Change model
+      </button>
+    </div>
+  );
+}
+
 /**
  * An upload can run for up to two minutes, and the only sighted cue is a dimmed bubble. `aria-busy`
  * marks the region as changing; it does not announce anything. A text send acknowledges in under a
@@ -472,6 +494,7 @@ const THREAD_COMPONENTS = {
   Footer,
   UserMessageFrame: UserFrame,
   AssistantMessageFrame: AssistantFrame,
+  SystemMessageFrame: SystemFrame,
   tools: TOOL_UIS,
 };
 
@@ -548,6 +571,7 @@ export function CompanionTranscript({
   onStop,
   onCancelQueued,
   onOpenRoutineRun,
+  onChangeModel,
   onThread,
 }: {
   companion: Companion;
@@ -574,6 +598,8 @@ export function CompanionTranscript({
   onCancelQueued?: (turnId: string) => Promise<void>;
   /** Open the private history associated with a routine-origin marker. */
   onOpenRoutineRun?: (routine: NonNullable<CompanionTranscriptEntry["routine"]>) => void;
+  /** Open the existing settings flow directly at its model picker. */
+  onChangeModel?: () => void;
   /** Replace the thread after a permission card is decided, without a full poll cycle. */
   onThread: (thread: Thread) => void;
 }) {
@@ -869,6 +895,7 @@ export function CompanionTranscript({
     expandedRoutineNotifyGroups,
     onToggleRoutineNotifyGroup: toggleRoutineNotifyGroup,
     dequeueingTurnId,
+    onChangeModel,
   }), [
     attachmentError,
     attachments,
@@ -887,6 +914,7 @@ export function CompanionTranscript({
     onAttach,
     onRemoveAttachment,
     onOpenRoutineRun,
+    onChangeModel,
     onLoadOlderMessages,
     onStop,
     replying,

--- a/apps/web/src/components/companions/CompanionsApp.list.client.test.ts
+++ b/apps/web/src/components/companions/CompanionsApp.list.client.test.ts
@@ -885,6 +885,38 @@ describe("CompanionsApp conversation list", () => {
     expect(row(container).querySelector(".cmprow__unread")).toBeNull();
   });
 
+  it("opens the existing model picker from a terminal model error without replaying chat", async () => {
+    companionsApi.getCompanionThread.mockResolvedValue(thread({
+      entries: [{
+        event_id: "v3:22222222-2222-4222-8222-222222222222:error:17",
+        ordinal: 0,
+        role: "system",
+        content: "The selected model is unavailable. Choose a different model and try again.",
+        author_id: null,
+        author_name: null,
+        tool: null,
+        decision: null,
+        attachments: [],
+        reasoning: null,
+        routine: null,
+        trigger: null,
+        turn_id: null,
+        queued: false,
+        created_at: "2026-08-14T09:05:00.000Z",
+      }],
+    }));
+    const container = await render([companion()], companionId);
+
+    const changeModel = [...container.querySelectorAll("button")]
+      .find((button) => button.textContent?.trim() === "Change model") as HTMLButtonElement;
+    await act(async () => changeModel.click());
+
+    expect(routerPush).toHaveBeenCalledWith(
+      `/companions/${companionId}/settings#companion-model`,
+    );
+    expect(companionsApi.sendCompanionMessage).not.toHaveBeenCalled();
+  });
+
   it("keeps a preview a runtime read did not answer with", async () => {
     // Runtime reads that update lifecycle state may report `last_message: null`; replacing the row
     // wholesale would blank the line the sidebar is showing.

--- a/apps/web/src/components/companions/CompanionsApp.tsx
+++ b/apps/web/src/components/companions/CompanionsApp.tsx
@@ -1421,6 +1421,9 @@ export function CompanionsApp({
               onSettings={opened.access === "viewer"
                 ? null
                 : () => router.push(`/companions/${opened.id}/settings`)}
+              onChangeModel={opened.access === "viewer"
+                ? null
+                : () => router.push(`/companions/${opened.id}/settings#companion-model`)}
               onThread={acceptThreadProjection}
               onDesktop={() => void onDesktop()}
               onCancelTurn={onCancelTurn}

--- a/apps/web/src/components/companions/transcriptMessages.test.ts
+++ b/apps/web/src/components/companions/transcriptMessages.test.ts
@@ -230,6 +230,22 @@ describe("grouping a transcript into messages", () => {
 });
 
 describe("converting a message for the thread", () => {
+  it("renders the stable terminal model error as an in-thread system note", () => {
+    const groups = groupTranscriptEntries([entry({
+      event_id: "v3:turn:error:17",
+      role: "system",
+      content: "The selected model is unavailable. Choose a different model and try again.",
+    })], context);
+    expect(groups[0]?.displayContent).toBe(
+      "The selected model is unavailable. Choose a different model and try again.",
+    );
+    expect(rendered(groups.flatMap((group) => group.entries))).toEqual([{
+      id: "v3:turn:error:17",
+      role: "system",
+      parts: ["text:The selected model is unavailable. Choose a different model and try again."],
+    }]);
+  });
+
   it("puts reasoning before the reply it produced", () => {
     const [message] = rendered([entry({ reasoning: "checked the logs", content: "Two timed out." })]);
 

--- a/apps/web/src/components/companions/transcriptMessages.ts
+++ b/apps/web/src/components/companions/transcriptMessages.ts
@@ -25,6 +25,10 @@ import { transcriptAuthor, transcriptDisplayContent, utcDay } from "./transcript
 export const COMPANION_TOOL_NAME = "companion_tool";
 export const COMPANION_DECISION_TOOL_NAME = "companion_decision";
 
+/** Product-owned copy for an expurgated terminal model failure. No provider detail reaches here. */
+export const MODEL_UNAVAILABLE_MESSAGE =
+  "The selected model is unavailable. Choose a different model and try again.";
+
 /**
  * How long a writer keeps the floor. Consecutive messages from the same writer inside this window
  * read as one passage, so the transcript names the writer and the clock once per passage instead of
@@ -70,6 +74,11 @@ export interface TranscriptMessage {
   startsNew: boolean;
   /** The entries this message was built from, in transcript order. */
   entries: readonly CompanionTranscriptEntry[];
+}
+
+/** A system note that can offer the existing settings model picker as its recovery action. */
+export function isModelUnavailableMessage(message: TranscriptMessage | undefined): boolean {
+  return message?.role === "system" && message.displayContent === MODEL_UNAVAILABLE_MESSAGE;
 }
 
 export interface TranscriptGroupingContext {

--- a/docs/companions-runtime.md
+++ b/docs/companions-runtime.md
@@ -474,6 +474,9 @@ Runtime bakes the current image marker into a throwaway baker Box (never a tenan
 creates new generation Boxes with `from` that snapshot so the first send skips the five-minute
 package install. The baker Box is created with the five-minute unnamed-orphan TTL, then patched to
 one hour so layout and snapshot can finish; each attempt has a strict 40-minute outer budget.
+Its id is checkpointed before the first follow-up command. A provider HTTP `409` from that first
+layout command is treated as a transient post-create readiness race only in this image-bake path,
+with bounded 1/2/5/10/30-second backoff fenced by cancellation and the same outer attempt deadline.
 Before publishing, it writes a `.boxignore` that excludes only regenerable logs, transient staging
 archives, credentials, attachments, and outbox data; embeds the static Companion-skill archive;
 archives and resumes the baker Box; warms Node/Pi; and requires a stable `.ascii/playbook.json`. A
@@ -1002,6 +1005,16 @@ before Pi executes that tool batch. Runtime records the tool lifecycle separatel
 assistant event from the chat projection. Only the later assistant message without a tool call is
 shown as the answer, so the thread never exposes pre-tool narration while tool and decision cards
 remain visible and durable.
+
+An assistant `message_end` without a tool call remains the primary final-result shape. Runtime also
+recognizes Pi's documented terminal copies: at `agent_settled`, and only if no primary assistant was
+already projected, it promotes `turn_end.message` or otherwise the final usable assistant in
+`agent_end.messages`. User messages, tool messages, and assistant tool-call narration are never
+eligible. The redacted candidate is checkpointed on the Turn before its journal page is
+acknowledged, because a later page may contain `agent_settled` after executor takeover. Re-reading
+the page is idempotent. Main turns project the candidate into the shared transcript; background
+routine turns project it into their private run transcript. If no usable result exists, the main
+turn still settles visibly as `pi_result_missing`; `agent_settled` remains the sole quiescence proof.
 
 **Outputs.** The layout-14 broker creates and empties `~/outbox` when it binds a new response root,
 immediately before prompt delivery; native steers never erase output already produced by that

--- a/docs/companions-runtime.md
+++ b/docs/companions-runtime.md
@@ -1015,6 +1015,13 @@ acknowledged, because a later page may contain `agent_settled` after executor ta
 the page is idempotent. Main turns project the candidate into the shared transcript; background
 routine turns project it into their private run transcript. If no usable result exists, the main
 turn still settles visibly as `pi_result_missing`; `agent_settled` remains the sole quiescence proof.
+When the terminal assistant envelopes instead prove a model error with no usable text, or Pi reports
+an exhausted automatic retry, runtime stores only a cursor—not the provider error—and settles with
+`model_unavailable`, the `switch_model` action, and a product-owned system note. Main turns show the
+note in chat and background turns keep it in their private run transcript. Runtime does not replay
+the prompt or select a different model. An editable main thread offers a direct **Change model**
+action on that note; it opens and focuses the existing settings picker, whose ordinary save path
+applies the change between turns without holding the chat queue.
 
 **Outputs.** The layout-14 broker creates and empties `~/outbox` when it binds a new response root,
 immediately before prompt delivery; native steers never erase output already produced by that

--- a/docs/design.md
+++ b/docs/design.md
@@ -448,6 +448,12 @@ and `agent_end.messages` envelopes are retained only as redacted, bounded fallba
 promoted at `agent_settled` only when no primary assistant result exists. The candidate checkpoint
 lives on the Turn because acknowledged journal pages may be separated from `agent_settled` by an
 executor takeover. The same rule feeds main transcripts and private background routine entries.
+Terminal assistant errors and exhausted Pi automatic retries use a separate cursor-only checkpoint:
+raw provider text never enters PostgreSQL. At `agent_settled`, and only when neither primary nor
+fallback assistant text exists, the terminal projector writes the stable `model_unavailable` /
+`switch_model` outcome and an in-thread system note atomically. It never replays the prompt or
+changes the selected model. On an editable web thread the note links directly to the existing
+settings model picker; loading, save, and failure stay in that settings flow and never gate chat.
 
 The routine cutover extends this broker layout without adding a second harness or runtime owner. A
 routine-origin turn is serialized by the Companion's `background` PostgreSQL lease while the `main`

--- a/docs/design.md
+++ b/docs/design.md
@@ -360,6 +360,9 @@ Lifecycle and broker-observation calls that are known idempotent retry network, 
 failures up to five times with jittered 1/2/5/10/30-second backoff. Observation-only broker state
 and journal reads also retry `409` while the provider is temporarily transitioning the Box. Every
 claim revalidates the lease before Box contact. Prompt and decision writes never use this path.
+The throwaway image baker has one additional, local readiness exception: after it checkpoints a
+new baker Box id, the first layout command retries provider HTTP `409` with bounded exponential
+backoff inside the existing build-attempt deadline. Tenant Companion commands remain unchanged.
 When the direct hosted-agent endpoint fails, runtime stays on the safe exec fallback and re-probes
 only through broker state with bounded exponential backoff. Reading the same durable endpoint on a
 later claim preserves that suspect state; only a newer staging observation or a successful probe
@@ -439,6 +442,12 @@ Layout 14 installs a small Node broker under systemd between runtime commands an
   exit separately;
 - malformed or oversized lines advance without persisting their raw content;
 - unknown event types are counted and ignored rather than treated as user-fatal errors.
+
+Assistant `message_end` remains the primary result projection. Pi's documented `turn_end.message`
+and `agent_end.messages` envelopes are retained only as redacted, bounded fallback candidates and
+promoted at `agent_settled` only when no primary assistant result exists. The candidate checkpoint
+lives on the Turn because acknowledged journal pages may be separated from `agent_settled` by an
+executor takeover. The same rule feeds main transcripts and private background routine entries.
 
 The routine cutover extends this broker layout without adding a second harness or runtime owner. A
 routine-origin turn is serialized by the Companion's `background` PostgreSQL lease while the `main`

--- a/packages/box-runtime/src/companionRuntimeBaker.test.ts
+++ b/packages/box-runtime/src/companionRuntimeBaker.test.ts
@@ -2,6 +2,7 @@
 import { describe, expect, it, vi } from "vitest";
 
 import { BoxRuntimeAdapterError, type BoxRuntimeLifecycleClient } from "./boxMaintenanceClient";
+import { BoxRuntimeProviderError } from "./boxCompanionRuntime";
 import {
   bakeCompanionRuntimeImageOnce,
   deleteCompanionRuntimeBakerBox,
@@ -64,6 +65,10 @@ const bundledSkill = {
   checksum: `sha256:${"1".repeat(64)}`,
   archive: Buffer.from("bundled"),
 };
+
+function providerError(status: number): BoxRuntimeProviderError {
+  return new BoxRuntimeProviderError("The Box command was not ready", status);
+}
 
 describe("bakeCompanionRuntimeImageOnce", () => {
   it("reuses a ready named snapshot without creating a baker Box", async () => {
@@ -167,6 +172,151 @@ describe("bakeCompanionRuntimeImageOnce", () => {
     const cleanupInput = vi.mocked(client.deletePermanentlyAndWait).mock.calls[0]?.[0];
     expect(cleanupInput?.signal).not.toBe(attemptController.signal);
     expect(cleanupInput?.signal?.aborted).toBe(false);
+  });
+
+  it("checkpoints the created Box before any follow-up lifecycle or command work", async () => {
+    const events: string[] = [];
+    const getNamedSnapshot = vi.fn()
+      .mockImplementationOnce(async () => null)
+      .mockResolvedValue(snapshot(identity.imageName));
+    const client = lifecycle({
+      getNamedSnapshot,
+      createEphemeralBox: vi.fn(async () => {
+        events.push("created");
+        return { boxId: "bx_23456789" };
+      }),
+    });
+    const onBoxCreated = vi.fn(async () => {
+      events.push("checkpointed");
+    });
+    const refreshTtl = vi.fn(async () => {
+      events.push("ttl");
+    });
+    const existingBoxStatus = vi.fn(async () => {
+      events.push("status");
+      return { boxId: "bx_23456789", state: "ready" as const };
+    });
+    const refreshPiLayout = vi.fn(async () => {
+      events.push("layout");
+      return { boxId: "bx_23456789", applied: "base" as const };
+    });
+
+    await expect(bakeCompanionRuntimeImageOnce({
+      identity,
+      lifecycle: client,
+      runtime: runtime({ existingBoxStatus, refreshTtl, refreshPiLayout }),
+      onBoxCreated,
+      signal: new AbortController().signal,
+    })).resolves.toMatchObject({ ready: true, baked: true });
+
+    expect(events.slice(0, 5)).toEqual([
+      "created",
+      "checkpointed",
+      "ttl",
+      "status",
+      "layout",
+    ]);
+    expect(onBoxCreated).toHaveBeenCalledWith({
+      boxId: "bx_23456789",
+      parentImageName: null,
+    });
+    expect(client.deletePermanentlyAndWait).toHaveBeenCalledWith(expect.objectContaining({
+      boxId: "bx_23456789",
+    }));
+  });
+
+  it("retries only an immediate post-create 409 with bounded exponential backoff", async () => {
+    const sleeps: number[] = [];
+    const getNamedSnapshot = vi.fn()
+      .mockImplementationOnce(async () => null)
+      .mockResolvedValue(snapshot(identity.imageName));
+    const refreshPiLayout = vi.fn()
+      .mockRejectedValueOnce(providerError(409))
+      .mockRejectedValueOnce(providerError(409))
+      .mockResolvedValue({ boxId: "bx_23456789", applied: "base" as const });
+
+    await expect(bakeCompanionRuntimeImageOnce({
+      identity,
+      lifecycle: lifecycle({ getNamedSnapshot }),
+      runtime: runtime({ refreshPiLayout }),
+      sleep: async (ms) => {
+        sleeps.push(ms);
+      },
+      signal: new AbortController().signal,
+    })).resolves.toEqual({
+      name: identity.imageName,
+      ready: true,
+      baked: true,
+      parentImageName: null,
+    });
+
+    expect(refreshPiLayout).toHaveBeenCalledTimes(3);
+    expect(sleeps).toEqual([1_000, 2_000]);
+  });
+
+  it("fails fast for a non-409 layout error and does not retry it", async () => {
+    const failure = providerError(500);
+    const sleep = vi.fn(async () => undefined);
+    const refreshPiLayout = vi.fn().mockRejectedValue(failure);
+
+    await expect(bakeCompanionRuntimeImageOnce({
+      identity,
+      lifecycle: lifecycle(),
+      runtime: runtime({ refreshPiLayout }),
+      sleep,
+      signal: new AbortController().signal,
+    })).rejects.toBe(failure);
+
+    expect(refreshPiLayout).toHaveBeenCalledOnce();
+    expect(sleep).not.toHaveBeenCalled();
+  });
+
+  it("stops readiness retries at the attempt deadline", async () => {
+    let clock = 0;
+    const sleeps: number[] = [];
+    const refreshPiLayout = vi.fn()
+      .mockRejectedValueOnce(providerError(409))
+      .mockRejectedValueOnce(providerError(409));
+
+    await expect(bakeCompanionRuntimeImageOnce({
+      identity,
+      lifecycle: lifecycle({
+        getNamedSnapshot: vi.fn()
+          .mockResolvedValueOnce(null)
+          .mockResolvedValue(snapshot(identity.imageName)),
+      }),
+      runtime: runtime({ refreshPiLayout }),
+      now: () => clock,
+      deadlineAt: 1_500,
+      sleep: async (ms) => {
+        sleeps.push(ms);
+        clock += ms;
+      },
+      signal: new AbortController().signal,
+    })).rejects.toMatchObject({ status: 409 });
+
+    expect(refreshPiLayout).toHaveBeenCalledTimes(2);
+    expect(sleeps).toEqual([1_000]);
+  });
+
+  it("cancels readiness backoff through the attempt signal", async () => {
+    const controller = new AbortController();
+    const refreshPiLayout = vi.fn().mockRejectedValue(providerError(409));
+    const sleep = vi.fn(async (_ms: number, signal: AbortSignal) => {
+      controller.abort(new Error("image bake cancelled"));
+      signal.throwIfAborted();
+    });
+
+    await expect(bakeCompanionRuntimeImageOnce({
+      identity,
+      lifecycle: lifecycle(),
+      runtime: runtime({ refreshPiLayout }),
+      sleep,
+      signal: controller.signal,
+    })).rejects.toThrow("image bake cancelled");
+
+    expect(refreshPiLayout).toHaveBeenCalledOnce();
+    expect(sleep).toHaveBeenCalledWith(1_000, controller.signal);
   });
 
   it("falls back to an empty baker Box when the parent snapshot disappeared", async () => {

--- a/packages/box-runtime/src/companionRuntimeBaker.ts
+++ b/packages/box-runtime/src/companionRuntimeBaker.ts
@@ -2,7 +2,10 @@
 import { COMPANION_BUDGETS_BASE } from "@companion/contracts";
 
 import { BoxRuntimeAdapterError, type BoxRuntimeLifecycleClient } from "./boxMaintenanceClient";
-import type { CompanionBoxRuntime } from "./boxCompanionRuntime";
+import {
+  BoxRuntimeProviderError,
+  type CompanionBoxRuntime,
+} from "./boxCompanionRuntime";
 import type { CompanionRuntimeSkill } from "./companionPiInjection";
 import {
   isCompanionRuntimeImageName,
@@ -18,6 +21,10 @@ const SNAPSHOT_POLL_INTERVAL_MS = 2_000;
 // the bake holds a durable registry lease, so waiting here is safe and cheaper than failing.
 const BOX_READY_TIMEOUT_MS = 900_000;
 const SNAPSHOT_READY_TIMEOUT_MS = 600_000;
+// A freshly provisioned/resumed Box can report a runnable lifecycle state before its command
+// endpoint accepts work. Keep this retry policy local to image baking: normal runtime commands must
+// retain their single-dispatch/explicit-failure semantics.
+const IMAGE_BAKE_READINESS_RETRY_DELAYS_MS = [1_000, 2_000, 5_000, 10_000, 30_000] as const;
 // `provisioned` is a bootable disk: staging installs layout over SSH, so a bake may proceed
 // without waiting for the provider's own boot handshake to reach its terminal ready state.
 const READY_STATES = new Set(["ready", "idle", "running", "provisioned"]);
@@ -38,6 +45,8 @@ export async function bakeCompanionRuntimeImageOnce(input: {
   now?: () => number;
   sleep?: (ms: number, signal: AbortSignal) => Promise<void>;
   signal: AbortSignal;
+  /** Absolute outer attempt deadline; the readiness retry never sleeps beyond it. */
+  deadlineAt?: number;
   /** Persists the provider Box identity immediately after create, before layout side effects. */
   onBoxCreated?: (input: { boxId: string; parentImageName: string | null }) => Promise<void>;
   /** Revalidates the builder epoch immediately before the bounded provider snapshot write. */
@@ -58,6 +67,7 @@ export async function bakeCompanionRuntimeImageOnce(input: {
     now: input.now ?? Date.now,
     sleep: input.sleep ?? defaultSleep,
     signal: input.signal,
+    deadlineAt: input.deadlineAt,
     onBoxCreated: input.onBoxCreated,
     onBeforeSnapshotPublish: input.onBeforeSnapshotPublish,
     onBoxDeletionIntentRecorded: input.onBoxDeletionIntentRecorded,
@@ -76,6 +86,7 @@ async function ensureImage(input: {
   now: () => number;
   sleep: (ms: number, signal: AbortSignal) => Promise<void>;
   signal: AbortSignal;
+  deadlineAt?: number;
   onBoxCreated?: (input: { boxId: string; parentImageName: string | null }) => Promise<void>;
   onBeforeSnapshotPublish?: (input: { boxId: string }) => Promise<void>;
   onBoxDeletionIntentRecorded?: (input: { boxId: string }) => Promise<void>;
@@ -102,29 +113,36 @@ async function ensureImage(input: {
   let boxId: string | null = null;
   try {
     const created = await createBakerBox(input, parent);
-    boxId = created.boxId;
-    await input.onBoxCreated?.({ boxId, parentImageName: created.parentImageName });
+    const bakerBoxId = created.boxId;
+    boxId = bakerBoxId;
+    await input.onBoxCreated?.({ boxId: bakerBoxId, parentImageName: created.parentImageName });
     await input.runtime.refreshTtl({
-      boxId,
+      boxId: bakerBoxId,
       ttlSeconds: BAKER_WORK_TTL_SECONDS,
       signal: input.signal,
     });
-    await waitBoxReady(input, boxId);
-    await input.runtime.refreshPiLayout({ boxId, signal: input.signal });
+    await waitBoxReady(input, bakerBoxId);
+    // The provider may expose `ready`/`provisioned` just before its command endpoint is usable.
+    // This is the only post-create command in the baker that receives this narrow 409 treatment;
+    // status, snapshot, cleanup, and ordinary Companion runtime paths remain fail-fast.
+    await retryImageBakeReadiness(input, () => input.runtime.refreshPiLayout({
+      boxId: bakerBoxId,
+      signal: input.signal,
+    }));
     if (input.bundledSkill) {
       if (!input.runtime.prepareRuntimeImage) {
         throw new Error("The runtime image warmup adapter is unavailable.");
       }
       await input.runtime.prepareRuntimeImage({
-        boxId,
+        boxId: bakerBoxId,
         bundledSkill: input.bundledSkill,
         signal: input.signal,
       });
     }
-    await input.onBeforeSnapshotPublish?.({ boxId });
+    await input.onBeforeSnapshotPublish?.({ boxId: bakerBoxId });
     try {
       await input.lifecycle.saveNamedSnapshot({
-        boxId,
+        boxId: bakerBoxId,
         name: input.identity.imageName,
         deadlineAt: input.now() + 30_000,
         signal: input.signal,
@@ -256,8 +274,9 @@ async function waitBoxReady(input: {
   sleep: (ms: number, signal: AbortSignal) => Promise<void>;
   now: () => number;
   signal: AbortSignal;
+  deadlineAt?: number;
 }, boxId: string): Promise<void> {
-  const deadline = input.now() + BOX_READY_TIMEOUT_MS;
+  const deadline = Math.min(input.deadlineAt ?? Number.POSITIVE_INFINITY, input.now() + BOX_READY_TIMEOUT_MS);
   while (input.now() < deadline) {
     input.signal.throwIfAborted();
     const observed = await input.runtime.existingBoxStatus({ boxId, signal: input.signal });
@@ -268,6 +287,49 @@ async function waitBoxReady(input: {
     await input.sleep(READY_POLL_INTERVAL_MS, input.signal);
   }
   throw new Error("The runtime image baker Box did not become ready before its deadline.");
+}
+
+/**
+ * Retry only the first layout command after the baker Box reports ready. Box command HTTP 409 is a
+ * transient provider readiness race here; every other status and every other baker operation keeps
+ * its original fail-fast behavior. The caller's signal and outer attempt deadline fence each retry.
+ */
+async function retryImageBakeReadiness<T>(
+  input: {
+    now: () => number;
+    sleep: (ms: number, signal: AbortSignal) => Promise<void>;
+    signal: AbortSignal;
+    deadlineAt?: number;
+  },
+  operation: () => Promise<T>,
+): Promise<T> {
+  const deadlineAt = input.deadlineAt ?? input.now() + BOX_READY_TIMEOUT_MS;
+  let lastError: unknown;
+  for (let attempt = 0; attempt <= IMAGE_BAKE_READINESS_RETRY_DELAYS_MS.length; attempt += 1) {
+    input.signal.throwIfAborted();
+    if (attempt > 0) {
+      const delayMs = IMAGE_BAKE_READINESS_RETRY_DELAYS_MS[attempt - 1]!;
+      const remainingMs = deadlineAt - input.now();
+      if (remainingMs <= delayMs) throw lastError;
+      await input.sleep(delayMs, input.signal);
+      input.signal.throwIfAborted();
+      if (input.now() >= deadlineAt) throw lastError;
+    }
+    try {
+      return await operation();
+    } catch (error) {
+      lastError = error;
+      if (!isTransientImageBakeReadinessError(error)
+        || attempt === IMAGE_BAKE_READINESS_RETRY_DELAYS_MS.length) {
+        throw error;
+      }
+    }
+  }
+  throw lastError ?? new Error("The runtime image baker readiness retry did not settle.");
+}
+
+function isTransientImageBakeReadinessError(error: unknown): boolean {
+  return error instanceof BoxRuntimeProviderError && error.status === 409;
 }
 
 async function waitNamedSnapshot(input: {

--- a/packages/companion-runtime/src/piEvents.test.ts
+++ b/packages/companion-runtime/src/piEvents.test.ts
@@ -532,6 +532,42 @@ describe("Pi journal validation and projection", () => {
     expect(classified.projections).toEqual([{ sequence: 2n, type: "settled" }]);
   });
 
+  it("expurgates a retried terminal model failure without inventing an assistant result", () => {
+    const providerError = "429 code 1311: current subscription plan does not include access to GLM-5.3-Highspeed";
+    const failedAssistant = {
+      role: "assistant",
+      content: [],
+      stopReason: "error",
+      errorMessage: providerError,
+    } satisfies Record<string, SnapshotValue>;
+    const events: Parameters<typeof classifyEvents>[0] = [];
+    for (let retry = 0; retry < 4; retry += 1) {
+      events.push(
+        { type: "message_start", message: failedAssistant },
+        { type: "message_end", message: failedAssistant },
+        { type: "turn_end", message: failedAssistant },
+        { type: "agent_end", messages: [failedAssistant], willRetry: true },
+      );
+    }
+    events.push(
+      { type: "auto_retry_end", success: false, finalError: providerError },
+      { type: "agent_settled" },
+    );
+
+    const classified = classifyEvents(events);
+
+    expect(classified.projections.filter((item) => item.type === "assistant")).toEqual([]);
+    expect(classified.assistantFallbacks).toEqual([]);
+    expect(classified.terminalError).toEqual({
+      sequence: 17n,
+      code: "model_unavailable",
+      message: "The selected model is unavailable. Choose a different model and try again.",
+      action: "switch_model",
+    });
+    expect(JSON.stringify(classified, bigintAwareReplacer)).not.toContain(providerError);
+    expect(classified.settled).toBe(true);
+  });
+
   it("redacts exact credentials from disclosed tool arguments and results", () => {
     const opaqueSecret = "mF9xOpaqueCredentialValue";
     const page = validatePiJournalRead({

--- a/packages/companion-runtime/src/piEvents.test.ts
+++ b/packages/companion-runtime/src/piEvents.test.ts
@@ -20,6 +20,27 @@ function bigintAwareReplacer(_key: string, value: SnapshotValue): SnapshotValue 
     : value;
 }
 
+function classifyEvents(events: Array<{ [key: string]: SnapshotValue }>, after = 0n) {
+  const rows = events.map((event, index) => ({
+    sequence: Number(after) + index + 1,
+    invocationId: PI_INVOCATION_ID,
+    attemptId: ATTEMPT_ID,
+    kind: "pi_event",
+    event,
+  }));
+  return classifyPiJournalPage(validatePiJournalRead({
+    value: {
+      events: rows,
+      nextCursor: Number(after) + rows.length,
+      acknowledgedCursor: Number(after),
+      hasMore: false,
+    },
+    after,
+    attemptId: ATTEMPT_ID,
+    invocationId: PI_INVOCATION_ID,
+  }));
+}
+
 describe("Pi journal validation and projection", () => {
   it("projects accepted compaction metadata and routine terminal calls without generic tool cards", () => {
     const page = validatePiJournalRead({
@@ -398,6 +419,117 @@ describe("Pi journal validation and projection", () => {
       expect.objectContaining({ type: "tool" }),
     ]));
     expect(JSON.stringify(projections, bigintAwareReplacer)).not.toContain("inspect that now");
+  });
+
+  it("keeps message_end primary while retaining documented terminal fallback candidates", () => {
+    const classified = classifyEvents([
+      {
+        type: "message_end",
+        message: { role: "assistant", content: [{ type: "text", text: "Primary answer" }] },
+      },
+      {
+        type: "turn_end",
+        message: { role: "assistant", content: [{ type: "text", text: "Turn copy" }] },
+      },
+      {
+        type: "agent_end",
+        messages: [{ role: "assistant", content: [{ type: "text", text: "Agent copy" }] }],
+      },
+      { type: "agent_settled" },
+    ]);
+
+    expect(classified.projections.filter((item) => item.type === "assistant")).toEqual([
+      expect.objectContaining({ content: "Primary answer" }),
+    ]);
+    expect(classified.assistantFallbacks).toEqual([
+      { sequence: 2n, source: "turn_end", content: "Turn copy" },
+      { sequence: 3n, source: "agent_end", content: "Agent copy" },
+    ]);
+    expect(classified.settled).toBe(true);
+  });
+
+  it("retains turn_end.message as the preferred usable terminal fallback", () => {
+    const classified = classifyEvents([
+      {
+        type: "turn_end",
+        message: { role: "assistant", content: [{ type: "text", text: "Recovered answer" }] },
+      },
+      { type: "agent_settled" },
+    ]);
+
+    expect(classified.assistantFallbacks).toEqual([
+      { sequence: 1n, source: "turn_end", content: "Recovered answer" },
+    ]);
+  });
+
+  it("retains only the final usable assistant from agent_end.messages", () => {
+    const classified = classifyEvents([
+      {
+        type: "agent_end",
+        messages: [
+          { role: "assistant", content: [{ type: "text", text: "Earlier answer" }] },
+          { role: "tool", content: [{ type: "text", text: "Tool narration" }] },
+          { role: "assistant", content: [{ type: "text", text: "Final answer" }] },
+        ],
+      },
+      { type: "agent_settled" },
+    ]);
+
+    expect(classified.assistantFallbacks).toEqual([
+      { sequence: 1n, source: "agent_end", content: "Final answer" },
+    ]);
+    expect(JSON.stringify(classified.assistantFallbacks, bigintAwareReplacer))
+      .not.toContain("Tool narration");
+  });
+
+  it("never retains user, tool-only, or assistant tool-call narration as a fallback", () => {
+    const classified = classifyEvents([
+      { type: "turn_end", message: { role: "user", content: "User copy" } },
+      {
+        type: "agent_end",
+        messages: [
+          { role: "tool", content: [{ type: "text", text: "Tool result" }] },
+          {
+            role: "assistant",
+            content: [
+              { type: "text", text: "I will call a tool" },
+              { type: "toolCall", name: "read", arguments: { path: "README.md" } },
+            ],
+          },
+        ],
+      },
+      { type: "agent_settled" },
+    ]);
+
+    expect(classified.assistantFallbacks).toEqual([]);
+    expect(classified.projections).toEqual([{ sequence: 3n, type: "settled" }]);
+  });
+
+  it("classifies terminal candidates deterministically across page boundaries and re-reads", () => {
+    const first = classifyEvents([{
+      type: "turn_end",
+      message: { role: "assistant", content: [{ type: "text", text: "Page one" }] },
+    }]);
+    const replayed = classifyEvents([{
+      type: "turn_end",
+      message: { role: "assistant", content: [{ type: "text", text: "Page one" }] },
+    }]);
+    const second = classifyEvents([{ type: "agent_settled" }], 1n);
+
+    expect(replayed.assistantFallbacks).toEqual(first.assistantFallbacks);
+    expect(first).toMatchObject({ throughCursor: 1n, settled: false });
+    expect(second).toMatchObject({ throughCursor: 2n, settled: true });
+  });
+
+  it("keeps agent_settled terminal and result-free when no documented envelope is usable", () => {
+    const classified = classifyEvents([
+      { type: "agent_end", messages: [{ role: "assistant", content: [] }] },
+      { type: "agent_settled" },
+    ]);
+
+    expect(classified.assistantFallbacks).toEqual([]);
+    expect(classified.settled).toBe(true);
+    expect(classified.projections).toEqual([{ sequence: 2n, type: "settled" }]);
   });
 
   it("redacts exact credentials from disclosed tool arguments and results", () => {

--- a/packages/companion-runtime/src/piEvents.ts
+++ b/packages/companion-runtime/src/piEvents.ts
@@ -153,8 +153,20 @@ export type RuntimePiProjection =
   | { sequence: bigint; type: "settled" }
   | { sequence: bigint; type: "process_exit"; code: number | null; signal: string | null };
 
+/**
+ * A documented terminal-envelope copy of the final assistant message. Runtime v3 checkpoints
+ * these candidates separately and promotes exactly one only when `agent_settled` proves the
+ * response is quiescent and no primary `message_end` result exists.
+ */
+export interface PiAssistantFallbackProjection {
+  sequence: bigint;
+  source: "turn_end" | "agent_end";
+  content: string;
+}
+
 export interface ClassifiedPiJournalPage {
   projections: RuntimePiProjection[];
+  assistantFallbacks: PiAssistantFallbackProjection[];
   throughCursor: bigint;
   unknownEvents: number;
   activity: boolean;
@@ -418,14 +430,13 @@ function contentBlocks(message: Record<string, unknown>): Record<string, unknown
     : [];
 }
 
-function assistantProjection(
+function assistantMessageProjection(
   sequence: bigint,
-  event: Record<string, unknown>,
+  messageValue: unknown,
   redact: RuntimeVisibleTextRedactor,
 ): Extract<RuntimePiProjection, { type: "assistant" }> | null {
-  if (event.type !== "message_end") return null;
-  if (!event.message || typeof event.message !== "object" || Array.isArray(event.message)) return null;
-  const message = event.message as Record<string, unknown>;
+  if (!messageValue || typeof messageValue !== "object" || Array.isArray(messageValue)) return null;
+  const message = messageValue as Record<string, unknown>;
   if (message.role !== "assistant") return null;
   const blocks = contentBlocks(message);
   // Pi emits one completed assistant message before executing each tool batch, then another model
@@ -457,6 +468,35 @@ function assistantProjection(
     content: bounded(content, MAX_ASSISTANT),
     ...(text && redactedReasoning ? { reasoning: boundedReasoning(redactedReasoning) } : {}),
   };
+}
+
+function assistantProjection(
+  sequence: bigint,
+  event: Record<string, unknown>,
+  redact: RuntimeVisibleTextRedactor,
+): Extract<RuntimePiProjection, { type: "assistant" }> | null {
+  return event.type === "message_end"
+    ? assistantMessageProjection(sequence, event.message, redact)
+    : null;
+}
+
+function assistantFallbackProjection(
+  sequence: bigint,
+  event: Record<string, unknown>,
+  redact: RuntimeVisibleTextRedactor,
+): PiAssistantFallbackProjection | null {
+  if (event.type === "turn_end") {
+    const assistant = assistantMessageProjection(sequence, event.message, redact);
+    return assistant
+      ? { sequence, source: "turn_end", content: assistant.content }
+      : null;
+  }
+  if (event.type !== "agent_end" || !Array.isArray(event.messages)) return null;
+  for (let index = event.messages.length - 1; index >= 0; index -= 1) {
+    const assistant = assistantMessageProjection(sequence, event.messages[index], redact);
+    if (assistant) return { sequence, source: "agent_end", content: assistant.content };
+  }
+  return null;
 }
 
 function dictionary(value: unknown): Record<string, unknown> | null {
@@ -1136,6 +1176,8 @@ export function classifyPiJournalPage(
   redact: RuntimeVisibleTextRedactor = genericRuntimeVisibleTextRedactor,
 ): ClassifiedPiJournalPage {
   const projections: RuntimePiProjection[] = [];
+  let turnEndFallback: PiAssistantFallbackProjection | null = null;
+  let agentEndFallback: PiAssistantFallbackProjection | null = null;
   let unknownEvents = 0;
   let activity = false;
   let needsInput = false;
@@ -1186,6 +1228,9 @@ export function classifyPiJournalPage(
     }
     const assistant = assistantProjection(record.sequence, record.event, redact);
     if (assistant) projections.push(assistant);
+    const assistantFallback = assistantFallbackProjection(record.sequence, record.event, redact);
+    if (assistantFallback?.source === "turn_end") turnEndFallback = assistantFallback;
+    if (assistantFallback?.source === "agent_end") agentEndFallback = assistantFallback;
     const tool = toolProjection(record.sequence, record.event, redact);
     if (tool) projections.push(tool);
     if (ACTIVITY_EVENT_TYPES.has(eventType)) {
@@ -1198,6 +1243,9 @@ export function classifyPiJournalPage(
 
   return {
     projections,
+    assistantFallbacks: [turnEndFallback, agentEndFallback]
+      .filter((item): item is PiAssistantFallbackProjection => item !== null)
+      .sort((left, right) => left.sequence < right.sequence ? -1 : 1),
     throughCursor: page.nextCursor,
     unknownEvents,
     activity,

--- a/packages/companion-runtime/src/piEvents.ts
+++ b/packages/companion-runtime/src/piEvents.ts
@@ -164,9 +164,18 @@ export interface PiAssistantFallbackProjection {
   content: string;
 }
 
+/** Product-owned, expurgated outcome for a terminal model error that produced no assistant text. */
+export interface PiTerminalErrorProjection {
+  sequence: bigint;
+  code: "model_unavailable";
+  message: "The selected model is unavailable. Choose a different model and try again.";
+  action: "switch_model";
+}
+
 export interface ClassifiedPiJournalPage {
   projections: RuntimePiProjection[];
   assistantFallbacks: PiAssistantFallbackProjection[];
+  terminalError: PiTerminalErrorProjection | null;
   throughCursor: bigint;
   unknownEvents: number;
   activity: boolean;
@@ -497,6 +506,36 @@ function assistantFallbackProjection(
     if (assistant) return { sequence, source: "agent_end", content: assistant.content };
   }
   return null;
+}
+
+function terminalAssistantError(messageValue: unknown): boolean {
+  const message = dictionary(messageValue);
+  return message?.role === "assistant"
+    && message.stopReason === "error"
+    && typeof message.errorMessage === "string"
+    && message.errorMessage.trim().length > 0;
+}
+
+function terminalErrorProjection(
+  sequence: bigint,
+  event: Record<string, unknown>,
+): PiTerminalErrorProjection | null {
+  const failedAssistant = event.type === "message_end" || event.type === "turn_end"
+    ? terminalAssistantError(event.message)
+    : event.type === "agent_end" && Array.isArray(event.messages)
+      ? event.messages.some(terminalAssistantError)
+      : false;
+  const exhaustedRetry = event.type === "auto_retry_end"
+    && event.success === false
+    && typeof event.finalError === "string"
+    && event.finalError.trim().length > 0;
+  if (!failedAssistant && !exhaustedRetry) return null;
+  return {
+    sequence,
+    code: "model_unavailable",
+    message: "The selected model is unavailable. Choose a different model and try again.",
+    action: "switch_model",
+  };
 }
 
 function dictionary(value: unknown): Record<string, unknown> | null {
@@ -1178,6 +1217,7 @@ export function classifyPiJournalPage(
   const projections: RuntimePiProjection[] = [];
   let turnEndFallback: PiAssistantFallbackProjection | null = null;
   let agentEndFallback: PiAssistantFallbackProjection | null = null;
+  let terminalError: PiTerminalErrorProjection | null = null;
   let unknownEvents = 0;
   let activity = false;
   let needsInput = false;
@@ -1231,6 +1271,8 @@ export function classifyPiJournalPage(
     const assistantFallback = assistantFallbackProjection(record.sequence, record.event, redact);
     if (assistantFallback?.source === "turn_end") turnEndFallback = assistantFallback;
     if (assistantFallback?.source === "agent_end") agentEndFallback = assistantFallback;
+    const classifiedError = terminalErrorProjection(record.sequence, record.event);
+    if (classifiedError) terminalError = classifiedError;
     const tool = toolProjection(record.sequence, record.event, redact);
     if (tool) projections.push(tool);
     if (ACTIVITY_EVENT_TYPES.has(eventType)) {
@@ -1246,6 +1288,7 @@ export function classifyPiJournalPage(
     assistantFallbacks: [turnEndFallback, agentEndFallback]
       .filter((item): item is PiAssistantFallbackProjection => item !== null)
       .sort((left, right) => left.sequence < right.sequence ? -1 : 1),
+    terminalError,
     throughCursor: page.nextCursor,
     unknownEvents,
     activity,

--- a/packages/companion-runtime/src/v3/progression.test.ts
+++ b/packages/companion-runtime/src/v3/progression.test.ts
@@ -887,6 +887,65 @@ describe("Runtime v3 progression interface", () => {
     expect(acknowledge).toHaveBeenCalledOnce();
   });
 
+  it("settles an exhausted terminal model error with a safe switch-model outcome", async () => {
+    const project = vi.fn().mockResolvedValue(true);
+    const acknowledge = vi.fn().mockResolvedValue(2n);
+    const prompt = vi.fn();
+    const advance = createRuntimeV3WarmTurnAdvance({
+      persistence: {
+        authorize: vi.fn().mockResolvedValue({
+          boxId: "bx_23456789", piInvocationId: "invocation-1", content: "finish", cursor: 0n,
+        }),
+        beginAdmission: vi.fn(), recordAdmission: vi.fn(), project,
+      },
+      pi: {
+        prompt,
+        read: vi.fn().mockResolvedValue({
+          events: [
+            {
+              sequence: 1n, invocationId: "invocation-1", attemptId: acceptedTurn.id,
+              kind: "pi_event", event: {
+                type: "auto_retry_end", success: false,
+                finalError: "429 provider entitlement payload that must not escape",
+              },
+            },
+            {
+              sequence: 2n, invocationId: "invocation-1", attemptId: acceptedTurn.id,
+              kind: "pi_event", event: { type: "agent_settled" },
+            },
+          ],
+          nextCursor: 2n, acknowledgedCursor: 0n, hasMore: false,
+        }),
+        acknowledge,
+      },
+    });
+
+    await expect(advance({
+      ...mainClaim, turn: { ...acceptedTurn, state: "running" as const },
+    })).resolves.toEqual({
+      kind: "failed",
+      code: "model_unavailable",
+      message: "The selected model is unavailable. Choose a different model and try again.",
+      action: "switch_model",
+    });
+    expect(project).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({
+        assistant: [],
+        settled: true,
+        terminalError: {
+          sequence: 1n,
+          code: "model_unavailable",
+          message: "The selected model is unavailable. Choose a different model and try again.",
+          action: "switch_model",
+        },
+      }),
+      expect.any(AbortSignal),
+    );
+    expect(acknowledge).toHaveBeenCalledOnce();
+    expect(prompt).not.toHaveBeenCalled();
+  });
+
   it("does not reread the outbox after a committed harvest is taken over", async () => {
     const harvest = vi.fn();
     const recordOutputs = vi.fn();

--- a/packages/companion-runtime/src/v3/progression.test.ts
+++ b/packages/companion-runtime/src/v3/progression.test.ts
@@ -848,6 +848,45 @@ describe("Runtime v3 progression interface", () => {
     expect(acknowledge).not.toHaveBeenCalled();
   });
 
+  it("keeps settled-without-result terminal and visible as pi_result_missing", async () => {
+    const project = vi.fn().mockResolvedValue(true);
+    const acknowledge = vi.fn().mockResolvedValue(1n);
+    const advance = createRuntimeV3WarmTurnAdvance({
+      persistence: {
+        authorize: vi.fn().mockResolvedValue({
+          boxId: "bx_23456789", piInvocationId: "invocation-1", content: "finish", cursor: 0n,
+        }),
+        beginAdmission: vi.fn(), recordAdmission: vi.fn(), project,
+      },
+      pi: {
+        prompt: vi.fn(),
+        read: vi.fn().mockResolvedValue({
+          events: [{
+            sequence: 1n, invocationId: "invocation-1", attemptId: acceptedTurn.id,
+            kind: "pi_event", event: { type: "agent_settled" },
+          }],
+          nextCursor: 1n, acknowledgedCursor: 0n, hasMore: false,
+        }),
+        acknowledge,
+      },
+    });
+
+    await expect(advance({
+      ...mainClaim, turn: { ...acceptedTurn, state: "running" as const },
+    })).resolves.toEqual({
+      kind: "failed",
+      code: "pi_result_missing",
+      message: "Pi settled without an assistant result.",
+      action: "none",
+    });
+    expect(project).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({ assistant: [], assistantFallbacks: [], settled: true }),
+      expect.any(AbortSignal),
+    );
+    expect(acknowledge).toHaveBeenCalledOnce();
+  });
+
   it("does not reread the outbox after a committed harvest is taken over", async () => {
     const harvest = vi.fn();
     const recordOutputs = vi.fn();

--- a/packages/companion-runtime/src/v3/progression.ts
+++ b/packages/companion-runtime/src/v3/progression.ts
@@ -2,6 +2,7 @@ import { safeRuntimeError } from "../errors";
 import {
   classifyPiJournalPage,
   type PiAssistantFallbackProjection,
+  type PiTerminalErrorProjection,
   type RuntimePiProjection,
   type ValidatedPiJournalRead,
 } from "../piEvents";
@@ -497,6 +498,8 @@ export interface RuntimeV3WarmTurnProjection {
   assistant: Array<{ eventId: string; content: string }>;
   /** Durable terminal-envelope candidates; persistence promotes one only at settlement. */
   assistantFallbacks?: PiAssistantFallbackProjection[];
+  /** Expurgated terminal model error candidate; persistence promotes it only without a reply. */
+  terminalError?: PiTerminalErrorProjection | null;
   compactions?: Array<{
     cursor: bigint;
     summary: string;
@@ -1286,6 +1289,7 @@ export function createRuntimeV3WarmTurnAdvance(
           throughCursor: classified.throughCursor,
           assistant,
           assistantFallbacks: classified.assistantFallbacks,
+          terminalError: classified.terminalError,
           compactions: classified.projections.flatMap((item) => item.type === "compaction"
             ? [{
               cursor: item.sequence,
@@ -1369,6 +1373,14 @@ export function createRuntimeV3WarmTurnAdvance(
         }
         if (projectedNeedsInput) return { kind: "release" };
         if (classified.settled) {
+          if (!material.backgroundRoutine && assistantResults === 0 && classified.terminalError) {
+            return {
+              kind: "failed",
+              code: classified.terminalError.code,
+              message: classified.terminalError.message,
+              action: classified.terminalError.action,
+            };
+          }
           return material.backgroundRoutine || assistantResults === 1
             ? { kind: "succeeded" }
             : {

--- a/packages/companion-runtime/src/v3/progression.ts
+++ b/packages/companion-runtime/src/v3/progression.ts
@@ -1,6 +1,7 @@
 import { safeRuntimeError } from "../errors";
 import {
   classifyPiJournalPage,
+  type PiAssistantFallbackProjection,
   type RuntimePiProjection,
   type ValidatedPiJournalRead,
 } from "../piEvents";
@@ -494,6 +495,8 @@ export interface RuntimeV3WarmTurnMaterial {
 export interface RuntimeV3WarmTurnProjection {
   throughCursor: bigint;
   assistant: Array<{ eventId: string; content: string }>;
+  /** Durable terminal-envelope candidates; persistence promotes one only at settlement. */
+  assistantFallbacks?: PiAssistantFallbackProjection[];
   compactions?: Array<{
     cursor: bigint;
     summary: string;
@@ -1282,6 +1285,7 @@ export function createRuntimeV3WarmTurnAdvance(
         const projection = {
           throughCursor: classified.throughCursor,
           assistant,
+          assistantFallbacks: classified.assistantFallbacks,
           compactions: classified.projections.flatMap((item) => item.type === "compaction"
             ? [{
               cursor: item.sequence,

--- a/packages/db/drizzle/0180_companion_runtime_v3_terminal_assistant_fallback.sql
+++ b/packages/db/drizzle/0180_companion_runtime_v3_terminal_assistant_fallback.sql
@@ -1,0 +1,148 @@
+-- Retain only redacted, bounded assistant candidates from Pi's documented terminal envelopes.
+-- They are promoted by the existing main/background page projector only after agent_settled, and
+-- only when no primary message_end result has already been projected for the Turn.
+ALTER TABLE public.companion_v3_turns
+  ADD COLUMN terminal_assistant_fallback_source text,
+  ADD COLUMN terminal_assistant_fallback_cursor bigint,
+  ADD COLUMN terminal_assistant_fallback_content text,
+  ADD COLUMN terminal_assistant_fallback_admitted_at timestamptz;
+--> statement-breakpoint
+
+ALTER TABLE public.companion_v3_turns
+  ADD CONSTRAINT companion_v3_turns_terminal_assistant_fallback_check CHECK (
+    (
+      terminal_assistant_fallback_source IS NULL
+      AND terminal_assistant_fallback_cursor IS NULL
+      AND terminal_assistant_fallback_content IS NULL
+      AND terminal_assistant_fallback_admitted_at IS NULL
+    ) OR (
+      terminal_assistant_fallback_source IS NOT NULL
+      AND terminal_assistant_fallback_cursor IS NOT NULL
+      AND terminal_assistant_fallback_content IS NOT NULL
+      AND terminal_assistant_fallback_admitted_at IS NOT NULL
+      AND terminal_assistant_fallback_source IN ('turn_end', 'agent_end')
+      AND terminal_assistant_fallback_cursor >= 0
+      AND char_length(terminal_assistant_fallback_content) BETWEEN 1 AND 100000
+    )
+  );
+--> statement-breakpoint
+
+CREATE FUNCTION public.companion_v3_runtime_record_native_fallback_v8(
+  p_org_id uuid,p_companion_id uuid,p_lane public.companion_v3_lane,p_turn_id uuid,
+  p_claim_token uuid,p_claim_epoch bigint,p_gate_epoch bigint,p_fallbacks jsonb,p_protocol integer
+) RETURNS boolean LANGUAGE plpgsql SECURITY DEFINER
+SET search_path=pg_catalog,public SET row_security=on AS $$
+DECLARE
+  v_now timestamptz:=clock_timestamp();v_item jsonb;v_source text;v_cursor bigint;v_content text;
+  v_current_source text;v_current_cursor bigint;v_current_content text;
+  v_candidate_admitted_at timestamptz;v_turn_admitted_at timestamptz;
+BEGIN
+  IF p_protocol IS DISTINCT FROM 8 OR jsonb_typeof(p_fallbacks) IS DISTINCT FROM 'array'
+    OR jsonb_array_length(p_fallbacks)>2 THEN
+    RAISE EXCEPTION 'Runtime v3 terminal fallback protocol 8 is required' USING ERRCODE='42501';
+  END IF;
+  SELECT turn_row.terminal_assistant_fallback_source,
+    turn_row.terminal_assistant_fallback_cursor,
+    turn_row.terminal_assistant_fallback_content,
+    turn_row.terminal_assistant_fallback_admitted_at,turn_row.admitted_at
+  INTO v_current_source,v_current_cursor,v_current_content,
+    v_candidate_admitted_at,v_turn_admitted_at
+  FROM public.companion_v3_lane_leases lease
+  JOIN public.companion_runtime_control control ON control.id='runtime-v3'
+    AND control.enabled AND control.gate_epoch=p_gate_epoch
+  JOIN public.companion_v3_turns turn_row ON turn_row.org_id=lease.org_id
+    AND turn_row.companion_id=lease.companion_id AND turn_row.id=lease.turn_id
+    AND turn_row.lane=p_lane AND turn_row.admission_state='accepted'
+    AND turn_row.state IN ('admitted','running','needs_input')
+  WHERE lease.org_id=p_org_id AND lease.companion_id=p_companion_id
+    AND lease.lane=p_lane AND lease.turn_id=p_turn_id
+    AND lease.claim_token=p_claim_token AND lease.claim_epoch=p_claim_epoch
+    AND lease.gate_epoch=p_gate_epoch AND lease.expires_at>v_now
+  FOR UPDATE OF lease,turn_row;
+  IF NOT FOUND THEN RETURN false;END IF;
+  IF v_candidate_admitted_at IS DISTINCT FROM v_turn_admitted_at THEN
+    v_current_source:=NULL;v_current_cursor:=NULL;v_current_content:=NULL;
+  END IF;
+
+  FOR v_item IN SELECT value FROM jsonb_array_elements(p_fallbacks) LOOP
+    v_source:=v_item->>'source';v_content:=v_item->>'content';
+    IF jsonb_typeof(v_item) IS DISTINCT FROM 'object' OR v_source IS NULL
+      OR v_source NOT IN ('turn_end','agent_end')
+      OR coalesce(v_item->>'sequence','')!~'^[0-9]{1,16}$'
+      OR char_length(coalesce(v_content,'')) NOT BETWEEN 1 AND 100000 THEN
+      RAISE EXCEPTION 'invalid Runtime v3 terminal assistant fallback' USING ERRCODE='22023';
+    END IF;
+    v_cursor:=(v_item->>'sequence')::bigint;
+    IF v_current_cursor=v_cursor AND (
+      v_current_source IS DISTINCT FROM v_source OR v_current_content IS DISTINCT FROM v_content
+    ) THEN
+      RAISE EXCEPTION 'Runtime v3 terminal assistant fallback conflict' USING ERRCODE='23505';
+    END IF;
+    IF v_current_source IS NULL
+      OR (v_source='turn_end' AND v_current_source='agent_end')
+      OR (v_source=v_current_source AND v_cursor>v_current_cursor) THEN
+      UPDATE public.companion_v3_turns turn_row SET
+        terminal_assistant_fallback_source=v_source,
+        terminal_assistant_fallback_cursor=v_cursor,
+        terminal_assistant_fallback_content=v_content,
+        terminal_assistant_fallback_admitted_at=v_turn_admitted_at,
+        updated_at=v_now
+      WHERE turn_row.org_id=p_org_id AND turn_row.companion_id=p_companion_id
+        AND turn_row.id=p_turn_id;
+      v_current_source:=v_source;v_current_cursor:=v_cursor;v_current_content:=v_content;
+    END IF;
+  END LOOP;
+  RETURN true;
+END $$;
+--> statement-breakpoint
+
+REVOKE ALL ON FUNCTION public.companion_v3_runtime_record_native_fallback_v8(
+  uuid,uuid,public.companion_v3_lane,uuid,uuid,bigint,bigint,jsonb,integer
+) FROM PUBLIC;
+--> statement-breakpoint
+
+CREATE FUNCTION public.companion_v3_runtime_read_native_fallback_v8(
+  p_org_id uuid,p_companion_id uuid,p_lane public.companion_v3_lane,p_turn_id uuid,
+  p_claim_token uuid,p_claim_epoch bigint,p_gate_epoch bigint,p_protocol integer
+) RETURNS TABLE(sequence bigint,content text) LANGUAGE plpgsql SECURITY DEFINER
+SET search_path=pg_catalog,public SET row_security=on AS $$
+DECLARE v_now timestamptz:=clock_timestamp();
+BEGIN
+  IF p_protocol IS DISTINCT FROM 8 THEN
+    RAISE EXCEPTION 'Runtime v3 terminal fallback protocol 8 is required' USING ERRCODE='42501';
+  END IF;
+  RETURN QUERY
+  SELECT turn_row.terminal_assistant_fallback_cursor,
+    turn_row.terminal_assistant_fallback_content
+  FROM public.companion_v3_lane_leases lease
+  JOIN public.companion_runtime_control control ON control.id='runtime-v3'
+    AND control.enabled AND control.gate_epoch=p_gate_epoch
+  JOIN public.companion_v3_turns turn_row ON turn_row.org_id=lease.org_id
+    AND turn_row.companion_id=lease.companion_id AND turn_row.id=lease.turn_id
+    AND turn_row.lane=p_lane AND turn_row.admission_state='accepted'
+    AND turn_row.state IN ('admitted','running','needs_input')
+  WHERE lease.org_id=p_org_id AND lease.companion_id=p_companion_id
+    AND lease.lane=p_lane AND lease.turn_id=p_turn_id
+    AND lease.claim_token=p_claim_token AND lease.claim_epoch=p_claim_epoch
+    AND lease.gate_epoch=p_gate_epoch AND lease.expires_at>v_now
+    AND turn_row.terminal_assistant_fallback_source IS NOT NULL
+    AND turn_row.terminal_assistant_fallback_admitted_at=turn_row.admitted_at
+    AND (
+      p_lane='main' AND NOT EXISTS (
+        SELECT 1 FROM public.companion_transcript_entries entry
+        WHERE entry.org_id=p_org_id AND entry.companion_id=p_companion_id
+          AND entry.role='assistant'
+          AND entry.event_id LIKE 'v3:'||p_turn_id::text||':%'
+      )
+      OR p_lane='background' AND NOT EXISTS (
+        SELECT 1 FROM public.companion_v3_routine_run_entries entry
+        WHERE entry.org_id=p_org_id AND entry.companion_id=p_companion_id
+          AND entry.run_id=p_turn_id AND entry.role='assistant'
+      )
+    );
+END $$;
+--> statement-breakpoint
+
+REVOKE ALL ON FUNCTION public.companion_v3_runtime_read_native_fallback_v8(
+  uuid,uuid,public.companion_v3_lane,uuid,uuid,bigint,bigint,integer
+) FROM PUBLIC;

--- a/packages/db/drizzle/0180_companion_runtime_v3_terminal_assistant_fallback.sql
+++ b/packages/db/drizzle/0180_companion_runtime_v3_terminal_assistant_fallback.sql
@@ -5,7 +5,9 @@ ALTER TABLE public.companion_v3_turns
   ADD COLUMN terminal_assistant_fallback_source text,
   ADD COLUMN terminal_assistant_fallback_cursor bigint,
   ADD COLUMN terminal_assistant_fallback_content text,
-  ADD COLUMN terminal_assistant_fallback_admitted_at timestamptz;
+  ADD COLUMN terminal_assistant_fallback_admitted_at timestamptz,
+  ADD COLUMN terminal_model_error_cursor bigint,
+  ADD COLUMN terminal_model_error_admitted_at timestamptz;
 --> statement-breakpoint
 
 ALTER TABLE public.companion_v3_turns
@@ -24,6 +26,14 @@ ALTER TABLE public.companion_v3_turns
       AND terminal_assistant_fallback_cursor >= 0
       AND char_length(terminal_assistant_fallback_content) BETWEEN 1 AND 100000
     )
+  );
+--> statement-breakpoint
+
+ALTER TABLE public.companion_v3_turns
+  ADD CONSTRAINT companion_v3_turns_terminal_model_error_check CHECK (
+    (terminal_model_error_cursor IS NULL AND terminal_model_error_admitted_at IS NULL)
+    OR (terminal_model_error_cursor IS NOT NULL AND terminal_model_error_cursor >= 0
+      AND terminal_model_error_admitted_at IS NOT NULL)
   );
 --> statement-breakpoint
 
@@ -145,4 +155,180 @@ END $$;
 
 REVOKE ALL ON FUNCTION public.companion_v3_runtime_read_native_fallback_v8(
   uuid,uuid,public.companion_v3_lane,uuid,uuid,bigint,bigint,integer
+) FROM PUBLIC;
+--> statement-breakpoint
+
+-- Record only the existence and cursor of a product-classified terminal model failure. The raw
+-- provider error is deliberately absent from both the function contract and durable storage.
+CREATE FUNCTION public.companion_v3_runtime_record_terminal_model_error_v9(
+  p_org_id uuid,p_companion_id uuid,p_lane public.companion_v3_lane,p_turn_id uuid,
+  p_claim_token uuid,p_claim_epoch bigint,p_gate_epoch bigint,p_error jsonb,p_protocol integer
+) RETURNS boolean LANGUAGE plpgsql SECURITY DEFINER
+SET search_path=pg_catalog,public SET row_security=on AS $$
+DECLARE v_now timestamptz:=clock_timestamp();v_cursor bigint;v_admitted_at timestamptz;
+BEGIN
+  IF p_protocol IS DISTINCT FROM 9 OR jsonb_typeof(p_error) IS DISTINCT FROM 'object'
+    OR coalesce(p_error->>'sequence','')!~'^[0-9]{1,16}$'
+    OR p_error->>'code' IS DISTINCT FROM 'model_unavailable'
+    OR p_error->>'message' IS DISTINCT FROM
+      'The selected model is unavailable. Choose a different model and try again.'
+    OR p_error->>'action' IS DISTINCT FROM 'switch_model'
+    OR p_error - ARRAY['sequence','code','message','action'] <> '{}'::jsonb THEN
+    RAISE EXCEPTION 'invalid Runtime v3 terminal model error' USING ERRCODE='22023';
+  END IF;
+  v_cursor:=(p_error->>'sequence')::bigint;
+  SELECT turn_row.admitted_at INTO v_admitted_at
+  FROM public.companion_v3_lane_leases lease
+  JOIN public.companion_runtime_control control ON control.id='runtime-v3'
+    AND control.enabled AND control.gate_epoch=p_gate_epoch
+  JOIN public.companion_v3_turns turn_row ON turn_row.org_id=lease.org_id
+    AND turn_row.companion_id=lease.companion_id AND turn_row.id=lease.turn_id
+    AND turn_row.lane=p_lane AND turn_row.admission_state='accepted'
+    AND turn_row.state IN ('admitted','running','needs_input')
+  WHERE lease.org_id=p_org_id AND lease.companion_id=p_companion_id
+    AND lease.lane=p_lane AND lease.turn_id=p_turn_id
+    AND lease.claim_token=p_claim_token AND lease.claim_epoch=p_claim_epoch
+    AND lease.gate_epoch=p_gate_epoch AND lease.expires_at>v_now
+  FOR UPDATE OF lease,turn_row;
+  IF NOT FOUND THEN RETURN false;END IF;
+  UPDATE public.companion_v3_turns turn_row SET
+    terminal_model_error_cursor=CASE
+      WHEN turn_row.terminal_model_error_admitted_at IS DISTINCT FROM v_admitted_at
+        OR turn_row.terminal_model_error_cursor IS NULL
+        OR v_cursor>turn_row.terminal_model_error_cursor THEN v_cursor
+      ELSE turn_row.terminal_model_error_cursor END,
+    terminal_model_error_admitted_at=v_admitted_at,updated_at=v_now
+  WHERE turn_row.org_id=p_org_id AND turn_row.companion_id=p_companion_id
+    AND turn_row.id=p_turn_id;
+  RETURN true;
+END $$;
+--> statement-breakpoint
+
+REVOKE ALL ON FUNCTION public.companion_v3_runtime_record_terminal_model_error_v9(
+  uuid,uuid,public.companion_v3_lane,uuid,uuid,bigint,bigint,jsonb,integer
+) FROM PUBLIC;
+--> statement-breakpoint
+
+-- Promote the stable failure and its visible system note in the same transaction as terminal page
+-- projection. A primary or fallback assistant result makes v7 succeed and always wins.
+CREATE FUNCTION public.companion_v3_runtime_project_native_page_v8(
+  p_org_id uuid,p_companion_id uuid,p_lane public.companion_v3_lane,p_turn_id uuid,
+  p_claim_token uuid,p_claim_epoch bigint,p_gate_epoch bigint,p_through_cursor bigint,
+  p_assistant jsonb,p_compactions jsonb,p_decisions jsonb,p_needs_input boolean,
+  p_correlated_activity boolean,p_terminal text,p_protocol integer
+) RETURNS text LANGUAGE plpgsql SECURITY DEFINER
+SET search_path=pg_catalog,public SET row_security=on AS $$
+DECLARE v_result text;v_cursor bigint;v_event_id text;v_now timestamptz:=clock_timestamp();
+  v_ordinal integer;v_projection bigint;
+BEGIN
+  IF p_protocol IS DISTINCT FROM 8 THEN
+    RAISE EXCEPTION 'Runtime v3 native projection protocol 8 is required' USING ERRCODE='42501';
+  END IF;
+  v_result:=public.companion_v3_runtime_project_native_page_v7(
+    p_org_id,p_companion_id,p_lane,p_turn_id,p_claim_token,p_claim_epoch,p_gate_epoch,
+    p_through_cursor,p_assistant,p_compactions,p_decisions,p_needs_input,
+    p_correlated_activity,p_terminal,7);
+  IF v_result IS DISTINCT FROM 'failed' OR p_terminal IS DISTINCT FROM 'settled' THEN
+    RETURN v_result;
+  END IF;
+  SELECT turn_row.terminal_model_error_cursor INTO v_cursor
+  FROM public.companion_v3_turns turn_row
+  WHERE turn_row.org_id=p_org_id AND turn_row.companion_id=p_companion_id
+    AND turn_row.id=p_turn_id
+    AND turn_row.terminal_model_error_admitted_at=turn_row.admitted_at;
+  IF v_cursor IS NULL THEN RETURN v_result;END IF;
+
+  UPDATE public.companion_v3_turns turn_row SET
+    outcome_code='model_unavailable',
+    outcome_message='The selected model is unavailable. Choose a different model and try again.',
+    outcome_action='switch_model',updated_at=v_now
+  WHERE turn_row.org_id=p_org_id AND turn_row.companion_id=p_companion_id
+    AND turn_row.lane=p_lane AND turn_row.admission_state='accepted'
+    AND turn_row.response_turn_id=p_turn_id AND turn_row.state='failed'
+    AND turn_row.outcome_code='pi_result_missing';
+  v_event_id:='v3:'||p_turn_id::text||':error:'||v_cursor::text;
+  IF NOT EXISTS (
+    SELECT 1 FROM public.companion_transcript_entries entry
+    WHERE entry.org_id=p_org_id AND entry.companion_id=p_companion_id
+      AND entry.event_id=v_event_id
+  ) THEN
+    UPDATE public.companion_threads thread SET next_ordinal=thread.next_ordinal+1,
+      projection_sequence=thread.projection_sequence+1,last_message_at=v_now,updated_at=v_now
+    WHERE thread.org_id=p_org_id AND thread.companion_id=p_companion_id
+    RETURNING thread.next_ordinal-1,thread.projection_sequence INTO v_ordinal,v_projection;
+    INSERT INTO public.companion_transcript_entries(
+      org_id,companion_id,event_id,ordinal,projection_sequence,role,content,created_at
+    ) VALUES (
+      p_org_id,p_companion_id,v_event_id,v_ordinal,v_projection,'system',
+      'The selected model is unavailable. Choose a different model and try again.',v_now
+    );
+  END IF;
+  RETURN 'failed';
+END $$;
+--> statement-breakpoint
+
+REVOKE ALL ON FUNCTION public.companion_v3_runtime_project_native_page_v8(
+  uuid,uuid,public.companion_v3_lane,uuid,uuid,bigint,bigint,bigint,jsonb,jsonb,jsonb,
+  boolean,boolean,text,integer
+) FROM PUBLIC;
+--> statement-breakpoint
+
+-- Routine/trigger failures remain private to their run transcript but use the same stable outcome.
+CREATE FUNCTION public.companion_v3_runtime_project_background_page_v10(
+  p_org_id uuid,p_companion_id uuid,p_turn_id uuid,p_claim_token uuid,p_claim_epoch bigint,
+  p_gate_epoch bigint,p_through_cursor bigint,p_entries jsonb,p_decisions jsonb,p_returns jsonb,
+  p_needs_input boolean,p_activity boolean,p_terminal text,p_protocol integer
+) RETURNS text LANGUAGE plpgsql SECURITY DEFINER
+SET search_path=pg_catalog,public SET row_security=on AS $$
+DECLARE v_result text;v_cursor bigint;v_now timestamptz:=clock_timestamp();v_ordinal integer;
+BEGIN
+  IF p_protocol IS DISTINCT FROM 10 THEN
+    RAISE EXCEPTION 'Runtime v3 background projection protocol 10 is required' USING ERRCODE='42501';
+  END IF;
+  v_result:=public.companion_v3_runtime_project_background_page_v9(
+    p_org_id,p_companion_id,p_turn_id,p_claim_token,p_claim_epoch,p_gate_epoch,
+    p_through_cursor,p_entries,p_decisions,p_returns,p_needs_input,p_activity,p_terminal,9);
+  IF v_result IS DISTINCT FROM 'succeeded' OR p_terminal IS DISTINCT FROM 'settled'
+    OR jsonb_array_length(p_returns)<>0 THEN RETURN v_result;END IF;
+  SELECT turn_row.terminal_model_error_cursor INTO v_cursor
+  FROM public.companion_v3_turns turn_row
+  WHERE turn_row.org_id=p_org_id AND turn_row.companion_id=p_companion_id
+    AND turn_row.id=p_turn_id
+    AND turn_row.terminal_model_error_admitted_at=turn_row.admitted_at
+    AND NOT EXISTS (
+      SELECT 1 FROM public.companion_v3_routine_run_entries entry
+      WHERE entry.org_id=p_org_id AND entry.companion_id=p_companion_id
+        AND entry.run_id=p_turn_id AND entry.role='assistant'
+    );
+  IF v_cursor IS NULL THEN RETURN v_result;END IF;
+
+  UPDATE public.companion_v3_turns turn_row SET state='failed',outcome='failed',
+    outcome_code='model_unavailable',
+    outcome_message='The selected model is unavailable. Choose a different model and try again.',
+    outcome_action='switch_model',updated_at=v_now
+  WHERE turn_row.org_id=p_org_id AND turn_row.companion_id=p_companion_id
+    AND turn_row.id=p_turn_id AND turn_row.state='succeeded';
+  UPDATE public.companion_v3_routine_runs run SET outcome='failed',settled_at=v_now
+  WHERE run.org_id=p_org_id AND run.companion_id=p_companion_id AND run.turn_id=p_turn_id;
+  IF NOT EXISTS (
+    SELECT 1 FROM public.companion_v3_routine_run_entries entry
+    WHERE entry.org_id=p_org_id AND entry.companion_id=p_companion_id
+      AND entry.run_id=p_turn_id AND entry.event_id='error:'||v_cursor::text
+  ) THEN
+    UPDATE public.companion_v3_routine_runs run SET next_ordinal=run.next_ordinal+1
+    WHERE run.org_id=p_org_id AND run.companion_id=p_companion_id AND run.turn_id=p_turn_id
+    RETURNING run.next_ordinal-1 INTO v_ordinal;
+    INSERT INTO public.companion_v3_routine_run_entries(
+      org_id,companion_id,run_id,event_id,ordinal,role,content,created_at
+    ) VALUES (
+      p_org_id,p_companion_id,p_turn_id,'error:'||v_cursor::text,v_ordinal,'system',
+      'The selected model is unavailable. Choose a different model and try again.',v_now
+    );
+  END IF;
+  RETURN 'failed';
+END $$;
+--> statement-breakpoint
+
+REVOKE ALL ON FUNCTION public.companion_v3_runtime_project_background_page_v10(
+  uuid,uuid,uuid,uuid,bigint,bigint,bigint,jsonb,jsonb,jsonb,boolean,boolean,text,integer
 ) FROM PUBLIC;

--- a/packages/db/drizzle/meta/_journal.json
+++ b/packages/db/drizzle/meta/_journal.json
@@ -1261,6 +1261,13 @@
       "when": 1793376400000,
       "tag": "0179_companion_runtime_v3_contraction",
       "breakpoints": true
+    },
+    {
+      "idx": 180,
+      "version": "7",
+      "when": 1793380000000,
+      "tag": "0180_companion_runtime_v3_terminal_assistant_fallback",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/db/runtime-role-grants.sql
+++ b/packages/db/runtime-role-grants.sql
@@ -1159,6 +1159,15 @@ BEGIN
       ];
     END IF;
 
+    IF pg_catalog.to_regprocedure(
+      'public.companion_v3_runtime_record_native_fallback_v8(uuid,uuid,public.companion_v3_lane,uuid,uuid,bigint,bigint,jsonb,integer)'
+    ) IS NOT NULL THEN
+      companion_runtime_functions := companion_runtime_functions || ARRAY[
+        'public.companion_v3_runtime_record_native_fallback_v8(uuid,uuid,public.companion_v3_lane,uuid,uuid,bigint,bigint,jsonb,integer)'::regprocedure,
+        'public.companion_v3_runtime_read_native_fallback_v8(uuid,uuid,public.companion_v3_lane,uuid,uuid,bigint,bigint,integer)'::regprocedure
+      ];
+    END IF;
+
     -- 0179 is the contraction point: the API keeps only v3 write entry points and the runtime
     -- keeps only v3 progression plus the read-only desktop handoff. Historical v2 functions stay
     -- owner-only for the offline purge/rehearsal and can never be claimed by a process login.

--- a/packages/db/runtime-role-grants.sql
+++ b/packages/db/runtime-role-grants.sql
@@ -1168,6 +1168,16 @@ BEGIN
       ];
     END IF;
 
+    IF pg_catalog.to_regprocedure(
+      'public.companion_v3_runtime_record_terminal_model_error_v9(uuid,uuid,public.companion_v3_lane,uuid,uuid,bigint,bigint,jsonb,integer)'
+    ) IS NOT NULL THEN
+      companion_runtime_functions := companion_runtime_functions || ARRAY[
+        'public.companion_v3_runtime_record_terminal_model_error_v9(uuid,uuid,public.companion_v3_lane,uuid,uuid,bigint,bigint,jsonb,integer)'::regprocedure,
+        'public.companion_v3_runtime_project_native_page_v8(uuid,uuid,public.companion_v3_lane,uuid,uuid,bigint,bigint,bigint,jsonb,jsonb,jsonb,boolean,boolean,text,integer)'::regprocedure,
+        'public.companion_v3_runtime_project_background_page_v10(uuid,uuid,uuid,uuid,bigint,bigint,bigint,jsonb,jsonb,jsonb,boolean,boolean,text,integer)'::regprocedure
+      ];
+    END IF;
+
     -- 0179 is the contraction point: the API keeps only v3 write entry points and the runtime
     -- keeps only v3 progression plus the read-only desktop handoff. Historical v2 functions stay
     -- owner-only for the offline purge/rehearsal and can never be claimed by a process login.

--- a/packages/db/src/runtimeRole.ts
+++ b/packages/db/src/runtimeRole.ts
@@ -146,7 +146,10 @@ WITH runtime_role AS (
     ('public.companion_v3_runtime_begin_background_admission_v9(uuid,uuid,uuid,uuid,bigint,bigint,text,bigint,integer)'),
     ('public.companion_v3_runtime_project_background_page_v9(uuid,uuid,uuid,uuid,bigint,bigint,bigint,jsonb,jsonb,jsonb,boolean,boolean,text,integer)'),
     ('public.companion_v3_runtime_record_native_fallback_v8(uuid,uuid,public.companion_v3_lane,uuid,uuid,bigint,bigint,jsonb,integer)'),
-    ('public.companion_v3_runtime_read_native_fallback_v8(uuid,uuid,public.companion_v3_lane,uuid,uuid,bigint,bigint,integer)')
+    ('public.companion_v3_runtime_read_native_fallback_v8(uuid,uuid,public.companion_v3_lane,uuid,uuid,bigint,bigint,integer)'),
+    ('public.companion_v3_runtime_record_terminal_model_error_v9(uuid,uuid,public.companion_v3_lane,uuid,uuid,bigint,bigint,jsonb,integer)'),
+    ('public.companion_v3_runtime_project_native_page_v8(uuid,uuid,public.companion_v3_lane,uuid,uuid,bigint,bigint,bigint,jsonb,jsonb,jsonb,boolean,boolean,text,integer)'),
+    ('public.companion_v3_runtime_project_background_page_v10(uuid,uuid,uuid,uuid,bigint,bigint,bigint,jsonb,jsonb,jsonb,boolean,boolean,text,integer)')
 ), decision_required(signature) AS (
   VALUES
     ('public.companion_v3_runtime_claim_warm_v6(text,public.companion_v3_lane,integer,integer)'),

--- a/packages/db/src/runtimeRole.ts
+++ b/packages/db/src/runtimeRole.ts
@@ -144,7 +144,9 @@ WITH runtime_role AS (
     ('public.companion_v3_runtime_authorize_warm_turn_v8(uuid,uuid,public.companion_v3_lane,uuid,uuid,bigint,bigint,integer)'),
     ('public.companion_v3_runtime_authorize_background_v9(uuid,uuid,uuid,uuid,bigint,bigint,integer)'),
     ('public.companion_v3_runtime_begin_background_admission_v9(uuid,uuid,uuid,uuid,bigint,bigint,text,bigint,integer)'),
-    ('public.companion_v3_runtime_project_background_page_v9(uuid,uuid,uuid,uuid,bigint,bigint,bigint,jsonb,jsonb,jsonb,boolean,boolean,text,integer)')
+    ('public.companion_v3_runtime_project_background_page_v9(uuid,uuid,uuid,uuid,bigint,bigint,bigint,jsonb,jsonb,jsonb,boolean,boolean,text,integer)'),
+    ('public.companion_v3_runtime_record_native_fallback_v8(uuid,uuid,public.companion_v3_lane,uuid,uuid,bigint,bigint,jsonb,integer)'),
+    ('public.companion_v3_runtime_read_native_fallback_v8(uuid,uuid,public.companion_v3_lane,uuid,uuid,bigint,bigint,integer)')
 ), decision_required(signature) AS (
   VALUES
     ('public.companion_v3_runtime_claim_warm_v6(text,public.companion_v3_lane,integer,integer)'),

--- a/packages/db/src/schema.ts
+++ b/packages/db/src/schema.ts
@@ -1487,6 +1487,11 @@ export const companionV3Turns = pgTable(
     terminalAssistantFallbackAdmittedAt: timestamp("terminal_assistant_fallback_admitted_at", {
       withTimezone: true,
     }),
+    /** Cursor-only proof of an expurgated terminal model failure for the current admission. */
+    terminalModelErrorCursor: bigint("terminal_model_error_cursor", { mode: "number" }),
+    terminalModelErrorAdmittedAt: timestamp("terminal_model_error_admitted_at", {
+      withTimezone: true,
+    }),
     lastActivityAt: timestamp("last_activity_at", { withTimezone: true }),
     firstActivityAt: timestamp("first_activity_at", { withTimezone: true }),
     inactivityDeadlineAt: timestamp("inactivity_deadline_at", { withTimezone: true }),
@@ -1581,6 +1586,10 @@ export const companionV3Turns = pgTable(
     terminalAssistantFallbackCheck: check(
       "companion_v3_turns_terminal_assistant_fallback_check",
       sql`(${t.terminalAssistantFallbackSource} is null and ${t.terminalAssistantFallbackCursor} is null and ${t.terminalAssistantFallbackContent} is null and ${t.terminalAssistantFallbackAdmittedAt} is null) or (${t.terminalAssistantFallbackSource} is not null and ${t.terminalAssistantFallbackCursor} is not null and ${t.terminalAssistantFallbackContent} is not null and ${t.terminalAssistantFallbackAdmittedAt} is not null and ${t.terminalAssistantFallbackSource} in ('turn_end', 'agent_end') and ${t.terminalAssistantFallbackCursor} >= 0 and char_length(${t.terminalAssistantFallbackContent}) between 1 and 100000)`,
+    ),
+    terminalModelErrorCheck: check(
+      "companion_v3_turns_terminal_model_error_check",
+      sql`(${t.terminalModelErrorCursor} is null and ${t.terminalModelErrorAdmittedAt} is null) or (${t.terminalModelErrorCursor} is not null and ${t.terminalModelErrorCursor} >= 0 and ${t.terminalModelErrorAdmittedAt} is not null)`,
     ),
     admissionCheck: check(
       "companion_v3_turns_admission_check",

--- a/packages/db/src/schema.ts
+++ b/packages/db/src/schema.ts
@@ -1478,6 +1478,15 @@ export const companionV3Turns = pgTable(
     activityCursor: bigint("activity_cursor", { mode: "number" }).notNull().default(0),
     correlatedActivityCursor: bigint("correlated_activity_cursor", { mode: "number" })
       .notNull().default(0),
+    /** Redacted assistant candidate retained from Pi's documented terminal envelopes. */
+    terminalAssistantFallbackSource: text("terminal_assistant_fallback_source"),
+    terminalAssistantFallbackCursor: bigint("terminal_assistant_fallback_cursor", {
+      mode: "number",
+    }),
+    terminalAssistantFallbackContent: text("terminal_assistant_fallback_content"),
+    terminalAssistantFallbackAdmittedAt: timestamp("terminal_assistant_fallback_admitted_at", {
+      withTimezone: true,
+    }),
     lastActivityAt: timestamp("last_activity_at", { withTimezone: true }),
     firstActivityAt: timestamp("first_activity_at", { withTimezone: true }),
     inactivityDeadlineAt: timestamp("inactivity_deadline_at", { withTimezone: true }),
@@ -1568,6 +1577,10 @@ export const companionV3Turns = pgTable(
     cursorCheck: check(
       "companion_v3_turns_cursor_check",
       sql`${t.activityCursor} >= 0 and ${t.correlatedActivityCursor} >= 0 and ${t.correlatedActivityCursor} <= ${t.activityCursor} and (${t.admissionCursor} is null or ${t.admissionCursor} >= 0)`,
+    ),
+    terminalAssistantFallbackCheck: check(
+      "companion_v3_turns_terminal_assistant_fallback_check",
+      sql`(${t.terminalAssistantFallbackSource} is null and ${t.terminalAssistantFallbackCursor} is null and ${t.terminalAssistantFallbackContent} is null and ${t.terminalAssistantFallbackAdmittedAt} is null) or (${t.terminalAssistantFallbackSource} is not null and ${t.terminalAssistantFallbackCursor} is not null and ${t.terminalAssistantFallbackContent} is not null and ${t.terminalAssistantFallbackAdmittedAt} is not null and ${t.terminalAssistantFallbackSource} in ('turn_end', 'agent_end') and ${t.terminalAssistantFallbackCursor} >= 0 and char_length(${t.terminalAssistantFallbackContent}) between 1 and 100000)`,
     ),
     admissionCheck: check(
       "companion_v3_turns_admission_check",


### PR DESCRIPTION
## Summary

- keep `message_end` as Pi's primary assistant projection, then recover one redacted usable assistant result from documented `turn_end.message` or `agent_end.messages` only when `agent_settled` proves quiescence and no primary result exists
- cover both ordinary main turns and routine/background turns across acknowledged pages and executor takeover without projecting user/tool narration or duplicating successful replies
- classify terminal assistant errors and exhausted Pi retry sequences with no usable text as the stable `model_unavailable` / `switch_model` outcome; raw provider error text never enters PostgreSQL or the transcript
- show the product-owned failure note in the main chat and private routine run; editable web chat adds a direct **Change model** action that opens and focuses the existing settings picker with its accessible save/loading/error flow
- retain the image baker Box id before its first follow-up command and retry only an immediate image-bake command HTTP 409 with bounded 1/2/5/10/30-second backoff, cancellation, and the existing attempt deadline

## Reliability behavior

`agent_settled` remains the sole quiescence proof. Successful `message_end`, `turn_end`, or `agent_end` assistant text always wins over an error candidate. A terminal model failure does not replay the prompt, switch models silently, contact Box from reads, or hold the chat queue; later turns continue normally.

The captured Pi sequence is covered directly: four assistant `message_start` / `message_end` / `turn_end` error cycles with `agent_end(willRetry)`, followed by `auto_retry_end(success=false)` and `agent_settled`. Classification discards the raw provider text and persists only the stable outcome plus a cursor/admission proof.

Pi owns the observed automatic retry cycle. The current journal seam has no narrow provider-independent signal that distinguishes entitlement rejection before exhaustion, so this PR does not add fragile provider-specific retry parsing.

## Why the database checkpoint is necessary

Pi journal pages are acknowledged independently. A documented terminal-envelope result or error candidate can be on an earlier page than `agent_settled`; after that page is acknowledged, executor takeover cannot safely reread it. Migration 0180 therefore retains a redacted bounded assistant candidate, or only an error cursor, on the Turn behind the existing runtime fence before ACK. The settling executor promotes it idempotently through the main transcript or private routine-run projector. Error promotion covers every admitted Turn correlated to the same native response root, including steers.

This does not assert a provider-specific event shape beyond the supplied captured sequence.

## Verification

- Pi classifier and progression: 122 tests passed
- web transcript/settings/route behavior: 145 tests passed
- API runtime-role grants: 8 tests passed
- focused fresh PostgreSQL projection: 6 fallback/error/deduplication tests passed
- post-review correlated prompt+steer model error: 2 main/background tests passed
- image baker: 17 tests passed; image worker: 11 tests passed
- `pnpm verify:change -- --base origin/conductor/runtime-v3-stack-19-the-528`: 26 quality tasks and 5 builds passed; exit 2 only for the four printed environment follow-ups
- focused Standards + Spec review: one shared P1 response-group finding fixed; no remaining P0-P3 findings
- independent ship review artifacts: no remaining issues

Per task constraints, Docker/container smoke, Box Lab, a live provider canary, and the full browser environment were not run locally. CI owns the visible latest-SHA gates.




<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

The PR adds durable recovery for terminal Pi replies and model failures, alongside bounded image-baker readiness retries and a web recovery action.
- Checkpoints redacted terminal assistant candidates and promotes them after settlement when no primary reply exists.
- Persists stable model-unavailable outcomes without retaining raw provider errors.
- Adds a Change model action linked to the existing settings picker.
- Retains baker Box cleanup identity and retries immediate post-create command conflicts within the attempt deadline.
</details>


<details><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge because no blocking failure remains.

No blocking failure remains.
</details>


<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| packages/companion-runtime/src/piEvents.ts | Classifies documented terminal assistant envelopes and expurgated terminal model-error candidates. |
| packages/companion-runtime/src/v3/progression.ts | Carries fallback and error candidates through progression while preserving primary assistant-result precedence. |
| apps/runtime/src/runtimeV3ProgressionStore.ts | Persists fenced fallback/error checkpoints and promotes fallback content only after settlement. |
| packages/db/drizzle/0180_companion_runtime_v3_terminal_assistant_fallback.sql | Adds bounded checkpoint columns and fenced functions for terminal fallback and model-error projection. |
| packages/box-runtime/src/companionRuntimeBaker.ts | Checkpoints newly created baker Boxes and adds deadline-bound retries for immediate post-create command conflicts. |
| apps/web/src/components/companions/CompanionTranscript.tsx | Adds a Change model action only to recognized model-unavailable system messages. |
| apps/web/src/components/companions/CompanionSettings.tsx | Focuses the existing model picker for fragment-linked recovery and exposes form busy state. |

</details>


<details open><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
  participant Pi
  participant Runtime
  participant DB
  participant Web
  Pi->>Runtime: Journal page with reply/error candidate
  Runtime->>DB: Checkpoint redacted candidate before ACK
  Runtime->>Pi: Acknowledge journal page
  Pi->>Runtime: agent_settled
  Runtime->>DB: Read checkpoint under active fence
  alt Primary assistant reply exists
    DB-->>Runtime: Suppress fallback and error
  else Usable fallback exists
    DB->>DB: Project one assistant reply
  else Terminal model error exists
    DB->>DB: Persist model_unavailable outcome and note
    DB-->>Web: Stable system message
    Web->>Web: Open and focus model picker
  end
```
</details>

<sub>Reviews (3): Last reviewed commit: ["fix(ci): recognize terminal projection f..."](https://github.com/the-vibe-company/companion/commit/566b414c56de50e1e032150549558654d699f577) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=60094241)</sub>

<!-- /greptile_comment -->