### PR TITLE
fix(runtime): reconcile v2 purge deletion absence

### DIFF
--- a/apps/runtime/src/companionV2Purge.test.ts
+++ b/apps/runtime/src/companionV2Purge.test.ts
@@ -2,11 +2,13 @@ import { describe, expect, it } from "vitest";
 import { BoxRuntimeAdapterError } from "@companion/box-runtime";
 
 import {
+  companionV2BoxPresent,
   collectCompanionV2ObjectKeys,
   assertCompanionV2PurgeDisabled,
   mergeCompanionV2PurgeTargets,
   parseCompanionV2PurgeArgs,
   processCompanionV2PurgeTargets,
+  removeCompanionV2BoxTarget,
   type CompanionV2PurgeJournal,
   type CompanionV2PurgeTarget,
 } from "./companionV2Purge";
@@ -281,8 +283,9 @@ describe("Runtime v2 external purge checkpoints", () => {
     expect({ effects, outcomes }).toEqual({ effects: [], outcomes: ["absent"] });
   });
 
-  it("polls a durable Box operation even after the Box leaves ordinary inventory", async () => {
+  it("settles a resumed durable Box operation when fresh inventory proves absence", async () => {
     const effects: string[] = [];
+    const outcomes: Array<{ outcome: string; operationId: string | null | undefined }> = [];
     await processCompanionV2PurgeTargets({
       targets: [{
         kind: "box",
@@ -293,7 +296,9 @@ describe("Runtime v2 external purge checkpoints", () => {
       }],
       journal: {
         async markRequesting() {},
-        async markComplete() {},
+        async markComplete(target, outcome) {
+          outcomes.push({ outcome, operationId: target.operationId });
+        },
         async markFailure() {},
       },
       providerPresent: () => false,
@@ -302,10 +307,61 @@ describe("Runtime v2 external purge checkpoints", () => {
         return "completed";
       },
     });
-    expect(effects).toEqual(["bdop_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"]);
+    expect(effects).toEqual([]);
+    expect(outcomes).toEqual([{
+      outcome: "absent",
+      operationId: "bdop_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+    }]);
   });
 
-  it("fails closed before a requesting effect when authenticated reconciliation fails", async () => {
+  it("settles a newly accepted Box deletion after checkpoint when inventory proves absence", async () => {
+    const operationId = "bdop_bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb";
+    const checkpoints: string[] = [];
+    const boxClient = {
+      requestPermanentDeletion: async () => ({
+        outcome: "accepted" as const,
+        operation: {
+          id: operationId,
+          targetId: "bx_newly_admitted",
+          status: "blocked" as const,
+          attemptCount: 1,
+          requestedAt: new Date(0).toISOString(),
+          completedAt: null,
+        },
+      }),
+      listAllBoxes: async () => [],
+      getDeletionOperation: async () => {
+        throw new Error("operation polling must not run after authoritative absence");
+      },
+    };
+
+    await expect(removeCompanionV2BoxTarget({
+      target: {
+        kind: "box",
+        key: "bx_newly_admitted",
+        evidence: ["provider-name:companion-generation"],
+      },
+      journal: {
+        async markRequesting() {},
+        async markAbsent() {},
+        async markOperation(_boxId, operation) { checkpoints.push(operation.id); },
+        async markError() {},
+      },
+      boxClient,
+    })).resolves.toBe("absent");
+    expect(checkpoints).toEqual([operationId]);
+  });
+
+  it("fails closed on unavailable or malformed Box reconciliation reads", async () => {
+    await expect(companionV2BoxPresent({
+      listAllBoxes: async () => { throw new Error("authenticated Box inventory unavailable"); },
+    }, "bx_unknown")).rejects.toThrow("authenticated Box inventory unavailable");
+    await expect(companionV2BoxPresent({
+      listAllBoxes: async () => null,
+    }, "bx_unknown")).rejects.toThrow("Box inventory returned a malformed response");
+  });
+
+  it("fails closed before polling a recorded operation when reconciliation fails", async () => {
     const events: string[] = [];
     await expect(processCompanionV2PurgeTargets({
       targets: [{
@@ -313,7 +369,7 @@ describe("Runtime v2 external purge checkpoints", () => {
         key: "bx_unknown",
         evidence: ["database:runtime-instance"],
         state: "requesting",
-        operationId: null,
+        operationId: "bdop_cccccccccccccccccccccccccccccccc",
       }],
       journal: {
         async markRequesting() { events.push("requesting"); },

--- a/apps/runtime/src/companionV2Purge.test.ts
+++ b/apps/runtime/src/companionV2Purge.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import { BoxRuntimeAdapterError } from "@companion/box-runtime";
 
 import {
@@ -350,6 +350,71 @@ describe("Runtime v2 external purge checkpoints", () => {
       boxClient,
     })).resolves.toBe("absent");
     expect(checkpoints).toEqual([operationId]);
+  });
+
+  it("settles when a Box disappears during nonterminal operation polling", async () => {
+    vi.useFakeTimers();
+    try {
+      const operationId = "bdop_dddddddddddddddddddddddddddddddd";
+      const operationCheckpoints: string[] = [];
+      let inventoryReads = 0;
+      let operationReads = 0;
+      const removal = removeCompanionV2BoxTarget({
+        target: {
+          kind: "box",
+          key: "bx_delayed_absence",
+          evidence: ["provider-name:companion-generation"],
+        },
+        journal: {
+          async markRequesting() {},
+          async markAbsent() {},
+          async markOperation(_boxId, operation) {
+            operationCheckpoints.push(operation.id);
+          },
+          async markError() {},
+        },
+        boxClient: {
+          async requestPermanentDeletion() {
+            return {
+              outcome: "accepted" as const,
+              operation: {
+                id: operationId,
+                targetId: "bx_delayed_absence",
+                status: "pending" as const,
+                attemptCount: 0,
+                requestedAt: new Date(0).toISOString(),
+                completedAt: null,
+              },
+            };
+          },
+          async listAllBoxes() {
+            inventoryReads += 1;
+            return inventoryReads === 1 ? [{ id: "bx_delayed_absence" }] : [];
+          },
+          async getDeletionOperation() {
+            operationReads += 1;
+            return {
+              id: operationId,
+              targetId: "bx_delayed_absence",
+              status: "blocked" as const,
+              attemptCount: 1,
+              requestedAt: new Date(0).toISOString(),
+              completedAt: null,
+            };
+          },
+        },
+      });
+
+      await vi.advanceTimersByTimeAsync(1_000);
+      await expect(removal).resolves.toBe("absent");
+      expect({ inventoryReads, operationReads, operationCheckpoints }).toEqual({
+        inventoryReads: 2,
+        operationReads: 1,
+        operationCheckpoints: [operationId, operationId],
+      });
+    } finally {
+      vi.useRealTimers();
+    }
   });
 
   it("fails closed on unavailable or malformed Box reconciliation reads", async () => {

--- a/apps/runtime/src/companionV2Purge.ts
+++ b/apps/runtime/src/companionV2Purge.ts
@@ -210,9 +210,7 @@ export async function processCompanionV2PurgeTargets(input: {
         })))(delay);
       }
     }
-    const present = target.kind === "box" && target.operationId
-      ? undefined
-      : await input.providerPresent(target);
+    const present = await input.providerPresent(target);
     if (present === false) {
       await input.journal.markComplete(target, "absent");
       continue;
@@ -654,14 +652,10 @@ function createCompanionWithRuntimePurgeJournal(client: CompanionV2PurgeSql): Co
   };
 }
 
-function boxJournal(
-  client: CompanionV2PurgeSql,
-  onTerminal: (outcome: "completed" | "absent") => void,
-): LegacyTargetJournal {
+function boxJournal(client: CompanionV2PurgeSql): LegacyTargetJournal {
   return {
     async markRequesting() {},
     async markAbsent(boxId) {
-      onTerminal("absent");
       await client`
         update public.companion_v2_purge_targets
         set operation_id = null, retry_after = null, updated_at = statement_timestamp()
@@ -669,7 +663,6 @@ function boxJournal(
       `;
     },
     async markOperation(boxId, operation) {
-      if (operation.status === "completed") onTerminal("completed");
       await client`
         update public.companion_v2_purge_targets
         set operation_id = ${operation.id}, retry_after = null, updated_at = statement_timestamp()
@@ -680,27 +673,27 @@ function boxJournal(
   };
 }
 
-async function removeCompanionV2BoxTarget(input: {
+export async function removeCompanionV2BoxTarget(input: {
   target: CompanionV2PurgeTarget;
-  client: CompanionV2PurgeSql;
-  boxClient: CompanionV2BoxPurgeClient;
+  journal: LegacyTargetJournal;
+  boxClient: Pick<CompanionV2BoxPurgeClient,
+    "listAllBoxes" | "requestPermanentDeletion" | "getDeletionOperation">;
   afterRequestAccepted?(target: CompanionV2PurgeTarget): Promise<void>;
   afterOperationCheckpoint?(target: CompanionV2PurgeTarget): Promise<void>;
 }): Promise<"completed" | "absent"> {
-  let outcome: "completed" | "absent" = "completed";
-  const journal = boxJournal(input.client, (terminal) => { outcome = terminal; });
   let operationId = input.target.operationId ?? null;
   if (!operationId) {
     const deletion = await input.boxClient.requestPermanentDeletion({ boxId: input.target.key });
     if (deletion.outcome === "absent") {
-      await journal.markAbsent(input.target.key);
+      await input.journal.markAbsent(input.target.key);
       return "absent";
     }
     await input.afterRequestAccepted?.(input.target);
     operationId = deletion.operation.id;
-    await journal.markOperation(input.target.key, deletion.operation, false);
+    await input.journal.markOperation(input.target.key, deletion.operation, false);
     await input.afterOperationCheckpoint?.(input.target);
-    if (deletion.operation.status === "completed") return outcome;
+    if (deletion.operation.status === "completed") return "completed";
+    if (!await companionV2BoxPresent(input.boxClient, input.target.key)) return "absent";
   }
 
   const deadline = Date.now() + BOX_DELETE_TIMEOUT_MS;
@@ -713,9 +706,20 @@ async function removeCompanionV2BoxTarget(input: {
       operationId,
       boxId: input.target.key,
     });
-    await journal.markOperation(input.target.key, operation, true);
-    if (operation.status === "completed") return outcome;
+    await input.journal.markOperation(input.target.key, operation, true);
+    if (operation.status === "completed") return "completed";
   }
+}
+
+export async function companionV2BoxPresent(
+  boxClient: { listAllBoxes(): Promise<readonly { id: string }[] | null> },
+  boxId: string,
+): Promise<boolean> {
+  const boxes = await boxClient.listAllBoxes();
+  if (!Array.isArray(boxes)) {
+    throw new Error("Box inventory returned a malformed response");
+  }
+  return boxes.some((box) => box.id === boxId);
 }
 
 async function removeCompanionV2Target(input: {
@@ -740,7 +744,7 @@ async function removeCompanionV2Target(input: {
   if (input.target.kind === "box") {
     return removeCompanionV2BoxTarget({
       target: input.target,
-      client: input.client,
+      journal: boxJournal(input.client),
       boxClient: input.boxClient,
       afterRequestAccepted: input.afterBoxRequestAccepted,
       afterOperationCheckpoint: input.afterBoxOperationCheckpoint,
@@ -917,7 +921,7 @@ export async function executeConfirmedCompanionV2Purge(input: {
     // reads immediately, before the retained bdop finishes. Presence therefore proves admission
     // did not occur; absence is sufficient to close this purge target without replaying DELETE.
     // https://docs.ascii.dev/box/api/reference/boxes/permanently-delete-box-data.md
-    return (await input.boxClient.listAllBoxes()).some((box) => box.id === target.key);
+    return companionV2BoxPresent(input.boxClient, target.key);
   };
   const processing: Parameters<typeof processCompanionV2PurgeTargets>[0] = {
     targets,

--- a/apps/runtime/src/companionV2Purge.ts
+++ b/apps/runtime/src/companionV2Purge.ts
@@ -708,6 +708,7 @@ export async function removeCompanionV2BoxTarget(input: {
     });
     await input.journal.markOperation(input.target.key, operation, true);
     if (operation.status === "completed") return "completed";
+    if (!await companionV2BoxPresent(input.boxClient, input.target.key)) return "absent";
   }
 }
 

--- a/docs/companions-runtime.md
+++ b/docs/companions-runtime.md
@@ -1403,12 +1403,13 @@ storage/Box/snapshot inventory covers those resources, and complete authenticate
 or Sentry lookup covers remote triggers. Proven absence closes the target without another DELETE.
 Every Box target, including one with a recorded operation, is reconciled through fresh authenticated
 ordinary inventory first; absence is authoritative admission evidence and preserves any recorded
-operation id, while a still-visible operation-bearing Box resumes by polling. A newly accepted
-deletion is reconciled again immediately after its operation checkpoint, so an already-absent Box
-settles without waiting for physical erasure. Fresh visibility without an operation proves the
-provider's documented immediate-removal admission boundary was not crossed and permits a new
-request. An unavailable, malformed, or unknown observation fails closed; known-negative DELETE
-rejection is retried only after backoff.
+operation id, while a still-visible operation-bearing Box resumes by polling. Every nonterminal
+operation observation is followed by another ordinary inventory read, so later authoritative
+absence also settles without waiting for physical erasure. A newly accepted deletion receives the
+same reconciliation immediately after its operation checkpoint. Fresh visibility without an
+operation proves the provider's documented immediate-removal admission boundary was not crossed and
+permits a new request. An unavailable, malformed, or unknown observation fails closed;
+known-negative DELETE rejection is retried only after backoff.
 Automatic trigger registrations whose create may have committed before `remote_hook_id` was saved
 remain purge targets whenever their provider account is still owned. Report and dry-run inventory
 their provider, account, and non-secret locator without selecting or serializing the callback

--- a/docs/companions-runtime.md
+++ b/docs/companions-runtime.md
@@ -1397,14 +1397,18 @@ skipped on retry. Sentry's
 [documented pagination contract](https://docs.sentry.io/api/pagination/) always exposes a `next`
 cursor, so that link must carry exactly one boolean `results` parameter: `false` is authoritative
 end-of-list and only `true` advances to the cursor. GitHub does not require that Sentry-specific
-parameter. A recorded Box operation is polled rather than resubmitted. A nonterminal retry performs an
+parameter. A recorded Box operation is never resubmitted. A nonterminal retry performs an
 authoritative provider observation first:
 storage/Box/snapshot inventory covers those resources, and complete authenticated GitHub, Linear,
-or Sentry lookup covers remote triggers. Proven absence closes the target without another DELETE; an
-operation-bearing Box resumes by polling. Without an operation id, fresh authenticated Box absence
-closes the target without replay, while fresh visibility proves the provider's documented
-immediate-removal admission boundary was not crossed and permits a new request. An unavailable or
-unknown observation fails closed; known-negative DELETE rejection is retried only after backoff.
+or Sentry lookup covers remote triggers. Proven absence closes the target without another DELETE.
+Every Box target, including one with a recorded operation, is reconciled through fresh authenticated
+ordinary inventory first; absence is authoritative admission evidence and preserves any recorded
+operation id, while a still-visible operation-bearing Box resumes by polling. A newly accepted
+deletion is reconciled again immediately after its operation checkpoint, so an already-absent Box
+settles without waiting for physical erasure. Fresh visibility without an operation proves the
+provider's documented immediate-removal admission boundary was not crossed and permits a new
+request. An unavailable, malformed, or unknown observation fails closed; known-negative DELETE
+rejection is retried only after backoff.
 Automatic trigger registrations whose create may have committed before `remote_hook_id` was saved
 remain purge targets whenever their provider account is still owned. Report and dry-run inventory
 their provider, account, and non-secret locator without selecting or serializing the callback

--- a/docs/design.md
+++ b/docs/design.md
@@ -322,15 +322,17 @@ The FK-free purge ledger stores only resource kind/key, bounded evidence, provid
 identity, terminal state, and expurgated failure text. Remote trigger registrations,
 attachment/output objects, named v2 snapshots, build Boxes, duplicate Boxes, and every generation
 Box are removed before the final SQL transaction. `404` is successful absence; another failure
-leaves all Companion ownership rows intact. A retry skips terminal targets and resumes any recorded
-Box operation. `requesting` targets are never blindly replayed: current storage/Box/snapshot
-inventory and authenticated provider-specific trigger lookup first prove whether the resource is
-present or absent. For Box DELETE, a durable operation id is always polled. Without one, fresh
-authenticated absence means the `202` admission was acquired (or the Box was already absent), so
-the ledger closes without replay; fresh visibility means the documented immediate-removal boundary
-was not crossed and permits a new attempt. Unknown reads fail closed. Known-negative Box failures
-return to `discovered` with a bounded backoff. The owner-only runtime enable function takes the same
-advisory lock, so it cannot reactivate claims during provider cleanup.
+leaves all Companion ownership rows intact. A retry skips terminal targets and never resubmits a
+recorded Box operation. `requesting` targets are never blindly replayed: current
+storage/Box/snapshot inventory and authenticated provider-specific trigger lookup first prove
+whether the resource is present or absent. For Box DELETE, fresh authenticated ordinary inventory
+is authoritative before polling: absence closes the ledger while preserving any durable operation
+id, and a still-visible Box with an operation resumes that poll. A newly accepted deletion repeats
+the inventory check after its operation checkpoint, so absence may settle without waiting for
+physical erasure. Without an operation id, fresh visibility means the documented immediate-removal
+boundary was not crossed and permits a new attempt. Unknown or malformed reads fail closed.
+Known-negative Box failures return to `discovered` with a bounded backoff. The owner-only runtime
+enable function takes the same advisory lock, so it cannot reactivate claims during provider cleanup.
 
 The finalizer deletes the Companion aggregate and all v2 runtime children. It locks preserved
 tables and takes the before/after baseline only around that final transaction; normal Skills Hub

--- a/docs/design.md
+++ b/docs/design.md
@@ -327,9 +327,10 @@ recorded Box operation. `requesting` targets are never blindly replayed: current
 storage/Box/snapshot inventory and authenticated provider-specific trigger lookup first prove
 whether the resource is present or absent. For Box DELETE, fresh authenticated ordinary inventory
 is authoritative before polling: absence closes the ledger while preserving any durable operation
-id, and a still-visible Box with an operation resumes that poll. A newly accepted deletion repeats
-the inventory check after its operation checkpoint, so absence may settle without waiting for
-physical erasure. Without an operation id, fresh visibility means the documented immediate-removal
+id, and a still-visible Box with an operation resumes that poll. Each nonterminal operation
+observation repeats the inventory check, so later absence may settle without waiting for physical
+erasure; a newly accepted deletion receives the same check after its operation checkpoint. Without
+an operation id, fresh visibility means the documented immediate-removal
 boundary was not crossed and permits a new attempt. Unknown or malformed reads fail closed.
 Known-negative Box failures return to `discovered` with a bounded backoff. The owner-only runtime
 enable function takes the same advisory lock, so it cannot reactivate claims during provider cleanup.

--- a/docs/runbooks/companions-runtime.md
+++ b/docs/runbooks/companions-runtime.md
@@ -267,10 +267,11 @@ returns `202` and immediately removes the Box from ordinary reads while the reta
 operation completes; [data retention](https://docs.ascii.dev/box/data-retention.md) is separate from
 that admission boundary. Therefore fresh authenticated ordinary inventory is checked before a
 recorded operation is polled; absence records `absent` without replay and retains the operation id
-as admission evidence. After a newly accepted deletion is checkpointed, the same inventory check
-may settle an already-absent Box without waiting for physical erasure. Only a still-visible Box with
-a recorded operation is polled, while fresh visibility without one proves admission did not occur
-and permits a new attempt. `absent` does not claim that physical erasure has finished. Malformed,
+as admission evidence. After a newly accepted deletion is checkpointed and after every nonterminal
+operation observation, the same inventory check may settle an absent Box without waiting for
+physical erasure. Only a still-visible Box with a recorded operation continues polling, while fresh
+visibility without one proves admission did not occur and permits a new attempt. `absent` does not
+claim that physical erasure has finished. Malformed,
 unsupported, unknown, or unavailable reads fail closed. A known-negative DELETE rejection returns
 to retryable state with bounded backoff.
 

--- a/docs/runbooks/companions-runtime.md
+++ b/docs/runbooks/companions-runtime.md
@@ -265,8 +265,11 @@ Absence closes the ledger without another DELETE. Box recovery follows the provi
 [permanent deletion](https://docs.ascii.dev/box/api/reference/boxes/permanently-delete-box-data.md)
 returns `202` and immediately removes the Box from ordinary reads while the retained `bdop_...`
 operation completes; [data retention](https://docs.ascii.dev/box/data-retention.md) is separate from
-that admission boundary. Therefore a recorded operation is polled, fresh authenticated absence
-without one is recorded `absent` without replay, and fresh visibility proves admission did not occur
+that admission boundary. Therefore fresh authenticated ordinary inventory is checked before a
+recorded operation is polled; absence records `absent` without replay and retains the operation id
+as admission evidence. After a newly accepted deletion is checkpointed, the same inventory check
+may settle an already-absent Box without waiting for physical erasure. Only a still-visible Box with
+a recorded operation is polled, while fresh visibility without one proves admission did not occur
 and permits a new attempt. `absent` does not claim that physical erasure has finished. Malformed,
 unsupported, unknown, or unavailable reads fail closed. A known-negative DELETE rejection returns
 to retryable state with bounded backoff.


### PR DESCRIPTION
## Summary
- reconcile every nonterminal Box purge target through fresh authenticated ordinary inventory, including resumed targets with retained operation ids
- after checkpointing a newly accepted deletion, settle authoritative absence without waiting for physical erasure or replaying DELETE
- preserve retained operation ids, fail closed on unavailable or malformed inventory, and align runtime/operator documentation

## Verification
- [x] `pnpm --filter @companion/runtime exec vitest run src/companionV2Purge.test.ts` - 16 focused tests passed
- [x] `pnpm --filter @companion/runtime test` - 246 runtime tests passed
- [x] `pnpm --filter @companion/runtime typecheck` - passed
- [x] `pnpm verify:change` fast checks - hygiene, anti-slop, scoped quality, and build passed
- [ ] disposable-PostgreSQL database/runtime integration - delegated to PR CI because this workspace has no configured disposable database roles
- [ ] container smoke - delegated to PR CI; Docker was explicitly excluded from local verification

## CI
- Latest commit: `22ad728`
- Status: pending
- Checks: GitHub checks will run on this PR

## Review Gate
- `review-code-dev`: passed after one documentation P2 was fixed and targeted re-review found no issues
- Required lenses: async/state, idempotency, fail-closed provider reconciliation

## Risk
- Narrow offline Runtime v2 purge behavior change; no schema, API, runtime-v3, or provider client changes
- Ordinary authenticated Box absence is used only after the provider adapter validates the complete list response

## Human Review Notes
- Live incident evidence: the retained deletion operation reported `blocked` while authenticated ordinary Box inventory no longer contained the target; provider admission and physical erasure completion are separate
- The coordinator will handle CI, merge, and production execution

<!-- conductor-workspace-link -->

---

[Open workspace in Conductor](https://app.conductor.build/workspace/430dc606-6519-4ac2-97c8-1780c99984e2)


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/The-Vibe-Company/companion/pull/736?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->





<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

The PR completes the Runtime v2 Box purge reconciliation fix by treating authenticated ordinary-inventory absence as authoritative before and during deletion-operation polling.
- Reconciles resumed and newly accepted Box deletion operations without replaying DELETE.
- Preserves retained operation IDs while settling absent targets.
- Fails closed when Box inventory is unavailable or malformed.
- Adds focused tests and aligns runtime, design, and runbook documentation.
</details>


<details><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge.

The previously reported polling-absence failure is fixed: every nonterminal operation poll now performs an authenticated inventory reconciliation, returns `absent` when the Box disappears, and the outer journal persists that terminal outcome.
</details>


<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| apps/runtime/src/companionV2Purge.ts | Reconciles Box presence before and during operation polling, persists returned terminal outcomes through the outer purge journal, and rejects malformed inventory responses. |
| apps/runtime/src/companionV2Purge.test.ts | Covers resumed operations, post-checkpoint absence, disappearance during polling, operation-ID retention, and fail-closed inventory errors. |
| docs/companions-runtime.md | Documents authoritative Box inventory reconciliation and the distinction between admission evidence and physical erasure. |
| docs/design.md | Updates the purge-ledger design to describe reconciliation before and during operation polling. |
| docs/runbooks/companions-runtime.md | Aligns operator guidance with the implemented Box deletion recovery behavior. |

</details>


<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Nonterminal Box purge target] --> B[Read authenticated ordinary inventory]
    B -->|Absent| C[Mark target absent]
    B -->|Present with retained operation ID| D[Poll deletion operation]
    B -->|Present without operation ID| E[Request permanent deletion]
    E --> F[Checkpoint operation ID]
    F --> G[Read ordinary inventory]
    D --> H{Operation completed?}
    H -->|Yes| I[Mark target completed]
    H -->|No| G
    G -->|Absent| C
    G -->|Present| D
    B -->|Unavailable or malformed| J[Fail closed]
```
</details>

<sub>Reviews (2): Last reviewed commit: ["fix(runtime): reconcile absence during p..."](https://github.com/the-vibe-company/companion/commit/260b98c6188c5d50e0bd7290ee30d34fbe4cf28b) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=60204405)</sub>

<!-- /greptile_comment -->