### PR TITLE
fix(runtime): install baker boxignore safely

### DIFF
--- a/packages/box-runtime/src/boxCompanionRuntime.test.ts
+++ b/packages/box-runtime/src/boxCompanionRuntime.test.ts
@@ -884,6 +884,8 @@ describe("provider Box lifecycle states", () => {
         return response({ box: box("ready") }, 202);
       }
       if (url.endsWith("/commands") && method === "POST") {
+        const command = String((body as { command?: string }).command ?? "");
+        if (command.includes("runtime_image_boxignore")) return response(commandResult());
         warmupCommands += 1;
         if (warmupCommands === 1) {
           return response({ message: "Box command service is still starting" }, 409);
@@ -924,9 +926,136 @@ describe("provider Box lifecycle states", () => {
 
     expect(archivePolls).toBe(4);
     expect(warmupCommands).toBe(3);
-    const warmup = requests.find((request) => request.url.endsWith("/commands"))?.body;
+    const warmup = requests.find((request) => (
+      request.url.endsWith("/commands")
+      && String((request.body as { command?: string } | undefined)?.command).includes("seq 1 300")
+    ))?.body;
     expect(warmup).toMatchObject({ timeoutSeconds: 45 });
     expect(String((warmup as { command?: string } | undefined)?.command)).toContain("seq 1 300");
+  });
+
+  it("installs the exact image ignore file without using the reserved provider file path", async () => {
+    const expectedBoxIgnore = [
+      ".companion/runtime/logs/",
+      ".companion/runtime/routines/",
+      ".companion/runtime/state/skill-archives/",
+      ".companion/runtime/state/control-bundle-v1.json",
+      ".companion/runtime/control-transaction-v1/",
+      ".companion/runtime/state/providers.env",
+      "attachments/",
+      "outbox/",
+    ].join("\n") + "\n";
+    let installedBoxIgnore: string | null = null;
+    let archived = false;
+    let resumed = false;
+    const providerFileWrites: string[] = [];
+    vi.stubGlobal("fetch", vi.fn(async (rawUrl: string | URL | Request, init?: RequestInit) => {
+      const url = String(rawUrl);
+      const method = init?.method ?? "GET";
+      const body = init?.body ? JSON.parse(String(init.body)) as {
+        command?: string;
+        path?: string;
+      } : {};
+      if (url.endsWith("/files") && method === "PUT") {
+        if (body.path === ".boxignore") {
+          return response({ message: "reserved path" }, 400);
+        }
+        expect(body.path).toMatch(/^\.companion\/runtime\/image\/companion-.+\.tar\.gz\.b64$/);
+        providerFileWrites.push(body.path ?? "");
+        return response({ ok: true });
+      }
+      if (url.endsWith("/commands") && method === "POST") {
+        if (body.command?.includes("runtime_image_boxignore")) {
+          expect(body.command).toContain('mktemp "$HOME/.boxignore.tmp.XXXXXX"');
+          expect(body.command).toContain('chmod 600 "$runtime_image_boxignore"');
+          expect(body.command).toContain('mv -f -- "$runtime_image_boxignore" "$HOME/.boxignore"');
+          const encoded = /printf '%s' '([^']+)' \| base64 --decode/.exec(body.command)?.[1];
+          expect(encoded).toBeTruthy();
+          installedBoxIgnore = Buffer.from(encoded!, "base64").toString("utf8");
+          return response(commandResult());
+        }
+        return response(commandResult("companion-runtime-playbook-ready\n"));
+      }
+      if (url.endsWith("/stop") && method === "POST") {
+        expect(installedBoxIgnore).toBe(expectedBoxIgnore);
+        archived = true;
+        return response({ box: box("archived") });
+      }
+      if (url.endsWith("/boxes/bx_23456789") && method === "GET") {
+        return response({ box: box(archived && !resumed ? "archived" : "ready") });
+      }
+      if (url.endsWith("/resume") && method === "POST") {
+        resumed = true;
+        return response({ box: box("ready") }, 202);
+      }
+      throw new Error(`unexpected request ${method} ${url}`);
+    }));
+    const bundledSkill = {
+      slug: "companion-runtime",
+      version: "1.0.0",
+      checksum: "b".repeat(64),
+      archive: Buffer.from("skill"),
+    };
+    const runtime = new AsciiBoxCompanionRuntime({
+      COMPANION_BOX_API_KEY: "box_test",
+      COMPANION_BOX_POLL_INTERVAL_MS: "1",
+      COMPANION_BOX_READY_TIMEOUT_MS: "100",
+    }, { companionSkillChecksum: bundledSkill.checksum });
+
+    await expect(runtime.prepareRuntimeImage({
+      boxId: "bx_23456789",
+      bundledSkill,
+    })).resolves.toBeUndefined();
+
+    expect(installedBoxIgnore).toBe(expectedBoxIgnore);
+    expect(archived).toBe(true);
+    expect(providerFileWrites).toEqual([
+      `.companion/runtime/image/companion-${bundledSkill.checksum}.tar.gz.b64`,
+    ]);
+  });
+
+  it("refuses to archive a runtime image when the ignore file command fails", async () => {
+    const fileWrites: string[] = [];
+    let archiveRequests = 0;
+    vi.stubGlobal("fetch", vi.fn(async (rawUrl: string | URL | Request, init?: RequestInit) => {
+      const url = String(rawUrl);
+      const method = init?.method ?? "GET";
+      const body = init?.body ? JSON.parse(String(init.body)) as {
+        command?: string;
+        path?: string;
+      } : {};
+      if (url.endsWith("/commands") && method === "POST") {
+        expect(body.command).toContain("runtime_image_boxignore");
+        return response({ success: false, exitCode: 1, stdout: "", stderr: "write refused" });
+      }
+      if (url.endsWith("/files") && method === "PUT") {
+        fileWrites.push(body.path ?? "");
+        return response({ ok: true });
+      }
+      if (url.endsWith("/stop") && method === "POST") {
+        archiveRequests += 1;
+        return response({ box: box("archived") });
+      }
+      throw new Error(`unexpected request ${method} ${url}`);
+    }));
+    const bundledSkill = {
+      slug: "companion-runtime",
+      version: "1.0.0",
+      checksum: "c".repeat(64),
+      archive: Buffer.from("skill"),
+    };
+    const runtime = new AsciiBoxCompanionRuntime(
+      { COMPANION_BOX_API_KEY: "box_test" },
+      { companionSkillChecksum: bundledSkill.checksum },
+    );
+
+    await expect(runtime.prepareRuntimeImage({
+      boxId: "bx_23456789",
+      bundledSkill,
+    })).rejects.toThrow("Runtime image Box ignore file failed to install");
+
+    expect(fileWrites).toEqual([]);
+    expect(archiveRequests).toBe(0);
   });
 
   it("reads live GET box.info and resume box.resuming envelopes", async () => {

--- a/packages/box-runtime/src/boxCompanionRuntime.ts
+++ b/packages/box-runtime/src/boxCompanionRuntime.ts
@@ -4554,7 +4554,23 @@ rm -f "/run/user/$(id -u)/companion/providers.env" \
       throw new BoxRuntimeProviderError("Runtime image Companion skill identity changed", 409);
     }
     const bakedSkillPath = `.companion/runtime/image/companion-${input.bundledSkill.checksum}.tar.gz.b64`;
-    await this.#writeFile(input.boxId, ".boxignore", RUNTIME_IMAGE_BOXIGNORE);
+    const encodedBoxIgnore = Buffer.from(RUNTIME_IMAGE_BOXIGNORE, "utf8").toString("base64");
+    const installedBoxIgnore = await this.#command(
+      input.boxId,
+      `set -euo pipefail
+runtime_image_boxignore="$(mktemp "$HOME/.boxignore.tmp.XXXXXX")"
+cleanup_runtime_image_boxignore() { rm -f "$runtime_image_boxignore"; }
+trap cleanup_runtime_image_boxignore EXIT
+printf '%s' ${shellQuote(encodedBoxIgnore)} | base64 --decode > "$runtime_image_boxignore"
+chmod 600 "$runtime_image_boxignore"
+mv -f -- "$runtime_image_boxignore" "$HOME/.boxignore"
+trap - EXIT`,
+      30,
+      input.signal,
+    );
+    if (!installedBoxIgnore.success) {
+      throw new BoxRuntimeProviderError("Runtime image Box ignore file failed to install", 502);
+    }
     await this.#writeFile(input.boxId, bakedSkillPath, input.bundledSkill.archive.toString("base64"));
 
     await this.#archiveBox({ boxId: input.boxId, signal: input.signal });


### PR DESCRIPTION
## Summary
- install the fixed runtime-image `.boxignore` through a bounded command with a same-filesystem temporary file, mode `0600`, and atomic rename, avoiding ascii.dev's reserved provider file path
- keep the bundled Companion skill archive on the existing file/chunk transport and fail before archive when the ignore file cannot be installed
- add provider-boundary regression coverage for exact ignore contents, archive ordering, reserved-path avoidance, and fail-closed command failure

## Verification
- [x] `pnpm --filter @companion/box-runtime exec vitest run src/boxCompanionRuntime.test.ts` - 99 tests passed after the final stack-21 rebase
- [x] `pnpm --filter @companion/box-runtime typecheck` - passed after the final stack-21 rebase
- [x] `pnpm --filter @companion/box-runtime test` - 17 files and 346 tests passed before the conflict-free final rebase
- [x] `pnpm --filter @companion/runtime exec vitest run src/imageBuildWorker.test.ts src/boxAdapters.test.ts` - 31 tests passed; failed images retain cold fallback
- [x] `pnpm typecheck` - all 20 workspaces passed before the conflict-free final rebase
- [x] `pnpm verify:change -- --base origin/conductor/runtime-v3-stack-20-live-pi-replies` - selected fast checks passed; exited 2 for database/runtime/container CI follow-ups
- [ ] Box Lab, live provider canary, Docker, and full local stack - intentionally not run per task constraints

## CI
- Latest commit: `4a8a21c`
- Status: pending
- Checks: quality, build, database, deterministic runtime integration, and containers are expected from scope selection

## Review Gate
- `review-code-dev`: passed with no accepted findings; narrow inline fallback reconfirmed after the isolated reviewer wrote artifacts but did not return control
- Required lenses: shell/file boundary, expurgated failures, behavior coverage, image-builder cold fallback

## Risk
- The command relies on the same GNU/Linux `base64`, `mktemp`, `chmod`, and `mv` tools already used by the Runtime v3 Box layout.
- Image preparation remains optional and isolated from tenant Box creation; failures continue to select the existing cold path.

## Human Review Notes
- Please focus on the provider boundary: `.boxignore` must never be sent through `PUT /files`, while the bundled skill archive must continue to use that path.

<!-- conductor-workspace-link -->

---

[Open workspace in Conductor](https://app.conductor.build/workspace/5ae4f87b-161a-4d22-a40b-4e3761d7d246)


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/The-Vibe-Company/companion/pull/734?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->





<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

The PR replaces the reserved provider file write for the runtime-image `.boxignore` with a bounded command that installs it atomically before uploading and archiving the bundled skill.
- Creates the ignore file through a mode-`0600`, same-filesystem temporary file and atomic rename.
- Fails image preparation before skill upload or archive when installation fails.
- Adds regression coverage for exact contents, request ordering, reserved-path avoidance, and fail-closed behavior.
</details>


<details><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge, with no blocking code failure remaining from the prior review thread.

No blocking failure remains; live-provider smoke and credentialed canary validation were explicitly retained as deferred environment gates rather than code changes.
</details>


<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| packages/box-runtime/src/boxCompanionRuntime.ts | Safely installs the runtime-image `.boxignore` through the command boundary and aborts before upload or archive on failure. |
| packages/box-runtime/src/boxCompanionRuntime.test.ts | Adds deterministic provider-boundary coverage for ignore contents, atomic-install command shape, ordering, reserved-path avoidance, and failure handling. |

</details>

<sub>Reviews (2): Last reviewed commit: ["fix(runtime): install baker boxignore sa..."](https://github.com/the-vibe-company/companion/commit/2d6e17505012189b240bf22d5fe25f8a4d55efed) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=60133157)</sub>

<!-- /greptile_comment -->