### PR TITLE
fix(ci): ignore audited runtime purge fixtures

### DIFF
--- a/.gitleaksignore
+++ b/.gitleaksignore
@@ -34,3 +34,5 @@ a30e3cf92fcfbe99e33402deee30505dc2b3d3b7:packages/contracts/test/companions.test
 # exact inventory/reconciliation behavior. Keep both historical findings fingerprint-specific.
 5bbc924152ca00f9f83eaa15f7c3321065a1e0e3:apps/runtime/src/companionV2Purge.test.ts:generic-api-key:52
 5bbc924152ca00f9f83eaa15f7c3321065a1e0e3:apps/runtime/src/companionV2Purge.test.ts:generic-api-key:66
+edf96916b33d636529965f763a00233499eabd94:apps/runtime/src/companionV2Purge.test.ts:generic-api-key:75
+edf96916b33d636529965f763a00233499eabd94:apps/runtime/src/companionV2Purge.test.ts:generic-api-key:89


### PR DESCRIPTION
## Summary
- annotate only the two confirmed synthetic Runtime v2 purge-test findings with exact historical fingerprints
- leave the possible progression-test identifiers unsuppressed because the pinned scanner does not flag them

## Verification
- [x] pinned CI Gitleaks v8.30.1, exact `8c3bf661..1a7232b` push range — no leaks
- [x] pinned CI Gitleaks v8.30.1, `8c3bf661..HEAD` and `origin/main..HEAD` — no leaks
- [x] `pnpm --filter @companion/runtime test -- src/companionV2Purge.test.ts` — 14 tests passed
- [x] `pnpm --filter @companion/companion-runtime test -- src/v3/progression.test.ts` — 69 tests passed
- [x] `pnpm verify:change` fast checks — 40 lint/typecheck/test tasks, six builds, hygiene/design/skill guards passed
- [x] repository-selected CI lanes — database, runtime-integrated database path, browser, containers, dependency audit, Apple, build, and quality passed

## CI
- Latest commit: `3808fa057a4ca1893890fcb6f7ee8deff4ba61a3`
- Status: all visible non-skipped checks green
- Checks: Hygiene, Greptile, Quality, CI Gate, Apple Quality, Application Build, Database Integration, Railway Containers, Browser Critical Flows, Scope, Vercel, and Vercel Preview Comments passed

## Review Gate
- incident `code-review`: passed, 0 Standards findings and 0 Spec findings
- `review-code-dev`: passed, no issues found
- Required lenses: tooling/security hygiene

## Risk
- No production behavior, tests, migrations, Railway configuration, or broad Gitleaks allowlist changed.
- Exact fingerprint annotations are intentionally tied to the historical commit, file, rule, and line.

## Human Review Notes
- Confirm the two exact fixture annotations are the only intended diff.
