### PR TITLE
fix(companions): restore Runtime v3 MCP control

### DIFF
--- a/apps/api/src/companionControlMcp.test.ts
+++ b/apps/api/src/companionControlMcp.test.ts
@@ -13,6 +13,7 @@ const dependencies: CompanionControlMcpDependencies = {
   finishCompanionControlInvocation: vi.fn(),
   getCompanionDelegation: vi.fn(),
   registerCompanionControlInvocation: vi.fn(),
+  scheduleCompanionPiRestart: vi.fn(),
   updateCompanionWithRuntime: vi.fn(),
 };
 
@@ -80,6 +81,12 @@ describe("executeCompanionControlMcp idempotence", () => {
     vi.mocked(dependencies.companionControlActor)
       .mockResolvedValue({ id: "actor-1", email: "owner@example.com", name: "Owner" });
     vi.mocked(dependencies.updateCompanionWithRuntime).mockResolvedValue(companion);
+    vi.mocked(dependencies.scheduleCompanionPiRestart).mockImplementation(async ({ authorization, id }) => ({
+      id,
+      status: "pending",
+      source_turn_id: authorization.turnId,
+      operation_id: null,
+    }));
     vi.mocked(dependencies.finishCompanionControlInvocation).mockImplementation(async ({ result }) => result);
   });
 
