### PR TITLE
fix(runtime): restore v3 MCP broker access

### DIFF
--- a/apps/runtime/test/integration/runtimeV3McpBrokerResolverMigration.integration.test.ts
+++ b/apps/runtime/test/integration/runtimeV3McpBrokerResolverMigration.integration.test.ts
@@ -1,0 +1,230 @@
+/**
+ * Product promise: a current Runtime v3 MCP broker capability resolves without a retired Runtime
+ * v2 projection, while token rotation, expiry, revocation, and inactive lifecycle state fail closed.
+ *
+ * Why integrated: the resolver is SECURITY DEFINER behind FORCE RLS and derives its authority from
+ * the fully migrated PostgreSQL schema; a unit fake cannot prove the table binding or role ACL.
+ */
+import { randomUUID } from "node:crypto";
+import { readFile, readdir } from "node:fs/promises";
+import { fileURLToPath } from "node:url";
+import postgres from "postgres";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+
+const databaseUrl = process.env.DATABASE_MIGRATION_URL ?? process.env.DATABASE_URL;
+if (!databaseUrl?.trim()) {
+  throw new Error("Runtime v3 MCP resolver migration test requires a disposable PostgreSQL URL");
+}
+
+const migrationsDir = fileURLToPath(new URL("../../../../packages/db/drizzle/", import.meta.url));
+const grantsFile = fileURLToPath(
+  new URL("../../../../packages/db/runtime-role-grants.sql", import.meta.url),
+);
+const suffix = randomUUID().replaceAll("-", "").slice(0, 16);
+const databaseName = `v3_mcp_resolver_${suffix}`;
+const apiRole = `v3_mcp_api_${suffix}`;
+const workerRole = `v3_mcp_worker_${suffix}`;
+const runtimeRole = `v3_mcp_runtime_${suffix}`;
+const actorId = `v3-mcp-owner-${suffix}`;
+const orgId = randomUUID();
+const companionId = randomUUID();
+const currentTokenId = randomUUID();
+const wrongCurrentTokenId = randomUUID();
+const revokedTokenId = randomUUID();
+const expiredTokenId = randomUUID();
+const currentTokenHash = "a".repeat(64);
+const wrongCurrentTokenHash = "b".repeat(64);
+const revokedTokenHash = "c".repeat(64);
+const expiredTokenHash = "d".repeat(64);
+const accountRefs = [{ account_id: randomUUID(), credential_generation: randomUUID() }];
+const adminSql = postgres(databaseUrl, { max: 1 });
+const upgradeUrl = new URL(databaseUrl);
+upgradeUrl.pathname = `/${databaseName}`;
+upgradeUrl.search = "";
+let upgradeSql: ReturnType<typeof postgres>;
+
+async function applyMigrationFile(name: string): Promise<void> {
+  const source = await readFile(`${migrationsDir}/${name}`, "utf8");
+  const statements = source
+    .split("--> statement-breakpoint")
+    .map((statement) => statement.trim())
+    .filter(Boolean);
+  await upgradeSql.begin(async (transaction) => {
+    for (const statement of statements) await transaction.unsafe(statement);
+  });
+}
+
+async function applySplitGrants(): Promise<void> {
+  const source = await readFile(grantsFile, "utf8");
+  const beginMarker = "-- companion-runtime-grants-begin";
+  const endMarker = "-- companion-runtime-grants-end";
+  const begin = source.indexOf(beginMarker);
+  const end = source.indexOf(endMarker);
+  if (begin < 0 || end <= begin) throw new Error("runtime grant hook markers are missing");
+  const connection = await upgradeSql.reserve();
+  try {
+    await connection`select set_config('companion.api_role', ${apiRole}, false)`;
+    await connection`select set_config('companion.worker_role', ${workerRole}, false)`;
+    await connection`select set_config('companion.companion_runtime_role', ${runtimeRole}, false)`;
+    await connection`select set_config('companion.retired_runtime_role', '', false)`;
+    await connection.unsafe(source.slice(begin + beginMarker.length, end).trim());
+  } finally {
+    connection.release();
+  }
+}
+
+async function resolveAsApi(tokenHash: string): Promise<Array<{
+  orgId: string;
+  companionId: string;
+  actorId: string;
+  accountRefs: typeof accountRefs;
+}>> {
+  return await upgradeSql.begin(async (transaction) => {
+    await transaction.unsafe(`set local role ${apiRole}`);
+    return await transaction`
+      select org_id as "orgId", companion_id as "companionId", actor_id as "actorId",
+        account_refs as "accountRefs"
+      from public.companion_resolve_mcp_broker_token(${tokenHash})
+    `;
+  });
+}
+
+describe("0183 Runtime v3 MCP broker resolver migration", () => {
+  beforeAll(async () => {
+    await adminSql.unsafe(`
+      create role ${apiRole} login nosuperuser nobypassrls noinherit;
+      create role ${workerRole} login nosuperuser nobypassrls noinherit;
+      create role ${runtimeRole} login nosuperuser nobypassrls noinherit;
+    `);
+    await adminSql.unsafe(`create database "${databaseName}"`);
+    upgradeSql = postgres(upgradeUrl.toString(), { max: 1 });
+
+    const migrations = (await readdir(migrationsDir))
+      .filter((name) => /^\d{4}_.+\.sql$/.test(name))
+      .sort();
+    const cutoverIndex = migrations.findIndex((name) => name.startsWith("0094_"));
+    if (cutoverIndex < 0) throw new Error("Runtime v2 cutover migration is missing");
+    const resolverMigrationIndex = migrations.findIndex((name) => name.startsWith("0183_"));
+    if (resolverMigrationIndex < 0) throw new Error("Runtime v3 MCP resolver migration is missing");
+    for (const migration of migrations.slice(0, cutoverIndex)) await applyMigrationFile(migration);
+    await applySplitGrants();
+    for (const migration of migrations.slice(cutoverIndex, resolverMigrationIndex)) {
+      await applyMigrationFile(migration);
+    }
+    await applySplitGrants();
+    await applyMigrationFile(migrations[resolverMigrationIndex]!);
+
+    await upgradeSql`
+      insert into public."user" (id, name, email, email_verified)
+      values (${actorId}, 'MCP Resolver Owner', ${`${actorId}@example.test`}, true)
+    `;
+    await upgradeSql`
+      insert into public.organizations (id, name, slug, kind)
+      values (${orgId}::uuid, 'MCP Resolver', ${`mcp-resolver-${suffix}`}, 'team')
+    `;
+    await upgradeSql`
+      insert into public.memberships (org_id, user_id, org_role)
+      values (${orgId}::uuid, ${actorId}, 'owner')
+    `;
+    await upgradeSql`
+      insert into public.companions (id, org_id, owner_id, name)
+      values (${companionId}::uuid, ${orgId}::uuid, ${actorId}, 'MCP Resolver Companion')
+    `;
+    await upgradeSql`
+      insert into public.companion_v3_instances (
+        org_id, companion_id, desired_lifecycle_actor_id
+      ) values (${orgId}::uuid, ${companionId}::uuid, ${actorId})
+    `;
+    await upgradeSql`
+      insert into public.companion_mcp_broker_tokens (
+        id, org_id, companion_id, actor_id, token_prefix, token_hash, account_refs,
+        expires_at, revoked_at
+      ) values
+        (${currentTokenId}::uuid, ${orgId}::uuid, ${companionId}::uuid, ${actorId},
+          'cmp_mcp_curren', ${currentTokenHash}, ${upgradeSql.json(accountRefs)},
+          now() + interval '1 hour', null),
+        (${wrongCurrentTokenId}::uuid, ${orgId}::uuid, ${companionId}::uuid, ${actorId},
+          'cmp_mcp_wrong_', ${wrongCurrentTokenHash}, ${upgradeSql.json(accountRefs)},
+          now() + interval '1 hour', null),
+        (${revokedTokenId}::uuid, ${orgId}::uuid, ${companionId}::uuid, ${actorId},
+          'cmp_mcp_revoke', ${revokedTokenHash}, ${upgradeSql.json(accountRefs)},
+          now() + interval '1 hour', now()),
+        (${expiredTokenId}::uuid, ${orgId}::uuid, ${companionId}::uuid, ${actorId},
+          'cmp_mcp_expire', ${expiredTokenHash}, ${upgradeSql.json(accountRefs)},
+          now() - interval '1 second', null)
+    `;
+    await upgradeSql`
+      update public.companion_v3_instances set mcp_broker_token_id = ${currentTokenId}::uuid
+      where org_id = ${orgId}::uuid and companion_id = ${companionId}::uuid
+    `;
+  }, 120_000);
+
+  afterAll(async () => {
+    if (upgradeSql) await upgradeSql.end({ timeout: 1 });
+    await adminSql.unsafe(`drop database if exists "${databaseName}" with (force)`);
+    await adminSql.unsafe(`drop role if exists ${apiRole}, ${workerRole}, ${runtimeRole}`);
+    await adminSql.end({ timeout: 1 });
+  }, 30_000);
+
+  it("resolves only the current active v3 capability without a legacy runtime row", async () => {
+    expect(await upgradeSql`
+      select companion_id from public.companion_runtime_instances
+      where org_id = ${orgId}::uuid and companion_id = ${companionId}::uuid
+    `).toEqual([]);
+
+    expect(await resolveAsApi(currentTokenHash)).toEqual([{
+      orgId,
+      companionId,
+      actorId,
+      accountRefs,
+    }]);
+    expect(await resolveAsApi(wrongCurrentTokenHash)).toEqual([]);
+
+    await upgradeSql`
+      update public.companion_v3_instances set mcp_broker_token_id = ${revokedTokenId}::uuid
+      where org_id = ${orgId}::uuid and companion_id = ${companionId}::uuid
+    `;
+    expect(await resolveAsApi(revokedTokenHash)).toEqual([]);
+
+    await upgradeSql`
+      update public.companion_v3_instances set mcp_broker_token_id = ${expiredTokenId}::uuid
+      where org_id = ${orgId}::uuid and companion_id = ${companionId}::uuid
+    `;
+    expect(await resolveAsApi(expiredTokenHash)).toEqual([]);
+
+    await upgradeSql`
+      update public.companion_v3_instances set mcp_broker_token_id = ${currentTokenId}::uuid,
+        desired_lifecycle = 'archive'
+      where org_id = ${orgId}::uuid and companion_id = ${companionId}::uuid
+    `;
+    expect(await resolveAsApi(currentTokenHash)).toEqual([]);
+
+    await upgradeSql`
+      update public.companion_v3_instances set desired_lifecycle = 'prepare',
+        lifecycle_state = 'archived'
+      where org_id = ${orgId}::uuid and companion_id = ${companionId}::uuid
+    `;
+    expect(await resolveAsApi(currentTokenHash)).toEqual([]);
+  });
+
+  it("retains the resolver's SECURITY DEFINER, RLS, search path, and API-only execution surface", async () => {
+    const [definition] = await upgradeSql<Array<{
+      securityDefiner: boolean;
+      config: string[];
+      apiCanExecute: boolean;
+      publicCanExecute: boolean;
+    }>>`
+      select procedure.prosecdef as "securityDefiner", procedure.proconfig as config,
+        has_function_privilege(${apiRole}, procedure.oid, 'EXECUTE') as "apiCanExecute",
+        has_function_privilege('public', procedure.oid, 'EXECUTE') as "publicCanExecute"
+      from pg_catalog.pg_proc procedure
+      where procedure.oid = 'public.companion_resolve_mcp_broker_token(text)'::regprocedure
+    `;
+    expect(definition).toEqual({
+      securityDefiner: true,
+      config: ["search_path=pg_catalog, public", "row_security=on"],
+      apiCanExecute: true,
+      publicCanExecute: false,
+    });
+  });
+});

