### PR TITLE
fix(runtime): restore Companion creation and queue convergence

### DIFF
--- a/apps/runtime/src/imageBuildWorker.test.ts
+++ b/apps/runtime/src/imageBuildWorker.test.ts
@@ -52,6 +52,7 @@ function harness(input: {
   deleteError?: Error;
   authorizePublication?: boolean;
   attemptBudgetMs?: number;
+  visibleBoxId?: string;
 } = {}): {
   options: ImageBuildWorkerOptions;
   calls: RegistryCalls;
@@ -132,7 +133,9 @@ function harness(input: {
     identity: IDENTITY,
     lifecycle: {
       async listAllBoxes() {
-        return [];
+        return input.visibleBoxId
+          ? [{ id: input.visibleBoxId, state: "ready" as const }]
+          : [];
       },
       async requestPermanentDeletion(deleteInput: Record<string, unknown>) {
         calls.deletionRequests.push(deleteInput);
@@ -386,6 +389,7 @@ describe("image build worker", () => {
       parentImageName: null,
     });
     const { calls, controller, done } = harness({
+      visibleBoxId: "bx_orphaned01",
       claim: {
         digest: IDENTITY.imageMarker,
         imageName: IDENTITY.imageName,
@@ -416,6 +420,7 @@ describe("image build worker", () => {
 
   it("settles an expired terminal claim after cleanup without starting a fifth bake", async () => {
     const { calls, controller, done } = harness({
+      visibleBoxId: "bx_terminal01",
       claim: {
         digest: IDENTITY.imageMarker,
         imageName: IDENTITY.imageName,
@@ -447,6 +452,7 @@ describe("image build worker", () => {
 
   it("records cleanup failure without clearing the durable Box pointer", async () => {
     const { calls, controller, done } = harness({
+      visibleBoxId: "bx_orphaned01",
       claim: {
         digest: IDENTITY.imageMarker,
         imageName: IDENTITY.imageName,

--- a/apps/runtime/src/server.test.ts
+++ b/apps/runtime/src/server.test.ts
@@ -13,6 +13,7 @@ import {
   type RuntimeHttpServer,
   type RuntimeSchedulerHealthSnapshot,
 } from "./server";
+import { COMPANION_RUNTIME_V3_BUDGETS } from "@companion/contracts";
 
 const hmacSecret = Buffer.alloc(32, 23);
 const nowMs = 1_800_000_000_000;
@@ -121,14 +122,39 @@ describe("private runtime HTTP server", () => {
     expect(stillFresh.status).toBe(200);
     expect(await stillFresh.json()).toMatchObject({ checks: { sweep_fresh: true } });
 
-    // Only a sweep older than the full widened window is stale.
+    // A recently started active sweep is live work, even before its first completion. This keeps a
+    // bounded cold preparation from failing the platform's deployment health gate.
     handle.setSnapshot({
       ...healthySnapshot(),
+      lastSweepCompletedAt: new Date(nowMs - 16_000),
+    });
+    const activeSweep = await fetch(`${handle.server.baseUrl}/healthz`);
+    expect(activeSweep.status).toBe(200);
+    expect(await activeSweep.json()).toMatchObject({ checks: { sweep_fresh: true } });
+
+    // An idle scheduler still requires a completion inside the short freshness window.
+    handle.setSnapshot({
+      ...healthySnapshot(),
+      activeCount: 0,
       lastSweepCompletedAt: new Date(nowMs - 16_000),
     });
     const staleSweep = await fetch(`${handle.server.baseUrl}/healthz`);
     expect(staleSweep.status).toBe(503);
     expect(await staleSweep.json()).toMatchObject({ checks: { sweep_fresh: false } });
+
+    // Active work does not mask a convergence that exceeded the longest durable runtime budget.
+    handle.setSnapshot({
+      ...healthySnapshot(),
+      lastSweepStartedAt: new Date(
+        nowMs - COMPANION_RUNTIME_V3_BUDGETS.preparationDeadlineMs - 1,
+      ),
+      lastSweepCompletedAt: new Date(
+        nowMs - COMPANION_RUNTIME_V3_BUDGETS.preparationDeadlineMs - 1,
+      ),
+    });
+    const wedgedSweep = await fetch(`${handle.server.baseUrl}/healthz`);
+    expect(wedgedSweep.status).toBe(503);
+    expect(await wedgedSweep.json()).toMatchObject({ checks: { sweep_fresh: false } });
 
     handle.setSnapshot({
       ...healthySnapshot(),

--- a/apps/runtime/src/server.ts
+++ b/apps/runtime/src/server.ts
@@ -9,6 +9,7 @@ import {
   DESKTOP_TIMESTAMP_HEADER,
   verifyDesktopRequest,
 } from "@companion/companion-runtime/runtime-support";
+import { COMPANION_RUNTIME_V3_BUDGETS } from "@companion/contracts";
 
 const DEFAULT_BODY_LIMIT_BYTES = 4 * 1024;
 // Widened from 1s so a single slow DB ping does not flap /healthz (and trip a restart) when the
@@ -20,6 +21,14 @@ const DEFAULT_HEALTH_PING_TIMEOUT_MS = 2_500;
 // it stable even when the sweep interval is very short.
 const MIN_SWEEP_FRESH_WINDOW_MS = 15_000;
 const SWEEP_FRESH_WINDOW_MULTIPLE = 5;
+// A convergence may legitimately own one bounded preparation or Turn command longer than the
+// ordinary sweep cadence. Health must cover the longest durable runtime deadline; an earlier
+// platform restart would turn healthy long work into an ambiguous dispatch.
+const ACTIVE_SWEEP_FRESH_WINDOW_MS = Math.max(
+  COMPANION_RUNTIME_V3_BUDGETS.preparationDeadlineMs,
+  COMPANION_RUNTIME_V3_BUDGETS.heartbeatCommandMs
+    + COMPANION_RUNTIME_V3_BUDGETS.heartbeatSettlementMs,
+);
 
 export interface RuntimeSchedulerHealthSnapshot {
   claimLoopAlive: boolean;
@@ -143,19 +152,27 @@ export function createRuntimeHttpServer(options: RuntimeHttpServerOptions): Runt
       snapshot = emptyUnhealthySnapshot();
     }
     const database = await settlesBefore(options.health.ping(), healthPingTimeoutMs);
+    const startedAt = validDate(snapshot.lastSweepStartedAt);
     const completedAt = validDate(snapshot.lastSweepCompletedAt);
     const errorAt = validDate(snapshot.claimLoopErrorAt);
-    const elapsed = completedAt ? now() - completedAt.getTime() : Number.POSITIVE_INFINITY;
+    const completedElapsed = completedAt
+      ? now() - completedAt.getTime()
+      : Number.POSITIVE_INFINITY;
+    const activeCount = Number.isSafeInteger(snapshot.activeCount) && snapshot.activeCount >= 0
+      ? snapshot.activeCount
+      : 0;
     const sweepFreshWindow = Math.max(
       options.sweepIntervalMs * SWEEP_FRESH_WINDOW_MULTIPLE,
       MIN_SWEEP_FRESH_WINDOW_MS,
     );
-    const sweepFresh = elapsed >= 0 && elapsed <= sweepFreshWindow;
+    const completedSweepFresh = completedElapsed >= 0 && completedElapsed <= sweepFreshWindow;
+    const activeElapsed = startedAt ? now() - startedAt.getTime() : Number.POSITIVE_INFINITY;
+    const activeSweepFresh = activeCount > 0
+      && activeElapsed >= 0
+      && activeElapsed <= ACTIVE_SWEEP_FRESH_WINDOW_MS;
+    const sweepFresh = completedSweepFresh || activeSweepFresh;
     const unrecoveredClaimError = errorAt !== null
       && (completedAt === null || errorAt.getTime() >= completedAt.getTime());
-    const activeCount = Number.isSafeInteger(snapshot.activeCount) && snapshot.activeCount >= 0
-      ? snapshot.activeCount
-      : 0;
     const claimLoop = snapshot.claimLoopAlive && !snapshot.fatal && !unrecoveredClaimError;
     // Image builder liveness (when present) is a hard health gate: a dead loop means every create
     // silently cold-installs. A `failed` digest is only informational — creates still succeed via the

--- a/apps/runtime/test/integration/runtimeV3Progression.integration.test.ts
+++ b/apps/runtime/test/integration/runtimeV3Progression.integration.test.ts
@@ -301,6 +301,47 @@ describe("Runtime v3 progression facts", () => {
       where org_id = ${ids.org}::uuid and companion_id = ${ids.companion}::uuid`;
   });
 
+  it("invalidates a cached queued message when its v3 Turn becomes terminal", async () => {
+    await seedPreparedV3("thread-projection-pi");
+    const messageId = randomUUID();
+    const eventId = `msg:${messageId}`;
+    let turnId = "";
+    let initialSequence = "";
+
+    await asApi(async (sql) => {
+      const accepted = await sql<Array<{ turn: { id: string } }>>`
+        select turn from public.companion_v3_api_enqueue_warm_turn(
+          ${ids.org}::uuid,${ids.companion}::uuid,${messageId}::uuid,
+          'replace my cached queue state')`;
+      turnId = accepted[0]!.turn.id;
+      const window = await sql<Array<{ syncSequence: string }>>`
+        select sync_sequence::text as "syncSequence"
+        from public.companion_api_read_thread_window(
+          ${ids.org}::uuid,${ids.companion}::uuid,null,50,false)`;
+      initialSequence = window[0]!.syncSequence;
+    });
+
+    await ownerSql`update public.companion_v3_turns
+      set state='succeeded',outcome='succeeded',settled_at=clock_timestamp(),
+        updated_at=clock_timestamp()
+      where org_id=${ids.org}::uuid and companion_id=${ids.companion}::uuid
+        and id=${turnId}::uuid`;
+
+    await asApi(async (sql) => {
+      const changes = await sql<Array<{ changedEntries: Array<{
+        event_id: string;
+        queued: boolean;
+      }> }>>`
+        select changed_entries as "changedEntries"
+        from public.companion_api_read_thread_changes(
+          ${ids.org}::uuid,${ids.companion}::uuid,${initialSequence}::bigint,200)`;
+      expect(changes[0]!.changedEntries).toContainEqual(expect.objectContaining({
+        event_id: eventId,
+        queued: false,
+      }));
+    });
+  });
+
   it("creates a cold Companion, durably queues its first Turn, and claims preparation", async () => {
     let coldCompanion: string | null = null;
     const message = randomUUID();

--- a/docs/companion-image-pipeline.md
+++ b/docs/companion-image-pipeline.md
@@ -82,12 +82,16 @@ Semantics:
   `ready` would publish a false clone source. Registry-aware retention/garbage collection belongs
   to phase 3; until then, a provider snapshot-limit error fails visibly and creation takes the
   explicit cold-install path.
-- `build_box_id` is cleared only after provider deletion succeeds behind the active epoch fence.
+- `build_box_id` is cleared only after provider deletion completes or fresh authenticated ordinary
+  inventory proves the Box absent behind the active epoch fence.
   Runtime stores `build_delete_intent_at` before issuing the irreversible call, then stores an
   accepted operation in `build_delete_operation_id` before polling. Takeover resumes a known
-  operation. If the accepted response or its checkpoint is lost, takeover performs only read-only
-  absence reconciliation and never replays `DELETE`; the baker Box's bounded TTL supplies eventual
-  cleanup. A failed or blocked cleanup leaves the intent and both pointers durable. An expired
+  operation only while the Box remains visible. The provider removes an accepted deletion from
+  ordinary inventory before physical erasure and its retained operation may remain nonterminal;
+  proven absence therefore settles cleanup without replaying `DELETE` or waiting on that operation.
+  If the accepted response or its checkpoint is lost, takeover performs only read-only absence
+  reconciliation and never replays `DELETE`; the baker Box's bounded TTL supplies eventual cleanup.
+  A failed or blocked cleanup while the Box remains visible leaves the intent and both pointers durable. An expired
   fourth attempt is reclaimable for cleanup and terminal settlement, but can never start a fifth
   bake.
 - `claim_epoch` is monotonic for the lifetime of a digest row and is never reset on settlement;

--- a/docs/companions-runtime.md
+++ b/docs/companions-runtime.md
@@ -105,6 +105,12 @@ restarts anything, and they never appear in an operation snapshot or reach Pi.
 The user transcript message and turn are inserted in one transaction. Repeating the same POST returns
 the existing Turn and never produces a second Pi admission merely because a proxy or client retried.
 
+Every visible v3 Turn state transition also advances the projection sequence of its originating
+user transcript entry. Incremental clients therefore replace a cached `queued` entry when the Turn
+is admitted, completed, interrupted, or cancelled; receiving the assistant entry alone is not an
+implicit queue acknowledgement. Migration `0182` touches already-terminal v3 entries once so
+clients open during the initial cutover self-repair on their next ordinary delta sync.
+
 The state machine is:
 
 ```text
@@ -459,10 +465,13 @@ table privileges. Each registry worker claims only its configured digest and ima
 epoch-fenced 45-minute lease, runs one bake attempt inside a strict 40-minute outer budget, records
 the baker Box before layout work, and publishes readiness or a stable bounded failure. Immediately
 before the bounded snapshot write it revalidates the exact epoch and Box with lease headroom. The
-Box pointer is cleared only after provider deletion succeeds under that fence. Irreversible-delete intent is persisted before the
+Box pointer is cleared only after provider deletion completes or fresh authenticated ordinary
+inventory proves the Box absent under that fence. Irreversible-delete intent is persisted before the
 provider call; once `DELETE` is accepted, its provider operation id is persisted before polling.
-A blocked cleanup stays durable and takeover resumes the same operation without issuing another
-`DELETE`. If the accepted response or operation checkpoint is lost, takeover uses read-only Box
+Because accepted deletion removes the Box from ordinary inventory before physical erasure, proven
+absence settles cleanup without waiting for a retained nonterminal operation. A blocked cleanup
+stays durable only while the Box remains visible, and takeover resumes the same operation without
+issuing another `DELETE`. If the accepted response or operation checkpoint is lost, takeover uses read-only Box
 absence reconciliation and the bounded baker TTL instead of replaying the write. Takeover reconciles
 those retained pointers before any new bake, including cleanup-only settlement of an expired fourth
 attempt. Retry backoff uses jittered 1, 5, 15, then 60-minute bases with four attempts; availability
@@ -1436,7 +1445,11 @@ provider credentials, and plugin trigger keys are unchanged.
 ## Health, observability, and acceptance
 
 `apps/runtime /healthz` is unhealthy when PostgreSQL is unavailable, the claim loop is stalled, or
-the latest sweep is stale. Operators must be able to observe queue age, claim latency, lifecycle and
+the latest sweep is stale. A recently started active convergence remains fresh through the longest
+durable preparation or Turn deadline, so Railway does not reject a deployment merely because it
+began by finishing queued cold preparation or a healthy long Turn; an active convergence beyond
+that bound is stale.
+Operators must be able to observe queue age, claim latency, lifecycle and
 Turn duration, lease takeover, deadline settlement, unknown/malformed event counts, canonical and
 duplicate Box discovery, permanent-delete progress, and expurgated failure codes without accessing
 secret payloads.

--- a/docs/design.md
+++ b/docs/design.md
@@ -107,7 +107,9 @@ Runtime state is explicit and durable:
   expurgated lifecycle errors.
 - `companion_v3_turns` owns `client_message_id`, command identity, `main` or `background` lane,
   FIFO sequence, admission/activity/outcome facts, durable deadlines, and one stable expurgated
-  error.
+  error. A state-change trigger advances the originating transcript entry's projection sequence,
+  making queue-state replacement part of the same incremental thread contract on web, iOS, and
+  macOS.
 - `companion_v3_lifecycle_requests` idempotently records Owner/Editor prepare, archive, Pi recycle,
   and Owner-only delete intent while provider progress remains on the aggregate.
 - `companion_v3_lane_leases` owns independently fenced `main` and `background` claim tokens,
@@ -353,6 +355,10 @@ startup observes only its run-scoped broker and never idles or recycles the main
 execution interrupts only the scheduler's backoff sleep so a start can hand its newly idle Pi
 directly to the queued turn. `/healthz` fails when PostgreSQL, the claim loop, or the
 latest sweep is unhealthy.
+One recently started active convergence remains fresh through the longest durable preparation or
+Turn deadline. This lets a new replica finish queued cold preparation or a healthy long Turn
+without failing its deployment healthcheck, while work beyond that bound still flips health
+unhealthy.
 
 The production composition owns only Runtime v3 convergence: main lifecycle/preparation/Turn work,
 background Turn work, and deadline enforcement run on independent clocks. There is no reachable
@@ -366,6 +372,10 @@ claim revalidates the lease before Box contact. Prompt and decision writes never
 The throwaway image baker has one additional, local readiness exception: after it checkpoints a
 new baker Box id, the first layout command retries provider HTTP `409` with bounded exponential
 backoff inside the existing build-attempt deadline. Tenant Companion commands remain unchanged.
+Its cleanup checkpoints irreversible-delete intent and the accepted provider operation before
+polling. Fresh authenticated ordinary-inventory absence after that checkpoint is authoritative:
+runtime clears the fenced baker pointer without replaying `DELETE` or waiting for physical erasure;
+a still-visible Box keeps the cleanup durable and retryable.
 When the direct hosted-agent endpoint fails, runtime stays on the safe exec fallback and re-probes
 only through broker state with bounded exponential backoff. Reading the same durable endpoint on a
 later claim preserves that suspect state; only a newer staging observation or a successful probe

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -23,6 +23,7 @@ slow, local-only final validation and is intentionally not part of CI.
 | Agent Auth grants only exact-workspace Skills Hub capabilities | Mixed workspace approval or hosted-runtime access | HTTP + compatibility + PostgreSQL | Broaden the capability registry |
 | Agent Auth child PATs inherit only the active exact-workspace grant snapshot | PAT-to-PAT minting, caller-chosen scope/org, expired inheritance, target mismatch, or plaintext persistence | Contracts + Core + HTTP + PostgreSQL + bundled client | Remove provenance, target binding, pipe-only handoff, or redaction |
 | One accepted message creates exactly one durable turn | Duplicate message/turn after client or proxy retry | Contracts + HTTP + PostgreSQL | Remove `(companion_id, client_message_id)` uniqueness |
+| A completed v3 Turn leaves every client queue projection | An answered message remains visibly queued in a long-lived mobile cache | Core + PostgreSQL + iOS | Stop advancing the user entry when the v3 Turn state changes |
 | A due Companion routine fires exactly once per scheduled instant, and queued routine work is skipped on disable/delete or after ten minutes | Duplicate turn after worker retry, catch-up after flag-off, stuck work after a routine mutation, or a routine row blocking a user message | Core + worker + runtime + PostgreSQL | Drop uuidv5 stamping, the ten-minute cleanup, generation match, or the lane fence |
 | A Companion response notifies only its still-authorized durable author | Cross-user preview disclosure, duplicate push, stale-device delivery, or cancelled-turn alert | Contracts + HTTP + worker + PostgreSQL + iOS | Skip claim-time ACL revalidation or event uniqueness |
 | The API persists runtime intent but never contacts Box/Pi | Lost work after `202`, request-held lifecycle, or duplicate executor | HTTP + provider spy + PostgreSQL | Construct the Box adapter in an API route |
@@ -61,7 +62,8 @@ record desired lifecycle, and converge; main and background claims are obtained 
 independently so a blocked main claim cannot serialize or starve background work. PostgreSQL tests
 prove idempotent command admission, per-lane FIFO, monotonic takeover epochs, stale-fence rejection,
 shared kill-switch epoch invalidation, invalid-boundary rejection before lease mutation, forced RLS,
-distinct API/worker/runtime function grants, and isolation from every retired executor. Async preparation tests create through the public
+distinct API/worker/runtime function grants, isolation from every retired executor, and incremental
+user-entry invalidation whenever a v3 Turn leaves `queued`. Async preparation tests create through the public
 v3 acceptance seam, send before readiness, and fault Box create and Pi activation while proving the
 Turn remains queued with a bounded retry. The simulator replays a lost `POST /boxes` response from
 the same provider `Idempotency-Key` without creating a second Box. The warm-text tracer bullet additionally runs the
@@ -302,7 +304,9 @@ newest eligible failed delete with a retained provider operation id.
   approval.
 - Inactivity stall: ten minutes plus one sweep while running; absolute deadline: two hours plus one
   sweep.
-- `/healthz` fails when PostgreSQL, the claim loop, or the most recent sweep is unhealthy.
+- `/healthz` fails when PostgreSQL, the claim loop, or the most recent sweep is unhealthy. A newly
+  started active convergence remains healthy through the longest durable preparation or Turn
+  deadline, then becomes unhealthy if it still has not completed.
 
 Deterministic fault tests cover every boundary around list, create, resume, bundle upload/apply,
 pre-execution cleanup, activation, durable checkpoint, direct prompt write, ledger fsync, HTTP

--- a/packages/box-runtime/src/companionRuntimeBaker.test.ts
+++ b/packages/box-runtime/src/companionRuntimeBaker.test.ts
@@ -36,6 +36,7 @@ function lifecycle(overrides: Partial<BoxRuntimeLifecycleClient> = {}): BoxRunti
     completedAt: null,
   };
   return {
+    listAllBoxes: vi.fn(async () => [{ id: "bx_23456789", state: "ready" as const }]),
     getNamedSnapshot: vi.fn(async () => null),
     listNamedSnapshots: vi.fn(async () => []),
     createEphemeralBox: vi.fn(async () => ({ boxId: "bx_23456789" })),
@@ -321,6 +322,7 @@ describe("bakeCompanionRuntimeImageOnce", () => {
 
   it("falls back to an empty baker Box when the parent snapshot disappeared", async () => {
     const client = lifecycle({
+      listAllBoxes: vi.fn(async () => [{ id: "bx_abcdefgh", state: "ready" as const }]),
       listNamedSnapshots: vi.fn(async () => [snapshot("companion-l14-bbbbbbbbbbbb")]),
       createEphemeralBox: vi.fn()
         .mockRejectedValueOnce(new BoxRuntimeAdapterError({
@@ -510,6 +512,54 @@ describe("bakeCompanionRuntimeImageOnce", () => {
     });
     expect(requestPermanentDeletion).not.toHaveBeenCalled();
     expect(client.deletePermanentlyAndWait).not.toHaveBeenCalled();
+  });
+
+  it("settles retained baker cleanup when authenticated inventory proves the Box is absent", async () => {
+    const deletePermanentlyAndWait = vi.fn<BoxRuntimeLifecycleClient["deletePermanentlyAndWait"]>(
+      async () => {
+        throw new Error("operation polling must not run after authoritative absence");
+      },
+    );
+    const client = lifecycle({
+      listAllBoxes: vi.fn(async () => []),
+      deletePermanentlyAndWait,
+    });
+
+    await expect(deleteCompanionRuntimeBakerBox({
+      lifecycle: client,
+      boxId: "bx_23456789",
+      deletionIntentRecorded: true,
+      operationId: "bdop_00000000000000000000000000000001",
+      deadlineAt: Date.now() + 30_000,
+      signal: new AbortController().signal,
+    })).resolves.toBeUndefined();
+    expect(deletePermanentlyAndWait).not.toHaveBeenCalled();
+  });
+
+  it("settles newly accepted baker cleanup when inventory proves immediate absence", async () => {
+    const onDeletionRequested = vi.fn();
+    const deletePermanentlyAndWait = vi.fn<BoxRuntimeLifecycleClient["deletePermanentlyAndWait"]>(
+      async () => {
+        throw new Error("operation polling must not run after authoritative absence");
+      },
+    );
+    const client = lifecycle({
+      listAllBoxes: vi.fn(async () => []),
+      deletePermanentlyAndWait,
+    });
+
+    await expect(deleteCompanionRuntimeBakerBox({
+      lifecycle: client,
+      boxId: "bx_23456789",
+      deadlineAt: Date.now() + 30_000,
+      signal: new AbortController().signal,
+      onDeletionRequested,
+    })).resolves.toBeUndefined();
+    expect(onDeletionRequested).toHaveBeenCalledWith({
+      boxId: "bx_23456789",
+      operationId: "bdop_00000000000000000000000000000001",
+    });
+    expect(deletePermanentlyAndWait).not.toHaveBeenCalled();
   });
 
   it("uses an independent cleanup signal after the bake signal is aborted", async () => {

--- a/packages/box-runtime/src/companionRuntimeBaker.ts
+++ b/packages/box-runtime/src/companionRuntimeBaker.ts
@@ -209,11 +209,7 @@ export async function deleteCompanionRuntimeBakerBox(input: {
   let operationId = input.operationId ?? null;
   if (!operationId) {
     if (input.deletionIntentRecorded) {
-      const boxes = await input.lifecycle.listAllBoxes({
-        deadlineAt: input.deadlineAt,
-        signal: input.signal,
-      });
-      if (!boxes.some((box) => box.id === input.boxId)) return;
+      if (!await bakerBoxPresent(input)) return;
       throw new BoxRuntimeAdapterError({
         stableCode: "box_deletion_deadline_exceeded",
         message: "The runtime image baker Box deletion has an ambiguous accepted outcome",
@@ -233,6 +229,11 @@ export async function deleteCompanionRuntimeBakerBox(input: {
     operationId = requested.operation.id;
     await input.onDeletionRequested?.({ boxId: input.boxId, operationId });
   }
+  // ascii.dev removes a Box from ordinary inventory as soon as permanent deletion is
+  // accepted, while its retained operation can remain nonterminal during physical erasure.
+  // Authenticated absence is therefore authoritative cleanup evidence and avoids pinning every
+  // later image-build claim to an operation that can outlive the baker cleanup budget.
+  if (!await bakerBoxPresent(input)) return;
   const terminal = await input.lifecycle.deletePermanentlyAndWait({
     boxId: input.boxId,
     operationId,
@@ -249,6 +250,19 @@ export async function deleteCompanionRuntimeBakerBox(input: {
       outcomeUnknown: false,
     });
   }
+}
+
+async function bakerBoxPresent(input: {
+  lifecycle: BoxRuntimeLifecycleClient;
+  boxId: string;
+  deadlineAt: number;
+  signal: AbortSignal;
+}): Promise<boolean> {
+  const boxes = await input.lifecycle.listAllBoxes({
+    deadlineAt: input.deadlineAt,
+    signal: input.signal,
+  });
+  return boxes.some((box) => box.id === input.boxId);
 }
 
 async function selectParentSnapshot(input: {

--- a/packages/db/drizzle/0182_companion_runtime_v3_thread_projection.sql
+++ b/packages/db/drizzle/0182_companion_runtime_v3_thread_projection.sql
@@ -1,0 +1,22 @@
+-- A Runtime v3 Turn is projected onto its durable user transcript entry by the API layer. Advance
+-- that entry's existing thread-change sequence whenever the Turn leaves one visible state for
+-- another, so incremental clients replace their cached `queued` bit instead of retaining it after
+-- the assistant reply arrives.
+CREATE TRIGGER companion_v3_turns_touch_thread_update
+  AFTER UPDATE OF state ON public.companion_v3_turns
+  FOR EACH ROW
+  WHEN (NEW.lane = 'main' AND OLD.state IS DISTINCT FROM NEW.state)
+  EXECUTE FUNCTION public.companion_thread_touch_turn_entry();
+--> statement-breakpoint
+
+-- Repair clients that cached a queued v3 entry before this trigger existed. The established entry
+-- update trigger allocates a fresh per-thread projection sequence without changing transcript
+-- content; the next ordinary delta read then overlays the current v3 Turn state.
+UPDATE public.companion_transcript_entries entry
+SET projection_sequence = entry.projection_sequence
+FROM public.companion_v3_turns turn_row
+WHERE turn_row.org_id = entry.org_id
+  AND turn_row.companion_id = entry.companion_id
+  AND turn_row.message_event_id = entry.event_id
+  AND turn_row.lane = 'main'
+  AND turn_row.state <> 'queued';

--- a/packages/db/drizzle/meta/_journal.json
+++ b/packages/db/drizzle/meta/_journal.json
@@ -1275,6 +1275,13 @@
       "when": 1793383600000,
       "tag": "0181_companion_runtime_v3_desktop_authorization",
       "breakpoints": true
+    },
+    {
+      "idx": 182,
+      "version": "7",
+      "when": 1793387200000,
+      "tag": "0182_companion_runtime_v3_thread_projection",
+      "breakpoints": true
     }
   ]
 }


### PR DESCRIPTION
## Summary

- reconcile an accepted baker Box deletion from authenticated ordinary inventory instead of waiting indefinitely on a retained provider operation
- keep Runtime `/healthz` healthy while one bounded active cold-preparation convergence is making progress
- advance transcript projection sequences when Runtime v3 main-turn state changes, with a one-time backfill for clients that already cached stale `queued` entries

## Incident evidence

Production turns completed and assistant messages were persisted, but mobile continued to display their originating user messages in the queue. Runtime v3 state changes did not advance those transcript entries, so incremental sync delivered the assistant entry without invalidating the client's cached `queued: true` projection.

Cold preparation also exceeded the deployment health window while npm staging was active, and image creation remained pinned to a retained deletion operation after the baker Box had already disappeared from authenticated inventory.

## Verification

- full `@companion/box-runtime` tests: 348 passed
- full `@companion/runtime` unit tests: 247 passed
- runtime, Box runtime, and database typechecks passed
- `pnpm verify:change` fast gates passed; disposable PostgreSQL, runtime integration, browser smoke, and container smoke are delegated to CI
- independent review: no issues found

## Risk

Migration `0182` installs a narrow `AFTER UPDATE OF state` trigger for main-lane v3 turns and advances existing projection sequences once for already-terminal rows. It changes no transcript content and excludes routine-lane turns.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/The-Vibe-Company/companion/pull/737?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->





<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR restores convergence across image cleanup, runtime health, and transcript projections.
- Reconciles accepted baker Box deletion against authenticated inventory after the Box disappears.
- Keeps health checks green during bounded active cold preparation or turn execution.
- Adds a migration trigger and one-time backfill so main-lane v3 state changes invalidate cached queued transcript entries.
</details>


<details><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge.

No blocking failure remains.
</details>


<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| apps/runtime/src/server.ts | Extends sweep freshness while bounded scheduler work is active and retains a durable-deadline health cutoff. |
| packages/box-runtime/src/companionRuntimeBaker.ts | Treats absence from authenticated ordinary inventory as successful convergence after an accepted baker Box deletion. |
| packages/db/drizzle/0182_companion_runtime_v3_thread_projection.sql | Advances transcript projection sequences for main-lane turn state updates and backfills existing terminal turns. |
| apps/runtime/test/integration/runtimeV3Progression.integration.test.ts | Verifies terminal v3 turn transitions invalidate cached queued transcript projections. |

</details>


<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
  A[Runtime v3 turn state changes] --> B[Projection trigger advances sequence]
  B --> C[Incremental sync refreshes queued entry]
  D[Active bounded convergence] --> E[Runtime health remains healthy]
  E --> F[Convergence completes or reaches durable deadline]
  G[Baker deletion accepted] --> H[Authenticated inventory no longer contains Box]
  H --> I[Cleanup converges and image creation continues]
```
</details>

<sub>Reviews (2): Last reviewed commit: ["fix(runtime): restore Companion creation..."](https://github.com/the-vibe-company/companion/commit/2bfd6f2ce87c777ddfd5882a281b08a572f16c03) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=60291909)</sub>

<!-- /greptile_comment -->