@@ -140,6 +147,35 @@ describe("executeCompanionControlMcp idempotence", () => {
     expect(first?.requestKey).toMatch(new RegExp(`^${authorization.attemptId}:[0-9a-f]{64}$`));
     expect(second?.requestKey).toMatch(new RegExp(`^${authorization.attemptId}:[0-9a-f]{64}$`));
     expect(first?.requestKey).not.toBe(second?.requestKey);
+  });
+
+  it("uses a fresh Pi recycle lifecycle request for each control Turn", async () => {
+    vi.mocked(dependencies.registerCompanionControlInvocation)
+      .mockResolvedValue({ replayed: false, result: null });
+    const restartCall = {
+      jsonrpc: "2.0" as const,
+      id: "restart-1",
+      method: "tools/call" as const,
+      params: { name: "companion_restart_pi", arguments: {} },
+    };
+    const nextAuthorization = {
+      ...authorization,
+      turnId: "55555555-5555-4555-8555-555555555555",
+      attemptId: "55555555-5555-4555-8555-555555555555",
+    };
+
+    await executeCompanionControlMcp({
+      raw: restartCall, authorization, database, dependencies,
+    });
+    await executeCompanionControlMcp({
+      raw: restartCall, authorization: nextAuthorization, database, dependencies,
+    });
+
+    const firstId = vi.mocked(dependencies.scheduleCompanionPiRestart).mock.calls[0]?.[0].id;
+    const secondId = vi.mocked(dependencies.scheduleCompanionPiRestart).mock.calls[1]?.[0].id;
+    expect(firstId).toMatch(/^[0-9a-f-]{36}$/);
+    expect(secondId).toMatch(/^[0-9a-f-]{36}$/);
+    expect(firstId).not.toBe(secondId);
   });
 
   it("cancels a delegation through its Runtime v3 target Turn seam", async () => {

--- a/apps/api/src/companionControlMcp.ts
+++ b/apps/api/src/companionControlMcp.ts
@@ -84,6 +84,7 @@ export interface CompanionControlMcpDependencies {
   finishCompanionControlInvocation: typeof finishCompanionControlInvocation;
   getCompanionDelegation: typeof getCompanionDelegation;
   registerCompanionControlInvocation: typeof registerCompanionControlInvocation;
+  scheduleCompanionPiRestart: typeof scheduleCompanionPiRestart;
   updateCompanionWithRuntime: typeof updateCompanionWithRuntime;
 }
 
@@ -93,6 +94,7 @@ const defaultDependencies: CompanionControlMcpDependencies = {
   finishCompanionControlInvocation,
   getCompanionDelegation,
   registerCompanionControlInvocation,
+  scheduleCompanionPiRestart,
   updateCompanionWithRuntime,
 };
 
@@ -380,9 +382,9 @@ export async function executeCompanionControlMcp(input: {
       case "companion_restart_pi": {
         emptySchema.parse(args);
         const identity = callIdentity(a, call.id, call.params.name, args);
-        const restart = await scheduleCompanionPiRestart({
+        const restart = await dependencies.scheduleCompanionPiRestart({
           authorization: a,
-          id: deterministicControlUuid(identity.digest, "pi-restart"),
+          id: deterministicControlUuid(identity.digest, `pi-restart:${identity.key}`),
           database: input.database,
         });
         return ok(call.id, {

--- a/packages/core/src/companionControl.ts
+++ b/packages/core/src/companionControl.ts
@@ -282,24 +282,19 @@ export async function scheduleCompanionPiRestart(input: {
   database: Db;
 }): Promise<{ id: string; status: "pending" | "enqueued" | "cancelled"; source_turn_id: string; operation_id: string | null }> {
   const a = input.authorization;
-  const result = await input.database.execute<{
-    id: string;
-    status: "pending" | "enqueued" | "cancelled";
-    source_turn_id: string;
-    operation_id: string | null;
-  }>(sql`
-    select * from public.companion_api_schedule_pi_restart(
-      ${a.orgId}::uuid,${a.companionId}::uuid,${input.id}::uuid,${a.turnId}::uuid,${a.attemptId}::uuid
+  const result = await input.database.execute<{ intent: string; revision: string }>(sql`
+    select intent::text,revision::text from public.companion_v3_api_request_pi_recycle(
+      ${a.orgId}::uuid,${a.companionId}::uuid,${input.id}::uuid
     )
   `);
-  const [row] = rows<{
-    id: string;
-    status: "pending" | "enqueued" | "cancelled";
-    source_turn_id: string;
-    operation_id: string | null;
-  }>(result);
-  if (!row) throw new Error("failed to schedule Companion Pi restart");
-  return row;
+  const [row] = rows<{ intent: string; revision: string }>(result);
+  if (row?.intent !== "recycle_pi") throw new Error("failed to schedule Companion Pi restart");
+  return {
+    id: input.id,
+    status: "pending",
+    source_turn_id: a.turnId,
+    operation_id: null,
+  };
 }
 
 export async function listCompanionControlSkills(input: {

--- a/packages/core/src/companionMcpBroker.ts
+++ b/packages/core/src/companionMcpBroker.ts
@@ -32,7 +32,7 @@ export type CompanionMcpAccessToken = z.infer<typeof companionMcpAccessTokenSche
 const accountRefsSchema = z.array(z.object({
   account_id: z.string().uuid(),
   credential_generation: z.string().uuid(),
-}).strict()).min(1).max(50);
+}).strip()).min(1).max(50);
 const selectedAccountLockSchema = z.object({ authorized: z.boolean() }).strict();
 
 export class CompanionMcpBrokerAuthorizationError extends Error {

--- a/packages/core/test/companionControl.test.ts
+++ b/packages/core/test/companionControl.test.ts
@@ -5,6 +5,7 @@ import {
   createCompanionControlRequest,
   grantCompanionPeerAccess,
   listCompanionDelegations,
+  scheduleCompanionPiRestart,
   type CompanionControlAuthorization,
 } from "../src/companionControl";
 
@@ -26,6 +27,22 @@ function databaseReturning(rows: unknown[]): Db {
 }
 
 describe("Companion control public projections", () => {
+  it("schedules Pi recycle through the Runtime v3 lifecycle seam", async () => {
+    const restartId = "55555555-5555-4555-8555-555555555555";
+    const restart = await scheduleCompanionPiRestart({
+      authorization,
+      id: restartId,
+      database: databaseReturning([{ intent: "recycle_pi", revision: "2" }]),
+    });
+
+    expect(restart).toEqual({
+      id: restartId,
+      status: "pending",
+      source_turn_id: authorization.turnId,
+      operation_id: null,
+    });
+  });
+
   it("strips private control-request columns returned by SQL", async () => {
     const now = new Date("2026-09-01T00:00:00.000Z");
     const request = await createCompanionControlRequest({

--- a/packages/core/test/companionMcpBroker.test.ts
+++ b/packages/core/test/companionMcpBroker.test.ts
@@ -4,6 +4,7 @@ import type { Db } from "@companion/db";
 import {
   CompanionMcpBrokerAuthorizationError,
   issueCompanionMcpAccessToken,
+  resolveCompanionMcpBrokerAuthorization,
 } from "../src/companionMcpBroker";
 import {
   decryptCompanionMcpRuntimeCredential,
@@ -37,6 +38,24 @@ const authorization = {
 };
 
 describe("Companion MCP access-token broker", () => {
+  it("projects Runtime v3 preparation references without rejecting their version fence", async () => {
+    const database = databaseReturning([{
+      org_id: orgId,
+      companion_id: companionId,
+      actor_id: actorId,
+      account_refs: [{
+        account_id: accountId,
+        credential_generation: credentialGeneration,
+        credential_version: 7,
+      }],
+    }]);
+
+    await expect(resolveCompanionMcpBrokerAuthorization(
+      `cmp_mcp_${"a".repeat(48)}`,
+      database,
+    )).resolves.toEqual(authorization);
+  });
+
   it("rejects an account removed from the Companion's current selection", async () => {
     const refreshOauth = vi.fn();
     const database = fakeDatabase({ rows: [accountRow(oauth("access", nowMs + 1_000))], selected: [] });
@@ -236,6 +255,15 @@ describe("Companion MCP access-token broker", () => {
     expect(rows).toHaveLength(1);
   });
 });
+
+function databaseReturning(rows: unknown[]): Db {
+  // SAFETY: this authorization projection exercises only `database.execute`.
+  const database: Db = Object.create(null);
+  Object.defineProperty(database, "execute", {
+    value: vi.fn(async () => rows),
+  });
+  return database;
+}
 
 function oauth(
   accessToken: string,


### PR DESCRIPTION
## Summary
- accept Runtime v3 MCP preparation references while projecting only the broker identity fields
- route Companion-controlled Pi recycle through the native Runtime v3 lifecycle seam
- keep lifecycle idempotency scoped to the current control Turn and cover both production regressions

## Verification
- [x] `pnpm --filter @companion/core test -- companionMcpBroker.test.ts companionControl.test.ts`
- [x] `pnpm --filter @companion/core typecheck`
- [x] `pnpm --filter @companion/api test -- companionControlMcp.test.ts companionRoutes.test.ts`
- [x] `pnpm --filter @companion/api typecheck`
- [x] `pnpm lint:anti-slop`
- [x] `pnpm verify:change` fast checks, dependent tests/typechecks, and builds
- [ ] PostgreSQL/runtime/browser/container follow-up gates run in CI

## Review Gate
- deep `review-code-dev`: one cross-turn idempotency P1 fixed
- targeted follow-up: no remaining P0-P2 issues

## Risk
- no schema migration and no Box replacement/restart behavior
- reuses the already-deployed Runtime v3 Pi recycle function


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/The-Vibe-Company/companion/pull/742?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR restores Runtime v3 MCP control behavior without changing schemas or restarting Boxes.
- Accepts Runtime v3 MCP preparation references while projecting only broker identity fields.
- Routes Companion-requested Pi recycling through the native Runtime v3 lifecycle function.
- Scopes recycle request identity to the current control Turn and adds regression coverage for cross-Turn behavior.
</details>


<details><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge with no concrete blocking or independently actionable non-blocking issues identified.

The broker projection preserves the authorization identity and downstream revalidation, while the Turn-scoped recycle request uses the existing idempotent Runtime v3 lifecycle seam consistently with current callers and documented behavior.
</details>


<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| apps/api/src/companionControlMcp.ts | Injects the Pi-restart dependency and derives a deterministic lifecycle request ID that remains stable within an invocation while differing across control Turns. |
| packages/core/src/companionControl.ts | Replaces the legacy restart scheduler with the deployed Runtime v3 Pi-recycle lifecycle function and validates its returned intent. |
| packages/core/src/companionMcpBroker.ts | Accepts producer-supplied preparation metadata while retaining only account and credential-generation identity fields. |
| apps/api/src/companionControlMcp.test.ts | Adds regression coverage proving separate control Turns receive distinct Pi-recycle request IDs. |
| packages/core/test/companionControl.test.ts | Covers the Runtime v3 Pi-recycle seam and its public control projection. |
| packages/core/test/companionMcpBroker.test.ts | Verifies Runtime v3 preparation references containing credential-version metadata resolve to the expected broker authorization. |

</details>


<details open><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant Pi as Companion Pi
    participant MCP as Control MCP
    participant Core as Companion Core
    participant DB as Runtime v3 lifecycle
    Pi->>MCP: companion_restart_pi
    MCP->>MCP: Derive Turn-scoped request UUID
    MCP->>Core: scheduleCompanionPiRestart
    Core->>DB: companion_v3_api_request_pi_recycle
    DB-->>Core: recycle_pi intent and revision
    Core-->>MCP: pending recycle projection
    MCP-->>Pi: "apply_pending=true"
```
</details>

<sub>Reviews (1): Last reviewed commit: ["fix(companions): restore Runtime v3 MCP ..."](https://github.com/the-vibe-company/companion/commit/b2b955d756963a5164704a53036e3a5d61977152) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=60356961)</sub>

<!-- /greptile_comment -->