--- a/docs/companions-runtime.md
+++ b/docs/companions-runtime.md
@@ -1127,6 +1127,11 @@ account-generation refs. The Pi broker starts a loopback HTTP gateway before Pi 
 `pi-mcp-adapter` with its dynamic local URLs. That gateway calls
 `POST /v1/runtime/mcp-access-token` just before remote access; the API revalidates the active
 Companion instance, membership, owner, current plugin selection, and generation on every request.
+The token resolver binds the capability to the current
+`companion_v3_instances.mcp_broker_token_id`; it never consults the retired Runtime v2 instance
+projection. A completed legacy purge therefore cannot invalidate a current staged capability, while
+rotation, expiry, revocation, an inactive lifecycle, Companion removal, or membership loss still
+denies access.
 The API role keeps `companions` read-only: a narrow `SECURITY DEFINER` capability pins the acting
 member, Companion selection, and any Editor grant while the existing account-row lock vends or
 refreshes the token. Concurrent membership, ACL, or plugin detachment waits for that transaction;

--- a/docs/design.md
+++ b/docs/design.md
@@ -632,6 +632,12 @@ unselected accounts cannot use it. An explicit upstream `401` before any MCP res
 one refresh and one retry. Timeouts, disconnects, redirects, and other ambiguous outcomes are never
 replayed.
 
+The broker capability resolver derives current-instance authority exclusively from
+`companion_v3_instances.mcp_broker_token_id`. It has no dependency on the retired Runtime v2
+projection: the offline purge may remove every legacy runtime row without making a currently staged
+v3 MCP account unreachable. Token rotation, expiry, revocation, inactive lifecycle state, Companion
+removal, and membership loss continue to fail closed.
+
 Slack follows the same selected-account boundary without pretending Slack's user-token MCP endpoint
 is a Bot User integration. API owns the fixed Slack OAuth v2 authorize and token endpoints. For a
 selected Slack account, the loopback gateway terminates a small stateless MCP surface and maps only

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -35,6 +35,7 @@ slow, local-only final validation and is intentionally not part of CI.
 | Every active turn reaches a bounded visible state | Forever-replying turn after Pi/provider failure | Runtime + simulator + browser | Suppress `agent_settled` or correlated activity |
 | Viewer and ordinary reads never contact or wake Box | Read causes spend, secret access, or lifecycle mutation | HTTP + browser + provider spy | Instantiate Box before the runner guard |
 | Provider/MCP secrets stay write-only and runtime errors stay expurgated | Token, signed URL, provider payload, or Pi line persisted | Core + runtime + HTTP + logs | Return raw adapter error text |
+| A current v3 MCP broker capability remains usable after the legacy runtime purge | Every selected MCP appears attached but the Box loopback gateway returns 502 | Fully migrated PostgreSQL with split roles | Resolve the token through the retired v2 instance projection |
 | Permanent legacy purge deletes external ownership before rows | Orphan Box or irrecoverable ownership loss | Command + PostgreSQL + provider contract | Delete the row before provider confirmation |
 | Offline Runtime v2 purge is resumable, expurgated, and preserves the Skills Hub | Duplicate provider effects, orphan object/webhook/Box, leaked content, or collateral data loss | Command + disposable fully migrated PostgreSQL + object/provider adapters | Remove the pre-effect checkpoint, terminal-target skip, ownership guard, or preservation fingerprint |
 | Production activation uses complete approved evidence | Loss, replay, stale-fence settlement, privacy breach, a lane blocked over 15 minutes, or activation before seven dedicated canary days | Aggregate acceptance report + disposable PostgreSQL + simulator + reviewed canary evidence | Omit one SLO series, accept an unavailable source, or shorten the canary window |
@@ -237,6 +238,10 @@ live canary does not replace local installation acceptance.
 - Replay migrations from an historical snapshot and test legacy purge report, dry-run, confirmation,
   advisory lock, Box `404`, provider error, resume after partial progress, and preservation of
   provider/MCP encrypted rows.
+- On a fully migrated database with no legacy runtime instance, resolve a current v3 MCP broker
+  capability through the restricted API role. Prove rotated, expired, revoked, and inactive-instance
+  capabilities remain denied and that the `SECURITY DEFINER`, forced-RLS configuration, search path,
+  and API-only execute grant survive the replacement migration.
 
 ### End-to-end topology
 

--- a/packages/db/drizzle/0183_companion_runtime_v3_mcp_broker_resolver.sql
+++ b/packages/db/drizzle/0183_companion_runtime_v3_mcp_broker_resolver.sql
@@ -1,0 +1,43 @@
+-- The MCP broker resolver predates Runtime v3 and was not included in 0179's companion_v3_*
+-- function rewrite. Resolve the current capability against the v3 aggregate so a completed
+-- Runtime v2 purge cannot make a valid Box-local MCP request look unauthorized.
+CREATE OR REPLACE FUNCTION public.companion_resolve_mcp_broker_token(p_token_hash text)
+RETURNS TABLE (
+  org_id uuid,
+  companion_id uuid,
+  actor_id text,
+  account_refs jsonb
+)
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = pg_catalog, public
+SET row_security = on
+AS $$
+DECLARE
+  v_now timestamp with time zone := clock_timestamp();
+BEGIN
+  IF p_token_hash IS NULL OR p_token_hash !~ '^[0-9a-f]{64}$' THEN RETURN; END IF;
+  RETURN QUERY
+  UPDATE public.companion_mcp_broker_tokens token
+  SET last_used_at = v_now
+  FROM public.companion_v3_instances instance,
+       public.companions companion,
+       public.memberships membership
+  WHERE token.token_hash = p_token_hash
+    AND token.revoked_at IS NULL
+    AND token.expires_at > v_now
+    AND instance.org_id = token.org_id
+    AND instance.companion_id = token.companion_id
+    AND instance.mcp_broker_token_id = token.id
+    AND instance.desired_lifecycle = 'prepare'
+    AND instance.lifecycle_state = 'active'
+    AND companion.org_id = token.org_id
+    AND companion.id = token.companion_id
+    AND membership.org_id = token.org_id
+    AND membership.user_id = token.actor_id
+  RETURNING token.org_id, token.companion_id, token.actor_id, token.account_refs;
+END
+$$;
+--> statement-breakpoint
+
+REVOKE ALL ON FUNCTION public.companion_resolve_mcp_broker_token(text) FROM PUBLIC;

--- a/packages/db/drizzle/meta/_journal.json
+++ b/packages/db/drizzle/meta/_journal.json
@@ -1282,6 +1282,13 @@
       "when": 1793387200000,
       "tag": "0182_companion_runtime_v3_thread_projection",
       "breakpoints": true
+    },
+    {
+      "idx": 183,
+      "version": "7",
+      "when": 1793390800000,
+      "tag": "0183_companion_runtime_v3_mcp_broker_resolver",
+      "breakpoints": true
     }
   ]
 }

--- a/scripts/ci-runtime-integration.sh
+++ b/scripts/ci-runtime-integration.sh
@@ -24,6 +24,7 @@ DATABASE_URL="$DATABASE_MIGRATION_URL" \
   pnpm --filter @companion/runtime exec vitest run \
     --config vitest.integration.config.ts \
     test/integration/companionV2Purge.integration.test.ts \
+    test/integration/runtimeV3McpBrokerResolverMigration.integration.test.ts \
     test/integration/runtimeV3DesktopAuthorization.integration.test.ts \
     test/integration/runtimeV3Progression.integration.test.ts \
     test/integration/runtimeFullStack.integration.test.ts


### PR DESCRIPTION
## Summary
- resolve current MCP broker capabilities from the Runtime v3 instance after the legacy purge
- preserve current-token, lifecycle, membership, RLS, and API-only authorization checks
- add a fully migrated PostgreSQL regression and run it in the existing Runtime Integration CI gate
- document the v3-only broker authority contract

## Verification
- targeted Runtime v3 MCP resolver PostgreSQL test: 2 passed
- pnpm typecheck: passed
- pnpm lint: passed
- pnpm verify:change fast checks: passed; expected exit 2 for CI-owned database/runtime/browser/container follow-ups
- git diff --check: passed
- review-code-dev: clean after fixing its P2 CI-coverage finding

## Production cause
Migration 0179 rewrote companion_v3_* functions away from the retired runtime table, but the historically named companion_resolve_mcp_broker_token function was outside that rewrite. Once the Runtime v2 purge removed legacy instances, every selected MCP token failed authorization and the Box loopback gateway surfaced 502.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/The-Vibe-Company/companion/pull/738?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

The PR restores MCP broker token resolution against the Runtime v3 instance projection while retaining the existing token, lifecycle, membership, RLS, and role restrictions.

- Adds migration 0183 to bind broker capabilities to the current v3 instance token.
- Adds fully migrated PostgreSQL regression coverage to the Runtime integration CI gate.
- Documents the v3-only broker authority and legacy-purge behavior.
</details>


<details><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge with no concrete changed-code defects identified.

The resolver targets the v3 instance authority while retaining the existing current-token, expiry, revocation, lifecycle, membership, RLS, search-path, and execution-role protections, and the new integration coverage exercises the intended migrated deployment path.
</details>


<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| packages/db/drizzle/0183_companion_runtime_v3_mcp_broker_resolver.sql | Replaces the legacy runtime-instance join with the v3 authority projection while preserving token validity, lifecycle, companion, membership, RLS, search-path, and public-execution constraints. |
| apps/runtime/test/integration/runtimeV3McpBrokerResolverMigration.integration.test.ts | Replays the migrated schema with split roles and verifies successful v3 resolution, fail-closed states, function security configuration, and API-only execution. |
| scripts/ci-runtime-integration.sh | Adds the new PostgreSQL migration regression to the existing Runtime integration test gate. |
| packages/db/drizzle/meta/_journal.json | Registers migration 0183 in sequence with the matching migration tag. |

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(runtime): restore v3 MCP broker acce..."](https://github.com/the-vibe-company/companion/commit/543dc9c50000930262c7ef3e56c95f5e0cd6c33e) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=60309008)</sub>

<!-- /greptile_comment -->